### PR TITLE
✨ feat(conventional-commit): forbid AI attribution in PRs too

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Think of skills as reusable expertise — instead of explaining your documentati
 |-------|----------|--------------|
 | **openspec** | OpenSpec, /opsx, proposal, spec delta, change-id | Vanilla OpenSpec spec-driven workflow (explore → propose → validate → apply → archive) |
 | **openspec-drivezone** | the DriveZone "rito", forked schema | DriveZone forked-schema variant — mandatory Fallback / Tests & Bug-Hunter / Validation gates |
-| **conventional-commit** | creating/amending commits, commit messages, /commit | Conventional Commits + gitmoji icon per type; forbids AI attribution in commits |
+| **conventional-commit** | creating/amending commits, commit messages, /commit, opening/editing PRs | Conventional Commits + gitmoji icon per type; forbids AI attribution in commits & PRs |
 
 ### DevOps & docs
 

--- a/claude/global/personal-rules.md
+++ b/claude/global/personal-rules.md
@@ -11,8 +11,10 @@ Portable rules for Claude Code. Included from `~/.claude/CLAUDE.md` via the `@` 
 - Prefer the best long-term outcome over speed.
 - Always stay technical and concrete.
 
-## Commits
+## Commits & Pull Requests
 - NEVER include the `Co-Authored-By` line in commit messages. Do not add any AI attribution or co-author references to commits under any circumstances.
+- The same rule applies to **Pull Requests**: no AI attribution in the PR title, body, or description. Never add `🤖 Generated with Claude Code`, "Generated with", "Created by Claude", "Made with AI", or any line stating the commit/PR was produced by Claude, Anthropic, or any other AI. If a default PR-body template appends such a line (e.g. via `gh pr create`), strip it before submitting.
+- Rationale: this is a human–AI interaction where I am the author and idealizer; the AI is a tool. Git artifacts must not attribute authorship to the AI.
 
 ## Model & Effort Tiering (token economy + quality)
 Match effort and model to task **difficulty** — do not max everything (maxing trivial work wastes tokens, the opposite of the goal).

--- a/claude/skills/conventional-commit/SKILL.md
+++ b/claude/skills/conventional-commit/SKILL.md
@@ -3,11 +3,12 @@ name: conventional-commit
 description: >-
   Format every git commit message using Conventional Commits (type(scope) plus short description)
   prefixed with a gitmoji icon matching the type. Use whenever creating a commit, amending a commit, or
-  writing a commit message via /commit, heredoc, -m flag, or any skill. Never include any AI
-  attribution or co-author reference in commits.
+  writing a commit message via /commit, heredoc, -m flag, or any skill — and when opening or editing a
+  pull request (gh pr create, PR title, PR body, PR description). Never include any AI attribution or
+  co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: git
 license: MIT
 compatibility: Works in any environment with git access.

--- a/cursor/rules/conventional-commit.mdc
+++ b/cursor/rules/conventional-commit.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Format every git commit message using Conventional Commits (type(scope) plus short description) prefixed with a gitmoji icon matching the type. Use whenever creating a commit, amending a commit, or writing a commit message via /commit, heredoc, -m flag, or any skill. Never include any AI attribution or co-author reference in commits.
+  Format every git commit message using Conventional Commits (type(scope) plus short description) prefixed with a gitmoji icon matching the type. Use whenever creating a commit, amending a commit, or writing a commit message via /commit, heredoc, -m flag, or any skill — and when opening or editing a pull request (gh pr create, PR title, PR body, PR description). Never include any AI attribution or co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 alwaysApply: false
 ---
 
@@ -46,10 +46,18 @@ stack icons.
 
 ## Hard rules
 
-- **NEVER** include any AI attribution or co-author reference in any commit message — no
-  `Co-Authored-By: Claude` (or any variant/model name, or `<noreply@anthropic.com>`), in new commits,
-  amends, rebases, squashes, or via any skill/heredoc/-m flag. This is non-negotiable and applies
-  under all circumstances.
+- **NEVER** include any AI attribution or reference to AI authorship in any git artifact — not in
+  commit messages, and not in **pull request titles, bodies, or descriptions**. This is
+  non-negotiable and applies under all circumstances. Specifically forbidden anywhere:
+  - `Co-Authored-By: Claude` (or any AI/model-name variant, or `<noreply@anthropic.com>`).
+  - Trailer or footer lines like `🤖 Generated with Claude Code`, "Generated with", "Created by
+    Claude", "Made with AI", or any wording stating that the commit/PR was produced by Claude,
+    Anthropic, or any other AI tool.
+  - Applies to new commits, amends, rebases, squashes, `gh pr create`/`gh pr edit`, and PR templates
+    — via any skill, heredoc, `-m`/`--body`/`--body-file` flag, or default tool boilerplate. If a
+    default PR body template appends such a line, strip it before submitting.
+  - **Rationale:** the work is a human–AI interaction where the human is the author and idealizer; AI
+    is a tool. Git artifacts must not attribute authorship to the AI.
 - Always use the `git commit -m "$(cat <<'EOF' ... EOF)"` heredoc pattern to avoid shell escaping
   issues.
 - Only stage files relevant to the change being committed — never `git add -A`/`git add .` blindly.

--- a/plugins/workflow/skills/conventional-commit/SKILL.md
+++ b/plugins/workflow/skills/conventional-commit/SKILL.md
@@ -3,11 +3,12 @@ name: conventional-commit
 description: >-
   Format every git commit message using Conventional Commits (type(scope) plus short description)
   prefixed with a gitmoji icon matching the type. Use whenever creating a commit, amending a commit, or
