### PR TITLE
✨ skill(claude-statusline): effort-tier icons, animated max, per-turn token pricing

### DIFF
--- a/claude/skills/claude-statusline/SKILL.md
+++ b/claude/skills/claude-statusline/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: claude-statusline
 description: >-
-  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, context usage, git state, cost, rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
+  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/cursor/rules/claude-statusline.mdc
+++ b/cursor/rules/claude-statusline.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, context usage, git state, cost, rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
+  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 alwaysApply: false
 ---
 
@@ -44,17 +44,24 @@ segments hidden outside a repo, token segment hidden before the first API respon
 rate-limit meters hidden on non-subscription accounts, empty lines suppressed):
 
 ```
-🤖 Opus 4.8 (1M context) | ⚡ medium | 🧠 thinking enabled | ⏱️ 1h 26m | 💰 $2.47
-🔗 my-project | 🌱 master | ● 2 ✚ 1 | 📝 +1347 -156 | 🎟️ In 135k · 95% cache · Out 2k
+🤖 Opus 4.8 (1M context) | 🔥 high | 🧠 thinking enabled | ⏱️ 1h 26m | 💰 $2.47
+🔗 my-project | 🌱 master | ● 2 ✚ 1 | 📝 +1347 -156 | ↑ In 135k $0.42 · ♻️ 95% · ↓ Out 2k $0.05
 📊 ctx ▓░░░░░░░ 16% | 🚦 5h ▓▓▓▓░░░░ 58% | 7d ▓▓▓▓▓▓░░ 84%
 ```
 
-- **Line 1 — identity + session**: model · effort · thinking on/off · session duration
-  (adaptive `Dd Hh` / `Hh Mm` / `Mm Ss`) · cost.
+- **Line 1 — identity + session**: model · **effort tier** (distinct icon + escalating color
+  per level: `🐢 low` / `⚡ medium` / `🔥 high` / `🚀 xhigh` / `💥 max`; `max` shimmers a
+  1-fps sweep when `refreshInterval` is set) · thinking on/off · session duration (adaptive
+  `Dd Hh` / `Hh Mm` / `Mm Ss`) · **cumulative session cost**. Note: `ultracode` is not a
+  distinct effort level — it reports as `xhigh`, so an ultracode turn shows as `🚀 xhigh`.
 - **Line 2 — place + tokens**: clickable GitHub repo link (OSC 8) · branch (short SHA when
   detached) · `●` staged / `✚` modified counts · worktree when in one · lines added/removed ·
-  last-response tokens (total input · **cache health %** [green ≥80, yellow 40–79, red <40 =
-  cache invalidated → next turn costs more] · output, humanized `k`/`M`).
+  last-response tokens with **per-turn cost**: `↑ In` (total input · priced $ = fresh input ×
+  rate + cache-write ×1.25 + cache-read ×0.1) · `♻️` **cache health %** [green ≥80, yellow
+  40–79, red <40 = cache invalidated → next turn costs more] · `↓ Out` (output · priced $).
+  Costs use a per-model rate table (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, Fable $10/$50 per
+  MTok) and are **hidden for unrecognized models**. This is the *last turn's* cost — distinct
+  from the cumulative session 💰 on line 1.
 - **Line 3 — meters**: all progress bars together — context-window, then 5h/7d rate limits
   (Pro/Max only). Each bar is colored green <50, yellow 50–79, red ≥80.
 
@@ -72,6 +79,10 @@ Steps:
      }
    }
    ```
+   Add `"refreshInterval": 1` (seconds; 1 is the documented minimum) only if you want the
+   animated `💥 max` effort shimmer — it re-runs the whole script every second even while
+   idle, so skip it otherwise. In large repos, cache `git status` by `session_id` first (the
+   script runs `git status` each tick).
 
 ---
 
@@ -97,8 +108,9 @@ follow these rules — they are what keep a status line from breaking or lagging
   output garbles, simplify. Use `printf '%b'` (not `echo -e`) for OSC 8 links.
 
 Extend the ready-made script rather than starting from scratch when the user wants "the
-same plus X" — its `jq` extraction, `bar()`, `human()`, and `pct_color()` helpers are
-reusable.
+same plus X" — its `jq` extraction and `bar()`, `human()`, `pct_color()`, `meter()`,
+`effort_render()` (icon+color per effort tier), and `price_rates()` (per-model $/MTok
+input/output, used to price the last turn's tokens) helpers are reusable.
 
 ---
 

--- a/plugins/tooling/skills/claude-statusline/SKILL.md
+++ b/plugins/tooling/skills/claude-statusline/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: claude-statusline
 description: >-
-  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, context usage, git state, cost, rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
+  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
@@ -49,17 +49,24 @@ segments hidden outside a repo, token segment hidden before the first API respon
 rate-limit meters hidden on non-subscription accounts, empty lines suppressed):
 
 ```
