### PR TITLE
fix(release): recognize gitmoji-prefixed commits in semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -25,7 +25,11 @@
             "type": "skill",
             "release": "minor"
           }
-        ]
+        ],
+        "parserOpts": {
+          "headerPattern": "^(?:[^\\w\\s]+\\s+)?(\\w+)(?:\\((.*)\\))?!?: (.*)$",
+          "headerCorrespondence": ["type", "scope", "subject"]
+        }
       }
     ],
     [
@@ -60,6 +64,10 @@
               "hidden": true
             }
           ]
+        },
+        "parserOpts": {
+          "headerPattern": "^(?:[^\\w\\s]+\\s+)?(\\w+)(?:\\((.*)\\))?!?: (.*)$",
+          "headerCorrespondence": ["type", "scope", "subject"]
         }
       }
     ],


### PR DESCRIPTION
## Problem

This repo's `conventional-commit` skill **mandates a gitmoji prefix** (e.g. `♻️ refactor(...)`, `🐛 fix(...)`). But `.releaserc.json` uses `preset: conventionalcommits` with **no custom `parserOpts`**, so the default `headerPattern` requires the `type` at the very start of the header. A leading emoji makes the parser see **no type** → the commit triggers **no release**.

That's why recent `🐛 fix` and `♻️ refactor` commits silently cut no release, while historical `skill:` commits (written without emoji) did. A real trap, especially across machines.

## Fix

Add a `parserOpts.headerPattern` to **both** `@semantic-release/commit-analyzer` and `@semantic-release/release-notes-generator` that tolerates an optional leading emoji + whitespace:

```
^(?:[^\w\s]+\s+)?(\w+)(?:\((.*)\))?!?: (.*)$
```

Groups stay `type` / `scope` / `subject`, so nothing else changes.

## Verification

Tested the regex (as loaded from the JSON) against representative headers:

| Header | Parsed type |
|---|---|
| `skill: add x` | `skill` ✓ |
| `♻️ refactor(claude-statusline): publish` | `refactor` ✓ |
| `🐛 fix(api): corrige` | `fix` ✓ |
| `👷 ci: allow tooling` | `ci` ✓ |
| `chore(release): 1.11.0 [skip ci]` | `chore` ✓ |
| `feat!: breaking` | `feat` (breaking) ✓ |
| `Merge pull request #1 …` | *(unparsed — ignored)* ✓ |

Emoji-prefixed commits now parse; non-emoji commits still parse; merge commits stay ignored.

## Effect on merge

Once merged, semantic-release re-analyzes with the new parser. The previously-stuck emoji commits since v1.11.0 become parseable (`🐛 fix` → patch, `♻️ refactor` → patch), so this also **cuts the pending v1.11.1** — superseding #1 (which can be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)