### PR TITLE
skill: add assettoserver-csp-lua for CSP online-script overlays

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,7 @@
     {
       "name": "ai-skills-game",
       "source": "./plugins/game",
-      "description": "React Three Fiber skills (10 topics).",
+      "description": "React Three Fiber + AssettoServer game-dev skills (12 topics).",
       "category": "productivity"
     },
     {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The marketplace ships **per-domain plugins** so a project enables only coherent 
 `ai-skills-fivem`, `ai-skills-nui` (NUI React/CEF), `ai-skills-frontend` (SPA API client),
 `ai-skills-game` (R3F + AssettoServer), `ai-skills-devops`, `ai-skills-docs`,
 `ai-skills-tooling` (Claude Code status line) — plus the full
-`ai-skills` bundle for whoever really wants all 27.
+`ai-skills` bundle for whoever really wants all 28.
 
 **B1 — manual**, inside Claude Code:
 
@@ -79,7 +79,7 @@ one accept, zero manual steps):
 ```
 
 Pick the groups that match the project (a FiveM repo takes `ai-skills-fivem`, an R3F game takes
-`ai-skills-game`, ...) — dumping all 27 skills into every project is noise, not help.
+`ai-skills-game`, ...) — dumping all 28 skills into every project is noise, not help.
 
 **B3 — user-level (whole machine)** — same snippet in `~/.claude/settings.json` enables the plugin
 for every project on the machine.
@@ -341,6 +341,7 @@ Think of skills as reusable expertise — instead of explaining your documentati
 |-------|----------|--------------|
 | **assettoserver-plugin** | AssettoServer plugin, AssettoServerModule, Qmmands/ACModuleBase, ChatMessage packet, plugin YAML config, plugin publish | C#/.NET plugin survival guide for the AssettoServer runtime — two-contract version pinning, disabled-by-default YAML config, forbidden runtime constructs + static accessor bridge, curl dual-transport backend calls, Mono.Cecil bug-hunter gate |
 | **assettoserver-ops** | server_cfg.ini, entry_list.ini, extra_cfg.yml, checksum mismatch, AI traffic, WSL2 ports, plugin deploy | Operating an AssettoServer dedicated AC server — config anatomy, checksum/CSP troubleshooting, AI-traffic enablement discipline, Docker/WSL2 orchestration, rite-gated plugin sync |
+| **assettoserver-csp-lua** | CSP online script, in-game overlay/HUD/toast, transparentWindow, DirectWrite/dwriteText, ac.OnlineEvent, sound in game, empty box / glued text / packet never arrives | The client-side Lua layer served by the server — single-window draw-list doctrine, DirectWrite trap table, byte-parity OnlineEvent packets, remote images/audio by URL (zero-install), mockup-first workflow and probes |
 
 ### Frontend
 

--- a/claude/skills/assettoserver-csp-lua/SKILL.md
+++ b/claude/skills/assettoserver-csp-lua/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: assettoserver-csp-lua
+description: >-
+  Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the
+  zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API
+  in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte
+  with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry,
+  and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a
+  production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD,
+  toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or
+  overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently
+  never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands,
+  publishing (that is assettoserver-plugin), for server configuration/deploy (that is
+  assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different
+  permissions), or for FiveM Lua (that is fivem-lua).
+metadata:
+  author: solvelab
+  version: 1.0.0
+  category: game
+license: MIT
+compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
+---
+
+Read and follow all instructions in ~/ai-skills/skills/assettoserver-csp-lua/SKILL.md
+
+Reference files are in ~/ai-skills/skills/assettoserver-csp-lua/references/ — read them when the skill instructions point to them.

--- a/claude/skills/assettoserver-ops/SKILL.md
+++ b/claude/skills/assettoserver-ops/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   backend receiving events (python-rest-api), or for FiveM servers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: devops
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/assettoserver-plugin/SKILL.md
+++ b/claude/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -9,6 +9,7 @@ Each skill @-includes the canonical skill from `skills/<name>/SKILL.md` — no d
 | Skill | Path |
 |-------|------|
 | `api-resilience-testing` | `codex/skills/api-resilience-testing/AGENTS.md` |
+| `assettoserver-csp-lua` | `codex/skills/assettoserver-csp-lua/AGENTS.md` |
 | `assettoserver-ops` | `codex/skills/assettoserver-ops/AGENTS.md` |
 | `assettoserver-plugin` | `codex/skills/assettoserver-plugin/AGENTS.md` |
 | `backend-resilience` | `codex/skills/backend-resilience/AGENTS.md` |

--- a/codex/skills/assettoserver-csp-lua/AGENTS.md
+++ b/codex/skills/assettoserver-csp-lua/AGENTS.md
@@ -1,0 +1,3 @@
+# assettoserver-csp-lua
+
+@../../skills/assettoserver-csp-lua/SKILL.md

--- a/copilot/instructions/assettoserver-csp-lua.instructions.md
+++ b/copilot/instructions/assettoserver-csp-lua.instructions.md
@@ -1,0 +1,5 @@
+# assettoserver-csp-lua
+
+Follow the instructions in [SKILL.md](../../skills/assettoserver-csp-lua/SKILL.md)
+
+Reference files: [references/](../../skills/assettoserver-csp-lua/references/)

--- a/cursor/rules/assettoserver-csp-lua.mdc
+++ b/cursor/rules/assettoserver-csp-lua.mdc
@@ -1,0 +1,184 @@
+---
+description: >-
+  Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry, and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD, toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different permissions), or for FiveM Lua (that is fivem-lua).
+alwaysApply: false
+---
+
+
+# CSP Lua online scripts (AssettoServer-served overlays)
+
+Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
+client by the server itself. Zero-install is the point — the player installs nothing; art, sound
+and code all arrive over the server's HTTP port. Every rule below was paid for with an in-game
+iteration; in this stack a wrong guess costs a deploy plus a human driving session to observe it.
+
+## What an online script is
+
+- The plugin registers it via `CSPServerScriptProvider.AddScript(script, debugFilename,
+  configValues)`; the server advertises `[SCRIPT_N-...]` sections in CSP extra options pointing at
+  `http://{ServerIP}:{ServerHTTPPort}/api/scripts/N`. The client downloads and runs it on join.
+- `["REQUIRED"] = 1` makes CSP refuse clients that do not run the script — reserve it for gate
+  flows (login). Cosmetic overlays MUST ship `["REQUIRED"] = 0`: a client without them just doesn't
+  see the overlay.
+- Server config reaches the script through `ac.configValues({ key = default, ... })`. Decimals
+  cross this boundary as strings — the C# side must format them with InvariantCulture or a pt-BR
+  host silently turns `0.7` into `"0,7"` and the script falls back to its Lua defaults with **no
+  symptom** (see `assettoserver-plugin`). Keep Lua defaults equal to the C# defaults so a missing
+  config degrades gracefully — but know that this same choice hides delivery failures.
+- Each script is an **isolated Lua state**: no shared globals, no runtime negotiation between
+  overlays. Anything two scripts must agree on (layout offsets, packet layouts) is agreed by
+  convention and documented on both sides.
+- If the script is embedded in the plugin DLL and mirrored in a UI repo, the copies must be
+  byte-identical — gate with `cmp -s` in the rite, not with good intentions.
+
+## Consult the SDK — never guess an API
+
+Every CSP install ships authoritative EmmyLua stubs, one per Lua context:
+
+```
+<AC root>/extension/internal/lua-sdk/ac_online_script/lib.lua   # ~17k lines; THIS context
+grep -nE "function ui\.drawRectFilled" ".../ac_online_script/lib.lua"
+```
+
+Read the signature and its doc comment before using any `ui.*` / `ac.*` function. The doc comments
+carry the load-bearing details (default args, corner flags, URL support, one-shot audio semantics).
+
+**The `withoutIO` myth.** The SDK's `rules.json` marks `withoutIO: true` only for
+`ac_track_script`, `ac_car_cphys` and `ac_car_scriptable_display` — NOT for online scripts. A
+server-served online script measurably has `web.*` (get/post/request/socket/loadRemoteAssets) and
+`io.*`. Route identity/credential traffic through the server plugin anyway — **by decision**
+(server-authoritative identity from the connection, credentials never handled client-side) — and
+write that reason in the comment. A false "the API doesn't exist" claim misleads the next reader
+into bad architecture the day they discover it does.
+
+## Render doctrine
+
+- **ONE `ui.transparentWindow` per overlay; everything inside is draw-list.** Paint order within a
+  window is deterministic (first call = bottom). Overlapping transparentWindows do NOT stratify —
+  the first stays on top. Symptom of getting this wrong: a flat, empty box where the overlay
+  should be.
+- `ui.transparentWindow(id, pos, size, noPadding, inputs, fn)` — 4th arg `noPadding` (`true` →
+  coordinates start at 0,0), 5th `inputs` (`false` = non-interactive overlay).
+- **Rounded corners + accent bar:** never draw two boxes with opposite `ui.CornerFlags` — the
+  straight corners of one are never covered by the curved corners of the other, leaving square
+  "teeth". Draw the full rounded panel, then re-draw the same rounded rect in the accent color
+  inside a clip — the CSS `overflow: hidden` equivalent:
+
+  ```lua
+  ui.drawRectFilled(vec2(0, 0), vec2(w, h), panelColor, 12)
+  ui.pushClipRect(vec2(0, 0), vec2(4, h), true)   -- 4px accent column
+  ui.drawRectFilled(vec2(0, 0), vec2(w, h), accentColor, 12)
+  ui.popClipRect()
+  ```
+
+  `ui.CornerFlags`: None 0 · TopLeft 1 · TopRight 2 · BottomLeft 4 · BottomRight 8 · Top 3 ·
+  Bottom 12 · Left 5 · Right 10 · All 15.
+- **Images by URL:** `ui.drawImage(src, p1, p2, color)` accepts URLs (documented); serve brand art
+  from the server's static hosting and let CSP download + cache. Zero-install.
+- **`pcall` around every overlay draw.** Decoration must never kill the script — a dead script
+  means no overlays at all, including the required ones.
+- **Colors vs a web mockup:** CSP renders more vivid than CSS — expect to tune saturated accents
+  slightly down. Panels meant to look solid need near-opaque alpha (≈0.98); semi-transparent
+  panels leak gameplay and read as "the background color is wrong".
+
+## DirectWrite text — the trap table
+
+Exact pixel sizes come from `ui.pushDWriteFont("Segoe UI;Weight=Bold")` + `ui.dwriteText(text,
+sizePx, color)` + `ui.measureDWriteText(text, sizePx)`. The font attribute string accepts only
+`Weight` / `Style` / `Stretch` — nothing else.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Segments glue together (`LABEL:value`, `unit0`) | DWrite discards the **trailing** space at measure AND draw; leading and inner spaces survive | Never encode separation as a trailing space — advance x by an explicit px gap |
+| Letter-spacing/tracking has no effect | No native tracking | Draw char-by-char advancing x by measured width + spacing; a space measures 0 alone — measure it as `measure("A A") - measure("AA")` |
+| Stacked lines overlap | A glyph box is ≈1.33× the font size (ascent+descent), not 1× | Derive every line y and the panel height from `ui.measureDWriteText(...).y`; cache the metrics (sizes are constants) |
+| `JOSé`, broken glyph after truncation | `string.upper`/`string.sub` are ASCII/byte-wise; LuaJIT ships no `utf8` lib | Iterate codepoints; Latin-1 Supplement uppercase = lead byte 0xC3, second 0xA0–0xBE minus 0x20, skipping 0xB7 (÷); truncate on codepoint boundaries |
+| Glyph renders as `?` | Built-in font lacks the glyph (★ and friends) | Ship a PNG and `ui.drawImage` it |
+| Accented literals garbled | Source encoding drift | Explicit UTF-8 escapes in literals: `"m\195\169dia"` = "média", `"\194\183"` = "·" |
+
+Copy-paste helpers for all of these: `references/snippets.lua`.
+
+## OnlineEvent packets
+
+- The Lua layout (`ac.StructItem.key(...)` + named/sized fields) must match the C# `OnlineEvent<T>`
+  **byte-for-byte** — enforce it with a static parity gate over the published DLL (see
+  `bug-hunter` → `references/track-dotnet-plugin.md`), not by review.
+- **Never name a field `key`.** It collides with the `ac.StructItem.key` mechanism and the packet
+  is silently never delivered — while every static gate passes, because the layouts do match.
+- Two scripts that register the **exact same layout both receive the event**. Reuse an existing
+  server→client packet in a second overlay instead of minting a new one.
+- Pass `{ processPostponed = true }` (5th arg) when the message may arrive before your listener
+  registers (login/session responses at connect time): CSP replays buffered TCP messages on the
+  next frame. Without it the packet raced your registration and is simply gone.
+- `sender == nil` → from the server; `sender.index == 0` → from this client. Client→server sends
+  always use `target = 255` — fail-closed: a layout drift kills your own connection instead of
+  broadcasting the payload to every player.
+- Payload style: one delimited string field (`"a|b|c|..."`) parsed in Lua. The field list INSIDE
+  the string may grow freely (only the Lua parser reads it); the packet layout — key, field names,
+  sizes — is the contract. Appending an optional trailing field keeps old parsers working.
+
+## Remote audio (and the one-shot trap)
+
+- `ac.AudioEvent.fromFile({ filename = "<URL>", use3D = false, loop = false }, false)` **accepts a
+  URL** — measured in production; the docs only promise URL support for images. MP3 decodes
+  natively (FMOD): no WAV conversion step.
+- An emitter created with `loop = false` becomes **invalid after playing once** (the doc warns:
+  "audio event will become invalid once played once"). Reusing it = sound plays exactly once, then
+  silence forever. Dispose the spent emitter and create a fresh one per shot — the FILE stays
+  cached ("consequent calls with the same parameters would reuse previously loaded audio file");
+  only the emitter is rebuilt.
+- `dispose()` means "stop and remove": re-triggering the same sound rapidly cuts the previous
+  instance. Fine for UI sounds with a natural minimum interval; only pool emitters if a real
+  overlap case exists.
+- `event.volume` is 0..1 — clamp config input. `use3D = false` for UI sounds (no world position,
+  no doppler).
+- **Sound is decoration.** Wrap load AND `start()` in `pcall`; a 404, bad format or sandbox
+  failure must degrade to silence — never block or delay the visual.
+- Calibrate loudness by **frequency of the trigger**, not by how good the sound is in isolation:
+  the event that fires on every attempt gets the softest cue; the rare summit event may be the
+  dramatic one. Inverting this makes players mute the feature.
+
+## Local telemetry
+
+- Your own car is NOT `ac.getSim().focusedCar` — that is the **camera** (wrong under spectator or
+  track cam). Scan `0 .. sim.carsCount-1` for `car.isUserControlled and not car.isRemote`, cache
+  the index, re-validate on use.
+- `ac.onCarCollision(carIndex, cb)` fires once per collision start, for walls AND cars. Register
+  with `-1` (all cars) and filter by your own index inside the callback — avoids the boot-time
+  ordering problem when your index is not resolved yet.
+- Guard `speedKmh` against NaN/infinity before integrating (`v ~= v` catches NaN).
+- When mirroring a server-side metric (speed floor, reset-on-collision), copy the **exact** rules
+  so the live number converges to the authoritative score — and state in a comment which number is
+  authoritative, because frame-rate sampling vs server-rate sampling will differ in the last digit.
+
+## Workflow — mockup first, probes when sight is not enough
+
+- **You cannot render CSP outside the game.** Iterate the visual in an HTML mockup first, get it
+  approved, then translate to Lua taking values FROM the mockup — `em × font-size → px`, flex
+  gaps/margins → explicit px gaps, exact hexes. Never translate by eye: every eyeballed value is
+  one more in-game round-trip.
+- **Validate Lua syntax before every deploy** with a real parser (a Python `luaparser` venv works
+  when `luac` is not installed). A syntax error otherwise only manifests in-game, as a silently
+  missing overlay.
+- **When behavior is in doubt, ship a temporary probe:** the script reports what it could do
+  (capability flags, load results, errors) to the server via a client→server packet; the plugin
+  just logs it. This turns "the player saw nothing" into data that separates rule-failure (never
+  pushed) from render-failure (pushed, not drawn). Config-gate the probe, default off, remove or
+  disable after the investigation. Mind probe blind spots: a sticky boolean cannot prove
+  repetition — count occurrences when repetition is the question.
+- **Overlay stacking is a convention, not a mechanism.** Separate scripts cannot negotiate layout
+  at runtime; y-offsets couple silently. Document the column (e.g. logo → live strip → toast) at
+  every coupling site and re-check the whole column whenever any member's height changes — heights
+  derived from font metrics move when text sizes do.
+- Keep test/debug chat commands behind config flags, default **off** in production; they are how
+  you validate visuals and sounds without driving laps.
+
+## See also
+
+- `assettoserver-plugin` — the C# side: registering scripts and configValues (InvariantCulture
+  decimals), packet classes and handlers, chat commands, the publish rite.
+- `assettoserver-ops` — operating the server that hosts these scripts; static assets under
+  `wwwroot/` are baked into the image (rebuild + recreate, not restart).
+- `bug-hunter` — `references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
+  Lua↔C# packet parity.
+- `conventional-commit` — commit format used by these repos.

--- a/cursor/rules/assettoserver-ops.mdc
+++ b/cursor/rules/assettoserver-ops.mdc
@@ -114,6 +114,12 @@ The lane file may live at the track ROOT `ai/` dir and serve all layouts — emp
   `netsh interface portproxy add v4tov4 listenport=9600 connectaddress=$wslIp connectport=9600`
   (repeat for 8081) plus firewall rules for 9600/tcp, 9600/udp, 8081/tcp. The WSL IP changes;
   recompute it (`wsl hostname -I`) after reboots.
+- **Static web assets ARE baked into the image** — the inverse of the runtime binary (which lives
+  in a named volume, see above). Anything under `server/wwwroot/` served at `/static` (brand
+  images, trophies, notification sounds consumed by CSP overlays) is `COPY`'d at build time:
+  adding or replacing an asset requires `docker compose build <service>` + `up -d` (recreate).
+  **A plain `restart` serves the stale asset** — the classic symptom is "I replaced the file but
+  the game still shows/plays the old one".
 
 ## Plugin deployment — rite-gated sync
 
@@ -154,6 +160,8 @@ runbook and the tooling can't drift apart.
 ## See also
 
 - `assettoserver-plugin` — writing/building the plugin this repo deploys; produces the rite proof.
+- `assettoserver-csp-lua` — the in-game overlays that consume the `/static` assets baked into this
+  image (brand art, trophies, notification sounds).
 - `log-event-collector` — the log-tailing collector run as the compose `collector` profile.
 - `python-rest-api` — the backend the collector and plugin talk to.
 - `documentation` — the runbook/docs tiers this kind of repo needs.

--- a/cursor/rules/assettoserver-plugin.mdc
+++ b/cursor/rules/assettoserver-plugin.mdc
@@ -167,6 +167,39 @@ doctrine (sibling of the `backend-resilience` skill, adapted to this runtime):
 - Sort/limit/tie-break API data **client-side** in the service; over-fetch
   (`Math.Max(limit, 10)`) then trim, so display rules don't depend on backend ordering.
 
+## Serving CSP Lua scripts (configValues + packets)
+
+The plugin can push Lua overlays to every client via `CSPServerScriptProvider.AddScript(script,
+debugFilename, configValues)`. The client side of those scripts is `assettoserver-csp-lua`; the
+traps below live on THIS side of the boundary:
+
+- **Format every `double` in configValues with `InvariantCulture` yourself.** The provider
+  serializes each value with `value.ToString()` — culture-sensitive. On a host with a non-invariant
+  locale (`LANG=pt_BR...`), `0.7` becomes `"0,7"`, CSP fails to parse it, and the script silently
+  falls back to its Lua defaults. When Lua defaults equal the C# defaults there is **no symptom** —
+  the config simply never applies. Ship a helper and use it for every decimal:
+
+  ```csharp
+  private static string Decimal(double value) => value.ToString(CultureInfo.InvariantCulture);
+  // ["soundVolume"] = Decimal(configuration.SoundVolume),
+  ```
+
+- **The flat fallback config loader needs a `case` per property — enforce it with a test, not
+  memory.** Commands read config through the DI-less fallback parser (see the static accessor
+  bridge above); a property without a `case` silently keeps its default, so the command lies
+  ("feature disabled") while the DI path works. This class of bug recurs; kill it with a
+  reflection guard that iterates EVERY config property, feeds the parser a YAML line with a
+  non-default probe value, and asserts the property changed — then prove the guard works by
+  removing one `case` and watching it fail with the property's name.
+
+- **OnlineEvent packet authoring:** server→client pushes need no registration — build the packet
+  and `client.SendPacket(packet)`. Client→server packets must be registered via
+  `CSPClientMessageTypeManager.RegisterOnlineEvent<TPacket>((client, packet) => ...)`; handlers run
+  on the network receive path — hand off to `Task.Run`, never block, never let an exception escape.
+  **Never name a packet field `key`**: on the Lua side it collides with the `ac.StructItem.key`
+  layout mechanism and the packet is silently never delivered, while every static parity gate
+  passes.
+
 ## Publish shape (what the plugin loader expects)
 
 ```xml
