### PR TITLE
fix(execute-backlog): step-by-step Kanban transitions, no column skipping

### DIFF
--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -27,6 +27,10 @@ to the `backlog` skill; consumes the same config.
    invent commands, never run migrations/deploys/destructive steps without an explicit ask.
 6. **Faithful reporting** — failing checks are reported with their output; skipped validations are
    listed as skipped, never implied as passed.
+7. **The project's rite wins** — at every stage the card advances, discover and follow the target
+   repo's own established process for that stage (spec/proposal rites, implementation and test
+   rites, review templates). The generic workflow here is the fallback, never an override
+   (`references/execution-flow.md`, *Per-stage rite discovery*).
 
 ## Workflow
 

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -38,7 +38,8 @@ to the `backlog` skill; consumes the same config.
 3. **Completeness gate** — the item must have enough to execute: goal, scope, acceptance
    criteria. Also re-check against the *current* codebase (drift since grooming: files renamed,
    feature landed meanwhile). Gaps/contradictions → report and ask: proceed as-is (user accepts
-   risk), refine first (point to `/backlog`), or abort. Never guess missing scope.
+   risk), refine first (point to `/backlog`), or abort. Never guess missing scope. Gate passed →
+   move the board item to the ready column (step-by-step Kanban flow, `references/board-sync.md`).
 4. **Context re-analysis** — Explore subagent(s) over the affected repo(s) (issue's Affected
    repositories section in workspace mode; verify local clones, offer `gh repo clone` for missing
    ones). Collect: current state of cited files, conventions, test setup, related recent changes.

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
@@ -55,7 +55,8 @@ to the `backlog` skill; consumes the same config.
 3. **Completeness gate** — the item must have enough to execute: goal, scope, acceptance
    criteria. Also re-check against the *current* codebase (drift since grooming: files renamed,
    feature landed meanwhile). Gaps/contradictions → report and ask: proceed as-is (user accepts
-   risk), refine first (point to `/backlog`), or abort. Never guess missing scope.
+   risk), refine first (point to `/backlog`), or abort. Never guess missing scope. Gate passed →
+   move the board item to the ready column (step-by-step Kanban flow, `references/board-sync.md`).
 4. **Context re-analysis** — Explore subagent(s) over the affected repo(s) (issue's Affected
    repositories section in workspace mode; verify local clones, offer `gh repo clone` for missing
    ones). Collect: current state of cited files, conventions, test setup, related recent changes.

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -44,6 +44,10 @@ to the `backlog` skill; consumes the same config.
    invent commands, never run migrations/deploys/destructive steps without an explicit ask.
 6. **Faithful reporting** — failing checks are reported with their output; skipped validations are
    listed as skipped, never implied as passed.
+7. **The project's rite wins** — at every stage the card advances, discover and follow the target
+   repo's own established process for that stage (spec/proposal rites, implementation and test
+   rites, review templates). The generic workflow here is the fallback, never an override
+   (`references/execution-flow.md`, *Per-stage rite discovery*).
 
 ## Workflow
 

--- a/plugins/workflow/skills/execute-backlog/references/board-sync.md
+++ b/plugins/workflow/skills/execute-backlog/references/board-sync.md
@@ -12,17 +12,28 @@ gh project item-list NUM --owner OWNER --format json --jq '
 # not on the board → add it: gh project item-add NUM --owner OWNER --url ISSUE_URL
 ```
 
-## Transitions
+## Transitions — step by step, never skipping
+
+The card advances one column per lifecycle event; it must never jump straight from Backlog to a
+late column:
 
 | Moment | Target column |
 |---|---|
-| Plan approved, work starting | config `columns.in_progress` (default: option named like "In progress") |
-| PR(s) opened | config `columns.review` (default: option named like "In review") |
+| Item created by the `backlog` skill | config `defaults.status` (usually "Backlog") |
+| Completeness gate passed (item is executable) | config `columns.ready` (default: option named like "Ready") |
+| Plan approved, implementation starting | config `columns.in_progress` (default: "In progress") |
+| PR(s) opened | config `columns.review` (default: "In review") |
+| PR merged by a human (issue auto-closed via `Closes #n`) | "Done" — **never set by the skill**; enable the board's built-in workflow *Item closed → Done* |
+
+If a run starts with the card already past a column (e.g. resumed work, card manually moved),
+apply only the transitions that are still ahead of its current position — never move a card
+backwards without asking.
 
 Optional config extension (backwards-compatible — absent keys fall back to name heuristics):
 
 ```yaml
 columns:
+  ready: Ready
   in_progress: In progress
   review: In review
 ```

