### PR TITLE
📝 docs(openspec): fill the TBD Purpose sections left by the archive step

### DIFF
--- a/openspec/specs/skills-authoring/spec.md
+++ b/openspec/specs/skills-authoring/spec.md
@@ -1,7 +1,13 @@
 # skills-authoring Specification
 
 ## Purpose
-TBD - created by archiving change refactor-skills-quality-review. Update Purpose after archive.
+
+Conventions governing how every skill in this catalog is written, for human contributors and AI
+agents alike: uniform frontmatter metadata, English as the catalog locale, a single canonical home
+for each cross-cutting rule (siblings link instead of restating), and empirically verified claims
+about external tool behavior. CI and the skills-rite Quality Gates enforce these requirements on
+every change that touches `skills/`.
+
 ## Requirements
 ### Requirement: Single canonical home per rule
 

--- a/openspec/specs/skills-catalog/spec.md
+++ b/openspec/specs/skills-catalog/spec.md
@@ -1,7 +1,12 @@
 # skills-catalog Specification
 
 ## Purpose
-TBD - created by archiving change refactor-skills-quality-review. Update Purpose after archive.
+
+The composition of the published catalog and its discovery contract: which skills exist, which are
+superseded or removed, and the guarantee that `npx skills add <repo> --list` finds every skill at
+the expected count with no orphans or renamed leftovers. Changes that add, remove, or supersede
+skills are validated against this spec by the skills-rite Validation & Closure gate.
+
 ## Requirements
 ### Requirement: Catalog composition after the quality review
 


### PR DESCRIPTION
Closes #16

## What

Both current specs opened with the archiver's placeholder ("Purpose TBD - created by archiving change refactor-skills-quality-review. Update Purpose after archive.") since 2026-07-01. Filled:

- `openspec/specs/skills-authoring/spec.md` — authoring conventions (uniform frontmatter, English locale, single canonical home, verified enforcement claims) and where they are enforced.
- `openspec/specs/skills-catalog/spec.md` — catalog composition + the `npx skills` discovery contract and its closure gate.

## Evidence

| Acceptance criterion | Verdict | Evidence |
|---|---|---|
| `skills-authoring` Purpose written | ✅ | 4-line Purpose covering frontmatter/locale/canonical home |
| `skills-catalog` Purpose written | ✅ | 4-line Purpose covering composition + npx discovery contract |
| `openspec validate --all --strict` green | ✅ | 2 passed, 0 failed; `scripts/validate-rite.sh` also green |

Docs-only; Purpose is spec metadata (no requirement delta), updated direct per the archiver's own TODO.