### PR TITLE
✨ feat(execute-backlog): tick acceptance criteria with evidence

### DIFF
--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -5,15 +5,16 @@ description: >-
   validate it is complete enough to execute, re-analyze the current repo/workspace state, present
   an implementation plan for approval BEFORE touching code, implement on a dedicated branch
   following the repo's conventions, add/update tests, run the repo's discoverable validations
-  (tests/lint/build/typecheck), open pull request(s) linking the issue (Closes #n), and move the
-  GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says
+  (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by
+  evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to
+  the review column. Use when the user invokes /execute-backlog <n>, says
   "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
   issue turned into a PR. Uses the backlog skill's config (.github/backlog.yml or workspace
   backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search), validate it is complete enough to execute, re-analyze the current repo/workspace state, present an implementation plan for approval BEFORE touching code, implement on a dedicated branch following the repo's conventions, add/update tests, run the repo's discoverable validations (tests/lint/build/typecheck), open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing issue turned into a PR. Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+  Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search), validate it is complete enough to execute, re-analyze the current repo/workspace state, present an implementation plan for approval BEFORE touching code, implement on a dedicated branch following the repo's conventions, add/update tests, run the repo's discoverable validations (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing issue turned into a PR. Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 alwaysApply: false
 ---
 
@@ -12,6 +12,7 @@ to the `backlog` skill; consumes the same config.
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
 - **Discovering and running each repo's validations**: `references/validation-matrix.md`
+- **Ticking the item's checkboxes + evidence table + completeness gate**: `references/acceptance-tracking.md`
 - **Board transitions + PR↔issue linking + recovery**: `references/board-sync.md`
 
 ## CRITICAL: Safety rails
@@ -27,7 +28,11 @@ to the `backlog` skill; consumes the same config.
    invent commands, never run migrations/deploys/destructive steps without an explicit ask.
 6. **Faithful reporting** — failing checks are reported with their output; skipped validations are
    listed as skipped, never implied as passed.
-7. **The project's rite wins** — at every stage the card advances, discover and follow the target
+7. **Every checkbox gets a verdict** — before the PR, each acceptance criterion (and each rite
+   checklist item in the body) is either ticked because evidence proves it, or left unticked and
+   reported as a gap. Never bulk-tick, never tick from intent instead of proof, never leave a box
+   silently empty (`references/acceptance-tracking.md`).
+8. **The project's rite wins** — at every stage the card advances, discover and follow the target
    repo's own established process for that stage (spec/proposal rites, implementation and test
    rites, review templates). The generic workflow here is the fallback, never an override
    (`references/execution-flow.md`, *Per-stage rite discovery*).
@@ -55,11 +60,16 @@ to the `backlog` skill; consumes the same config.
 7. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
 8. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers.
