### PR TITLE
skill: add backlog — turn ideas into structured GitHub Project items

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ one accept, zero manual steps):
 ```
 
 Pick the groups that match the project (a FiveM repo takes `ai-skills-fivem`, an R3F game takes
-`ai-skills-game`, ...) — dumping all 28 skills into every project is noise, not help.
+`ai-skills-game`, ...) — dumping all 29 skills into every project is noise, not help.
 
 **B3 — user-level (whole machine)** — same snippet in `~/.claude/settings.json` enables the plugin
 for every project on the machine.
@@ -357,6 +357,7 @@ Think of skills as reusable expertise — instead of explaining your documentati
 | **openspec** | OpenSpec, /opsx, proposal, spec delta, change-id | Vanilla OpenSpec spec-driven workflow (explore → propose → validate → apply → archive) |
 | **openspec-drivezone** | the DriveZone "rito", forked schema | DriveZone forked-schema variant — mandatory Fallback / Tests & Bug-Hunter / Validation gates |
 | **conventional-commit** | creating/amending commits, commit messages, /commit, opening/editing PRs | Conventional Commits + gitmoji icon per type; forbids AI attribution in commits & PRs |
+| **backlog** | /backlog <idea>, "create a backlog item", "turn this idea into an issue" | Turns a natural-language idea into a context-rich GitHub issue placed in a Project v2 with fields set — repo & multi-repo workspace modes, first-run config wizard, preview before creation |
 
 ### DevOps & docs
 

--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: backlog
+description: >-
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the current
+  repository (or multi-repo workspace) for real context, draft a rich issue (context, problem,
+  scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create
+  the GitHub issue and add it to the configured GitHub Project v2 with fields set
+  (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
+  "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
+  idea", or wants an idea registered in a GitHub Project. First run per repo/workspace launches a
+  config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
+  use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
+  for non-GitHub trackers (Jira, Linear, Trello).
+metadata:
+  author: solvelab
+  version: 1.0.0
+  category: process
+license: MIT
+compatibility: >-
+  Requires the gh CLI (>= 2.40) authenticated with project,read:project scopes and write access to
+  the target repository. Works in any git repository or multi-repo workspace directory.
+---
+
+Read and follow all instructions in ~/ai-skills/skills/backlog/SKILL.md
+
+Reference files are in ~/ai-skills/skills/backlog/references/ — read them when the skill instructions point to them.

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -13,6 +13,7 @@ Each skill @-includes the canonical skill from `skills/<name>/SKILL.md` — no d
 | `assettoserver-ops` | `codex/skills/assettoserver-ops/AGENTS.md` |
 | `assettoserver-plugin` | `codex/skills/assettoserver-plugin/AGENTS.md` |
 | `backend-resilience` | `codex/skills/backend-resilience/AGENTS.md` |
+| `backlog` | `codex/skills/backlog/AGENTS.md` |
 | `bug-hunter` | `codex/skills/bug-hunter/AGENTS.md` |
 | `claude-statusline` | `codex/skills/claude-statusline/AGENTS.md` |
 | `conventional-commit` | `codex/skills/conventional-commit/AGENTS.md` |

--- a/codex/skills/backlog/AGENTS.md
+++ b/codex/skills/backlog/AGENTS.md
@@ -1,0 +1,3 @@
+# backlog
+
+@../../skills/backlog/SKILL.md

--- a/copilot/instructions/backlog.instructions.md
+++ b/copilot/instructions/backlog.instructions.md
@@ -1,0 +1,5 @@
+# backlog
+
+Follow the instructions in [SKILL.md](../../skills/backlog/SKILL.md)
+
+Reference files: [references/](../../skills/backlog/references/)

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -1,0 +1,98 @@
+---
+description: >-
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the current repository (or multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create the GitHub issue and add it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in a GitHub Project. First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT use for implementing an existing issue (that is execute-backlog), for creating pull requests, or for non-GitHub trackers (Jira, Linear, Trello).
+alwaysApply: false
+---
+
+
+# Backlog — idea → structured GitHub Project item
+
+Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
+configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
+codebase.
+
+- **Issue section template + writing guidance**: `references/issue-template.md`
+- **Config schema (both modes, precedence, wizard)**: `references/backlog-config.md`
+- **gh recipes for Projects v2 (IDs, item-edit, verification, recovery)**: `references/gh-projects.md`
+
+## CRITICAL: Ground rules
+
+1. **Preview gate** — nothing is created on GitHub before the user approves the full preview
+   (issue markdown + target repo + proposed field values). Approve / adjust / cancel; adjusting
+   loops back to a new preview.
+2. **No invention** — never guess org, repo, Project, field names or select options. Everything
+   comes from config, `gh` output, or the user. Select values must be options returned by
+   `gh project field-list`.
+3. **Anti-generic gate** — the draft must cite real files, modules or features found in the
+   repository. If context collection found nothing relevant, say so instead of padding.
+4. **Non-destructive** — never delete/close issues, never edit existing items, never merge. A
+   partially failed run reports the exact recovery command instead of rolling back.
+5. **IDs are runtime-only** — config stores field *names*; resolve project/field/option/item IDs
+   fresh each run (they drift and differ per Project).
+6. Ask questions **only** when essential information is missing or ambiguous (max ~3, objective).
+   Everything derivable from the repo must be derived, not asked.
+
+## Workflow
+
+1. **Parse** — the argument is the idea. Empty → ask for it and stop until answered.
+2. **Preflight** — `gh auth status` must list the `project` scope; missing → print
+   `gh auth refresh -s project,read:project` and stop (zero side effects). Detect mode and load
+   config (see `references/backlog-config.md`):
+   - cwd inside a git repo → **repo mode**, config `.github/backlog.yml` (walk up to repo root;
+     also check for a workspace `backlog.yml` one level above the repo — repo config wins).
+   - cwd not a repo but subdirectories are git repos → **workspace mode**, config `backlog.yml`
+     in cwd.
+   - No config → **setup wizard** (below), then continue.
+3. **Context collection** — spawn Explore subagent(s) (cheap model, low effort) over the target
+   repo(s): related modules/files, existing similar features, naming and test conventions, docs
+   (README/CLAUDE.md). Workspace mode: one subagent per candidate repo in parallel; conclude which
+   repos the idea affects and each repo's role.
+4. **Duplicate check** — `gh issue list -R <repo> --search "<key terms>" --state open`. Strong
+   candidate → show it and ask whether to continue, enrich the existing issue instead, or cancel.
+5. **Gap questions** — only for essentials the repo cannot answer (e.g. which provider, which of
+   two plausible scopes). Batch them in one round.
+6. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
+   apply. Workspace mode adds *Affected repositories* (role per repo) and elects the **primary
+   affected repo** (issue home, unless `issues_repo` is configured). Propose field values
+   (Status default from config; Priority/Size/Estimate heuristics) each with a 1-line rationale.
+7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
+   proposed field values. Only proceed on explicit approval.
+8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
+   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field.
+9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
+   fields, partial failures + recovery commands).
+
+## Setup wizard (first run, per repo/workspace)
+
+1. Discover candidate owner(s) from git remotes (`git remote get-url origin`; workspace mode:
+   remotes of child repos — they normally share one org).
+2. `gh project list --owner <owner>` → user picks the Project (auto-pick if exactly one, confirm).
+3. `gh project field-list <n> --owner <owner> --format json` → map standard fields by name
+   (Status, Priority, Size, Estimate — case-insensitive; report unmapped names).
+4. Pick the default Status for new items (suggest "Backlog" if present).
+5. Write the config file, show it, suggest committing it so the whole team inherits the setup.
+
+## Failure rules
+
+| Failure | Behavior |
+|---|---|
+| Missing `project` scope | Stop before any write; print the exact `gh auth refresh` command. |
+| Config invalid / Project not found | Report the exact `gh` error; create nothing. |
+| Configured field absent in Project | Warn + skip that field; still create the issue. |
+| `item-add`/`item-edit` fails after issue creation | Keep the issue; report it + the exact manual recovery command. |
+| Select option not found for a proposed value | Show available options; ask instead of guessing. |
+| Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
+
+## Trigger Test Cases
+
+Should trigger on:
+- "/backlog add social login authentication"
+- "Create a backlog item for rate limiting"
+- "Turn this idea into an issue on our board"
+- "Add this to the backlog of the project"
+
+Should NOT trigger on:
+- "Implement issue #123" (execute-backlog)
+- "Open a PR for this change"
+- "Create a ticket in Jira"
+- "List my GitHub issues"

--- a/openspec/changes/add-backlog-skill/design.md
+++ b/openspec/changes/add-backlog-skill/design.md
@@ -1,0 +1,43 @@
+# Design: `backlog` skill
+
+## Context
+
+Users work across multiple GitHub orgs and multi-repo workspaces (N repos of one org sharing a
+single Project v2). The catalog is public, so the skill must be 100% generic: all org/project data
+lives in per-target config files, never in the skill.
+
+## Goals / Non-Goals
+
+- **Goals**: generic skill; config-per-target; issue enriched with real repo context; preview gate
+  before any creation; workspace mode with affected-repo analysis; runtime ID resolution.
+- **Non-Goals**: executing backlog items (future `execute-backlog`); GitHub Apps/Actions/MCP
+  servers; draft-only Project items; auto-merge or auto-close of anything.
+
+## Decisions
+
+1. **Skill, not slash-command/agent/workflow** — needs rich instructions + references, user
+   interaction mid-flow (questions, preview approval), and distribution through this catalog's
+   existing pipeline. Subagents (Explore) are used internally for context collection only.
+2. **Issue + project item-add** (not draft items) — issues have numbers/URLs, labels, assignees,
+   and close via PR (`Closes #n`), which the future `execute-backlog` requires. Draft items are
+   GraphQL-node-only and fragile.
+3. **Config stores field *names*, never IDs** — IDs (field/option/item) drift and differ per
+   Project; resolved each run via `gh project field-list --format json`.
+4. **Workspace mode issue home = primary affected repo** (user decision), confirmed in the preview;
+   `issues_repo:` config override supports centralized-planning setups.
+5. **`gh` CLI is the only integration surface** — already authenticated per user, no token handling
+   in the skill, works for every org the user can access. Missing scopes → print
+   `gh auth refresh -s project,read:project` and stop with zero side effects.
+
+## Risks / Trade-offs
+
+- Projects v2 field editing needs option IDs → mitigated by recipes in `references/gh-projects.md`.
+- LLM-proposed priority/size are heuristics → always surfaced in the preview with 1-line rationale;
+  nothing is created without approval.
+- Partial failure (issue created, project add fails) → never delete the issue; report the exact
+  manual recovery command.
+- Config drift (renamed Project fields) → warn + skip missing fields instead of failing the run.
+
+## Migration
+
+None — additive change. Existing skills untouched.