-  writing a commit message via /commit, heredoc, -m flag, or any skill. Never include any AI
-  attribution or co-author reference in commits.
+  writing a commit message via /commit, heredoc, -m flag, or any skill — and when opening or editing a
+  pull request (gh pr create, PR title, PR body, PR description). Never include any AI attribution or
+  co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: git
 license: MIT
 compatibility: Works in any environment with git access.
@@ -54,10 +55,18 @@ stack icons.
 
 ## Hard rules
 
-- **NEVER** include any AI attribution or co-author reference in any commit message — no
-  `Co-Authored-By: Claude` (or any variant/model name, or `<noreply@anthropic.com>`), in new commits,
-  amends, rebases, squashes, or via any skill/heredoc/-m flag. This is non-negotiable and applies
-  under all circumstances.
+- **NEVER** include any AI attribution or reference to AI authorship in any git artifact — not in
+  commit messages, and not in **pull request titles, bodies, or descriptions**. This is
+  non-negotiable and applies under all circumstances. Specifically forbidden anywhere:
+  - `Co-Authored-By: Claude` (or any AI/model-name variant, or `<noreply@anthropic.com>`).
+  - Trailer or footer lines like `🤖 Generated with Claude Code`, "Generated with", "Created by
+    Claude", "Made with AI", or any wording stating that the commit/PR was produced by Claude,
+    Anthropic, or any other AI tool.
+  - Applies to new commits, amends, rebases, squashes, `gh pr create`/`gh pr edit`, and PR templates
+    — via any skill, heredoc, `-m`/`--body`/`--body-file` flag, or default tool boilerplate. If a
+    default PR body template appends such a line, strip it before submitting.
+  - **Rationale:** the work is a human–AI interaction where the human is the author and idealizer; AI
+    is a tool. Git artifacts must not attribute authorship to the AI.
 - Always use the `git commit -m "$(cat <<'EOF' ... EOF)"` heredoc pattern to avoid shell escaping
   issues.
 - Only stage files relevant to the change being committed — never `git add -A`/`git add .` blindly.

--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -3,11 +3,12 @@ name: conventional-commit
 description: >-
   Format every git commit message using Conventional Commits (type(scope) plus short description)
   prefixed with a gitmoji icon matching the type. Use whenever creating a commit, amending a commit, or
-  writing a commit message via /commit, heredoc, -m flag, or any skill. Never include any AI
-  attribution or co-author reference in commits.
+  writing a commit message via /commit, heredoc, -m flag, or any skill — and when opening or editing a
+  pull request (gh pr create, PR title, PR body, PR description). Never include any AI attribution or
+  co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: git
 license: MIT
 compatibility: Works in any environment with git access.
@@ -54,10 +55,18 @@ stack icons.
 
 ## Hard rules
 
-- **NEVER** include any AI attribution or co-author reference in any commit message — no
-  `Co-Authored-By: Claude` (or any variant/model name, or `<noreply@anthropic.com>`), in new commits,
-  amends, rebases, squashes, or via any skill/heredoc/-m flag. This is non-negotiable and applies
-  under all circumstances.
+- **NEVER** include any AI attribution or reference to AI authorship in any git artifact — not in
+  commit messages, and not in **pull request titles, bodies, or descriptions**. This is
+  non-negotiable and applies under all circumstances. Specifically forbidden anywhere:
+  - `Co-Authored-By: Claude` (or any AI/model-name variant, or `<noreply@anthropic.com>`).
+  - Trailer or footer lines like `🤖 Generated with Claude Code`, "Generated with", "Created by
+    Claude", "Made with AI", or any wording stating that the commit/PR was produced by Claude,
+    Anthropic, or any other AI tool.
+  - Applies to new commits, amends, rebases, squashes, `gh pr create`/`gh pr edit`, and PR templates
+    — via any skill, heredoc, `-m`/`--body`/`--body-file` flag, or default tool boilerplate. If a
+    default PR body template appends such a line, strip it before submitting.
+  - **Rationale:** the work is a human–AI interaction where the human is the author and idealizer; AI
+    is a tool. Git artifacts must not attribute authorship to the AI.
 - Always use the `git commit -m "$(cat <<'EOF' ... EOF)"` heredoc pattern to avoid shell escaping
   issues.
 - Only stage files relevant to the change being committed — never `git add -A`/`git add .` blindly.


### PR DESCRIPTION
## Contexto
Foi encontrado "Generated with Claude Code" no corpo de um PR real. A regra atual da ai-skills só proíbe atribuição a IA em **commits** — PR title/body/description ficavam descobertos.

## Mudança
Amplia a doutrina "no AI attribution" de commits para **Pull Requests** (título, corpo, descrição):

- `skills/conventional-commit/SKILL.md` (canônico): description + hard-rules agora cobrem PRs; lista explícita de formas proibidas (`Co-Authored-By`, `Generated with`, "Created by Claude", etc.) e instrução de remover o trailer default de template de PR. version 1.1.0 → 1.2.0.
- `claude/global/personal-rules.md`: seção `## Commits` → `## Commits & Pull Requests` com a cláusula de PR.
- `README.md`: row do conventional-commit atualizada.
- Wrappers regenerados via `./generate.sh` (claude/cursor/plugins).

## Racional
Interação humano–IA: o humano é o autor e idealizador; a IA é ferramenta. Artefatos git não devem atribuir autoria à IA.