-9. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
-   `Relates to <issue-url>`. No auto-merge. Follow `conventional-commit` PR rules when present.
-10. **Sync & report** — move the board item to the review column; comment on the issue with links
-    to the PR(s); present summary: what changed, validation evidence, deviations (if any,
-    pre-approved), next human step (review/merge).
+9. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
+    the validation evidence, tick the proven ones in the issue body (surgical read-modify-write),
+    and gate on the rest: unmet or manual-only criteria stop the run for a decision before any PR
+    is opened (`references/acceptance-tracking.md`).
+10. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
+    `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
+    left anything unticked. No auto-merge. Follow `conventional-commit` PR rules when present.
+11. **Sync & report** — move the board item to the review column; comment on the issue with links
+    to the PR(s); present summary: what changed, validation evidence, the criteria table with
+    every verdict, deviations (if any, pre-approved), next human step (review/merge).
 
 ## Trigger Test Cases
 

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -5,15 +5,16 @@ description: >-
   validate it is complete enough to execute, re-analyze the current repo/workspace state, present
   an implementation plan for approval BEFORE touching code, implement on a dedicated branch
   following the repo's conventions, add/update tests, run the repo's discoverable validations
-  (tests/lint/build/typecheck), open pull request(s) linking the issue (Closes #n), and move the
-  GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says
+  (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by
+  evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to
+  the review column. Use when the user invokes /execute-backlog <n>, says
   "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
   issue turned into a PR. Uses the backlog skill's config (.github/backlog.yml or workspace
   backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: process
 license: MIT
 compatibility: >-
@@ -29,6 +30,7 @@ to the `backlog` skill; consumes the same config.
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
 - **Discovering and running each repo's validations**: `references/validation-matrix.md`
+- **Ticking the item's checkboxes + evidence table + completeness gate**: `references/acceptance-tracking.md`
 - **Board transitions + PR↔issue linking + recovery**: `references/board-sync.md`
 
 ## CRITICAL: Safety rails
@@ -44,7 +46,11 @@ to the `backlog` skill; consumes the same config.
    invent commands, never run migrations/deploys/destructive steps without an explicit ask.
 6. **Faithful reporting** — failing checks are reported with their output; skipped validations are
    listed as skipped, never implied as passed.
-7. **The project's rite wins** — at every stage the card advances, discover and follow the target
+7. **Every checkbox gets a verdict** — before the PR, each acceptance criterion (and each rite
+   checklist item in the body) is either ticked because evidence proves it, or left unticked and
+   reported as a gap. Never bulk-tick, never tick from intent instead of proof, never leave a box
+   silently empty (`references/acceptance-tracking.md`).
+8. **The project's rite wins** — at every stage the card advances, discover and follow the target
    repo's own established process for that stage (spec/proposal rites, implementation and test
    rites, review templates). The generic workflow here is the fallback, never an override
    (`references/execution-flow.md`, *Per-stage rite discovery*).
@@ -72,11 +78,16 @@ to the `backlog` skill; consumes the same config.
 7. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
 8. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers.
-9. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
-   `Relates to <issue-url>`. No auto-merge. Follow `conventional-commit` PR rules when present.
-10. **Sync & report** — move the board item to the review column; comment on the issue with links
-    to the PR(s); present summary: what changed, validation evidence, deviations (if any,
-    pre-approved), next human step (review/merge).
+9. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
+    the validation evidence, tick the proven ones in the issue body (surgical read-modify-write),
+    and gate on the rest: unmet or manual-only criteria stop the run for a decision before any PR
+    is opened (`references/acceptance-tracking.md`).
+10. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
+    `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
+    left anything unticked. No auto-merge. Follow `conventional-commit` PR rules when present.
+11. **Sync & report** — move the board item to the review column; comment on the issue with links
+    to the PR(s); present summary: what changed, validation evidence, the criteria table with
+    every verdict, deviations (if any, pre-approved), next human step (review/merge).
 
 ## Trigger Test Cases
 