-🤖 Opus 4.8 (1M context) | ⚡ medium | 🧠 thinking enabled | ⏱️ 1h 26m | 💰 $2.47
-🔗 my-project | 🌱 master | ● 2 ✚ 1 | 📝 +1347 -156 | 🎟️ In 135k · 95% cache · Out 2k
+🤖 Opus 4.8 (1M context) | 🔥 high | 🧠 thinking enabled | ⏱️ 1h 26m | 💰 $2.47
+🔗 my-project | 🌱 master | ● 2 ✚ 1 | 📝 +1347 -156 | ↑ In 135k $0.42 · ♻️ 95% · ↓ Out 2k $0.05
 📊 ctx ▓░░░░░░░ 16% | 🚦 5h ▓▓▓▓░░░░ 58% | 7d ▓▓▓▓▓▓░░ 84%
 ```
 
-- **Line 1 — identity + session**: model · effort · thinking on/off · session duration
-  (adaptive `Dd Hh` / `Hh Mm` / `Mm Ss`) · cost.
+- **Line 1 — identity + session**: model · **effort tier** (distinct icon + escalating color
+  per level: `🐢 low` / `⚡ medium` / `🔥 high` / `🚀 xhigh` / `💥 max`; `max` shimmers a
+  1-fps sweep when `refreshInterval` is set) · thinking on/off · session duration (adaptive
+  `Dd Hh` / `Hh Mm` / `Mm Ss`) · **cumulative session cost**. Note: `ultracode` is not a
+  distinct effort level — it reports as `xhigh`, so an ultracode turn shows as `🚀 xhigh`.
 - **Line 2 — place + tokens**: clickable GitHub repo link (OSC 8) · branch (short SHA when
   detached) · `●` staged / `✚` modified counts · worktree when in one · lines added/removed ·
-  last-response tokens (total input · **cache health %** [green ≥80, yellow 40–79, red <40 =
-  cache invalidated → next turn costs more] · output, humanized `k`/`M`).
+  last-response tokens with **per-turn cost**: `↑ In` (total input · priced $ = fresh input ×
+  rate + cache-write ×1.25 + cache-read ×0.1) · `♻️` **cache health %** [green ≥80, yellow
+  40–79, red <40 = cache invalidated → next turn costs more] · `↓ Out` (output · priced $).
+  Costs use a per-model rate table (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, Fable $10/$50 per
+  MTok) and are **hidden for unrecognized models**. This is the *last turn's* cost — distinct
+  from the cumulative session 💰 on line 1.
 - **Line 3 — meters**: all progress bars together — context-window, then 5h/7d rate limits
   (Pro/Max only). Each bar is colored green <50, yellow 50–79, red ≥80.
 
@@ -77,6 +84,10 @@ Steps:
      }
    }
    ```
+   Add `"refreshInterval": 1` (seconds; 1 is the documented minimum) only if you want the
+   animated `💥 max` effort shimmer — it re-runs the whole script every second even while
+   idle, so skip it otherwise. In large repos, cache `git status` by `session_id` first (the
+   script runs `git status` each tick).
 
 ---
 
@@ -102,8 +113,9 @@ follow these rules — they are what keep a status line from breaking or lagging
   output garbles, simplify. Use `printf '%b'` (not `echo -e`) for OSC 8 links.
 
 Extend the ready-made script rather than starting from scratch when the user wants "the