--- a/plugins/workflow/skills/execute-backlog/references/execution-flow.md
+++ b/plugins/workflow/skills/execute-backlog/references/execution-flow.md
@@ -40,6 +40,28 @@ Deviation discovered mid-implementation (hidden dependency, wrong assumption in 
 3. On approval: comment on the issue documenting the approved change, then continue.
 4. On rejection: revert uncommitted deviation work, continue inside original scope or abort.
 
+## Per-stage rite discovery (respect the project's own process)
+
+Each project may have its own rite for each Kanban stage. Before acting in a stage, discover how
+the target repo runs that stage and follow it — the generic flow in SKILL.md is the fallback,
+never an override. When a rite exists, its artifacts (proposal, tasks file, checklists) become
+part of the deliverable and must appear in the plan.
+
+| Stage | What to look for | Examples |
+|---|---|---|
+| Ready (grooming gate) | Does the project require a formal proposal/spec before code? | `openspec/` directory → run its propose → `validate --strict` flow before planning; RFC/ADR templates in `docs/` |
+| In progress (implementation) | Implementation and test rites, commit conventions | OpenSpec `apply` with tasks checked one by one; adversarial-test rites (e.g. bug-hunter); `conventional-commit` |
+| In review (PR) | Review rites: PR templates, required checklists, CI gates | `.github/PULL_REQUEST_TEMPLATE*`, CONTRIBUTING review rules, project code-review skills |
+
+Discovery sources, in order:
+
+1. Project skills active in the session (they encode the rite explicitly).
+2. Repo docs: `CLAUDE.md`, `CONTRIBUTING.md`, `README`, `docs/`.
+3. Structural markers: `openspec/` dir, PR/issue templates, CI required checks.
+
+Conflict between the generic flow and a project rite → the project rite wins; state in the plan
+which rite is being followed per stage so the user sees it before approving.
+
 ## Multi-repo orchestration (workspace mode)
 
 - Source of truth for targets: the issue's *Affected repositories* section; re-validate it against

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
@@ -55,7 +55,8 @@ to the `backlog` skill; consumes the same config.
 3. **Completeness gate** — the item must have enough to execute: goal, scope, acceptance
    criteria. Also re-check against the *current* codebase (drift since grooming: files renamed,
    feature landed meanwhile). Gaps/contradictions → report and ask: proceed as-is (user accepts
-   risk), refine first (point to `/backlog`), or abort. Never guess missing scope.
+   risk), refine first (point to `/backlog`), or abort. Never guess missing scope. Gate passed →
+   move the board item to the ready column (step-by-step Kanban flow, `references/board-sync.md`).
 4. **Context re-analysis** — Explore subagent(s) over the affected repo(s) (issue's Affected
    repositories section in workspace mode; verify local clones, offer `gh repo clone` for missing
    ones). Collect: current state of cited files, conventions, test setup, related recent changes.

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -44,6 +44,10 @@ to the `backlog` skill; consumes the same config.
    invent commands, never run migrations/deploys/destructive steps without an explicit ask.
 6. **Faithful reporting** — failing checks are reported with their output; skipped validations are
    listed as skipped, never implied as passed.
+7. **The project's rite wins** — at every stage the card advances, discover and follow the target
+   repo's own established process for that stage (spec/proposal rites, implementation and test
+   rites, review templates). The generic workflow here is the fallback, never an override
+   (`references/execution-flow.md`, *Per-stage rite discovery*).
 
 ## Workflow
 