--- a/plugins/workflow/skills/execute-backlog/references/acceptance-tracking.md
+++ b/plugins/workflow/skills/execute-backlog/references/acceptance-tracking.md
@@ -1,0 +1,87 @@
+# Acceptance tracking — tick what is proven, never what is hoped
+
+Runs after validations, before the PR. Every checkbox in the item ends with an explicit verdict:
+ticked with evidence, or left unticked and reported. Silence is not an option — an unticked box in
+a closed issue is indistinguishable from forgotten work.
+
+## Which checkboxes
+
+Every checkbox list in the executed item's body that states a deliverable:
+
+- Acceptance criteria — always.
+- Rite checklists the repo's process adds to the body (test/bug-hunter groups, validation/closure
+  sections, task mirrors of an OpenSpec `tasks.md`).
+
+Headings may be in the repo's working language (`Critérios de aceite`, `Testes & Bug-Hunter`) —
+match by position and meaning, never by an English literal.
+
+Never touch checkboxes outside the executed item: a parent issue, a sibling sub-issue, or a linked
+tracking issue is edited by whoever executes it.
+
+## Verdicts
+
+| Verdict | Action |
+|---|---|
+| Met — proven by a command, test, or artifact | tick, record evidence |
+| Not met — out of what was implemented | leave unticked, list in the gate below |
+| Unverifiable here — needs runtime, staging, human eyes, third party | leave unticked, report as `manual` with the exact steps to verify |
+
+Evidence is a test name, a command output line, a migration result, a diff path. "Looks right",
+"should work", or "code implements it" is not evidence — if nothing executed it, it is `manual`.
+
+A `manual` criterion the user confirms in the session may be ticked; record who confirmed it and
+when in the evidence row.
+
+## Editing the body
+
+There is no per-checkbox API. It is a read-modify-write of the whole body, so it must be surgical:
+
+```bash
+gh issue view <n> --repo ORG/REPO --json body --jq .body > acceptance-<n>.md
+# flip only the proven lines
+gh issue edit <n> --repo ORG/REPO --body-file acceptance-<n>.md
+```
+
+Rules:
+
+1. **Re-fetch immediately before editing.** The body read back in the *Read fully* step is stale —
+   a human may have amended scope since. Body changed → re-read it, re-map the criteria, and say so
+   in the report.
+2. **Only `- [ ]` → `- [x]`, on the exact matched lines.** No rewrapping, no reordering, no
+   heading/spacing/markdown normalization, no trailing-newline changes.
+3. **Diff before writing.** `diff` the fetched body against the edited file; every hunk must be a
+   checkbox flip. Any other hunk → abort the edit and report it.
+4. Never untick a box someone else ticked; a box already `[x]` that the run disproved → leave it,
+   report the contradiction, ask.
+
+## Evidence table
+
+Same table in the PR body and in the final issue comment:
+
+| # | Criterion (short) | Verdict | Evidence |
+|---|---|---|---|
+| 1 | migrations up/down clean | met | `alembic upgrade head` + `downgrade -1` green |
+| 2 | invalid handle → 400 | met | `test_handle_rejects_reserved` (tests/api/test_profile.py) |
+| 3 | docs/API.md updated | met | `docs/API.md:212` |
+| 4 | zero-downtime on staging | manual | deploy to staging, check `/healthz` during rollout |
+
+## Gate before the PR
+
+Any criterion not met or `manual` → stop, present the list, ask:
+
+- implement the remainder (loop back to implementation), or
+- open the PR with the gap documented — a **Known gaps** section in the PR body listing each
+  unticked criterion and why, plus the same list as an issue comment, or
+- abort.
+
+Never open a PR that implies completeness it cannot prove. The primary PR carries `Closes #n`, so a
+human merge auto-closes the issue with those boxes still empty — the gap has to be visible before
+the merge, not discovered after it.
+
+## Recovery
+
+| Failure | Recovery |
+|---|---|
+| `gh issue edit` fails | report the exact command and the body-file path; the execution result stands, the ticks are pending |
+| body changed between fetch and edit | discard the edit, re-fetch, re-map, redo the flip |
+| criterion text no longer matches (item was rewritten mid-run) | do not guess a mapping; report the mismatch and ask |

--- a/plugins/workflow/skills/execute-backlog/references/board-sync.md
+++ b/plugins/workflow/skills/execute-backlog/references/board-sync.md
@@ -51,7 +51,8 @@ gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
 - Primary repo PR body: `Closes #<n>` (auto-closes on merge — the skill itself never closes).
 - Secondary repo PRs: `Relates to <issue-url>` — `Closes` across repos does not auto-close and
   misleads reviewers.
-- Final issue comment: list every PR, validation summary, and any approved scope deviations.
+- Final issue comment: list every PR, validation summary, the acceptance-criteria verdict table
+  (`references/acceptance-tracking.md`), and any approved scope deviations.
 
 ## Recovery
 

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -5,15 +5,16 @@ description: >-
   validate it is complete enough to execute, re-analyze the current repo/workspace state, present
   an implementation plan for approval BEFORE touching code, implement on a dedicated branch
   following the repo's conventions, add/update tests, run the repo's discoverable validations