@@ -212,6 +245,8 @@ commit) next to the DLL — the deploy side refuses to sync a DLL without a rite
 
 ## See also
 
+- `assettoserver-csp-lua` — the client side of the scripts and packets this plugin serves: render
+  doctrine, DirectWrite traps, packet layout mirroring, remote assets/audio by URL.
 - `assettoserver-ops` — operating the server that loads this plugin; the deploy/sync gate that
   consumes `plugin-rite-status.json`.
 - `bug-hunter` — the adversarial rite; `references/track-dotnet-plugin.md` is the generalized

--- a/plugins/devops/skills/assettoserver-ops/SKILL.md
+++ b/plugins/devops/skills/assettoserver-ops/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   backend receiving events (python-rest-api), or for FiveM servers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: devops
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -126,6 +126,12 @@ The lane file may live at the track ROOT `ai/` dir and serve all layouts — emp
   `netsh interface portproxy add v4tov4 listenport=9600 connectaddress=$wslIp connectport=9600`
   (repeat for 8081) plus firewall rules for 9600/tcp, 9600/udp, 8081/tcp. The WSL IP changes;
   recompute it (`wsl hostname -I`) after reboots.
+- **Static web assets ARE baked into the image** — the inverse of the runtime binary (which lives
+  in a named volume, see above). Anything under `server/wwwroot/` served at `/static` (brand
+  images, trophies, notification sounds consumed by CSP overlays) is `COPY`'d at build time:
+  adding or replacing an asset requires `docker compose build <service>` + `up -d` (recreate).
+  **A plain `restart` serves the stale asset** — the classic symptom is "I replaced the file but
+  the game still shows/plays the old one".
 
 ## Plugin deployment — rite-gated sync
 