--- a/openspec/changes/add-backlog-skill/proposal.md
+++ b/openspec/changes/add-backlog-skill/proposal.md
@@ -1,0 +1,34 @@
+# Change: Add `backlog` skill (idea → structured GitHub backlog item)
+
+## Why
+
+Turning a raw idea into a well-structured backlog item (issue + GitHub Project v2 placement with
+fields) is a repetitive, error-prone manual flow. A catalog skill can do it with real repository
+context — generic, so any user/org can adopt it without embedding personal project data in this
+public repo.
+
+## What Changes
+
+- **New skill `skills/backlog/`** — invoked as `/backlog <idea>`. Enriches the idea with actual
+  repository context, drafts a structured issue (template sections), previews it for approval, then
+  creates the GitHub issue and inserts it into the configured Project v2 with fields
+  (Status/Priority/Size/Estimate) via `gh` CLI.
+- **Two operation modes** detected from the current directory: *repo mode* (config at
+  `.github/backlog.yml`) and *workspace mode* (directory containing N repos of one org; config at
+  `backlog.yml` in the workspace root; skill analyzes which repos the idea affects and creates the
+  issue in the primary affected repo).
+- **First-run setup wizard** — discovers owner from git remotes, lists Projects, maps fields by
+  name, writes the config file. Field/option/item IDs are resolved at runtime, never persisted.
+- **References**: `references/issue-template.md` (canonical section template),
+  `references/backlog-config.md` (config schema), `references/gh-projects.md` (Projects v2 `gh`
+  recipes, including single-select option-ID resolution).
+- Regenerated wrappers (`generate.sh`) for claude/codex/cursor/copilot/plugins.
+
+Out of scope (separate future change): `execute-backlog` skill that implements an existing item.
+
+## Impact
+
+- Affected specs: `skills-catalog` (new skill added).
+- Affected code: `skills/backlog/**` (new), generated wrapper outputs, README catalog table.
+- No behavior change to existing skills. Requires `gh` CLI with `project,read:project` scopes at
+  usage time; degrades to a clean actionable error without them.