-  (tests/lint/build/typecheck), open pull request(s) linking the issue (Closes #n), and move the
-  GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says
+  (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by
+  evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to
+  the review column. Use when the user invokes /execute-backlog <n>, says
   "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
   issue turned into a PR. Uses the backlog skill's config (.github/backlog.yml or workspace
   backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: process
 license: MIT
 compatibility: >-
@@ -29,6 +30,7 @@ to the `backlog` skill; consumes the same config.
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
 - **Discovering and running each repo's validations**: `references/validation-matrix.md`
+- **Ticking the item's checkboxes + evidence table + completeness gate**: `references/acceptance-tracking.md`
 - **Board transitions + PR↔issue linking + recovery**: `references/board-sync.md`
 
 ## CRITICAL: Safety rails
@@ -44,7 +46,11 @@ to the `backlog` skill; consumes the same config.
    invent commands, never run migrations/deploys/destructive steps without an explicit ask.
 6. **Faithful reporting** — failing checks are reported with their output; skipped validations are
    listed as skipped, never implied as passed.
-7. **The project's rite wins** — at every stage the card advances, discover and follow the target
+7. **Every checkbox gets a verdict** — before the PR, each acceptance criterion (and each rite
+   checklist item in the body) is either ticked because evidence proves it, or left unticked and
+   reported as a gap. Never bulk-tick, never tick from intent instead of proof, never leave a box
+   silently empty (`references/acceptance-tracking.md`).
+8. **The project's rite wins** — at every stage the card advances, discover and follow the target
    repo's own established process for that stage (spec/proposal rites, implementation and test
    rites, review templates). The generic workflow here is the fallback, never an override
    (`references/execution-flow.md`, *Per-stage rite discovery*).
@@ -72,11 +78,16 @@ to the `backlog` skill; consumes the same config.
 7. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
 8. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers.
-9. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
-   `Relates to <issue-url>`. No auto-merge. Follow `conventional-commit` PR rules when present.
-10. **Sync & report** — move the board item to the review column; comment on the issue with links
-    to the PR(s); present summary: what changed, validation evidence, deviations (if any,
-    pre-approved), next human step (review/merge).
+9. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
+    the validation evidence, tick the proven ones in the issue body (surgical read-modify-write),
+    and gate on the rest: unmet or manual-only criteria stop the run for a decision before any PR
+    is opened (`references/acceptance-tracking.md`).
+10. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
+    `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
+    left anything unticked. No auto-merge. Follow `conventional-commit` PR rules when present.
+11. **Sync & report** — move the board item to the review column; comment on the issue with links
+    to the PR(s); present summary: what changed, validation evidence, the criteria table with
+    every verdict, deviations (if any, pre-approved), next human step (review/merge).
 
 ## Trigger Test Cases
 

--- a/skills/execute-backlog/references/acceptance-tracking.md
+++ b/skills/execute-backlog/references/acceptance-tracking.md
@@ -1,0 +1,87 @@
+# Acceptance tracking — tick what is proven, never what is hoped
+
+Runs after validations, before the PR. Every checkbox in the item ends with an explicit verdict:
+ticked with evidence, or left unticked and reported. Silence is not an option — an unticked box in
+a closed issue is indistinguishable from forgotten work.
+
+## Which checkboxes
+
+Every checkbox list in the executed item's body that states a deliverable:
+
+- Acceptance criteria — always.
+- Rite checklists the repo's process adds to the body (test/bug-hunter groups, validation/closure
+  sections, task mirrors of an OpenSpec `tasks.md`).
+
+Headings may be in the repo's working language (`Critérios de aceite`, `Testes & Bug-Hunter`) —
+match by position and meaning, never by an English literal.
+
+Never touch checkboxes outside the executed item: a parent issue, a sibling sub-issue, or a linked
+tracking issue is edited by whoever executes it.
+
+## Verdicts
+
+| Verdict | Action |
+|---|---|
+| Met — proven by a command, test, or artifact | tick, record evidence |
+| Not met — out of what was implemented | leave unticked, list in the gate below |
+| Unverifiable here — needs runtime, staging, human eyes, third party | leave unticked, report as `manual` with the exact steps to verify |
+
+Evidence is a test name, a command output line, a migration result, a diff path. "Looks right",
+"should work", or "code implements it" is not evidence — if nothing executed it, it is `manual`.
+
+A `manual` criterion the user confirms in the session may be ticked; record who confirmed it and
+when in the evidence row.
+
+## Editing the body
+
+There is no per-checkbox API. It is a read-modify-write of the whole body, so it must be surgical:
+
+```bash
+gh issue view <n> --repo ORG/REPO --json body --jq .body > acceptance-<n>.md
+# flip only the proven lines
+gh issue edit <n> --repo ORG/REPO --body-file acceptance-<n>.md
+```
+
+Rules:
+
+1. **Re-fetch immediately before editing.** The body read back in the *Read fully* step is stale —
+   a human may have amended scope since. Body changed → re-read it, re-map the criteria, and say so
+   in the report.
+2. **Only `- [ ]` → `- [x]`, on the exact matched lines.** No rewrapping, no reordering, no
+   heading/spacing/markdown normalization, no trailing-newline changes.
+3. **Diff before writing.** `diff` the fetched body against the edited file; every hunk must be a
+   checkbox flip. Any other hunk → abort the edit and report it.
+4. Never untick a box someone else ticked; a box already `[x]` that the run disproved → leave it,
+   report the contradiction, ask.
+
+## Evidence table
+
+Same table in the PR body and in the final issue comment:
+
+| # | Criterion (short) | Verdict | Evidence |
+|---|---|---|---|
+| 1 | migrations up/down clean | met | `alembic upgrade head` + `downgrade -1` green |
+| 2 | invalid handle → 400 | met | `test_handle_rejects_reserved` (tests/api/test_profile.py) |
+| 3 | docs/API.md updated | met | `docs/API.md:212` |
+| 4 | zero-downtime on staging | manual | deploy to staging, check `/healthz` during rollout |
+
+## Gate before the PR
+
+Any criterion not met or `manual` → stop, present the list, ask:
+
+- implement the remainder (loop back to implementation), or
+- open the PR with the gap documented — a **Known gaps** section in the PR body listing each
+  unticked criterion and why, plus the same list as an issue comment, or
+- abort.
+
+Never open a PR that implies completeness it cannot prove. The primary PR carries `Closes #n`, so a
+human merge auto-closes the issue with those boxes still empty — the gap has to be visible before
+the merge, not discovered after it.
+
+## Recovery
+
+| Failure | Recovery |
+|---|---|
+| `gh issue edit` fails | report the exact command and the body-file path; the execution result stands, the ticks are pending |
+| body changed between fetch and edit | discard the edit, re-fetch, re-map, redo the flip |
+| criterion text no longer matches (item was rewritten mid-run) | do not guess a mapping; report the mismatch and ask |

--- a/skills/execute-backlog/references/board-sync.md
+++ b/skills/execute-backlog/references/board-sync.md
@@ -51,7 +51,8 @@ gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
 - Primary repo PR body: `Closes #<n>` (auto-closes on merge — the skill itself never closes).
 - Secondary repo PRs: `Relates to <issue-url>` — `Closes` across repos does not auto-close and
   misleads reviewers.
-- Final issue comment: list every PR, validation summary, and any approved scope deviations.
+- Final issue comment: list every PR, validation summary, the acceptance-criteria verdict table
+  (`references/acceptance-tracking.md`), and any approved scope deviations.
 
 ## Recovery
 


### PR DESCRIPTION
## Problem

`/execute-backlog` drives an item to a merged PR, but the acceptance-criteria
checkboxes in the issue body stay empty. `Closes #n` then closes the issue with
every box unticked — a completed item looks identical to forgotten work, and an
unmet criterion disappears without anyone noticing.

## Change

New step 9, **Acceptance sweep**, between validation and PR:

- Every checkbox in the executed item's body (acceptance criteria + rite
  checklists like "Testes & Bug-Hunter") gets an explicit verdict: `met`,
  `not met`, or `manual`.