@@ -166,6 +172,8 @@ runbook and the tooling can't drift apart.
 ## See also
 
 - `assettoserver-plugin` — writing/building the plugin this repo deploys; produces the rite proof.
+- `assettoserver-csp-lua` — the in-game overlays that consume the `/static` assets baked into this
+  image (brand art, trophies, notification sounds).
 - `log-event-collector` — the log-tailing collector run as the compose `collector` profile.
 - `python-rest-api` — the backend the collector and plugin talk to.
 - `documentation` — the runbook/docs tiers this kind of repo needs.

--- a/plugins/game/skills/assettoserver-csp-lua/SKILL.md
+++ b/plugins/game/skills/assettoserver-csp-lua/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: assettoserver-csp-lua
+description: >-
+  Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the
+  zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API
+  in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte
+  with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry,
+  and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a
+  production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD,
+  toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or
+  overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently
+  never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands,
+  publishing (that is assettoserver-plugin), for server configuration/deploy (that is
+  assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different
+  permissions), or for FiveM Lua (that is fivem-lua).
+metadata:
+  author: solvelab
+  version: 1.0.0
+  category: game
+license: MIT
+compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
+---
+
+# CSP Lua online scripts (AssettoServer-served overlays)
+
+Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
+client by the server itself. Zero-install is the point — the player installs nothing; art, sound
+and code all arrive over the server's HTTP port. Every rule below was paid for with an in-game
+iteration; in this stack a wrong guess costs a deploy plus a human driving session to observe it.
+
+## What an online script is
+
+- The plugin registers it via `CSPServerScriptProvider.AddScript(script, debugFilename,
+  configValues)`; the server advertises `[SCRIPT_N-...]` sections in CSP extra options pointing at
+  `http://{ServerIP}:{ServerHTTPPort}/api/scripts/N`. The client downloads and runs it on join.
+- `["REQUIRED"] = 1` makes CSP refuse clients that do not run the script — reserve it for gate
+  flows (login). Cosmetic overlays MUST ship `["REQUIRED"] = 0`: a client without them just doesn't
+  see the overlay.
+- Server config reaches the script through `ac.configValues({ key = default, ... })`. Decimals
+  cross this boundary as strings — the C# side must format them with InvariantCulture or a pt-BR
+  host silently turns `0.7` into `"0,7"` and the script falls back to its Lua defaults with **no
+  symptom** (see `assettoserver-plugin`). Keep Lua defaults equal to the C# defaults so a missing
+  config degrades gracefully — but know that this same choice hides delivery failures.
+- Each script is an **isolated Lua state**: no shared globals, no runtime negotiation between
+  overlays. Anything two scripts must agree on (layout offsets, packet layouts) is agreed by
+  convention and documented on both sides.
+- If the script is embedded in the plugin DLL and mirrored in a UI repo, the copies must be
+  byte-identical — gate with `cmp -s` in the rite, not with good intentions.
+
+## Consult the SDK — never guess an API
+
+Every CSP install ships authoritative EmmyLua stubs, one per Lua context:
+
+```
+<AC root>/extension/internal/lua-sdk/ac_online_script/lib.lua   # ~17k lines; THIS context
+grep -nE "function ui\.drawRectFilled" ".../ac_online_script/lib.lua"
+```
+
+Read the signature and its doc comment before using any `ui.*` / `ac.*` function. The doc comments
+carry the load-bearing details (default args, corner flags, URL support, one-shot audio semantics).
+
+**The `withoutIO` myth.** The SDK's `rules.json` marks `withoutIO: true` only for
+`ac_track_script`, `ac_car_cphys` and `ac_car_scriptable_display` — NOT for online scripts. A
+server-served online script measurably has `web.*` (get/post/request/socket/loadRemoteAssets) and
+`io.*`. Route identity/credential traffic through the server plugin anyway — **by decision**
+(server-authoritative identity from the connection, credentials never handled client-side) — and
+write that reason in the comment. A false "the API doesn't exist" claim misleads the next reader
+into bad architecture the day they discover it does.
+
+## Render doctrine
+
+- **ONE `ui.transparentWindow` per overlay; everything inside is draw-list.** Paint order within a
+  window is deterministic (first call = bottom). Overlapping transparentWindows do NOT stratify —
+  the first stays on top. Symptom of getting this wrong: a flat, empty box where the overlay
+  should be.
+- `ui.transparentWindow(id, pos, size, noPadding, inputs, fn)` — 4th arg `noPadding` (`true` →
+  coordinates start at 0,0), 5th `inputs` (`false` = non-interactive overlay).
+- **Rounded corners + accent bar:** never draw two boxes with opposite `ui.CornerFlags` — the
+  straight corners of one are never covered by the curved corners of the other, leaving square
+  "teeth". Draw the full rounded panel, then re-draw the same rounded rect in the accent color
+  inside a clip — the CSS `overflow: hidden` equivalent:
+
+  ```lua
+  ui.drawRectFilled(vec2(0, 0), vec2(w, h), panelColor, 12)
+  ui.pushClipRect(vec2(0, 0), vec2(4, h), true)   -- 4px accent column
+  ui.drawRectFilled(vec2(0, 0), vec2(w, h), accentColor, 12)
+  ui.popClipRect()
+  ```
+
+  `ui.CornerFlags`: None 0 · TopLeft 1 · TopRight 2 · BottomLeft 4 · BottomRight 8 · Top 3 ·
+  Bottom 12 · Left 5 · Right 10 · All 15.
+- **Images by URL:** `ui.drawImage(src, p1, p2, color)` accepts URLs (documented); serve brand art
+  from the server's static hosting and let CSP download + cache. Zero-install.
+- **`pcall` around every overlay draw.** Decoration must never kill the script — a dead script
+  means no overlays at all, including the required ones.
+- **Colors vs a web mockup:** CSP renders more vivid than CSS — expect to tune saturated accents
+  slightly down. Panels meant to look solid need near-opaque alpha (≈0.98); semi-transparent
+  panels leak gameplay and read as "the background color is wrong".
+
+## DirectWrite text — the trap table
+
+Exact pixel sizes come from `ui.pushDWriteFont("Segoe UI;Weight=Bold")` + `ui.dwriteText(text,
+sizePx, color)` + `ui.measureDWriteText(text, sizePx)`. The font attribute string accepts only
+`Weight` / `Style` / `Stretch` — nothing else.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Segments glue together (`LABEL:value`, `unit0`) | DWrite discards the **trailing** space at measure AND draw; leading and inner spaces survive | Never encode separation as a trailing space — advance x by an explicit px gap |
+| Letter-spacing/tracking has no effect | No native tracking | Draw char-by-char advancing x by measured width + spacing; a space measures 0 alone — measure it as `measure("A A") - measure("AA")` |
+| Stacked lines overlap | A glyph box is ≈1.33× the font size (ascent+descent), not 1× | Derive every line y and the panel height from `ui.measureDWriteText(...).y`; cache the metrics (sizes are constants) |
+| `JOSé`, broken glyph after truncation | `string.upper`/`string.sub` are ASCII/byte-wise; LuaJIT ships no `utf8` lib | Iterate codepoints; Latin-1 Supplement uppercase = lead byte 0xC3, second 0xA0–0xBE minus 0x20, skipping 0xB7 (÷); truncate on codepoint boundaries |
+| Glyph renders as `?` | Built-in font lacks the glyph (★ and friends) | Ship a PNG and `ui.drawImage` it |
+| Accented literals garbled | Source encoding drift | Explicit UTF-8 escapes in literals: `"m\195\169dia"` = "média", `"\194\183"` = "·" |
+
+Copy-paste helpers for all of these: `references/snippets.lua`.
+
+## OnlineEvent packets
+
+- The Lua layout (`ac.StructItem.key(...)` + named/sized fields) must match the C# `OnlineEvent<T>`
+  **byte-for-byte** — enforce it with a static parity gate over the published DLL (see
+  `bug-hunter` → `references/track-dotnet-plugin.md`), not by review.
+- **Never name a field `key`.** It collides with the `ac.StructItem.key` mechanism and the packet
+  is silently never delivered — while every static gate passes, because the layouts do match.
+- Two scripts that register the **exact same layout both receive the event**. Reuse an existing
+  server→client packet in a second overlay instead of minting a new one.
+- Pass `{ processPostponed = true }` (5th arg) when the message may arrive before your listener
+  registers (login/session responses at connect time): CSP replays buffered TCP messages on the
+  next frame. Without it the packet raced your registration and is simply gone.
+- `sender == nil` → from the server; `sender.index == 0` → from this client. Client→server sends
+  always use `target = 255` — fail-closed: a layout drift kills your own connection instead of
+  broadcasting the payload to every player.
+- Payload style: one delimited string field (`"a|b|c|..."`) parsed in Lua. The field list INSIDE
+  the string may grow freely (only the Lua parser reads it); the packet layout — key, field names,
+  sizes — is the contract. Appending an optional trailing field keeps old parsers working.
+
+## Remote audio (and the one-shot trap)
+
+- `ac.AudioEvent.fromFile({ filename = "<URL>", use3D = false, loop = false }, false)` **accepts a
+  URL** — measured in production; the docs only promise URL support for images. MP3 decodes
+  natively (FMOD): no WAV conversion step.
+- An emitter created with `loop = false` becomes **invalid after playing once** (the doc warns:
+  "audio event will become invalid once played once"). Reusing it = sound plays exactly once, then
+  silence forever. Dispose the spent emitter and create a fresh one per shot — the FILE stays
+  cached ("consequent calls with the same parameters would reuse previously loaded audio file");
+  only the emitter is rebuilt.
+- `dispose()` means "stop and remove": re-triggering the same sound rapidly cuts the previous
+  instance. Fine for UI sounds with a natural minimum interval; only pool emitters if a real
+  overlap case exists.
+- `event.volume` is 0..1 — clamp config input. `use3D = false` for UI sounds (no world position,
+  no doppler).
+- **Sound is decoration.** Wrap load AND `start()` in `pcall`; a 404, bad format or sandbox
+  failure must degrade to silence — never block or delay the visual.
+- Calibrate loudness by **frequency of the trigger**, not by how good the sound is in isolation:
+  the event that fires on every attempt gets the softest cue; the rare summit event may be the
+  dramatic one. Inverting this makes players mute the feature.
+
+## Local telemetry
+
+- Your own car is NOT `ac.getSim().focusedCar` — that is the **camera** (wrong under spectator or
+  track cam). Scan `0 .. sim.carsCount-1` for `car.isUserControlled and not car.isRemote`, cache
+  the index, re-validate on use.
+- `ac.onCarCollision(carIndex, cb)` fires once per collision start, for walls AND cars. Register
+  with `-1` (all cars) and filter by your own index inside the callback — avoids the boot-time
+  ordering problem when your index is not resolved yet.
+- Guard `speedKmh` against NaN/infinity before integrating (`v ~= v` catches NaN).
+- When mirroring a server-side metric (speed floor, reset-on-collision), copy the **exact** rules
+  so the live number converges to the authoritative score — and state in a comment which number is
+  authoritative, because frame-rate sampling vs server-rate sampling will differ in the last digit.
+
+## Workflow — mockup first, probes when sight is not enough
+
+- **You cannot render CSP outside the game.** Iterate the visual in an HTML mockup first, get it
+  approved, then translate to Lua taking values FROM the mockup — `em × font-size → px`, flex
+  gaps/margins → explicit px gaps, exact hexes. Never translate by eye: every eyeballed value is
+  one more in-game round-trip.
+- **Validate Lua syntax before every deploy** with a real parser (a Python `luaparser` venv works
+  when `luac` is not installed). A syntax error otherwise only manifests in-game, as a silently
+  missing overlay.
+- **When behavior is in doubt, ship a temporary probe:** the script reports what it could do
+  (capability flags, load results, errors) to the server via a client→server packet; the plugin
+  just logs it. This turns "the player saw nothing" into data that separates rule-failure (never
+  pushed) from render-failure (pushed, not drawn). Config-gate the probe, default off, remove or
+  disable after the investigation. Mind probe blind spots: a sticky boolean cannot prove
+  repetition — count occurrences when repetition is the question.
+- **Overlay stacking is a convention, not a mechanism.** Separate scripts cannot negotiate layout
+  at runtime; y-offsets couple silently. Document the column (e.g. logo → live strip → toast) at
+  every coupling site and re-check the whole column whenever any member's height changes — heights
+  derived from font metrics move when text sizes do.
+- Keep test/debug chat commands behind config flags, default **off** in production; they are how
+  you validate visuals and sounds without driving laps.
+
+## See also
+
+- `assettoserver-plugin` — the C# side: registering scripts and configValues (InvariantCulture
+  decimals), packet classes and handlers, chat commands, the publish rite.
+- `assettoserver-ops` — operating the server that hosts these scripts; static assets under
+  `wwwroot/` are baked into the image (rebuild + recreate, not restart).
+- `bug-hunter` — `references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
+  Lua↔C# packet parity.
+- `conventional-commit` — commit format used by these repos.

--- a/plugins/game/skills/assettoserver-csp-lua/references/snippets.lua
+++ b/plugins/game/skills/assettoserver-csp-lua/references/snippets.lua
@@ -1,0 +1,224 @@
+-- Copy-paste helpers for CSP online scripts (ac_online_script context).
+-- Each block names the trap it defuses; see SKILL.md for the full doctrine.
+-- All snippets are context-free: paste, rename, wire your own config/colors.
+
+-- ===========================================================================
+-- UTF-8 (trap: string.upper/string.sub are ASCII/byte-wise; LuaJIT has no utf8 lib)
+-- ===========================================================================
+
+-- Split into UTF-8 codepoints. Byte-wise iteration cuts accents in half.
+local function utf8chars(s)
+  local out, i, n = {}, 1, #s
+  while i <= n do
+    local b = string.byte(s, i)
+    local size = 1
+    if b >= 240 then size = 4
+    elseif b >= 224 then size = 3
+    elseif b >= 192 then size = 2 end
+    out[#out + 1] = string.sub(s, i, i + size - 1)
+    i = i + size
+  end
+  return out
+end
+
+-- Uppercase covering Latin-1 Supplement: lowercase à..þ are 0xC3 0xA0..0xBE and
+-- uppercase À..Þ are 0xC3 0x80..0x9E — subtract 0x20, skipping 0xB7 (÷, not a letter).
+-- Plain string.upper would produce "JOSé".
+local function upperUtf8(s)
+  local out = {}
+  for _, ch in ipairs(utf8chars(s)) do
+    if #ch == 1 then
+      out[#out + 1] = string.upper(ch)
+    elseif #ch == 2 then
+      local b1, b2 = string.byte(ch, 1, 2)
+      if b1 == 195 and b2 >= 160 and b2 <= 190 and b2 ~= 183 then
+        out[#out + 1] = string.char(b1, b2 - 32)
+      else
+        out[#out + 1] = ch
+      end
+    else
+      out[#out + 1] = ch
+    end
+  end
+  return table.concat(out)
+end
+
+-- ===========================================================================
+-- DirectWrite text with letter-spacing
+-- (traps: no native tracking; trailing space discarded at measure AND draw;
+--  measuring " " alone returns 0)
+-- ===========================================================================
+
+-- Draw with per-character tracking. With `color` nil it only measures (returns width).
+-- Spacing in px = mockup's letter-spacing em × font size.
+local function spacedText(x, y, s, color, size, spacing)
+  ui.pushDWriteFont("Segoe UI;Weight=Bold")
+  local blank = ui.measureDWriteText("A A", size).x - ui.measureDWriteText("AA", size).x
+  local cx = x
+  for _, ch in ipairs(utf8chars(s)) do
+    if ch == " " then
+      cx = cx + blank + spacing
+    else
+      if color ~= nil then
+        ui.setCursor(vec2(cx, y))
+        ui.dwriteText(ch, size, color)
+      end
+      cx = cx + ui.measureDWriteText(ch, size).x + spacing
+    end
+  end
+  ui.popDWriteFont()
+  return math.max(0, cx - x - spacing)
+end
+
+local function spacedWidth(s, size, spacing)
+  return spacedText(0, 0, s, nil, size, spacing)
+end
+
+-- Ellipsis truncation on CODEPOINT boundaries (byte-wise sub breaks accents mid-glyph).
+local function fitSpaced(s, maxW, size, spacing)
+  if spacedWidth(s, size, spacing) <= maxW then return s end
+  local chars = utf8chars(s)
+  while #chars > 1 do
+    table.remove(chars)
+    local candidate = table.concat(chars) .. "..."
+    if spacedWidth(candidate, size, spacing) <= maxW then return candidate end
+  end
+  return "..."
+end
+
+-- ===========================================================================
+-- Metric line: big bold numbers + small muted units, base-aligned
+-- (trap: segments separated by embedded trailing spaces glue together — use px gaps)
+-- ===========================================================================
+
+local GAP_NUM_UNIT, GAP_UNIT_SEP, GAP_SEP_NUM = 3, 6, 5  -- from the mockup's flex margins
+
+local function drawMetric(x, y, bigSize, smallSize, numColor, unitColor, distText, unitText, avgText)
+  ui.pushDWriteFont("Segoe UI;Weight=Bold")
+  -- base-align small text against big text (glyph boxes differ in height)
+  local dy = ui.measureDWriteText("0", bigSize).y - ui.measureDWriteText("0", smallSize).y
+  local cx = x
+  local function seg(text, big, gapAfter)
+    local size = big and bigSize or smallSize
+    ui.setCursor(vec2(cx, big and y or (y + dy)))
+    ui.dwriteText(text, size, big and numColor or unitColor)
+    cx = cx + ui.measureDWriteText(text, size).x + (gapAfter or 0)
+  end
+  seg(distText, true, GAP_NUM_UNIT)
+  seg(unitText, false, GAP_UNIT_SEP)
+  seg("\194\183 m\195\169dia", false, GAP_SEP_NUM)  -- "· média" via explicit UTF-8 escapes
+  seg(avgText, true, GAP_NUM_UNIT)
+  seg("km/h", false)
+  ui.popDWriteFont()
+end
+
+-- ===========================================================================
+-- Layout derived from REAL font metrics
+-- (trap: a 30px "0" occupies ~40px of height — fixed stacked y offsets overlap)
+-- ===========================================================================
+
+local metrics = nil
+local function layout(sizeLabel, sizeNum, sizePilot, padTop, padBottom, gapA, gapB)
+  if metrics ~= nil then return metrics end
+  ui.pushDWriteFont("Segoe UI;Weight=Bold")
+  local hLabel = ui.measureDWriteText("0", sizeLabel).y
+  local hNum   = ui.measureDWriteText("0", sizeNum).y
+  local hPilot = ui.measureDWriteText("0", sizePilot).y
+  ui.popDWriteFont()
+  if hNum <= 0 then return nil end  -- font not ready this frame: retry next, don't cache zeros
+  local m = {}
+  m.yLabel = padTop
+  m.yNum   = m.yLabel + hLabel + gapA
+  m.yPilot = m.yNum + hNum + gapB
+  m.height = m.yPilot + hPilot + padBottom
+  metrics = m
+  return m
+end
+
+-- ===========================================================================
+-- Single-window toast skeleton: rounded panel + clipped accent bar
+-- (traps: stacked transparentWindows don't stratify — the empty-box bug;
+--  opposite CornerFlags leave square "teeth" — clip instead)
+-- ===========================================================================
+
+local function drawToast(pos, w, h, accent, panel, drawContent)
+  ui.transparentWindow("my_toast", pos, vec2(w, h), true, false, function()
+    ui.drawRectFilled(vec2(0, 0), vec2(w, h), panel, 12)
+    ui.pushClipRect(vec2(0, 0), vec2(4, h), true)          -- overflow:hidden equivalent
+    ui.drawRectFilled(vec2(0, 0), vec2(w, h), accent, 12)  -- accent follows the corner curve
+    ui.popClipRect()
+    pcall(drawContent)  -- decoration never kills the script
+  end)
+end
+
+-- ===========================================================================
+-- One-shot audio by URL
+-- (traps: loop=false emitter is INVALID after one play — dispose + recreate;
+--  the FILE stays cached, only the emitter is rebuilt; sound must degrade to silence)
+-- ===========================================================================
+
+local emitters = {}
+local function playSound(baseUrl, fileName, volume)
+  pcall(function()
+    local spent = emitters[fileName]
+    if spent ~= nil then
+      emitters[fileName] = nil
+      pcall(function() spent:dispose() end)  -- "stop and remove"
+    end
+    local event = ac.AudioEvent.fromFile({
+      filename = baseUrl .. fileName,  -- URL accepted (measured; docs only promise it for images)
+      use3D = false,                   -- UI sound: no world position, no doppler
+      loop = false,
+    }, false)
+    if event == nil or not event:isValid() then return end
+    event.volume = math.max(math.min(volume or 0.6, 1), 0)
+    emitters[fileName] = event
+    event:start()
+  end)
+end
+
+-- ===========================================================================
+-- Probe pattern: report capability/results to the server log
+-- (trap: "the player saw/heard nothing" cannot distinguish rule-failure from
+--  render-failure — make the client tell the server what it could do)
+-- ===========================================================================
+
+-- NEVER name a field `key` (collides with ac.StructItem.key: packet silently undelivered).
+local sendProbe = ac.OnlineEvent({
+  ac.StructItem.key("myplugin.audio.probe"),
+  data = ac.StructItem.string(192),
+}, function() end)
+
+local function reportProbe(result)          -- result: short "k=v|k=v" string
+  pcall(function() sendProbe({ data = result }, nil, 255) end)  -- 255 = server, fail-closed
+end
+
+-- ===========================================================================
+-- Own car + collision hook
+-- (traps: sim.focusedCar is the CAMERA, wrong under spectator; register collisions
+--  with -1 and filter, so boot-time index resolution can't race the hook)
+-- ===========================================================================
+
+local ownIndex = -1
+local function ownCar()
+  if ownIndex >= 0 then
+    local cached = ac.getCar(ownIndex)
+    if cached ~= nil and cached.isUserControlled then return cached end
+    ownIndex = -1
+  end
+  local sim = ac.getSim()
+  if sim == nil then return nil end
+  for i = 0, math.max(sim.carsCount, 1) - 1 do
+    local car = ac.getCar(i)
+    if car ~= nil and car.isUserControlled and not car.isRemote then
+      ownIndex = i
+      return car
+    end
+  end
+  return nil
+end
+
+ac.onCarCollision(-1, function(carIndex)
+  if ownIndex < 0 or carIndex ~= ownIndex then return end
+  -- your reset-on-collision logic here (mirror the server's exact rules)
+end)

--- a/plugins/game/skills/assettoserver-plugin/SKILL.md
+++ b/plugins/game/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -180,6 +180,39 @@ doctrine (sibling of the `backend-resilience` skill, adapted to this runtime):
 - Sort/limit/tie-break API data **client-side** in the service; over-fetch
   (`Math.Max(limit, 10)`) then trim, so display rules don't depend on backend ordering.
 
+## Serving CSP Lua scripts (configValues + packets)
+
+The plugin can push Lua overlays to every client via `CSPServerScriptProvider.AddScript(script,
+debugFilename, configValues)`. The client side of those scripts is `assettoserver-csp-lua`; the
+traps below live on THIS side of the boundary:
+
+- **Format every `double` in configValues with `InvariantCulture` yourself.** The provider
+  serializes each value with `value.ToString()` — culture-sensitive. On a host with a non-invariant
+  locale (`LANG=pt_BR...`), `0.7` becomes `"0,7"`, CSP fails to parse it, and the script silently
+  falls back to its Lua defaults. When Lua defaults equal the C# defaults there is **no symptom** —
+  the config simply never applies. Ship a helper and use it for every decimal:
+
+  ```csharp
+  private static string Decimal(double value) => value.ToString(CultureInfo.InvariantCulture);
+  // ["soundVolume"] = Decimal(configuration.SoundVolume),
+  ```
+
+- **The flat fallback config loader needs a `case` per property — enforce it with a test, not
+  memory.** Commands read config through the DI-less fallback parser (see the static accessor
+  bridge above); a property without a `case` silently keeps its default, so the command lies
+  ("feature disabled") while the DI path works. This class of bug recurs; kill it with a
+  reflection guard that iterates EVERY config property, feeds the parser a YAML line with a
+  non-default probe value, and asserts the property changed — then prove the guard works by
+  removing one `case` and watching it fail with the property's name.
+
+- **OnlineEvent packet authoring:** server→client pushes need no registration — build the packet
+  and `client.SendPacket(packet)`. Client→server packets must be registered via
+  `CSPClientMessageTypeManager.RegisterOnlineEvent<TPacket>((client, packet) => ...)`; handlers run
+  on the network receive path — hand off to `Task.Run`, never block, never let an exception escape.
+  **Never name a packet field `key`**: on the Lua side it collides with the `ac.StructItem.key`
+  layout mechanism and the packet is silently never delivered, while every static parity gate
+  passes.
+
 ## Publish shape (what the plugin loader expects)
 
 ```xml