--- a/openspec/changes/add-backlog-skill/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-backlog-skill/specs/skills-catalog/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Backlog item creation skill
+
+The catalog SHALL provide a `backlog` skill that turns a natural-language idea into a structured
+GitHub issue added to a configured GitHub Project v2 with fields filled, using only per-target
+config files (repo `.github/backlog.yml` or workspace-root `backlog.yml`) and the user's own `gh`
+CLI authentication. The skill SHALL contain no user-, org- or project-specific data.
+
+#### Scenario: Repo mode creation
+
+- **WHEN** `/backlog <idea>` runs inside a git repository containing `.github/backlog.yml`
+- **THEN** the skill drafts a structured issue enriched with real repository context, shows a
+  preview, and only after approval creates the issue in that repository and adds it to the
+  configured Project with mapped fields set
+
+#### Scenario: Workspace mode creation
+
+- **WHEN** `/backlog <idea>` runs in a directory that is not a git repository but contains multiple
+  repositories of one org, with `backlog.yml` at its root
+- **THEN** the skill analyzes which repositories the idea affects, includes an Affected
+  repositories section, and creates the issue in the primary affected repository (or the
+  `issues_repo` override), adding it to the org's configured Project
+
+#### Scenario: Missing Project scopes abort cleanly
+
+- **WHEN** the authenticated `gh` token lacks the `project` scope
+- **THEN** the skill stops before any write, printing the exact
+  `gh auth refresh -s project,read:project` remediation
+
+#### Scenario: First run without config launches the wizard
+
+- **WHEN** `/backlog <idea>` runs where no config file exists
+- **THEN** the skill discovers the owner from git remotes, lists that owner's Projects, maps fields
+  by name after the user picks one, and writes the config file before proceeding