- `met` requires evidence — a test name, a command output line, an artifact
  path. "The code implements it" is not evidence; that is `manual`.
- Proven boxes are ticked with a surgical read-modify-write: re-fetch the body
  immediately before editing (a human may have amended scope), flip only
  `- [ ]` → `- [x]` on matched lines, and `diff` before the write so any
  non-checkbox hunk aborts the edit.
- Section headings are matched by position and meaning, not by an English
  literal — issue bodies follow the repo's working language.
- Only the executed item's body is touched; parent and sibling sub-issues are
  never edited.
- Anything left unticked gates the PR: implement the remainder, open the PR with
  a documented **Known gaps** section, or abort.

## Files

- `skills/execute-backlog/references/acceptance-tracking.md` — new reference:
  verdicts, editing rules, evidence table, gate, recovery.
- `skills/execute-backlog/SKILL.md` — safety rail 7 ("every checkbox gets a
  verdict"), step 9, renumbered PR/sync steps, version 1.1.0 → 1.2.0.
- `skills/execute-backlog/references/board-sync.md` — final issue comment now
  carries the verdict table.
- Generated wrappers (`claude/`, `cursor/`, `plugins/`) regenerated.

## Validation

- `bash generate.sh` — wrappers in sync, no drift.
- CI frontmatter checks reproduced locally over `skills/*/SKILL.md` — `fail=0`.