-same plus X" — its `jq` extraction, `bar()`, `human()`, and `pct_color()` helpers are
-reusable.
+same plus X" — its `jq` extraction and `bar()`, `human()`, `pct_color()`, `meter()`,
+`effort_render()` (icon+color per effort tier), and `price_rates()` (per-model $/MTok
+input/output, used to price the last turn's tokens) helpers are reusable.
 
 ---
 

--- a/plugins/tooling/skills/claude-statusline/references/statusline.sh
+++ b/plugins/tooling/skills/claude-statusline/references/statusline.sh
@@ -28,6 +28,11 @@ C_MODEL=$'\e[1;36m'; C_TREE=$'\e[32m'; C_COST=$'\e[1;33m'; C_EFFORT=$'\e[35m'
 C_DIM=$'\e[2m'; C_RESET=$'\e[0m'; C_GREEN=$'\e[32m'; C_YELLOW=$'\e[33m'; C_RED=$'\e[31m'
 C_THINK_ON=$'\e[1;34m'   # bright blue when thinking is enabled
 C_THINK_OFF=$'\e[31m'    # red when thinking is disabled
+# effort-tier palette — escalating intensity (low → max)
+C_EFF_LOW=$'\e[2;37m'; C_EFF_MED=$'\e[36m'; C_EFF_HIGH=$'\e[1;33m'
+C_EFF_XHIGH=$'\e[1;38;5;208m'; C_EFF_MAX=$'\e[1;38;5;196m'
+C_HI=$'\e[1;97m'        # bright-white highlight for the max shimmer sweep
+C_IN=$'\e[36m'; C_OUT=$'\e[35m'   # token in (cyan) / out (magenta) labels
 SEP=" ${C_DIM}|${C_RESET} "
 
 join() { local out="" p; for p in "$@"; do out="${out:+$out$SEP}$p"; done; printf '%s\n' "$out"; }
@@ -52,6 +57,18 @@ human() {
   else printf '%s' "$n"; fi
 }
 
+# price_rates <model-name> — echoes "IN_RATE OUT_RATE" in $/1M tokens, or "" if unknown.
+# Opus 4.8's 1M context has NO >200k long-context premium — flat rates.
+price_rates() {
+  case "$1" in
+    *Fable*|*Mythos*) echo "10 50" ;;
+    *Opus*)           echo "5 25" ;;
+    *Sonnet*)         echo "3 15" ;;
+    *Haiku*)          echo "1 5" ;;
+    *)                echo "" ;;
+  esac
+}
+
 # pct_color <pct-int> — green <50, yellow 50-79, red >=80
 pct_color() {
   if   [ "$1" -ge 80 ]; then printf '%s' "$C_RED"
@@ -66,12 +83,37 @@ meter() {
   printf '%s %s%s%s %s%s%%%s' "$label" "$col" "$(bar "$p" 8)" "$C_RESET" "$col" "$p" "$C_RESET"
 }
 
+# effort_render <level> — icon + escalating color per effort tier.
+# NOTE: "ultracode" is not a distinct level — it reports as `xhigh` (same as /effort xhigh),
+# so 🚀 xhigh is how an ultracode turn shows up here.
+effort_render() {
+  case "$1" in
+    low)    printf '🐢 %slow%s'    "$C_EFF_LOW"   "$C_RESET" ;;
+    medium) printf '⚡ %smedium%s' "$C_EFF_MED"   "$C_RESET" ;;
+    high)   printf '🔥 %shigh%s'   "$C_EFF_HIGH"  "$C_RESET" ;;
+    xhigh)  printf '🚀 %sxhigh%s'  "$C_EFF_XHIGH" "$C_RESET" ;;
+    max)
+      # ultracode-style shimmer: a bright point sweeps across the label, one step per second.
+      # The status line refreshes at most 1×/s (refreshInterval), so this is a 1-fps pulse,
+      # not a smooth sub-second gradient — the frame is derived from wall-clock seconds.
+      local lbl="max" i ch col out="" frame
+      frame=$(( $(date +%s) % ${#lbl} ))
+      for ((i = 0; i < ${#lbl}; i++)); do
+        ch="${lbl:i:1}"
+        if [ "$i" -eq "$frame" ]; then col="$C_HI"; else col="$C_EFF_MAX"; fi
+        out+="${col}${ch}${C_RESET}"
+      done
+      printf '💥 %s' "$out" ;;
+    *)      printf '⚡ %s%s%s'     "$C_EFFORT" "$1" "$C_RESET" ;;
+  esac
+}
+
 cd "$DIR" 2>/dev/null
 
 # ---------- Line 1: identity — model | effort | thinking ----------
 line1=()
 line1+=("🤖 ${C_MODEL}${MODEL}${C_RESET}")
-[ "$EFFORT" != "-" ] && line1+=("⚡ ${C_EFFORT}${EFFORT}${C_RESET}")
+[ "$EFFORT" != "-" ] && line1+=("$(effort_render "$EFFORT")")
 case "$THINKING" in
   enabled)  line1+=("🧠 ${C_THINK_ON}thinking enabled${C_RESET}") ;;
   disabled) line1+=("🧠 ${C_THINK_OFF}thinking disabled${C_RESET}") ;;
@@ -119,14 +161,25 @@ esac
 if [ "${ADDED:-0}" -gt 0 ] 2>/dev/null || [ "${REMOVED:-0}" -gt 0 ] 2>/dev/null; then
   line2+=("📝 ${C_GREEN}+${ADDED}${C_RESET} ${C_RED}-${REMOVED}${C_RESET}")
 fi
-# 🎟️ last-response tokens — In (total) · cache health % · Out
+# tokens — 📥 In (total) · ♻️ cache health % · 📤 Out
 TOTAL_IN=$(( ${IN_TOK:-0} + ${CACHE_W:-0} + ${CACHE_R:-0} ))
 if [ "$TOTAL_IN" -gt 0 ]; then
   CACHE_PCT=$(( CACHE_R * 100 / TOTAL_IN ))
   if   [ "$CACHE_PCT" -ge 80 ]; then CACHE_COL="$C_GREEN"
   elif [ "$CACHE_PCT" -ge 40 ]; then CACHE_COL="$C_YELLOW"
   else CACHE_COL="$C_RED"; fi
-  line2+=("🎟️  In $(human "$TOTAL_IN") ${C_DIM}·${C_RESET} ${CACHE_COL}${CACHE_PCT}% cache${C_RESET} ${C_DIM}·${C_RESET} Out $(human "${OUT_TOK:-0}")")
+  # per-turn $ of the last response's tokens (fresh input full price, cache write 1.25x, cache read 0.1x)
+  seg_in="${C_IN}↑ In${C_RESET} $(human "$TOTAL_IN")"
+  seg_out="${C_OUT}↓ Out${C_RESET} $(human "${OUT_TOK:-0}")"
+  RATES=$(price_rates "$MODEL")
+  if [ -n "$RATES" ]; then
+    read -r IN_RATE OUT_RATE <<< "$RATES"
+    IN_COST=$(awk "BEGIN{printf \"%.2f\", (${IN_TOK:-0}*$IN_RATE + ${CACHE_W:-0}*$IN_RATE*1.25 + ${CACHE_R:-0}*$IN_RATE*0.1)/1000000}")
+    OUT_COST=$(awk "BEGIN{printf \"%.2f\", ${OUT_TOK:-0}*$OUT_RATE/1000000}")
+    seg_in="$seg_in ${C_COST}\$${IN_COST}${C_RESET}"
+    seg_out="$seg_out ${C_COST}\$${OUT_COST}${C_RESET}"
+  fi
+  line2+=("$seg_in ${C_DIM}·${C_RESET} ♻️ ${CACHE_COL}${CACHE_PCT}%${C_RESET} ${C_DIM}·${C_RESET} $seg_out")
 fi
 
 # ---------- Line 3: meters — ctx | 5h | 7d (all bars together) ----------

--- a/skills/claude-statusline/SKILL.md
+++ b/skills/claude-statusline/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: claude-statusline
 description: >-
-  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, context usage, git state, cost, rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
+  Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
@@ -49,17 +49,24 @@ segments hidden outside a repo, token segment hidden before the first API respon
 rate-limit meters hidden on non-subscription accounts, empty lines suppressed):
 
 ```
-🤖 Opus 4.8 (1M context) | ⚡ medium | 🧠 thinking enabled | ⏱️ 1h 26m | 💰 $2.47
-🔗 my-project | 🌱 master | ● 2 ✚ 1 | 📝 +1347 -156 | 🎟️ In 135k · 95% cache · Out 2k
+🤖 Opus 4.8 (1M context) | 🔥 high | 🧠 thinking enabled | ⏱️ 1h 26m | 💰 $2.47
+🔗 my-project | 🌱 master | ● 2 ✚ 1 | 📝 +1347 -156 | ↑ In 135k $0.42 · ♻️ 95% · ↓ Out 2k $0.05
 📊 ctx ▓░░░░░░░ 16% | 🚦 5h ▓▓▓▓░░░░ 58% | 7d ▓▓▓▓▓▓░░ 84%
 ```
 
-- **Line 1 — identity + session**: model · effort · thinking on/off · session duration
-  (adaptive `Dd Hh` / `Hh Mm` / `Mm Ss`) · cost.
+- **Line 1 — identity + session**: model · **effort tier** (distinct icon + escalating color
+  per level: `🐢 low` / `⚡ medium` / `🔥 high` / `🚀 xhigh` / `💥 max`; `max` shimmers a
+  1-fps sweep when `refreshInterval` is set) · thinking on/off · session duration (adaptive
+  `Dd Hh` / `Hh Mm` / `Mm Ss`) · **cumulative session cost**. Note: `ultracode` is not a
+  distinct effort level — it reports as `xhigh`, so an ultracode turn shows as `🚀 xhigh`.
 - **Line 2 — place + tokens**: clickable GitHub repo link (OSC 8) · branch (short SHA when
   detached) · `●` staged / `✚` modified counts · worktree when in one · lines added/removed ·
-  last-response tokens (total input · **cache health %** [green ≥80, yellow 40–79, red <40 =
-  cache invalidated → next turn costs more] · output, humanized `k`/`M`).
+  last-response tokens with **per-turn cost**: `↑ In` (total input · priced $ = fresh input ×
+  rate + cache-write ×1.25 + cache-read ×0.1) · `♻️` **cache health %** [green ≥80, yellow
+  40–79, red <40 = cache invalidated → next turn costs more] · `↓ Out` (output · priced $).
+  Costs use a per-model rate table (Opus $5/$25, Sonnet $3/$15, Haiku $1/$5, Fable $10/$50 per
+  MTok) and are **hidden for unrecognized models**. This is the *last turn's* cost — distinct
+  from the cumulative session 💰 on line 1.
 - **Line 3 — meters**: all progress bars together — context-window, then 5h/7d rate limits
   (Pro/Max only). Each bar is colored green <50, yellow 50–79, red ≥80.
 
@@ -77,6 +84,10 @@ Steps:
      }
    }
    ```
+   Add `"refreshInterval": 1` (seconds; 1 is the documented minimum) only if you want the
+   animated `💥 max` effort shimmer — it re-runs the whole script every second even while
+   idle, so skip it otherwise. In large repos, cache `git status` by `session_id` first (the
+   script runs `git status` each tick).
 
 ---
 
@@ -102,8 +113,9 @@ follow these rules — they are what keep a status line from breaking or lagging
   output garbles, simplify. Use `printf '%b'` (not `echo -e`) for OSC 8 links.
 
 Extend the ready-made script rather than starting from scratch when the user wants "the
-same plus X" — its `jq` extraction, `bar()`, `human()`, and `pct_color()` helpers are
-reusable.
+same plus X" — its `jq` extraction and `bar()`, `human()`, `pct_color()`, `meter()`,
+`effort_render()` (icon+color per effort tier), and `price_rates()` (per-model $/MTok
+input/output, used to price the last turn's tokens) helpers are reusable.
 
 ---
 

--- a/skills/claude-statusline/references/statusline.sh
+++ b/skills/claude-statusline/references/statusline.sh
@@ -28,6 +28,11 @@ C_MODEL=$'\e[1;36m'; C_TREE=$'\e[32m'; C_COST=$'\e[1;33m'; C_EFFORT=$'\e[35m'
 C_DIM=$'\e[2m'; C_RESET=$'\e[0m'; C_GREEN=$'\e[32m'; C_YELLOW=$'\e[33m'; C_RED=$'\e[31m'
 C_THINK_ON=$'\e[1;34m'   # bright blue when thinking is enabled
 C_THINK_OFF=$'\e[31m'    # red when thinking is disabled
+# effort-tier palette — escalating intensity (low → max)
+C_EFF_LOW=$'\e[2;37m'; C_EFF_MED=$'\e[36m'; C_EFF_HIGH=$'\e[1;33m'
+C_EFF_XHIGH=$'\e[1;38;5;208m'; C_EFF_MAX=$'\e[1;38;5;196m'
+C_HI=$'\e[1;97m'        # bright-white highlight for the max shimmer sweep
+C_IN=$'\e[36m'; C_OUT=$'\e[35m'   # token in (cyan) / out (magenta) labels
 SEP=" ${C_DIM}|${C_RESET} "
 
 join() { local out="" p; for p in "$@"; do out="${out:+$out$SEP}$p"; done; printf '%s\n' "$out"; }
@@ -52,6 +57,18 @@ human() {
   else printf '%s' "$n"; fi
 }
 
+# price_rates <model-name> — echoes "IN_RATE OUT_RATE" in $/1M tokens, or "" if unknown.
+# Opus 4.8's 1M context has NO >200k long-context premium — flat rates.
+price_rates() {
+  case "$1" in
+    *Fable*|*Mythos*) echo "10 50" ;;
+    *Opus*)           echo "5 25" ;;
+    *Sonnet*)         echo "3 15" ;;
+    *Haiku*)          echo "1 5" ;;
+    *)                echo "" ;;
+  esac
+}
+
 # pct_color <pct-int> — green <50, yellow 50-79, red >=80
 pct_color() {
   if   [ "$1" -ge 80 ]; then printf '%s' "$C_RED"
@@ -66,12 +83,37 @@ meter() {
   printf '%s %s%s%s %s%s%%%s' "$label" "$col" "$(bar "$p" 8)" "$C_RESET" "$col" "$p" "$C_RESET"
 }
 
+# effort_render <level> — icon + escalating color per effort tier.
+# NOTE: "ultracode" is not a distinct level — it reports as `xhigh` (same as /effort xhigh),
+# so 🚀 xhigh is how an ultracode turn shows up here.
+effort_render() {
+  case "$1" in
+    low)    printf '🐢 %slow%s'    "$C_EFF_LOW"   "$C_RESET" ;;
+    medium) printf '⚡ %smedium%s' "$C_EFF_MED"   "$C_RESET" ;;
+    high)   printf '🔥 %shigh%s'   "$C_EFF_HIGH"  "$C_RESET" ;;
+    xhigh)  printf '🚀 %sxhigh%s'  "$C_EFF_XHIGH" "$C_RESET" ;;
+    max)
+      # ultracode-style shimmer: a bright point sweeps across the label, one step per second.
+      # The status line refreshes at most 1×/s (refreshInterval), so this is a 1-fps pulse,
+      # not a smooth sub-second gradient — the frame is derived from wall-clock seconds.
+      local lbl="max" i ch col out="" frame
+      frame=$(( $(date +%s) % ${#lbl} ))
+      for ((i = 0; i < ${#lbl}; i++)); do
+        ch="${lbl:i:1}"
+        if [ "$i" -eq "$frame" ]; then col="$C_HI"; else col="$C_EFF_MAX"; fi
+        out+="${col}${ch}${C_RESET}"
+      done
+      printf '💥 %s' "$out" ;;
+    *)      printf '⚡ %s%s%s'     "$C_EFFORT" "$1" "$C_RESET" ;;
+  esac
+}
+
 cd "$DIR" 2>/dev/null
 
 # ---------- Line 1: identity — model | effort | thinking ----------
 line1=()
 line1+=("🤖 ${C_MODEL}${MODEL}${C_RESET}")
-[ "$EFFORT" != "-" ] && line1+=("⚡ ${C_EFFORT}${EFFORT}${C_RESET}")
+[ "$EFFORT" != "-" ] && line1+=("$(effort_render "$EFFORT")")
 case "$THINKING" in
   enabled)  line1+=("🧠 ${C_THINK_ON}thinking enabled${C_RESET}") ;;
   disabled) line1+=("🧠 ${C_THINK_OFF}thinking disabled${C_RESET}") ;;
@@ -119,14 +161,25 @@ esac
 if [ "${ADDED:-0}" -gt 0 ] 2>/dev/null || [ "${REMOVED:-0}" -gt 0 ] 2>/dev/null; then
   line2+=("📝 ${C_GREEN}+${ADDED}${C_RESET} ${C_RED}-${REMOVED}${C_RESET}")
 fi
-# 🎟️ last-response tokens — In (total) · cache health % · Out
+# tokens — 📥 In (total) · ♻️ cache health % · 📤 Out
 TOTAL_IN=$(( ${IN_TOK:-0} + ${CACHE_W:-0} + ${CACHE_R:-0} ))
 if [ "$TOTAL_IN" -gt 0 ]; then
   CACHE_PCT=$(( CACHE_R * 100 / TOTAL_IN ))
   if   [ "$CACHE_PCT" -ge 80 ]; then CACHE_COL="$C_GREEN"
   elif [ "$CACHE_PCT" -ge 40 ]; then CACHE_COL="$C_YELLOW"
   else CACHE_COL="$C_RED"; fi
-  line2+=("🎟️  In $(human "$TOTAL_IN") ${C_DIM}·${C_RESET} ${CACHE_COL}${CACHE_PCT}% cache${C_RESET} ${C_DIM}·${C_RESET} Out $(human "${OUT_TOK:-0}")")
+  # per-turn $ of the last response's tokens (fresh input full price, cache write 1.25x, cache read 0.1x)
+  seg_in="${C_IN}↑ In${C_RESET} $(human "$TOTAL_IN")"
+  seg_out="${C_OUT}↓ Out${C_RESET} $(human "${OUT_TOK:-0}")"
+  RATES=$(price_rates "$MODEL")
+  if [ -n "$RATES" ]; then
+    read -r IN_RATE OUT_RATE <<< "$RATES"
+    IN_COST=$(awk "BEGIN{printf \"%.2f\", (${IN_TOK:-0}*$IN_RATE + ${CACHE_W:-0}*$IN_RATE*1.25 + ${CACHE_R:-0}*$IN_RATE*0.1)/1000000}")
+    OUT_COST=$(awk "BEGIN{printf \"%.2f\", ${OUT_TOK:-0}*$OUT_RATE/1000000}")
+    seg_in="$seg_in ${C_COST}\$${IN_COST}${C_RESET}"
+    seg_out="$seg_out ${C_COST}\$${OUT_COST}${C_RESET}"
+  fi
+  line2+=("$seg_in ${C_DIM}·${C_RESET} ♻️ ${CACHE_COL}${CACHE_PCT}%${C_RESET} ${C_DIM}·${C_RESET} $seg_out")
 fi
 
 # ---------- Line 3: meters — ctx | 5h | 7d (all bars together) ----------


### PR DESCRIPTION
Enhancements to the `claude-statusline` skill, mirrored from my local `~/.claude/statusline.sh`.

## What changed
- **Effort tier (line 1)** — each level now has a distinct icon + escalating color instead of flat text: `🐢 low` / `⚡ medium` / `🔥 high` / `🚀 xhigh` / `💥 max`. `max` shimmers a 1-fps highlight sweep when `refreshInterval` is set. Documents that **ultracode reports as `xhigh`** (not a distinct level), so an ultracode turn shows as `🚀 xhigh`.
- **Tokens (line 2)** — `↑ In` / `↓ Out` opposite-direction arrows (cyan / magenta) replace the ambiguous 🎟️ ticket; `♻️` marks cache reuse; and a **per-turn cost in `$`** now sits next to each side.
  - Pricing computed locally via a per-model rate table (Opus `$5/$25`, Sonnet `$3/$15`, Haiku `$1/$5`, Fable `$10/$50` per MTok). Fresh input at full price, cache-write ×1.25, cache-read ×0.1. **Hidden for unrecognized models.**
  - This is the **last turn's** cost — distinct from the cumulative session 💰 on line 1.
- Skill `metadata.version` 1.0.0 → 1.1.0; wrappers regenerated via `./generate.sh` (CI wrappers-in-sync gate should pass).

## Notes
- Opus 4.8 pricing verified against the official reference; its 1M context has **no >200k long-context premium** (flat rates), so no tier logic needed.
- `refreshInterval` documented as optional (only for the animated `max`); note added to cache `git status` by `session_id` in large repos since it re-runs every second.

Leaving the merge to you (multi-machine PR workflow).