@@ -225,6 +258,8 @@ commit) next to the DLL — the deploy side refuses to sync a DLL without a rite
 
 ## See also
 
+- `assettoserver-csp-lua` — the client side of the scripts and packets this plugin serves: render
+  doctrine, DirectWrite traps, packet layout mirroring, remote assets/audio by URL.
 - `assettoserver-ops` — operating the server that loads this plugin; the deploy/sync gate that
   consumes `plugin-rite-status.json`.
 - `bug-hunter` — the adversarial rite; `references/track-dotnet-plugin.md` is the generalized

--- a/skills/assettoserver-csp-lua/SKILL.md
+++ b/skills/assettoserver-csp-lua/SKILL.md
@@ -1,0 +1,200 @@
+---
+name: assettoserver-csp-lua
+description: >-
+  Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the
+  zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API
+  in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte
+  with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry,
+  and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a
+  production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD,
+  toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or
+  overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently
+  never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands,
+  publishing (that is assettoserver-plugin), for server configuration/deploy (that is
+  assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different
+  permissions), or for FiveM Lua (that is fivem-lua).
+metadata:
+  author: solvelab
+  version: 1.0.0
+  category: game
+license: MIT
+compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
+---
+
+# CSP Lua online scripts (AssettoServer-served overlays)
+
+Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
+client by the server itself. Zero-install is the point — the player installs nothing; art, sound
+and code all arrive over the server's HTTP port. Every rule below was paid for with an in-game
+iteration; in this stack a wrong guess costs a deploy plus a human driving session to observe it.
+
+## What an online script is
+
+- The plugin registers it via `CSPServerScriptProvider.AddScript(script, debugFilename,
+  configValues)`; the server advertises `[SCRIPT_N-...]` sections in CSP extra options pointing at
+  `http://{ServerIP}:{ServerHTTPPort}/api/scripts/N`. The client downloads and runs it on join.
+- `["REQUIRED"] = 1` makes CSP refuse clients that do not run the script — reserve it for gate
+  flows (login). Cosmetic overlays MUST ship `["REQUIRED"] = 0`: a client without them just doesn't
+  see the overlay.
+- Server config reaches the script through `ac.configValues({ key = default, ... })`. Decimals
+  cross this boundary as strings — the C# side must format them with InvariantCulture or a pt-BR
+  host silently turns `0.7` into `"0,7"` and the script falls back to its Lua defaults with **no
+  symptom** (see `assettoserver-plugin`). Keep Lua defaults equal to the C# defaults so a missing
+  config degrades gracefully — but know that this same choice hides delivery failures.
+- Each script is an **isolated Lua state**: no shared globals, no runtime negotiation between
+  overlays. Anything two scripts must agree on (layout offsets, packet layouts) is agreed by
+  convention and documented on both sides.
+- If the script is embedded in the plugin DLL and mirrored in a UI repo, the copies must be
+  byte-identical — gate with `cmp -s` in the rite, not with good intentions.
+
+## Consult the SDK — never guess an API
+
+Every CSP install ships authoritative EmmyLua stubs, one per Lua context:
+
+```
+<AC root>/extension/internal/lua-sdk/ac_online_script/lib.lua   # ~17k lines; THIS context
+grep -nE "function ui\.drawRectFilled" ".../ac_online_script/lib.lua"
+```
+
+Read the signature and its doc comment before using any `ui.*` / `ac.*` function. The doc comments
+carry the load-bearing details (default args, corner flags, URL support, one-shot audio semantics).
+
+**The `withoutIO` myth.** The SDK's `rules.json` marks `withoutIO: true` only for
+`ac_track_script`, `ac_car_cphys` and `ac_car_scriptable_display` — NOT for online scripts. A
+server-served online script measurably has `web.*` (get/post/request/socket/loadRemoteAssets) and
+`io.*`. Route identity/credential traffic through the server plugin anyway — **by decision**
+(server-authoritative identity from the connection, credentials never handled client-side) — and
+write that reason in the comment. A false "the API doesn't exist" claim misleads the next reader
+into bad architecture the day they discover it does.
+
+## Render doctrine
+
+- **ONE `ui.transparentWindow` per overlay; everything inside is draw-list.** Paint order within a
+  window is deterministic (first call = bottom). Overlapping transparentWindows do NOT stratify —
+  the first stays on top. Symptom of getting this wrong: a flat, empty box where the overlay
+  should be.
+- `ui.transparentWindow(id, pos, size, noPadding, inputs, fn)` — 4th arg `noPadding` (`true` →
+  coordinates start at 0,0), 5th `inputs` (`false` = non-interactive overlay).
+- **Rounded corners + accent bar:** never draw two boxes with opposite `ui.CornerFlags` — the
+  straight corners of one are never covered by the curved corners of the other, leaving square
+  "teeth". Draw the full rounded panel, then re-draw the same rounded rect in the accent color
+  inside a clip — the CSS `overflow: hidden` equivalent:
+
+  ```lua
+  ui.drawRectFilled(vec2(0, 0), vec2(w, h), panelColor, 12)
+  ui.pushClipRect(vec2(0, 0), vec2(4, h), true)   -- 4px accent column
+  ui.drawRectFilled(vec2(0, 0), vec2(w, h), accentColor, 12)
+  ui.popClipRect()
+  ```
+
+  `ui.CornerFlags`: None 0 · TopLeft 1 · TopRight 2 · BottomLeft 4 · BottomRight 8 · Top 3 ·
+  Bottom 12 · Left 5 · Right 10 · All 15.
+- **Images by URL:** `ui.drawImage(src, p1, p2, color)` accepts URLs (documented); serve brand art
+  from the server's static hosting and let CSP download + cache. Zero-install.
+- **`pcall` around every overlay draw.** Decoration must never kill the script — a dead script
+  means no overlays at all, including the required ones.
+- **Colors vs a web mockup:** CSP renders more vivid than CSS — expect to tune saturated accents
+  slightly down. Panels meant to look solid need near-opaque alpha (≈0.98); semi-transparent
+  panels leak gameplay and read as "the background color is wrong".
+
+## DirectWrite text — the trap table
+
+Exact pixel sizes come from `ui.pushDWriteFont("Segoe UI;Weight=Bold")` + `ui.dwriteText(text,
+sizePx, color)` + `ui.measureDWriteText(text, sizePx)`. The font attribute string accepts only
+`Weight` / `Style` / `Stretch` — nothing else.
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Segments glue together (`LABEL:value`, `unit0`) | DWrite discards the **trailing** space at measure AND draw; leading and inner spaces survive | Never encode separation as a trailing space — advance x by an explicit px gap |
+| Letter-spacing/tracking has no effect | No native tracking | Draw char-by-char advancing x by measured width + spacing; a space measures 0 alone — measure it as `measure("A A") - measure("AA")` |
+| Stacked lines overlap | A glyph box is ≈1.33× the font size (ascent+descent), not 1× | Derive every line y and the panel height from `ui.measureDWriteText(...).y`; cache the metrics (sizes are constants) |
+| `JOSé`, broken glyph after truncation | `string.upper`/`string.sub` are ASCII/byte-wise; LuaJIT ships no `utf8` lib | Iterate codepoints; Latin-1 Supplement uppercase = lead byte 0xC3, second 0xA0–0xBE minus 0x20, skipping 0xB7 (÷); truncate on codepoint boundaries |
+| Glyph renders as `?` | Built-in font lacks the glyph (★ and friends) | Ship a PNG and `ui.drawImage` it |
+| Accented literals garbled | Source encoding drift | Explicit UTF-8 escapes in literals: `"m\195\169dia"` = "média", `"\194\183"` = "·" |
+
+Copy-paste helpers for all of these: `references/snippets.lua`.
+
+## OnlineEvent packets
+
+- The Lua layout (`ac.StructItem.key(...)` + named/sized fields) must match the C# `OnlineEvent<T>`
+  **byte-for-byte** — enforce it with a static parity gate over the published DLL (see
+  `bug-hunter` → `references/track-dotnet-plugin.md`), not by review.
+- **Never name a field `key`.** It collides with the `ac.StructItem.key` mechanism and the packet
+  is silently never delivered — while every static gate passes, because the layouts do match.
+- Two scripts that register the **exact same layout both receive the event**. Reuse an existing
+  server→client packet in a second overlay instead of minting a new one.
+- Pass `{ processPostponed = true }` (5th arg) when the message may arrive before your listener
+  registers (login/session responses at connect time): CSP replays buffered TCP messages on the
+  next frame. Without it the packet raced your registration and is simply gone.
+- `sender == nil` → from the server; `sender.index == 0` → from this client. Client→server sends
+  always use `target = 255` — fail-closed: a layout drift kills your own connection instead of
+  broadcasting the payload to every player.
+- Payload style: one delimited string field (`"a|b|c|..."`) parsed in Lua. The field list INSIDE
+  the string may grow freely (only the Lua parser reads it); the packet layout — key, field names,
+  sizes — is the contract. Appending an optional trailing field keeps old parsers working.
+
+## Remote audio (and the one-shot trap)
+
+- `ac.AudioEvent.fromFile({ filename = "<URL>", use3D = false, loop = false }, false)` **accepts a
+  URL** — measured in production; the docs only promise URL support for images. MP3 decodes
+  natively (FMOD): no WAV conversion step.
+- An emitter created with `loop = false` becomes **invalid after playing once** (the doc warns:
+  "audio event will become invalid once played once"). Reusing it = sound plays exactly once, then
+  silence forever. Dispose the spent emitter and create a fresh one per shot — the FILE stays
+  cached ("consequent calls with the same parameters would reuse previously loaded audio file");
+  only the emitter is rebuilt.
+- `dispose()` means "stop and remove": re-triggering the same sound rapidly cuts the previous
+  instance. Fine for UI sounds with a natural minimum interval; only pool emitters if a real
+  overlap case exists.
+- `event.volume` is 0..1 — clamp config input. `use3D = false` for UI sounds (no world position,
+  no doppler).
+- **Sound is decoration.** Wrap load AND `start()` in `pcall`; a 404, bad format or sandbox
+  failure must degrade to silence — never block or delay the visual.
+- Calibrate loudness by **frequency of the trigger**, not by how good the sound is in isolation:
+  the event that fires on every attempt gets the softest cue; the rare summit event may be the
+  dramatic one. Inverting this makes players mute the feature.
+
+## Local telemetry
+
+- Your own car is NOT `ac.getSim().focusedCar` — that is the **camera** (wrong under spectator or
+  track cam). Scan `0 .. sim.carsCount-1` for `car.isUserControlled and not car.isRemote`, cache
+  the index, re-validate on use.
+- `ac.onCarCollision(carIndex, cb)` fires once per collision start, for walls AND cars. Register
+  with `-1` (all cars) and filter by your own index inside the callback — avoids the boot-time
+  ordering problem when your index is not resolved yet.
+- Guard `speedKmh` against NaN/infinity before integrating (`v ~= v` catches NaN).
+- When mirroring a server-side metric (speed floor, reset-on-collision), copy the **exact** rules
+  so the live number converges to the authoritative score — and state in a comment which number is
+  authoritative, because frame-rate sampling vs server-rate sampling will differ in the last digit.
+
+## Workflow — mockup first, probes when sight is not enough
+
+- **You cannot render CSP outside the game.** Iterate the visual in an HTML mockup first, get it
+  approved, then translate to Lua taking values FROM the mockup — `em × font-size → px`, flex
+  gaps/margins → explicit px gaps, exact hexes. Never translate by eye: every eyeballed value is
+  one more in-game round-trip.
+- **Validate Lua syntax before every deploy** with a real parser (a Python `luaparser` venv works
+  when `luac` is not installed). A syntax error otherwise only manifests in-game, as a silently
+  missing overlay.
+- **When behavior is in doubt, ship a temporary probe:** the script reports what it could do
+  (capability flags, load results, errors) to the server via a client→server packet; the plugin
+  just logs it. This turns "the player saw nothing" into data that separates rule-failure (never
+  pushed) from render-failure (pushed, not drawn). Config-gate the probe, default off, remove or
+  disable after the investigation. Mind probe blind spots: a sticky boolean cannot prove
+  repetition — count occurrences when repetition is the question.
+- **Overlay stacking is a convention, not a mechanism.** Separate scripts cannot negotiate layout
+  at runtime; y-offsets couple silently. Document the column (e.g. logo → live strip → toast) at
+  every coupling site and re-check the whole column whenever any member's height changes — heights
+  derived from font metrics move when text sizes do.
+- Keep test/debug chat commands behind config flags, default **off** in production; they are how
+  you validate visuals and sounds without driving laps.
+
+## See also
+
+- `assettoserver-plugin` — the C# side: registering scripts and configValues (InvariantCulture
+  decimals), packet classes and handlers, chat commands, the publish rite.
+- `assettoserver-ops` — operating the server that hosts these scripts; static assets under
+  `wwwroot/` are baked into the image (rebuild + recreate, not restart).
+- `bug-hunter` — `references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
+  Lua↔C# packet parity.
+- `conventional-commit` — commit format used by these repos.

--- a/skills/assettoserver-csp-lua/references/snippets.lua
+++ b/skills/assettoserver-csp-lua/references/snippets.lua
@@ -1,0 +1,224 @@
+-- Copy-paste helpers for CSP online scripts (ac_online_script context).
+-- Each block names the trap it defuses; see SKILL.md for the full doctrine.
+-- All snippets are context-free: paste, rename, wire your own config/colors.
+
+-- ===========================================================================
+-- UTF-8 (trap: string.upper/string.sub are ASCII/byte-wise; LuaJIT has no utf8 lib)
+-- ===========================================================================
+
+-- Split into UTF-8 codepoints. Byte-wise iteration cuts accents in half.
+local function utf8chars(s)
+  local out, i, n = {}, 1, #s
+  while i <= n do
+    local b = string.byte(s, i)
+    local size = 1
+    if b >= 240 then size = 4
+    elseif b >= 224 then size = 3
+    elseif b >= 192 then size = 2 end
+    out[#out + 1] = string.sub(s, i, i + size - 1)
+    i = i + size
+  end
+  return out
+end
+
+-- Uppercase covering Latin-1 Supplement: lowercase à..þ are 0xC3 0xA0..0xBE and
+-- uppercase À..Þ are 0xC3 0x80..0x9E — subtract 0x20, skipping 0xB7 (÷, not a letter).
+-- Plain string.upper would produce "JOSé".
+local function upperUtf8(s)
+  local out = {}
+  for _, ch in ipairs(utf8chars(s)) do
+    if #ch == 1 then
+      out[#out + 1] = string.upper(ch)
+    elseif #ch == 2 then
+      local b1, b2 = string.byte(ch, 1, 2)
+      if b1 == 195 and b2 >= 160 and b2 <= 190 and b2 ~= 183 then
+        out[#out + 1] = string.char(b1, b2 - 32)
+      else
+        out[#out + 1] = ch
+      end
+    else
+      out[#out + 1] = ch
+    end
+  end
+  return table.concat(out)
+end
+
+-- ===========================================================================
+-- DirectWrite text with letter-spacing
+-- (traps: no native tracking; trailing space discarded at measure AND draw;
+--  measuring " " alone returns 0)
+-- ===========================================================================
+
+-- Draw with per-character tracking. With `color` nil it only measures (returns width).
+-- Spacing in px = mockup's letter-spacing em × font size.
+local function spacedText(x, y, s, color, size, spacing)
+  ui.pushDWriteFont("Segoe UI;Weight=Bold")
+  local blank = ui.measureDWriteText("A A", size).x - ui.measureDWriteText("AA", size).x
+  local cx = x
+  for _, ch in ipairs(utf8chars(s)) do
+    if ch == " " then
+      cx = cx + blank + spacing
+    else
+      if color ~= nil then
+        ui.setCursor(vec2(cx, y))
+        ui.dwriteText(ch, size, color)
+      end
+      cx = cx + ui.measureDWriteText(ch, size).x + spacing
+    end
+  end
+  ui.popDWriteFont()
+  return math.max(0, cx - x - spacing)
+end
+
+local function spacedWidth(s, size, spacing)
+  return spacedText(0, 0, s, nil, size, spacing)
+end
+
+-- Ellipsis truncation on CODEPOINT boundaries (byte-wise sub breaks accents mid-glyph).
+local function fitSpaced(s, maxW, size, spacing)
+  if spacedWidth(s, size, spacing) <= maxW then return s end
+  local chars = utf8chars(s)
+  while #chars > 1 do
+    table.remove(chars)
+    local candidate = table.concat(chars) .. "..."
+    if spacedWidth(candidate, size, spacing) <= maxW then return candidate end
+  end
+  return "..."
+end
+
+-- ===========================================================================
+-- Metric line: big bold numbers + small muted units, base-aligned
+-- (trap: segments separated by embedded trailing spaces glue together — use px gaps)
+-- ===========================================================================
+
+local GAP_NUM_UNIT, GAP_UNIT_SEP, GAP_SEP_NUM = 3, 6, 5  -- from the mockup's flex margins
+
+local function drawMetric(x, y, bigSize, smallSize, numColor, unitColor, distText, unitText, avgText)
+  ui.pushDWriteFont("Segoe UI;Weight=Bold")
+  -- base-align small text against big text (glyph boxes differ in height)
+  local dy = ui.measureDWriteText("0", bigSize).y - ui.measureDWriteText("0", smallSize).y
+  local cx = x
+  local function seg(text, big, gapAfter)
+    local size = big and bigSize or smallSize
+    ui.setCursor(vec2(cx, big and y or (y + dy)))
+    ui.dwriteText(text, size, big and numColor or unitColor)
+    cx = cx + ui.measureDWriteText(text, size).x + (gapAfter or 0)
+  end
+  seg(distText, true, GAP_NUM_UNIT)
+  seg(unitText, false, GAP_UNIT_SEP)
+  seg("\194\183 m\195\169dia", false, GAP_SEP_NUM)  -- "· média" via explicit UTF-8 escapes
+  seg(avgText, true, GAP_NUM_UNIT)
+  seg("km/h", false)
+  ui.popDWriteFont()
+end
+
+-- ===========================================================================
+-- Layout derived from REAL font metrics
+-- (trap: a 30px "0" occupies ~40px of height — fixed stacked y offsets overlap)
+-- ===========================================================================
+
+local metrics = nil
+local function layout(sizeLabel, sizeNum, sizePilot, padTop, padBottom, gapA, gapB)
+  if metrics ~= nil then return metrics end
+  ui.pushDWriteFont("Segoe UI;Weight=Bold")
+  local hLabel = ui.measureDWriteText("0", sizeLabel).y
+  local hNum   = ui.measureDWriteText("0", sizeNum).y
+  local hPilot = ui.measureDWriteText("0", sizePilot).y
+  ui.popDWriteFont()
+  if hNum <= 0 then return nil end  -- font not ready this frame: retry next, don't cache zeros
+  local m = {}
+  m.yLabel = padTop
+  m.yNum   = m.yLabel + hLabel + gapA
+  m.yPilot = m.yNum + hNum + gapB
+  m.height = m.yPilot + hPilot + padBottom
+  metrics = m
+  return m
+end
+
+-- ===========================================================================
+-- Single-window toast skeleton: rounded panel + clipped accent bar
+-- (traps: stacked transparentWindows don't stratify — the empty-box bug;
+--  opposite CornerFlags leave square "teeth" — clip instead)
+-- ===========================================================================
+
+local function drawToast(pos, w, h, accent, panel, drawContent)
+  ui.transparentWindow("my_toast", pos, vec2(w, h), true, false, function()
+    ui.drawRectFilled(vec2(0, 0), vec2(w, h), panel, 12)
+    ui.pushClipRect(vec2(0, 0), vec2(4, h), true)          -- overflow:hidden equivalent
+    ui.drawRectFilled(vec2(0, 0), vec2(w, h), accent, 12)  -- accent follows the corner curve
+    ui.popClipRect()
+    pcall(drawContent)  -- decoration never kills the script
+  end)
+end
+
+-- ===========================================================================
+-- One-shot audio by URL
+-- (traps: loop=false emitter is INVALID after one play — dispose + recreate;
+--  the FILE stays cached, only the emitter is rebuilt; sound must degrade to silence)
+-- ===========================================================================
+
+local emitters = {}
+local function playSound(baseUrl, fileName, volume)
+  pcall(function()
+    local spent = emitters[fileName]
+    if spent ~= nil then
+      emitters[fileName] = nil
+      pcall(function() spent:dispose() end)  -- "stop and remove"
+    end
+    local event = ac.AudioEvent.fromFile({
+      filename = baseUrl .. fileName,  -- URL accepted (measured; docs only promise it for images)
+      use3D = false,                   -- UI sound: no world position, no doppler
+      loop = false,
+    }, false)
+    if event == nil or not event:isValid() then return end
+    event.volume = math.max(math.min(volume or 0.6, 1), 0)
+    emitters[fileName] = event
+    event:start()
+  end)
+end
+
+-- ===========================================================================
+-- Probe pattern: report capability/results to the server log
+-- (trap: "the player saw/heard nothing" cannot distinguish rule-failure from
+--  render-failure — make the client tell the server what it could do)
+-- ===========================================================================
+
+-- NEVER name a field `key` (collides with ac.StructItem.key: packet silently undelivered).
+local sendProbe = ac.OnlineEvent({
+  ac.StructItem.key("myplugin.audio.probe"),
+  data = ac.StructItem.string(192),
+}, function() end)
+
+local function reportProbe(result)          -- result: short "k=v|k=v" string
+  pcall(function() sendProbe({ data = result }, nil, 255) end)  -- 255 = server, fail-closed
+end
+
+-- ===========================================================================
+-- Own car + collision hook
+-- (traps: sim.focusedCar is the CAMERA, wrong under spectator; register collisions
+--  with -1 and filter, so boot-time index resolution can't race the hook)
+-- ===========================================================================
+
+local ownIndex = -1
+local function ownCar()
+  if ownIndex >= 0 then
+    local cached = ac.getCar(ownIndex)
+    if cached ~= nil and cached.isUserControlled then return cached end
+    ownIndex = -1
+  end
+  local sim = ac.getSim()
+  if sim == nil then return nil end
+  for i = 0, math.max(sim.carsCount, 1) - 1 do
+    local car = ac.getCar(i)
+    if car ~= nil and car.isUserControlled and not car.isRemote then
+      ownIndex = i
+      return car
+    end
+  end
+  return nil
+end
+
+ac.onCarCollision(-1, function(carIndex)
+  if ownIndex < 0 or carIndex ~= ownIndex then return end
+  -- your reset-on-collision logic here (mirror the server's exact rules)
+end)

--- a/skills/assettoserver-ops/SKILL.md
+++ b/skills/assettoserver-ops/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   backend receiving events (python-rest-api), or for FiveM servers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: devops
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -126,6 +126,12 @@ The lane file may live at the track ROOT `ai/` dir and serve all layouts — emp
   `netsh interface portproxy add v4tov4 listenport=9600 connectaddress=$wslIp connectport=9600`
   (repeat for 8081) plus firewall rules for 9600/tcp, 9600/udp, 8081/tcp. The WSL IP changes;
   recompute it (`wsl hostname -I`) after reboots.
+- **Static web assets ARE baked into the image** — the inverse of the runtime binary (which lives
+  in a named volume, see above). Anything under `server/wwwroot/` served at `/static` (brand
+  images, trophies, notification sounds consumed by CSP overlays) is `COPY`'d at build time:
+  adding or replacing an asset requires `docker compose build <service>` + `up -d` (recreate).
+  **A plain `restart` serves the stale asset** — the classic symptom is "I replaced the file but
+  the game still shows/plays the old one".
 
 ## Plugin deployment — rite-gated sync
 
@@ -166,6 +172,8 @@ runbook and the tooling can't drift apart.
 ## See also
 
 - `assettoserver-plugin` — writing/building the plugin this repo deploys; produces the rite proof.
+- `assettoserver-csp-lua` — the in-game overlays that consume the `/static` assets baked into this
+  image (brand art, trophies, notification sounds).
 - `log-event-collector` — the log-tailing collector run as the compose `collector` profile.
 - `python-rest-api` — the backend the collector and plugin talk to.
 - `documentation` — the runbook/docs tiers this kind of repo needs.

--- a/skills/assettoserver-plugin/SKILL.md
+++ b/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -180,6 +180,39 @@ doctrine (sibling of the `backend-resilience` skill, adapted to this runtime):
 - Sort/limit/tie-break API data **client-side** in the service; over-fetch
   (`Math.Max(limit, 10)`) then trim, so display rules don't depend on backend ordering.
 
+## Serving CSP Lua scripts (configValues + packets)
+
+The plugin can push Lua overlays to every client via `CSPServerScriptProvider.AddScript(script,
+debugFilename, configValues)`. The client side of those scripts is `assettoserver-csp-lua`; the
+traps below live on THIS side of the boundary:
+
+- **Format every `double` in configValues with `InvariantCulture` yourself.** The provider
+  serializes each value with `value.ToString()` — culture-sensitive. On a host with a non-invariant
+  locale (`LANG=pt_BR...`), `0.7` becomes `"0,7"`, CSP fails to parse it, and the script silently
+  falls back to its Lua defaults. When Lua defaults equal the C# defaults there is **no symptom** —
+  the config simply never applies. Ship a helper and use it for every decimal:
+
+  ```csharp
+  private static string Decimal(double value) => value.ToString(CultureInfo.InvariantCulture);
+  // ["soundVolume"] = Decimal(configuration.SoundVolume),
+  ```
+
+- **The flat fallback config loader needs a `case` per property — enforce it with a test, not
+  memory.** Commands read config through the DI-less fallback parser (see the static accessor
+  bridge above); a property without a `case` silently keeps its default, so the command lies
+  ("feature disabled") while the DI path works. This class of bug recurs; kill it with a
+  reflection guard that iterates EVERY config property, feeds the parser a YAML line with a
+  non-default probe value, and asserts the property changed — then prove the guard works by
+  removing one `case` and watching it fail with the property's name.
+
+- **OnlineEvent packet authoring:** server→client pushes need no registration — build the packet
+  and `client.SendPacket(packet)`. Client→server packets must be registered via
+  `CSPClientMessageTypeManager.RegisterOnlineEvent<TPacket>((client, packet) => ...)`; handlers run
+  on the network receive path — hand off to `Task.Run`, never block, never let an exception escape.
+  **Never name a packet field `key`**: on the Lua side it collides with the `ac.StructItem.key`
+  layout mechanism and the packet is silently never delivered, while every static parity gate
+  passes.
+
 ## Publish shape (what the plugin loader expects)
 
 ```xml
