### PR TITLE
🧹 chore(backlog): configure /backlog for org Project AI-SKILLS (#3)

### DIFF
--- a/.github/backlog.yml
+++ b/.github/backlog.yml
@@ -1,0 +1,11 @@
+version: 1
+project:
+  owner: solvelab
+  number: 3
+fields:
+  status: Status
+  priority: Priority
+  size: Size
+  estimate: Estimate
+defaults:
+  status: Backlog


### PR DESCRIPTION
## Why

This repository is now dedicated to the AI-SKILLS org Project (https://github.com/orgs/solvelab/projects/3). Every flow that touches this repo goes through `/backlog` (idea → issue on the board) and `/execute-backlog` (issue → PR). Committing `.github/backlog.yml` makes every machine/clone inherit that setup — the skills read it and skip the first-run wizard.

## What

- `.github/backlog.yml` — repo-mode config: owner `solvelab`, Project `3`, standard field names (Status/Priority/Size/Estimate), new items land in **Backlog**.

Field names only — IDs are resolved at runtime by the skills. Priority/Effort are org-level issue fields and are set through the issue-field-values API automatically.

First items already on the board: #14 (README rite docs, Medium/S), #15 (openspec-drivezone enforcement fix, High/S), #16 (specs Purpose TBD, Low/XS).