### PR TITLE
✨ feat(openspec): skills-rite forked schema with CI-enforced gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
           done
           exit $fail
 
+      - name: OpenSpec rite gate (skills-rite schema)
+        run: bash scripts/validate-rite.sh
+
       - name: Claude plugin validation (best-effort)
         continue-on-error: true
         run: npx -y @anthropic-ai/claude-code@latest plugin validate . --strict || true

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,17 @@
+schema: skills-rite
+
+context: |
+  This repo is a Claude Code skills catalog (solvelab/ai-skills). "Code" here is skill
+  documentation: skills/<name>/SKILL.md + references/, mirrored into claude/skills/.
+  Conventions are governed by openspec/specs/skills-authoring (uniform frontmatter,
+  English-only content, single canonical home per cross-cutting rule) and
+  openspec/specs/skills-catalog (catalog composition, npx discovery).
+  The skills-rite schema forks vanilla spec-driven and forces three gates:
+  Canonical Home & Cross-Links (design.md), Quality Gates (tasks.md, second-to-last
+  group), Validation & Closure (tasks.md, last group).
+
+rules:
+  proposal:
+    - Name the affected skills explicitly in Impact (catalog composition changes are breaking for consumers of npx discovery)
+  tasks:
+    - Never drop the Quality Gates and Validation & Closure groups; they close the rite