@@ -225,6 +258,8 @@ commit) next to the DLL — the deploy side refuses to sync a DLL without a rite
 
 ## See also
 
+- `assettoserver-csp-lua` — the client side of the scripts and packets this plugin serves: render
+  doctrine, DirectWrite traps, packet layout mirroring, remote assets/audio by URL.
 - `assettoserver-ops` — operating the server that loads this plugin; the deploy/sync gate that
   consumes `plugin-rite-status.json`.
 - `bug-hunter` — the adversarial rite; `references/track-dotnet-plugin.md` is the generalized


### PR DESCRIPTION
## What

Adds **`assettoserver-csp-lua`** (category `game`, v1.0.0) — the client-side Lua layer served by
AssettoServer, which had zero coverage in the catalog — and documents the C#-side counterparts in
the two sibling skills.

### New skill: `assettoserver-csp-lua` (200 lines + `references/snippets.lua`)

- Render doctrine: **one** `transparentWindow` + draw-list (stacked windows do not stratify — the
  empty-box bug); rounded accent bars via `pushClipRect`, never opposite `CornerFlags`.
- **DirectWrite trap table**: trailing space discarded at measure AND draw; no native tracking
  (char-by-char with measured advance); glyph boxes ≈1.33× font size; `string.upper`/`sub` are
  byte-wise (UTF-8 helpers included); missing glyphs; UTF-8 escapes for accented literals.