--- a/skills/execute-backlog/references/board-sync.md
+++ b/skills/execute-backlog/references/board-sync.md
@@ -12,17 +12,28 @@ gh project item-list NUM --owner OWNER --format json --jq '
 # not on the board → add it: gh project item-add NUM --owner OWNER --url ISSUE_URL
 ```
 
-## Transitions
+## Transitions — step by step, never skipping
+
+The card advances one column per lifecycle event; it must never jump straight from Backlog to a
+late column:
 
 | Moment | Target column |
 |---|---|
-| Plan approved, work starting | config `columns.in_progress` (default: option named like "In progress") |
-| PR(s) opened | config `columns.review` (default: option named like "In review") |
+| Item created by the `backlog` skill | config `defaults.status` (usually "Backlog") |
+| Completeness gate passed (item is executable) | config `columns.ready` (default: option named like "Ready") |
+| Plan approved, implementation starting | config `columns.in_progress` (default: "In progress") |
+| PR(s) opened | config `columns.review` (default: "In review") |
+| PR merged by a human (issue auto-closed via `Closes #n`) | "Done" — **never set by the skill**; enable the board's built-in workflow *Item closed → Done* |
+
+If a run starts with the card already past a column (e.g. resumed work, card manually moved),
+apply only the transitions that are still ahead of its current position — never move a card
+backwards without asking.
 
 Optional config extension (backwards-compatible — absent keys fall back to name heuristics):
 
 ```yaml
 columns:
+  ready: Ready
   in_progress: In progress
   review: In review
 ```

--- a/skills/execute-backlog/references/execution-flow.md
+++ b/skills/execute-backlog/references/execution-flow.md
@@ -40,6 +40,28 @@ Deviation discovered mid-implementation (hidden dependency, wrong assumption in 
 3. On approval: comment on the issue documenting the approved change, then continue.
 4. On rejection: revert uncommitted deviation work, continue inside original scope or abort.
 
+## Per-stage rite discovery (respect the project's own process)
+
+Each project may have its own rite for each Kanban stage. Before acting in a stage, discover how
+the target repo runs that stage and follow it — the generic flow in SKILL.md is the fallback,
+never an override. When a rite exists, its artifacts (proposal, tasks file, checklists) become
+part of the deliverable and must appear in the plan.
+
+| Stage | What to look for | Examples |
+|---|---|---|
+| Ready (grooming gate) | Does the project require a formal proposal/spec before code? | `openspec/` directory → run its propose → `validate --strict` flow before planning; RFC/ADR templates in `docs/` |
+| In progress (implementation) | Implementation and test rites, commit conventions | OpenSpec `apply` with tasks checked one by one; adversarial-test rites (e.g. bug-hunter); `conventional-commit` |
+| In review (PR) | Review rites: PR templates, required checklists, CI gates | `.github/PULL_REQUEST_TEMPLATE*`, CONTRIBUTING review rules, project code-review skills |
+
+Discovery sources, in order:
+
+1. Project skills active in the session (they encode the rite explicitly).
+2. Repo docs: `CLAUDE.md`, `CONTRIBUTING.md`, `README`, `docs/`.
+3. Structural markers: `openspec/` dir, PR/issue templates, CI required checks.
+
+Conflict between the generic flow and a project rite → the project rite wins; state in the plan
+which rite is being followed per stage so the user sees it before approving.
+
 ## Multi-repo orchestration (workspace mode)
 
 - Source of truth for targets: the issue's *Affected repositories* section; re-validate it against


### PR DESCRIPTION
Card advances one column per lifecycle event instead of jumping from Backlog to a late column:

| Event | Column |
|---|---|
| Item created (`backlog`) | Backlog (`defaults.status`) |
| Completeness gate passed | Ready (`columns.ready`, name-heuristic fallback) |
| Plan approved, work starting | In progress |
| PR opened | In review |
| Human merges (`Closes #n`) | Done — via the board's built-in *Item closed → Done* workflow; the skill never sets it |

Resumed runs only apply transitions still ahead of the card's position, and never move a card backwards without asking.

**Also: per-stage rite discovery.** At every stage the skill discovers and follows the target project's own rite instead of the generic flow — Ready → proposal/spec rites (e.g. OpenSpec `propose` + `validate --strict`), In progress → implementation/test rites (spec apply, adversarial-test gates, commit conventions), In review → PR templates and review rules. Discovery: active project skills → repo docs (CLAUDE.md/CONTRIBUTING) → structural markers (`openspec/`, PR templates). Rite artifacts appear in the plan before approval; on conflict the project rite wins. Version 1.1.0.