--- a/openspec/schemas/skills-rite/schema.yaml
+++ b/openspec/schemas/skills-rite/schema.yaml
@@ -1,0 +1,272 @@
+name: skills-rite
+version: 1
+description: ai-skills forked workflow - vanilla flow + mandatory gates (Canonical Home, Quality Gates, Validation & Closure)
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Initial proposal document outlining the change
+    template: proposal.md
+    instruction: >
+      Create the proposal document that establishes WHY this change is needed.
+
+
+      Sections:
+
+      - **Why**: 1-2 sentences on the problem or opportunity. What problem does
+      this solve? Why now?
+
+      - **What Changes**: Bullet list of changes. Be specific about new
+      capabilities, modifications, or removals. Mark breaking changes with
+      **BREAKING**.
+
+      - **Capabilities**: Identify which specs will be created or modified:
+        - **New Capabilities**: List capabilities being introduced. Each becomes a new `specs/<name>/spec.md`. Use kebab-case names (e.g., `user-auth`, `data-export`).
+        - **Modified Capabilities**: List existing capabilities whose REQUIREMENTS are changing. Only include if spec-level behavior changes (not just implementation details). Each needs a delta spec file. Check `openspec/specs/` for existing spec names. Leave empty if no requirement changes.
+      - **Impact**: Affected code, APIs, dependencies, or systems.
+
+
+      IMPORTANT: The Capabilities section is critical. It creates the contract
+      between
+
+      proposal and specs phases. Research existing specs before filling this in.
+
+      Each capability listed here will need a corresponding spec file.
+
+
+      Keep it concise (1-2 pages). Focus on the "why" not the "how" -
+
+      implementation details belong in design.md.
+
+
+      This is the foundation - specs, design, and tasks all build on this.
+    requires: []
+  - id: specs
+    generates: specs/**/*.md
+    description: Detailed specifications for the change
+    template: spec.md
+    instruction: >
+      Create specification files that define WHAT the system should do.
+
+
+      Create one spec file per capability listed in the proposal's Capabilities
+      section.
+
+      - New capabilities: use the exact kebab-case name from the proposal
+      (specs/<capability>/spec.md).
+
+      - Modified capabilities: use the existing spec folder name from
+      openspec/specs/<capability>/ when creating the delta spec at
+      specs/<capability>/spec.md.
+
+
+      Delta operations (use ## headers):
+
+      - **ADDED Requirements**: New capabilities
+
+      - **MODIFIED Requirements**: Changed behavior - MUST include full updated
+      content
+
+      - **REMOVED Requirements**: Deprecated features - MUST include **Reason**
+      and **Migration**
+
+      - **RENAMED Requirements**: Name changes only - use FROM:/TO: format
+
+
+      Format requirements:
+
+      - Each requirement: `### Requirement: <name>` followed by description
+
+      - Use SHALL/MUST for normative requirements (avoid should/may)
+
+      - Each scenario: `#### Scenario: <name>` with WHEN/THEN format
+
+      - **CRITICAL**: Scenarios MUST use exactly 4 hashtags (`####`). Using 3
+      hashtags or bullets will fail silently.
+
+      - Every requirement MUST have at least one scenario.
+
+
+      MODIFIED requirements workflow:
+
+      1. Locate the existing requirement in openspec/specs/<capability>/spec.md
+
+      2. Copy the ENTIRE requirement block (from `### Requirement:` through all
+      scenarios)
+
+      3. Paste under `## MODIFIED Requirements` and edit to reflect new behavior
+
+      4. Ensure header text matches exactly (whitespace-insensitive)
+
+
+      Common pitfall: Using MODIFIED with partial content loses detail at
+      archive time.
+
+      If adding new concerns without changing existing behavior, use ADDED
+      instead.
+
+
+      Example:
+
+      ```
+
+      ## ADDED Requirements
+
+
+      ### Requirement: User can export data
+
+      The system SHALL allow users to export their data in CSV format.
+
+
+      #### Scenario: Successful export
+
+      - **WHEN** user clicks "Export" button
+
+      - **THEN** system downloads a CSV file with all user data
+
+
+      ## REMOVED Requirements
+
+
+      ### Requirement: Legacy export
+
+      **Reason**: Replaced by new export system
+
+      **Migration**: Use new export endpoint at /api/v2/export
+
+      ```
+
+
+      Specs should be testable - each scenario is a potential test case.
+    requires:
+      - proposal
+  - id: design
+    generates: design.md
+    description: Technical design document with implementation details
+    template: design.md
+    instruction: >
+      Create the design document that explains HOW to implement the change.
+
+
+      When to include design.md (create only if any apply):
+
+      - Cross-cutting change (multiple services/modules) or new architectural
+      pattern
+
+      - New external dependency or significant data model changes
+
+      - Security, performance, or migration complexity
+
+      - Ambiguity that benefits from technical decisions before coding
+
+
+      Sections:
+
+      - **Context**: Background, current state, constraints, stakeholders
+
+      - **Goals / Non-Goals**: What this design achieves and explicitly excludes
+
+      - **Decisions**: Key technical choices with rationale (why X over Y?).
+      Include alternatives considered for each decision.
+
+      - **Canonical Home & Cross-Links (MANDATORY)**: 3-column table. For EVERY
+      cross-cutting rule this change touches, declare the single canonical skill
+      that owns it and the action (link / move / already canonical). Rules are
+      never restated inline in a sibling skill — link with at most a one-line
+      summary. This section is a gate: never omit it, never leave the table
+      empty (if the change truly touches no cross-cutting rule, state that
+      explicitly under the heading).
+
+      - **Risks / Trade-offs**: Known limitations, things that could go wrong.
+      Format: [Risk] → Mitigation
+
+      - **Migration Plan**: Steps to deploy, rollback strategy (if applicable)
+
+      - **Open Questions**: Outstanding decisions or unknowns to resolve
+
+
+      Focus on architecture and approach, not line-by-line implementation.
+
+      Reference the proposal for motivation and specs for requirements.
+
+
+      Good design docs explain the "why" behind technical decisions.
+    requires:
+      - proposal
+  - id: tasks
+    generates: tasks.md
+    description: Implementation checklist with trackable tasks
+    template: tasks.md
+    instruction: >
+      Create the task list that breaks down the implementation work.
+
+
+      **IMPORTANT: Follow the template below exactly.** The apply phase parses
+
+      checkbox format to track progress. Tasks not using `- [ ]` won't be
+      tracked.
+
+
+      Guidelines:
+
+      - Group related tasks under ## numbered headings
+
+      - Each task MUST be a checkbox: `- [ ] X.Y Task description`
+
+      - Tasks should be small enough to complete in one session
+
+      - Order tasks by dependency (what must be done first?)
+
+
+      Example:
+
+      ```
+
+      ## 1. Setup
+
+
+      - [ ] 1.1 Create new module structure
+
+      - [ ] 1.2 Add dependencies to package.json
+
+
+      ## 2. Core Implementation
+
+
+      - [ ] 2.1 Implement data export function
+
+      - [ ] 2.2 Add CSV formatting utilities
+
+      ```
+
+
+      Reference specs for what needs to be built, design for how to build it.
+
+      Each task should be verifiable - you know when it's done.
+
+
+      MANDATORY GATES (this schema forks vanilla to force them — never drop
+      them from the generated tasks.md):
+
+      - Second-to-last group: `## N. Quality Gates (MANDATORY)` — adversarial
+      review of every skill touched: uniform frontmatter (name == directory,
+      folded description, metadata.author solvelab, semver version, category in
+      the controlled set, license MIT, compatibility), English-only content,
+      testable non-colliding description triggers with a "Do NOT use for"
+      boundary where overlap exists, and zero duplicated doctrine (links to the
+      canonical skill per design.md's Canonical Home table).
+
+      - Last group: `## N. Validation & Closure (MANDATORY)` — `openspec
+      validate <id> --strict` green, catalog discovery intact (`npx skills add
+      <repo> --list` finds every skill at the expected count), README/docs
+      updated when catalog composition or usage changes, then `openspec archive
+      <id> --yes`.
+    requires:
+      - specs
+      - design
+apply:
+  requires:
+    - tasks
+  tracks: tasks.md
+  instruction: |
+    Read context files, work through pending tasks, mark complete as you go.
+    Pause if you hit blockers or need clarification.

--- a/openspec/schemas/skills-rite/templates/design.md
+++ b/openspec/schemas/skills-rite/templates/design.md
@@ -1,0 +1,29 @@
+## Context
+
+<!-- Background and current state -->
+
+## Goals / Non-Goals
+
+**Goals:**
+<!-- What this design aims to achieve -->
+
+**Non-Goals:**
+<!-- What is explicitly out of scope -->
+
+## Decisions
+
+<!-- Key design decisions and rationale -->
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+<!-- For every cross-cutting rule this change touches, declare its single canonical skill.
+     Everywhere else links to it (one-line summary max). No inline restating of a sibling
+     skill's mechanism. Where a rule has no canonical home yet, decide one here. -->
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| <rule> | <skill-name> | <link from X / move from Y / already canonical> |
+
+## Risks / Trade-offs
+
+<!-- Known risks and trade-offs -->

--- a/openspec/schemas/skills-rite/templates/proposal.md
+++ b/openspec/schemas/skills-rite/templates/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+<!-- Explain the motivation for this change. What problem does this solve? Why now? -->
+
+## What Changes
+
+<!-- Describe what will change. Be specific about new capabilities, modifications, or removals. -->
+
+## Capabilities
+
+### New Capabilities
+<!-- Capabilities being introduced. Replace <name> with kebab-case identifier (e.g., user-auth, data-export, api-rate-limiting). Each creates specs/<name>/spec.md -->
+- `<name>`: <brief description of what this capability covers>
+
+### Modified Capabilities
+<!-- Existing capabilities whose REQUIREMENTS are changing (not just implementation).
+     Only list here if spec-level behavior changes. Each needs a delta spec file.
+     Use existing spec names from openspec/specs/. Leave empty if no requirement changes. -->
+- `<existing-name>`: <what requirement is changing>
+
+## Impact
+
+<!-- Affected code, APIs, dependencies, systems -->

--- a/openspec/schemas/skills-rite/templates/spec.md
+++ b/openspec/schemas/skills-rite/templates/spec.md
@@ -1,0 +1,8 @@
+## ADDED Requirements
+
+### Requirement: <!-- requirement name -->
+<!-- requirement text -->
+
+#### Scenario: <!-- scenario name -->
+- **WHEN** <!-- condition -->
+- **THEN** <!-- expected outcome -->

--- a/openspec/schemas/skills-rite/templates/tasks.md
+++ b/openspec/schemas/skills-rite/templates/tasks.md
@@ -1,0 +1,29 @@
+## 1. <!-- Task Group Name -->
+
+- [ ] 1.1 <!-- Task description -->
+- [ ] 1.2 <!-- Task description -->
+
+## 2. Quality Gates (MANDATORY)
+
+<!-- Adversarial review of the skills touched — not happy-path. Every skill added or edited
+     by this change gets checked against the skills-authoring spec. Keep the group number
+     as the second-to-last group. -->
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+
+## 3. Validation & Closure (MANDATORY)
+
+<!-- Always the last group. "Done" is verifiable, not an opinion. -->
+
+- [ ] V.1 `openspec validate <id> --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive <id> --yes` after all groups above are `[x]`

--- a/scripts/validate-rite.sh
+++ b/scripts/validate-rite.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Hard gate for the skills-rite OpenSpec schema.
+#
+# `openspec validate --strict` (v1.6.0) checks delta-spec format but NOT custom
+# template sections, so the schema's mandatory groups would be advisory only.
+# This script makes them structural: every active change must carry the gates
+# before it can merge or archive.
+#
+# Usage: scripts/validate-rite.sh   (from repo root; CI runs it on every PR)
+set -uo pipefail
+
+CHANGES_DIR="openspec/changes"
+fail=0
+
+for dir in "$CHANGES_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name="$(basename "$dir")"
+  [ "$name" = "archive" ] && continue
+
+  tasks="$dir/tasks.md"
+  if [ -f "$tasks" ]; then
+    grep -q 'Quality Gates (MANDATORY)' "$tasks" || {
+      echo "::error file=$tasks::Missing mandatory group 'Quality Gates (MANDATORY)'"; fail=1; }
+    grep -q 'Validation & Closure (MANDATORY)' "$tasks" || {
+      echo "::error file=$tasks::Missing mandatory group 'Validation & Closure (MANDATORY)'"; fail=1; }
+    last_group="$(grep '^## ' "$tasks" | tail -1)"
+    case "$last_group" in
+      *"Validation & Closure (MANDATORY)"*) ;;
+      *) echo "::error file=$tasks::'Validation & Closure (MANDATORY)' must be the LAST task group (found last: ${last_group:-none})"; fail=1 ;;
+    esac
+  fi
+
+  design="$dir/design.md"
+  if [ -f "$design" ]; then
+    grep -q 'Canonical Home & Cross-Links (MANDATORY)' "$design" || {
+      echo "::error file=$design::Missing mandatory section 'Canonical Home & Cross-Links (MANDATORY)'"; fail=1; }
+  fi
+done
+
+if command -v openspec >/dev/null 2>&1; then
+  openspec validate --all --strict || fail=1
+else
+  npx -y @fission-ai/openspec@latest validate --all --strict || fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "rite gate FAILED"
+  exit 1
+fi
+echo "rite gate OK"