- **OnlineEvent packets**: byte-parity with the C# plugin; never name a field `key` (collides with
  `ac.StructItem.key` — packet silently undelivered while every static gate passes);
  same-layout sharing between scripts; `processPostponed`; `target = 255` fail-closed.
- **Remote assets/audio by URL** (zero-install): `AudioEvent.fromFile` accepts URLs (measured in
  production — the docs only promise it for images); the `loop=false` one-shot emitter trap
  (dispose + recreate per play).
- Local telemetry (`focusedCar` is the camera, not the player) and the **mockup-first + probe
  workflow** for a runtime that cannot be rendered outside the game.
- `references/snippets.lua`: paste-ready helpers for every trap (Lua syntax validated).

### Sibling updates

- **assettoserver-plugin 1.1.0 → 1.2.0**: new "Serving CSP Lua scripts" section — configValues
  doubles must be `InvariantCulture`-formatted (the provider serializes with culture-sensitive
  `ToString()`; on a pt-BR host `0.7` becomes `"0,7"` and the script silently falls back to its
  Lua defaults with no symptom); the flat fallback loader needs a `case` per property, enforced by
  a reflection guard test; packet authoring rules (`SendPacket` vs `RegisterOnlineEvent`, no `key`
  field).
- **assettoserver-ops 1.1.0 → 1.2.0**: static `wwwroot/` assets ARE baked into the image (the
  inverse of the runtime binary) — replacing an asset requires compose build + recreate; a plain
  restart serves the stale file. The skill previously stated only the "NOT baked" half.

### Catalog plumbing

- README: new row in the AssettoServer table; skill counts 27 → 28.
- `marketplace.json`: `ai-skills-game` description was already stale ("React Three Fiber skills
  (10 topics)" while the group also ships assettoserver-plugin) — now "React Three Fiber +
  AssettoServer game-dev skills (12 topics)".
- All wrappers regenerated via `./generate.sh` and committed.

## Verification

- CI simulated locally: frontmatter checks pass on all three touched skills; `generate.sh` re-run
  produces zero drift; `VERSION` coherence intact.
- Content self-test: the skill answers, on its own, all 14 traps that were each paid for with an
  in-game iteration on a production server (empty box, glued text, tracking, glyph height, UTF-8,
  `key` field, one-shot audio, URL audio, focusedCar, probes, `processPostponed`, `target=255`,
  same-layout sharing, corner teeth).

## Provenance

Distilled from a production DriveZone deployment (live-run HUD, rank notifications with trophies
and sounds, in-game login) — the same source as the existing assettoserver skills.