--- a/openspec/changes/add-backlog-skill/tasks.md
+++ b/openspec/changes/add-backlog-skill/tasks.md
@@ -1,0 +1,46 @@
+# Tasks: add-backlog-skill
+
+## 1. Skill authoring
+
+- [x] 1.1 `skills/backlog/SKILL.md` — frontmatter per skills-authoring spec (`category: process`,
+      English, `compatibility` requiring `gh` CLI with `project,read:project` scopes); flow: mode
+      detection → preflight (scopes, config/wizard) → context collection (Explore subagents) →
+      duplicate check → essential-gap questions only → structured draft (anti-generic gate: must
+      cite real files/modules) → preview approval → create issue + project item-add + item-edit →
+      report with URLs; partial-failure and error rules.
+- [x] 1.2 `references/issue-template.md` — canonical section template (Title, Context, Problem,
+      Goal, Scope, Out of scope, Functional/Technical requirements, Acceptance criteria,
+      Dependencies, Risks, Test strategy, Affected files/components, Affected repositories
+      [workspace mode]) + writing guidance (omit non-applicable sections).
+- [x] 1.3 `references/backlog-config.md` — schema + commented examples for both modes
+      (`.github/backlog.yml`, workspace `backlog.yml`), precedence rule, `issues_repo` override.
+- [x] 1.4 `references/gh-projects.md` — `gh` recipes: scope check, project list/field-list JSON,
+      option-ID resolution, item-add/item-edit per field type, item-list verification, recovery
+      commands for partial failures.
+
+## 2. Wrappers & catalog integrity
+
+- [x] 2.1 Run `./generate.sh`; confirm wrappers for `backlog` appear in claude/codex/cursor/copilot
+      and `plugins/workflow/` (category process → workflow group).
+- [x] 2.2 Local CI parity: frontmatter check passes (name==dir, semver, controlled category);
+      `git diff` clean after regeneration; README catalog table updated if it enumerates skills.
+
+## 3. Tests & validation (controlled, DriveZoneFivem sandbox)
+
+- [x] 3.1 Negative — missing scopes: simulate token without `project` scope → skill aborts with the
+      exact `gh auth refresh -s project,read:project` instruction, zero side effects.
+- [x] 3.2 Wizard — run in the DriveZoneFivem workspace with no config → generated config points to
+      org project #1 (Assetto-Corsa) with correctly mapped Status/Priority/Size/Estimate fields.
+- [x] 3.3 Controlled creation — sample idea → preview shown and approved → issue created in primary
+      affected repo, item in project #1, fields set; verified via `gh issue view` +
+      `gh project item-list --format json`.
+- [x] 3.4 Duplicate detection — same idea again → warning before creation.
+- [x] 3.5 Invalid config — wrong owner/number → clear error, nothing created.
+- [x] 3.6 Partial failure — field configured but absent in Project → warn + skip, issue still
+      created, recovery command reported.
+
+## 4. Closure
+
+- [x] 4.1 Document usage/maintenance (skill body serves as doc; README entry present).
+- [ ] 4.2 Present validation evidence (URLs, JSON field dump) to the user; await approval before
+      starting the `execute-backlog` change.

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: backlog
+description: >-
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the current
+  repository (or multi-repo workspace) for real context, draft a rich issue (context, problem,
+  scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create
+  the GitHub issue and add it to the configured GitHub Project v2 with fields set
+  (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
+  "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
+  idea", or wants an idea registered in a GitHub Project. First run per repo/workspace launches a
+  config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
+  use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
+  for non-GitHub trackers (Jira, Linear, Trello).
+metadata:
+  author: solvelab
+  version: 1.0.0
+  category: process
+license: MIT
+compatibility: >-
+  Requires the gh CLI (>= 2.40) authenticated with project,read:project scopes and write access to
+  the target repository. Works in any git repository or multi-repo workspace directory.
+---
+
+# Backlog — idea → structured GitHub Project item
+
+Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
+configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
+codebase.
+
+- **Issue section template + writing guidance**: `references/issue-template.md`
+- **Config schema (both modes, precedence, wizard)**: `references/backlog-config.md`
+- **gh recipes for Projects v2 (IDs, item-edit, verification, recovery)**: `references/gh-projects.md`
+
+## CRITICAL: Ground rules
+
+1. **Preview gate** — nothing is created on GitHub before the user approves the full preview
+   (issue markdown + target repo + proposed field values). Approve / adjust / cancel; adjusting
+   loops back to a new preview.
+2. **No invention** — never guess org, repo, Project, field names or select options. Everything
+   comes from config, `gh` output, or the user. Select values must be options returned by
+   `gh project field-list`.
+3. **Anti-generic gate** — the draft must cite real files, modules or features found in the
+   repository. If context collection found nothing relevant, say so instead of padding.
+4. **Non-destructive** — never delete/close issues, never edit existing items, never merge. A
+   partially failed run reports the exact recovery command instead of rolling back.
+5. **IDs are runtime-only** — config stores field *names*; resolve project/field/option/item IDs
+   fresh each run (they drift and differ per Project).
+6. Ask questions **only** when essential information is missing or ambiguous (max ~3, objective).
+   Everything derivable from the repo must be derived, not asked.
+
+## Workflow
+
+1. **Parse** — the argument is the idea. Empty → ask for it and stop until answered.
+2. **Preflight** — `gh auth status` must list the `project` scope; missing → print
+   `gh auth refresh -s project,read:project` and stop (zero side effects). Detect mode and load
+   config (see `references/backlog-config.md`):
+   - cwd inside a git repo → **repo mode**, config `.github/backlog.yml` (walk up to repo root;
+     also check for a workspace `backlog.yml` one level above the repo — repo config wins).
+   - cwd not a repo but subdirectories are git repos → **workspace mode**, config `backlog.yml`
+     in cwd.
+   - No config → **setup wizard** (below), then continue.
+3. **Context collection** — spawn Explore subagent(s) (cheap model, low effort) over the target
+   repo(s): related modules/files, existing similar features, naming and test conventions, docs
+   (README/CLAUDE.md). Workspace mode: one subagent per candidate repo in parallel; conclude which
+   repos the idea affects and each repo's role.
+4. **Duplicate check** — `gh issue list -R <repo> --search "<key terms>" --state open`. Strong
+   candidate → show it and ask whether to continue, enrich the existing issue instead, or cancel.
+5. **Gap questions** — only for essentials the repo cannot answer (e.g. which provider, which of
+   two plausible scopes). Batch them in one round.
+6. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
+   apply. Workspace mode adds *Affected repositories* (role per repo) and elects the **primary
+   affected repo** (issue home, unless `issues_repo` is configured). Propose field values
+   (Status default from config; Priority/Size/Estimate heuristics) each with a 1-line rationale.
+7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
+   proposed field values. Only proceed on explicit approval.
+8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
+   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field.
+9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
+   fields, partial failures + recovery commands).
+
+## Setup wizard (first run, per repo/workspace)
+
+1. Discover candidate owner(s) from git remotes (`git remote get-url origin`; workspace mode:
+   remotes of child repos — they normally share one org).
+2. `gh project list --owner <owner>` → user picks the Project (auto-pick if exactly one, confirm).
+3. `gh project field-list <n> --owner <owner> --format json` → map standard fields by name
+   (Status, Priority, Size, Estimate — case-insensitive; report unmapped names).
+4. Pick the default Status for new items (suggest "Backlog" if present).
+5. Write the config file, show it, suggest committing it so the whole team inherits the setup.
+
+## Failure rules
+
+| Failure | Behavior |
+|---|---|
+| Missing `project` scope | Stop before any write; print the exact `gh auth refresh` command. |
+| Config invalid / Project not found | Report the exact `gh` error; create nothing. |
+| Configured field absent in Project | Warn + skip that field; still create the issue. |
+| `item-add`/`item-edit` fails after issue creation | Keep the issue; report it + the exact manual recovery command. |
+| Select option not found for a proposed value | Show available options; ask instead of guessing. |
+| Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
+
+## Trigger Test Cases
+
+Should trigger on:
+- "/backlog add social login authentication"
+- "Create a backlog item for rate limiting"
+- "Turn this idea into an issue on our board"
+- "Add this to the backlog of the project"
+
+Should NOT trigger on:
+- "Implement issue #123" (execute-backlog)
+- "Open a PR for this change"
+- "Create a ticket in Jira"
+- "List my GitHub issues"

--- a/plugins/workflow/skills/backlog/references/backlog-config.md
+++ b/plugins/workflow/skills/backlog/references/backlog-config.md
@@ -1,0 +1,62 @@
+# Config schema
+
+Two files, same schema. Field *names* only — IDs are resolved at runtime, never persisted.
+
+| Mode | File | When |
+|---|---|---|
+| Repo | `.github/backlog.yml` (repo root) | cwd is inside a git repository |
+| Workspace | `backlog.yml` (workspace root) | cwd is a directory whose subdirectories are git repos of one org |
+
+**Precedence**: inside a repo, the repo's own `.github/backlog.yml` wins; if absent, inherit the
+workspace `backlog.yml` from the parent directory (if any). Commit the file — teammates inherit the
+setup on clone; it contains no secrets (auth is each user's own `gh` login).
+
+## Repo mode example
+
+```yaml
+version: 1
+project:
+  owner: my-org        # org or user that owns the Project v2
+  number: 1            # gh project list --owner my-org
+# repo: my-org/my-repo # optional override; default = origin remote
+fields:                # Project field names as shown by gh project field-list
+  status: Status
+  priority: Priority
+  size: Size
+  estimate: Estimate
+defaults:
+  status: Backlog      # column for newly created items
+labels:                # optional: intent → existing repo label
+  feature: enhancement
+  bug: bug
+assignees: []          # optional default assignees (GitHub logins)
+```
+
+## Workspace mode example
+
+```yaml
+version: 1
+project:
+  owner: my-org
+  number: 1
+workspace:
+  # repos: [api, worker, web]   # optional allowlist; default = every child dir with .git
+  # issues_repo: my-org/planning # optional: force all issues into one repo;
+                                 # default = primary affected repo per item
+fields:
+  status: Status
+  priority: Priority
+  size: Size
+  estimate: Estimate
+defaults:
+  status: Backlog
+```
+
+## Validation rules
+
+- `project.owner` and `project.number` are required; anything else is optional.
+- Unknown keys: warn and ignore (forward compatibility).
+- A `fields:` entry naming a field that does not exist in the Project → warn + skip that field at
+  creation time (do not fail the run).
+- `defaults.status` must be one of the Status options returned by `gh project field-list`;
+  otherwise warn and leave Status unset.

--- a/plugins/workflow/skills/backlog/references/gh-projects.md
+++ b/plugins/workflow/skills/backlog/references/gh-projects.md
@@ -1,0 +1,101 @@
+# gh recipes — GitHub Projects v2
+
+Everything below is plumbing for the workflow in SKILL.md. `OWNER` = `project.owner`, `NUM` =
+`project.number` from config.
+
+## Preflight
+
+```bash
+gh auth status 2>&1 | grep -i 'token scopes'      # must contain 'project'
+# missing → tell the user to run:  gh auth refresh -s project,read:project
+```
+
+## Discovery
+
+```bash
+gh project list --owner OWNER --format json --jq '.projects[] | {number, title}'
+gh project view NUM --owner OWNER --format json --jq '{id, title}'          # .id = PROJECT_ID (PVT_…)
+gh project field-list NUM --owner OWNER --format json                       # fields + select options
+```
+
+Resolve a field and a select option by name (case-insensitive):
+
+```bash
+gh project field-list NUM --owner OWNER --format json --jq '
+  .fields[] | select(.name | ascii_downcase == "status")
+  | {fieldId: .id, options: (.options // [])}'
+# option id: .options[] | select(.name | ascii_downcase == "backlog") | .id
+```
+
+## Create and place the item
+
+```bash
+gh issue create -R OWNER/REPO --title "TITLE" --body-file /tmp/body.md \
+  --label enhancement                        # only labels that exist: gh label list -R OWNER/REPO
+# → prints the issue URL; capture it.
+
+gh project item-add NUM --owner OWNER --url ISSUE_URL --format json --jq .id
+# → ITEM_ID (PVTI_…)
+```
+
+## Set fields (one call per field)
+
+```bash
+# single-select (Status, Priority, Size):
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
+  --field-id FIELD_ID --single-select-option-id OPTION_ID
+
+# number (Estimate):
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID --field-id FIELD_ID --number 5
+
+# text / date:
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID --field-id FIELD_ID --text "…"
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID --field-id FIELD_ID --date 2026-07-18
+```
+
+## Verify (evidence for the report)
+
+```bash
+gh issue view ISSUE_URL --json number,title,labels,url
+gh project item-list NUM --owner OWNER --format json --jq '
+  .items[] | select(.content.url == "ISSUE_URL")
+  | {id, status: .status, fields: .}'
+```
+
+## Org issue fields (Priority/Effort mirrored into the board)
+
+A single-select field that `gh project field-list` returns with an **empty options array** is
+usually not a Project custom field but an **organization issue field** mirrored into the board
+(`updateProjectV2Field` fails with "Only custom fields can be updated"). Handle it at the issue
+level instead:
+
+```bash
+# discover org-level fields + their option names/ids
+gh api /orgs/OWNER/issue-fields
+
+# set a value on the issue (value = option NAME as a string)
+echo '[{"field_id": FIELD_ID, "value": "Medium"}]' | \
+  gh api -X POST /repos/OWNER/REPO/issues/NUM/issue-field-values --input -
+
+# verify
+gh api /repos/OWNER/REPO/issues/NUM/issue-field-values \
+  --jq '.[] | "\(.issue_field_name) = \(.single_select_option.name)"'
+```
+
+Only use option names returned by `/orgs/OWNER/issue-fields`. The board mirror may lag behind
+`gh project item-list`; the issue-field-values endpoint is the source of truth.
+
+## Duplicate check
+
+```bash
+gh issue list -R OWNER/REPO --search "KEY TERMS in:title,body" --state open \
+  --json number,title,url --limit 10
+```
+
+## Recovery (partial failure — never delete the issue)
+
+| Failed step | Recovery command to report |
+|---|---|
+| `item-add` | `gh project item-add NUM --owner OWNER --url ISSUE_URL` |
+| `item-edit` on field X | the exact `gh project item-edit …` line with resolved IDs |
+| label didn't exist | `gh label create NAME -R OWNER/REPO` then `gh issue edit URL --add-label NAME` |

--- a/plugins/workflow/skills/backlog/references/issue-template.md
+++ b/plugins/workflow/skills/backlog/references/issue-template.md
@@ -1,0 +1,75 @@
+# Issue template
+
+Title: short, imperative, outcome-focused (max ~70 chars). Prefix nothing — labels/fields carry
+type and priority.
+
+Omit any section that does not apply — an empty heading is worse than no heading. Every claim about
+the codebase must come from the context-collection step (real paths, real modules). Write the issue
+in the repository's working language (default: the language of its README).
+
+```markdown
+## Context
+
+What exists today, in this repo, that this idea touches. Cite real files/modules
+(`path/to/module.py`) and current behavior.
+
+## Problem
+
+The gap or pain. Why the current state is insufficient.
+
+## Goal
+
+The outcome once done — observable, one paragraph.
+
+## Scope
+
+- Bullet list of what IS included.
+
+## Out of scope
+
+- Explicitly excluded work (prevents scope creep in execution).
+
+## Functional requirements
+
+- FR1 …
+- FR2 …
+
+## Technical requirements
+
+- TR1 … (constraints: stack, patterns to follow — cite existing conventions/files)
+
+## Acceptance criteria
+
+- [ ] Verifiable statements, testable one by one.
+
+## Dependencies
+
+- Other issues, services, credentials, decisions this blocks on.
+
+## Risks
+
+- Risk → mitigation, one line each.
+
+## Test strategy
+
+How this will be validated (unit/integration/manual), following the repo's existing test
+conventions (cite the test dir/framework found).
+
+## Affected files/components
+
+- `path/…` — why it changes.
+
+## Affected repositories   <!-- workspace mode only -->
+
+- `org/repo-a` — role in the implementation (primary).
+- `org/repo-b` — role.
+```
+
+Field proposal guidance (shown in the preview with a 1-line rationale each):
+
+- **Status**: config default (usually Backlog).
+- **Priority**: infer from user wording and blast radius; when in doubt propose the middle option.
+- **Size/Estimate**: from the number of affected files/repos and requirement count; never present
+  as certainty — it is a triage hint, not a commitment.
+- **Labels**: only labels that already exist in the repo (`gh label list`); map via config
+  `labels:` when present.

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: backlog
+description: >-
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the current
+  repository (or multi-repo workspace) for real context, draft a rich issue (context, problem,
+  scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create
+  the GitHub issue and add it to the configured GitHub Project v2 with fields set
+  (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
+  "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
+  idea", or wants an idea registered in a GitHub Project. First run per repo/workspace launches a
+  config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
+  use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
+  for non-GitHub trackers (Jira, Linear, Trello).
+metadata:
+  author: solvelab
+  version: 1.0.0
+  category: process
+license: MIT
+compatibility: >-
+  Requires the gh CLI (>= 2.40) authenticated with project,read:project scopes and write access to
+  the target repository. Works in any git repository or multi-repo workspace directory.
+---
+
+# Backlog — idea → structured GitHub Project item
+
+Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
+configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
+codebase.
+
+- **Issue section template + writing guidance**: `references/issue-template.md`
+- **Config schema (both modes, precedence, wizard)**: `references/backlog-config.md`
+- **gh recipes for Projects v2 (IDs, item-edit, verification, recovery)**: `references/gh-projects.md`
+
+## CRITICAL: Ground rules
+
+1. **Preview gate** — nothing is created on GitHub before the user approves the full preview
+   (issue markdown + target repo + proposed field values). Approve / adjust / cancel; adjusting
+   loops back to a new preview.
+2. **No invention** — never guess org, repo, Project, field names or select options. Everything
+   comes from config, `gh` output, or the user. Select values must be options returned by
+   `gh project field-list`.
+3. **Anti-generic gate** — the draft must cite real files, modules or features found in the
+   repository. If context collection found nothing relevant, say so instead of padding.
+4. **Non-destructive** — never delete/close issues, never edit existing items, never merge. A
+   partially failed run reports the exact recovery command instead of rolling back.
+5. **IDs are runtime-only** — config stores field *names*; resolve project/field/option/item IDs
+   fresh each run (they drift and differ per Project).
+6. Ask questions **only** when essential information is missing or ambiguous (max ~3, objective).
+   Everything derivable from the repo must be derived, not asked.
+
+## Workflow
+
+1. **Parse** — the argument is the idea. Empty → ask for it and stop until answered.
+2. **Preflight** — `gh auth status` must list the `project` scope; missing → print
+   `gh auth refresh -s project,read:project` and stop (zero side effects). Detect mode and load
+   config (see `references/backlog-config.md`):
+   - cwd inside a git repo → **repo mode**, config `.github/backlog.yml` (walk up to repo root;
+     also check for a workspace `backlog.yml` one level above the repo — repo config wins).
+   - cwd not a repo but subdirectories are git repos → **workspace mode**, config `backlog.yml`
+     in cwd.
+   - No config → **setup wizard** (below), then continue.
+3. **Context collection** — spawn Explore subagent(s) (cheap model, low effort) over the target
+   repo(s): related modules/files, existing similar features, naming and test conventions, docs
+   (README/CLAUDE.md). Workspace mode: one subagent per candidate repo in parallel; conclude which
+   repos the idea affects and each repo's role.
+4. **Duplicate check** — `gh issue list -R <repo> --search "<key terms>" --state open`. Strong
+   candidate → show it and ask whether to continue, enrich the existing issue instead, or cancel.
+5. **Gap questions** — only for essentials the repo cannot answer (e.g. which provider, which of
+   two plausible scopes). Batch them in one round.
+6. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
+   apply. Workspace mode adds *Affected repositories* (role per repo) and elects the **primary
+   affected repo** (issue home, unless `issues_repo` is configured). Propose field values
+   (Status default from config; Priority/Size/Estimate heuristics) each with a 1-line rationale.
+7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
+   proposed field values. Only proceed on explicit approval.
+8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
+   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field.
+9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
+   fields, partial failures + recovery commands).
+
+## Setup wizard (first run, per repo/workspace)
+
+1. Discover candidate owner(s) from git remotes (`git remote get-url origin`; workspace mode:
+   remotes of child repos — they normally share one org).
+2. `gh project list --owner <owner>` → user picks the Project (auto-pick if exactly one, confirm).
+3. `gh project field-list <n> --owner <owner> --format json` → map standard fields by name
+   (Status, Priority, Size, Estimate — case-insensitive; report unmapped names).
+4. Pick the default Status for new items (suggest "Backlog" if present).
+5. Write the config file, show it, suggest committing it so the whole team inherits the setup.
+
+## Failure rules
+
+| Failure | Behavior |
+|---|---|
+| Missing `project` scope | Stop before any write; print the exact `gh auth refresh` command. |
+| Config invalid / Project not found | Report the exact `gh` error; create nothing. |
+| Configured field absent in Project | Warn + skip that field; still create the issue. |
+| `item-add`/`item-edit` fails after issue creation | Keep the issue; report it + the exact manual recovery command. |
+| Select option not found for a proposed value | Show available options; ask instead of guessing. |
+| Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
+
+## Trigger Test Cases
+
+Should trigger on:
+- "/backlog add social login authentication"
+- "Create a backlog item for rate limiting"
+- "Turn this idea into an issue on our board"
+- "Add this to the backlog of the project"
+
+Should NOT trigger on:
+- "Implement issue #123" (execute-backlog)
+- "Open a PR for this change"
+- "Create a ticket in Jira"
+- "List my GitHub issues"

--- a/skills/backlog/references/backlog-config.md
+++ b/skills/backlog/references/backlog-config.md
@@ -1,0 +1,62 @@
+# Config schema
+
+Two files, same schema. Field *names* only — IDs are resolved at runtime, never persisted.
+
+| Mode | File | When |
+|---|---|---|
+| Repo | `.github/backlog.yml` (repo root) | cwd is inside a git repository |
+| Workspace | `backlog.yml` (workspace root) | cwd is a directory whose subdirectories are git repos of one org |
+
+**Precedence**: inside a repo, the repo's own `.github/backlog.yml` wins; if absent, inherit the
+workspace `backlog.yml` from the parent directory (if any). Commit the file — teammates inherit the
+setup on clone; it contains no secrets (auth is each user's own `gh` login).
+
+## Repo mode example
+
+```yaml
+version: 1
+project:
+  owner: my-org        # org or user that owns the Project v2
+  number: 1            # gh project list --owner my-org
+# repo: my-org/my-repo # optional override; default = origin remote
+fields:                # Project field names as shown by gh project field-list
+  status: Status
+  priority: Priority
+  size: Size
+  estimate: Estimate
+defaults:
+  status: Backlog      # column for newly created items
+labels:                # optional: intent → existing repo label
+  feature: enhancement
+  bug: bug
+assignees: []          # optional default assignees (GitHub logins)
+```
+
+## Workspace mode example
+
+```yaml
+version: 1
+project:
+  owner: my-org
+  number: 1
+workspace:
+  # repos: [api, worker, web]   # optional allowlist; default = every child dir with .git
+  # issues_repo: my-org/planning # optional: force all issues into one repo;
+                                 # default = primary affected repo per item
+fields:
+  status: Status
+  priority: Priority
+  size: Size
+  estimate: Estimate
+defaults:
+  status: Backlog
+```
+
+## Validation rules
+
+- `project.owner` and `project.number` are required; anything else is optional.
+- Unknown keys: warn and ignore (forward compatibility).
+- A `fields:` entry naming a field that does not exist in the Project → warn + skip that field at
+  creation time (do not fail the run).
+- `defaults.status` must be one of the Status options returned by `gh project field-list`;
+  otherwise warn and leave Status unset.

--- a/skills/backlog/references/gh-projects.md
+++ b/skills/backlog/references/gh-projects.md
@@ -1,0 +1,101 @@
+# gh recipes — GitHub Projects v2
+
+Everything below is plumbing for the workflow in SKILL.md. `OWNER` = `project.owner`, `NUM` =
+`project.number` from config.
+
+## Preflight
+
+```bash
+gh auth status 2>&1 | grep -i 'token scopes'      # must contain 'project'
+# missing → tell the user to run:  gh auth refresh -s project,read:project
+```
+
+## Discovery
+
+```bash
+gh project list --owner OWNER --format json --jq '.projects[] | {number, title}'
+gh project view NUM --owner OWNER --format json --jq '{id, title}'          # .id = PROJECT_ID (PVT_…)
+gh project field-list NUM --owner OWNER --format json                       # fields + select options
+```
+
+Resolve a field and a select option by name (case-insensitive):
+
+```bash
+gh project field-list NUM --owner OWNER --format json --jq '
+  .fields[] | select(.name | ascii_downcase == "status")
+  | {fieldId: .id, options: (.options // [])}'
+# option id: .options[] | select(.name | ascii_downcase == "backlog") | .id
+```
+
+## Create and place the item
+
+```bash
+gh issue create -R OWNER/REPO --title "TITLE" --body-file /tmp/body.md \
+  --label enhancement                        # only labels that exist: gh label list -R OWNER/REPO
+# → prints the issue URL; capture it.
+
+gh project item-add NUM --owner OWNER --url ISSUE_URL --format json --jq .id
+# → ITEM_ID (PVTI_…)
+```
+
+## Set fields (one call per field)
+
+```bash
+# single-select (Status, Priority, Size):
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
+  --field-id FIELD_ID --single-select-option-id OPTION_ID
+
+# number (Estimate):
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID --field-id FIELD_ID --number 5
+
+# text / date:
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID --field-id FIELD_ID --text "…"
+gh project item-edit --project-id PROJECT_ID --id ITEM_ID --field-id FIELD_ID --date 2026-07-18
+```
+
+## Verify (evidence for the report)
+
+```bash
+gh issue view ISSUE_URL --json number,title,labels,url
+gh project item-list NUM --owner OWNER --format json --jq '
+  .items[] | select(.content.url == "ISSUE_URL")
+  | {id, status: .status, fields: .}'
+```
+
+## Org issue fields (Priority/Effort mirrored into the board)
+
+A single-select field that `gh project field-list` returns with an **empty options array** is
+usually not a Project custom field but an **organization issue field** mirrored into the board
+(`updateProjectV2Field` fails with "Only custom fields can be updated"). Handle it at the issue
+level instead:
+
+```bash
+# discover org-level fields + their option names/ids
+gh api /orgs/OWNER/issue-fields
+
+# set a value on the issue (value = option NAME as a string)
+echo '[{"field_id": FIELD_ID, "value": "Medium"}]' | \
+  gh api -X POST /repos/OWNER/REPO/issues/NUM/issue-field-values --input -
+
+# verify
+gh api /repos/OWNER/REPO/issues/NUM/issue-field-values \
+  --jq '.[] | "\(.issue_field_name) = \(.single_select_option.name)"'
+```
+
+Only use option names returned by `/orgs/OWNER/issue-fields`. The board mirror may lag behind
+`gh project item-list`; the issue-field-values endpoint is the source of truth.
+
+## Duplicate check
+
+```bash
+gh issue list -R OWNER/REPO --search "KEY TERMS in:title,body" --state open \
+  --json number,title,url --limit 10
+```
+
+## Recovery (partial failure — never delete the issue)
+
+| Failed step | Recovery command to report |
+|---|---|
+| `item-add` | `gh project item-add NUM --owner OWNER --url ISSUE_URL` |
+| `item-edit` on field X | the exact `gh project item-edit …` line with resolved IDs |
+| label didn't exist | `gh label create NAME -R OWNER/REPO` then `gh issue edit URL --add-label NAME` |

--- a/skills/backlog/references/issue-template.md
+++ b/skills/backlog/references/issue-template.md
@@ -1,0 +1,75 @@
+# Issue template
+
+Title: short, imperative, outcome-focused (max ~70 chars). Prefix nothing — labels/fields carry
+type and priority.
+
+Omit any section that does not apply — an empty heading is worse than no heading. Every claim about
+the codebase must come from the context-collection step (real paths, real modules). Write the issue
+in the repository's working language (default: the language of its README).
+
+```markdown
+## Context
+
+What exists today, in this repo, that this idea touches. Cite real files/modules
+(`path/to/module.py`) and current behavior.
+
+## Problem
+
+The gap or pain. Why the current state is insufficient.
+
+## Goal
+
+The outcome once done — observable, one paragraph.
+
+## Scope
+
+- Bullet list of what IS included.
+
+## Out of scope
+
+- Explicitly excluded work (prevents scope creep in execution).
+
+## Functional requirements
+
+- FR1 …
+- FR2 …
+
+## Technical requirements
+
+- TR1 … (constraints: stack, patterns to follow — cite existing conventions/files)
+
+## Acceptance criteria
+
+- [ ] Verifiable statements, testable one by one.
+
+## Dependencies
+
+- Other issues, services, credentials, decisions this blocks on.
+
+## Risks
+
+- Risk → mitigation, one line each.
+
+## Test strategy
+
+How this will be validated (unit/integration/manual), following the repo's existing test
+conventions (cite the test dir/framework found).
+
+## Affected files/components
+
+- `path/…` — why it changes.
+
+## Affected repositories   <!-- workspace mode only -->
+
+- `org/repo-a` — role in the implementation (primary).
+- `org/repo-b` — role.
+```
+
+Field proposal guidance (shown in the preview with a 1-line rationale each):
+
+- **Status**: config default (usually Backlog).
+- **Priority**: infer from user wording and blast radius; when in doubt propose the middle option.
+- **Size/Estimate**: from the number of affected files/repos and requirement count; never present
+  as certainty — it is a triage hint, not a commitment.
+- **Labels**: only labels that already exist in the repo (`gh label list`); map via config
+  `labels:` when present.


### PR DESCRIPTION
## What

New generic skill `backlog` (`/backlog <idea>`): turns a natural-language idea into a context-rich GitHub issue placed in a Project v2 with fields set, via the gh CLI.

- **Two modes**: repo (`.github/backlog.yml`) and multi-repo workspace (`backlog.yml` at workspace root — analyzes which repos the idea affects, issue lands in the primary one)
- **First-run wizard**: discovers owner from remotes, lists Projects, maps fields by name, writes the config; IDs always resolved at runtime
- **Preview gate**: nothing is created before user approval; anti-generic gate requires citing real files/modules
- **references/**: issue section template, config schema, gh Projects v2 recipes — including org-level issue fields (Priority/Effort) set via the `issue-field-values` endpoint
- OpenSpec change `add-backlog-skill` (proposal/design/tasks/spec delta, `validate --strict` green)
- Wrappers regenerated (claude/codex/cursor/copilot/plugins-workflow), README table + count updated

## Validation (real org project)

- Issue created from a sample idea with real codebase context, added to the org Project, Status/Size set via item-edit, Priority set via org issue field
- Negative paths exercised: missing `project` scope (clean abort + remediation), invalid project number, select field without options (warn + skip), duplicate detection
- CI parity checked locally: frontmatter rules + `generate.sh` diff clean