### PR DESCRIPTION
## Why

`openspec validate --strict` (CLI 1.6.0) validates delta-spec format but **not** custom template sections — verified empirically with a probe change that passed strict validation with no gate groups at all. A forked schema alone is therefore advisory: its mandatory sections only guide artifact generation through `openspec instructions`. Delivery guarantees need a structural gate.

## What

- **`openspec/schemas/skills-rite/`** — project-local fork of `spec-driven` adapted to a skills catalog, with three mandatory gates (mirrors the DriveZone rite skeleton, content from this repo's `skills-authoring` spec):
  - `design.md` → `## Canonical Home & Cross-Links (MANDATORY)` — anti-duplication table (single canonical skill per cross-cutting rule)
  - `tasks.md` → `## Quality Gates (MANDATORY)` — uniform frontmatter, English-only content, testable non-colliding triggers (second-to-last group)
  - `tasks.md` → `## Validation & Closure (MANDATORY)` — strict green + `npx skills` discovery intact + docs + archive (last group)
- **`openspec/config.yaml`** — selects `skills-rite`, adds repo context + per-artifact rules injected into `/opsx` generation
- **`scripts/validate-rite.sh`** — the hard gate: requires the three headings in every active change (Closure enforced as the last task group) and runs `openspec validate --all --strict`; tested in both directions (missing gates → fail, present → pass)
- **`.github/workflows/ci.yml`** — new "OpenSpec rite gate" step in the Validate job

## Notes

- `/opsx` commands and `openspec-*` skills are generated into `.claude/` (machine-local, excluded by global gitignore); regenerate with `openspec init --tools claude`.
- Requires no CI runner setup: the script falls back to `npx -y @fission-ai/openspec@latest` when the CLI is absent.