### PR TITLE
🐛 fix(skills): harden backend family against measured failure modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,18 +361,18 @@ Project v2 in the org/user. Full details live in the skills themselves:
 
 | Skill | Triggers | What It Does |
 |-------|----------|--------------|
-| **python-rest-api** | creating/reviewing a Python API, FastAPI service, response envelope, project layout | Production conventions distilled from real solvelab services — layering, error envelope + code registry, never-raw-500 handlers, tenant isolation, service-token catalog, domain-state idempotency, testing stack (golden OpenAPI, fuzz gate) |
-| **backend-resilience** | external call, timeout, 5xx, dependency down, config fetch, retry, fallback, negative cache | Stack-agnostic resilience doctrine — safe defaults, shared fallback helper, response-shape validation, clamping, bounded retries, negative caching, in-flight dedupe (Python examples) |
-| **api-resilience-testing** | "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", invalid payloads, status codes, auth, OpenAPI | Tests REST APIs beyond the happy path (negative/fuzz/contract/security); produces an endpoint map, scenarios, suggested tests and a resilience checklist |
+| **python-rest-api** | creating/reviewing a Python API, FastAPI service, response envelope, project layout, request size/depth limits | Production conventions distilled from real solvelab services — layering, error envelope + code registry, never-raw-500 handlers, request limits (measured: 2 KB nested body → 500, 20 MB body → 200 without them), tenant isolation, service-token catalog, domain-state idempotency, testing stack (golden OpenAPI, fuzz gate) |
+| **backend-resilience** | external call, timeout, deadline, 5xx, dependency down, config fetch, retry, backoff, jitter, fallback, negative cache | Stack-agnostic resilience doctrine, ordered timeout → deadline → bounded retry → negative cache + single-flight → fallback → surface — idempotent-only retries with jittered backoff, response-shape validation, clamping, observable degradation (Python examples) |
+| **api-resilience-testing** | "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", invalid payloads, status codes, auth, OpenAPI | Tests REST APIs beyond the happy path (negative/fuzz/contract/security); produces an endpoint map, scenarios, suggested tests, a resilience checklist and a measured baseline-behavior table so the checklist asserts codes the stack really returns |
 | **bug-hunter** | "bug hunt", "adversarial test", break it, anti-forge, edge cases of a change | Per-change adversarial testing rite — universal checklist + opt-in stack tracks (Python/pytest, FiveM/Lua, .NET plugin) |
-| **log-event-collector** | log tailer, log-to-event parser, file offset, log rotation, event dedup/idempotency, shutdown flush | Doctrine for a log-tailing collector sidecar — byte-offset persistence with rotation guard, atomic state, deterministic event keys, multi-line correlation, exactly-once shutdown flush, golden log fixture |
+| **log-event-collector** | log tailer, log-to-event parser, file offset, log rotation, partial lines, backpressure, event dedup/idempotency, shutdown flush | Doctrine for a log-tailing collector sidecar — byte-offset persistence that never advances past the last complete line, rotation guard, atomic state, occurrence-keyed dedup, multi-line correlation, backpressure, exactly-once shutdown flush, golden log fixture |
 
 ### FiveM
 
 | Skill | Triggers | What It Does |
 |-------|----------|--------------|
 | **fivem-lua** | RegisterNetEvent, RegisterNUICallback, fxmanifest, exports, NUI, CreateThread, StateBags, natives | CitizenFX Lua conventions — client-never-trusted boundary, explicit fxmanifest order, no busy loops, module-per-global, NUI focus/cleanup |
-| **fivem-fallback** | FiveM resource calling backend/Consul/another resource, config fetch, retry in Lua | FiveM/Lua adaptation of backend-resilience — SafeCall/clampNum, boot retry, NUI error signaling |
+| **fivem-fallback** | FiveM resource calling backend/Consul/another resource, config fetch, retry in Lua | FiveM/Lua adaptation of backend-resilience — SafeCall/clampNum, deadline-bounded jittered boot retry, idempotent-only retries, NUI error signaling |
 
 ### AssettoServer
 

--- a/claude/skills/api-resilience-testing/SKILL.md
+++ b/claude/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/backend-resilience/SKILL.md
+++ b/claude/skills/backend-resilience/SKILL.md
@@ -5,12 +5,14 @@ description: >-
   config store (Consul/KV), database, message broker, or another internal service. Use when adding or
   reviewing code that makes network calls that can time out, return 5xx, return partial payloads, or
   hit a dependency that is down — or when adding config fetch, retry logic, caching of failures, or
-  degraded-mode behavior. Enforces safe defaults, one shared fallback helper, response-shape validation,
-  clamping of remote values, bounded retries, negative caching, and in-flight deduplication. Examples in
-  Python; the doctrine is language-agnostic. For the FiveM/Lua adaptation use fivem-fallback instead.
+  degraded-mode behavior. Enforces explicit timeouts and a wall-clock deadline, retries only on
+  idempotent operations with exponential backoff + jitter, safe defaults, one shared fallback helper,
+  response-shape validation, clamping of remote values, negative caching with single-flight, and
+  observable degradation. Examples in Python; the doctrine is language-agnostic. For the FiveM/Lua
+  adaptation use fivem-fallback instead.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 2.0.0
   category: backend
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/claude/skills/fivem-fallback/SKILL.md
+++ b/claude/skills/fivem-fallback/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   services use backend-resilience instead.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/claude/skills/log-event-collector/SKILL.md
+++ b/claude/skills/log-event-collector/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   server's text logs, parses lines into normalized events, and ships them to a backend API.
   Distilled from a production collector for an Assetto Corsa server, but stack-agnostic. Use when
   building or reviewing a log tailer, log-to-event parser, file offset persistence, log rotation or
-  truncation handling, multi-line event correlation, shutdown flush, or idempotency/dedup keys for
-  shipped events. Do NOT use for configuring log aggregation stacks (Loki, Fluentd, Filebeat), for
-  the API that receives the events (that is python-rest-api), or for metrics/APM instrumentation.
+  truncation handling, partial-line reads, multi-line event correlation, backpressure, shutdown flush,
+  or idempotency/dedup keys for shipped events. Do NOT use for configuring log aggregation stacks
+  (Loki, Fluentd, Filebeat), for the API that receives the events (that is python-rest-api), or for
+  metrics/APM instrumentation of the monitored application.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/python-rest-api/SKILL.md
+++ b/claude/skills/python-rest-api/SKILL.md
@@ -8,11 +8,11 @@ description: >-
   pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures,
   testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis
   fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency
-  with partial unique indexes, JSONB dialect variants, and out-of-process ingestion workers (UDP).
-  The baseline that api-resilience-testing and bug-hunter assume.
+  with partial unique indexes, JSONB dialect variants, request size/depth limits, and out-of-process
+  ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/api-resilience-testing.mdc
+++ b/cursor/rules/api-resilience-testing.mdc
@@ -76,12 +76,19 @@ Run these in order. Produce concrete, runnable tests and a checklist — not pro
    403 authenticated-but-forbidden, 404 unknown resource, 405 wrong method,
    409 conflict, 413 too large, 415 unsupported media type, 422 semantic
    validation, 429 rate limit. A 500 on bad *input* is a bug — input errors must
-   be 4xx.
+   be 4xx. **Assert the code the stack actually returns, then decide whether the
+   difference is worth overriding** — a checklist that demands a code the
+   framework never emits marks a correct service as failing (see the baseline
+   table below).
 
-6. **Validate error responses are safe and useful.** Errors must be a consistent,
-   machine-readable shape (prefer RFC 9457 `application/problem+json`: type,
-   title, status, detail, instance). They must NOT leak stack traces, SQL,
-   internal paths, framework versions, or raw exception text. They MUST say
+6. **Validate error responses are safe and useful.** Errors must use **one
+   documented, machine-readable shape, applied to every error path** — the same
+   body for a 422 from the framework, a 409 from the database, and a 500 from
+   the catch-all. RFC 9457 `application/problem+json` (type, title, status,
+   detail, instance) is the right default for a greenfield API; an existing
+   documented envelope is equally valid and cheaper to keep — consistency is the
+   requirement, the specific shape is not. Errors must NOT leak stack traces,
+   SQL, internal paths, framework versions, or raw exception text. They MUST say
    clearly what was wrong so a client can fix it.
 
 7. **Verify authentication & authorization.** No token → 401. Expired/garbage/
@@ -120,14 +127,15 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 [ ] Over-length strings / oversized payload → 400/413
 [ ] Invalid format (email, uuid, date, enum) → 400/422
 [ ] Unknown/extra fields → ignored or rejected (documented, never crash)
-[ ] Malformed JSON / truncated body → 400 (not 500)
-[ ] Deeply nested / huge array payload → handled, no DoS
+[ ] Malformed JSON / truncated body → 4xx (not 500)
+[ ] Oversized payload → 413 (needs an explicit limit; no framework default)
+[ ] Deeply nested payload → 4xx (needs an explicit guard; 500 by default)
 
 ### Headers & content
-[ ] Missing Content-Type on a body request → 400/415
-[ ] Wrong Content-Type (text/plain for JSON) → 415
+[ ] Missing Content-Type on a body request → 4xx
+[ ] Wrong Content-Type (text/plain for JSON) → 4xx (415 only if you enforce it)
 [ ] Missing required custom headers → handled
-[ ] Unsupported Accept → 406 or sane default
+[ ] Unsupported Accept → 406 or sane default (200 by default — decide explicitly)
 
 ### Auth & authorization
 [ ] No token → 401
@@ -144,7 +152,7 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 
 ### Status codes & errors
 [ ] Input errors are 4xx, never 5xx
-[ ] Error body is consistent & machine-readable (ideally RFC 9457)
+[ ] Error body uses ONE documented shape on every error path (RFC 9457 if greenfield)
 [ ] No stack trace / SQL / internal path / version leaked in any error
 [ ] Error message is actionable (says what to fix)
 
@@ -160,6 +168,29 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 ```
 
 See `references/negative-test-catalog.md` for concrete request/response examples.
+
+## Baseline behavior — assert reality, not folklore
+
+A checklist that asserts a status code the framework never emits produces false failures. Measured on
+FastAPI 0.141.1 / pydantic 2.13.4 (the `python-rest-api` baseline), stock service, no extra handlers:
+
+| Negative case | Often asserted | Actually returned | Worth overriding? |
+|---|---|---|---|
+| Malformed / truncated JSON | 400 | **422** | No — 422 is a fine, consistent rejection |
+| Missing `Content-Type` on a body | 400/415 | **422** | No |
+| Wrong `Content-Type` (`text/plain`) | 415 | **422** | Only if a client contract needs 415 |
+| Unsupported `Accept` | 406 | **200** | Only if you really serve >1 media type |
+| Wrong path-param type (`/users/abc`) | 404 | **422** | No — the route matched, the value didn't |
+| Wrong HTTP method | 405 | **405** (with `Allow`) | Already correct |
+| Extra/unknown body field | rejected | **200**, ignored | Yes if the field is privileged (mass assignment) |
+| **2 KB body of nested brackets** | handled | **500** (`RecursionError`) | **Yes — this is the bug** |
+| **20 MB flat JSON body** | 413 | **200**, fully buffered | **Yes — no default limit exists** |
+
+The last two are not style preferences: a 2 KB unauthenticated request that returns 500 is a
+denial-of-service primitive. The guard belongs to the service baseline — see `python-rest-api`
+("Request limits"), which carries the verified middleware + handler.
+
+Re-run this table against your own stack and version before trusting any row of it.
 
 ---
 
@@ -193,8 +224,10 @@ See `references/negative-test-catalog.md` for concrete request/response examples
   endpoint, ask "what breaks it?" before approving.
 - **Contract as source of truth:** keep the OpenAPI spec accurate; a golden
   snapshot test of the generated schema catches accidental contract drift.
-- **Error standard:** adopt one error shape (RFC 9457) repo-wide so clients and
-  tests can rely on it and nothing leaks.
+- **Error standard:** adopt one error shape repo-wide — RFC 9457 for a greenfield
+  API, or the service's documented envelope where one already exists — so clients
+  and tests can rely on it and nothing leaks. Changing the shape of a live API is
+  a breaking change; consistency beats conformance here.
 
 ---
 

--- a/cursor/rules/backend-resilience.mdc
+++ b/cursor/rules/backend-resilience.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Resilience and fallback patterns for any service calling an unreliable dependency — external API, config store (Consul/KV), database, message broker, or another internal service. Use when adding or reviewing code that makes network calls that can time out, return 5xx, return partial payloads, or hit a dependency that is down — or when adding config fetch, retry logic, caching of failures, or degraded-mode behavior. Enforces safe defaults, one shared fallback helper, response-shape validation, clamping of remote values, bounded retries, negative caching, and in-flight deduplication. Examples in Python; the doctrine is language-agnostic. For the FiveM/Lua adaptation use fivem-fallback instead.
+  Resilience and fallback patterns for any service calling an unreliable dependency — external API, config store (Consul/KV), database, message broker, or another internal service. Use when adding or reviewing code that makes network calls that can time out, return 5xx, return partial payloads, or hit a dependency that is down — or when adding config fetch, retry logic, caching of failures, or degraded-mode behavior. Enforces explicit timeouts and a wall-clock deadline, retries only on idempotent operations with exponential backoff + jitter, safe defaults, one shared fallback helper, response-shape validation, clamping of remote values, negative caching with single-flight, and observable degradation. Examples in Python; the doctrine is language-agnostic. For the FiveM/Lua adaptation use fivem-fallback instead.
 alwaysApply: false
 ---
 
@@ -11,30 +11,76 @@ Defensive patterns for calling an unreliable dependency. The network boundary is
 5xx, partial payloads, dependency down, races. Every call needs a **safe default** so the service keeps
 working. Doctrine is stack-agnostic; examples are Python.
 
+Apply in this order — it is the order of risk reduction, and each layer assumes the one above it:
+**timeout → deadline → bounded retry (idempotent only) → negative cache + single-flight → fallback
+default → surface the degradation.**
+
 ## Principles
 
-1. **Every external call can fail.** A failed call must produce a safe default — never a crash, and
+1. **Every external call has an explicit timeout.** A call with no timeout is an unbounded outage
+   waiting to happen; a retry on a hung connection waits forever. Set connect and read timeouts
+   separately — never rely on the library default.
+2. **Bound the wall clock, not just the attempt count.** "3 attempts" says nothing about latency.
+   Give the whole operation a **deadline** and check it before each attempt; when the caller is
+   serving an HTTP request, that deadline must be shorter than the request's own budget.
+3. **Retry only what is safe to repeat.** GET/HEAD/PUT/DELETE are retriable. A POST that charges,
+   ships, or writes is retriable **only** with an idempotency key the dependency honors. Otherwise a
+   5xx is a final answer — surface it.
+4. **Every external call can fail.** A failed call must produce a safe default — never a crash, and
    never silent stale state presented as fresh.
-2. **One shared helper, not ad-hoc per module.** Scattered try/except + type-check copies drift.
+5. **One shared helper, not ad-hoc per module.** Scattered try/except + type-check copies drift.
    Provide a single `safe_call`/`with_fallback` utility and use it everywhere.
-3. **Validate the response shape**, not just transport success: check the type, the expected fields,
+6. **Validate the response shape**, not just transport success: check the type, the expected fields,
    and the status/code before trusting the data.
-4. **Clamp untrusted/remote numbers** into a sane range — a bad config value must not break the system.
-5. **Bound retries.** If the HTTP client already retries 5xx, don't stack an unbounded second retry
-   loop on top. Total attempts across all layers must be finite and known.
+7. **Clamp untrusted/remote numbers** into a sane range — a bad config value must not break the system.
+8. **Degradation is an event, not a silence.** Every fallback carries its cause into a log line and a
+   counter. A fallback nobody can see is indistinguishable from correct behavior.
+
+## Timeouts and the deadline budget
+
+```python
+TIMEOUT = httpx.Timeout(connect=1.0, read=2.0, write=2.0, pool=1.0)
+
+deadline = time.monotonic() + 3.0          # the WHOLE operation, retries included
+while time.monotonic() < deadline:
+    ...                                     # attempt; sleep only if it still fits in the deadline
+```
+
+Sizing rule: `attempts x timeout + total backoff <= deadline <= the caller's own budget`. If the
+numbers don't fit, cut the attempts — not the timeout. Worst-case latency must be a number you can
+state; if you can't state it, the policy is unbounded.
+
+Attempt counts above ~3 are almost always wrong on a request path. Measured worst cases for policies
+this catalog used to prescribe: 10 attempts at a 5s timeout = **50s**; the same client stacked under a
+20-attempt/3s boot loop = **~18 minutes** before a caller gets an answer.
 
 ## safe_call / clamp
 
+The helper must report **why** it fell back. Measured: four distinct causes — a dependency timeout, a
+`TypeError` from your own code, malformed JSON, and a `MemoryError` — collapsed into one
+indistinguishable `(False, fallback)` with zero log lines. An operator cannot tell a code bug from an
+outage, and neither can a dashboard.
+
 ```python
-from typing import Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 T = TypeVar("T")
 
-def safe_call(fn: Callable[[], T], fallback: T) -> tuple[bool, T]:
-    """Returns (ok, value). On any failure returns (False, fallback) — never raises."""
+def safe_call(fn: Callable[[], T], fallback: T, *, op: str) -> tuple[bool, T]:
+    """Returns (ok, value). On failure returns (False, fallback) — never raises."""
     try:
         return True, fn()
-    except Exception:
+    except Exception as exc:                       # noqa: BLE001 — boundary helper, by design
+        logger.warning("fallback_used", op=op, err_type=type(exc).__name__, err=str(exc))
+        FALLBACK_TOTAL.labels(op=op, err=type(exc).__name__).inc()
+        return False, fallback
+
+async def safe_call_async(fn: Callable[[], Awaitable[T]], fallback: T, *, op: str) -> tuple[bool, T]:
+    try:
+        return True, await fn()
+    except Exception as exc:                       # noqa: BLE001
+        logger.warning("fallback_used", op=op, err_type=type(exc).__name__, err=str(exc))
+        FALLBACK_TOTAL.labels(op=op, err=type(exc).__name__).inc()
         return False, fallback
 
 def clamp_num(value, lo: float, hi: float, default: float) -> float:
@@ -45,61 +91,132 @@ def clamp_num(value, lo: float, hi: float, default: float) -> float:
     return max(lo, min(hi, v))
 ```
 
-## Config / KV with hardcoded fallback
+The counter is part of the helper, not an afterthought: an alert on `rate(fallback_used)` is the only
+way a permanently-degraded service announces itself.
 
-Remote config (Consul KV, a `/config/*` endpoint) WILL be unavailable sometimes. Always ship a
-hardcoded default and merge field-by-field; clamp ranges.
+`asyncio.CancelledError` is a `BaseException` and correctly escapes `except Exception` — do **not**
+widen the catch to `BaseException`, that swallows shutdown and enclosing timeouts. In an `async def`
+path use `safe_call_async`: the sync helper wrapped around a blocking client blocks the event loop for
+every concurrent request, which is worse than no resilience at all.
+
+## Retry: bounded, backed off, jittered
 
 ```python
-FALLBACK = {"xp_per_level": 100, "max_level": 50}   # hardcoded safe default
-
-ok, cfg = safe_call(lambda: kv_client.get_json("game/config"), None)
-if not ok or not isinstance(cfg, dict):
-    cfg = dict(FALLBACK)                            # degrade, don't crash — and log it
-max_level = clamp_num(cfg.get("max_level"), 1, 999, FALLBACK["max_level"])
+for attempt in range(1, MAX_ATTEMPTS + 1):
+    if time.monotonic() >= deadline:
+        break
+    try:
+        return call()
+    except RetryableError as exc:
+        if attempt == MAX_ATTEMPTS or not is_idempotent:
+            raise
+        delay = min(BASE * 2 ** (attempt - 1), CAP)
+        delay = random.uniform(0, delay)           # full jitter — NOT a fixed ramp
+        if exc.retry_after:                        # 429/503 Retry-After wins over your backoff
+            delay = max(delay, exc.retry_after)
+        if time.monotonic() + delay >= deadline:
+            break
+        time.sleep(delay)
 ```
 
-## Negative cache (avoid timeout cascade)
+- **Retryable**: connect/read timeouts, connection resets, 502/503/504, and 429 (honoring
+  `Retry-After`). **Not retryable**: any other 4xx — a 4xx is an answer.
+- **Jitter is not optional.** Fixed or purely exponential backoff synchronizes every client onto the
+  same retry instants and re-kills the dependency the moment it recovers.
+- **Do not stack retry layers.** If the HTTP client already retries, the caller must not. Total
+  attempts across all layers must be finite, known, and written down next to the config.
+- **Retry budget**: cap retries at ~10-20% of normal traffic (a token bucket per dependency). Past
+  that, shed to the fallback — retries during a broad outage *are* the outage.
 
-When a dependency is unreachable, cache the *failure* briefly (a few seconds) so every subsequent call
-doesn't wait out the full timeout. Re-query after the fail-TTL expires.
+## Negative cache + single-flight (avoid timeout cascade)
 
-**Exception:** a real 404 / "not found" is an answer, not a transport failure — do NOT negative-cache it.
-The same applies to any fast non-200 or a malformed body: only the path that pays the timeout gets
-negative-cached. Full production-extracted implementation (Consul KV, two caches, ACL auto-detect):
-`references/consul-kv-negative-cache.md`.
+When a dependency is unreachable, cache the *failure* briefly so every subsequent call doesn't wait out
+the full timeout — **and** guard the probe with a single-flight lock so a concurrent burst sends one
+probe, not N.
+
+Measured: 200 concurrent callers against a down dependency, negative cache alone → **38** callers still
+paid the full timeout (a burst all misses the cold cache together); with a single-flight guard → **1**.
+A negative cache without single-flight only protects *sequential* callers, which is not the shape an
+outage has.
 
 ```python
 _fail_until = 0.0
+_probe = threading.Lock()
 FAIL_TTL = 15.0
 
 def get_price(item_id: str) -> float | None:
     global _fail_until
     if time.monotonic() < _fail_until:
         return None                                  # known-down: fail fast
+    if not _probe.acquire(blocking=False):
+        return None                                  # someone is already probing — don't pile on
     try:
+        if time.monotonic() < _fail_until:           # re-check under the guard
+            return None
         return pricing_client.get(item_id)           # a 404 here returns None, not an exception
     except TransportError:
-        _fail_until = time.monotonic() + FAIL_TTL    # transport failure: back off
+        _fail_until = time.monotonic() + FAIL_TTL * random.uniform(0.8, 1.2)   # jitter the TTL
         return None
+    finally:
+        _probe.release()
+```
+
+- **Jitter the fail-TTL.** With a fixed TTL every caller retries on the same instant: measured 200
+  simultaneous probes at `t = TTL`. `FAIL_TTL * uniform(0.8, 1.2)` spreads them.
+- **Key the cache per dependency-key**, not one global flag, or one dead key blinds every other.
+- **Exception:** a real 404 / "not found" is an answer, not a transport failure — do NOT
+  negative-cache it. Same for any fast non-200 or a malformed body: only the path that pays the
+  timeout gets negative-cached. Full production-extracted implementation (Consul KV, two caches, ACL
+  auto-detect): `references/consul-kv-negative-cache.md`.
+- **When a fail-flag is not enough**: if the dependency degrades *slowly and partially* (some calls
+  succeed, latency climbs), it never trips. Use a real circuit breaker — open on an error *rate* over
+  a rolling window, half-open with a single trial call — with the same fallback behind it.
+
+## Config / KV with hardcoded fallback
+
+Remote config (Consul KV, a `/config/*` endpoint) WILL be unavailable sometimes. Always ship a
+hardcoded default and merge **field by field** — one bad field must not discard an otherwise valid
+response — and clamp ranges.
+
+```python
+FALLBACK = {"xp_per_level": 100, "max_level": 50}   # hardcoded safe default
+
+ok, cfg = safe_call(lambda: kv_client.get_json("game/config"), None, op="game_config")
+if not ok or not isinstance(cfg, dict):
+    cfg = dict(FALLBACK)                            # degrade, don't crash — already logged + counted
+max_level = clamp_num(cfg.get("max_level"), 1, 999, FALLBACK["max_level"])
 ```
 
 ## Startup config: retry then degrade
 
-At boot, retry the config fetch a bounded number of times, then start in degraded mode on the hardcoded
-fallback — a config outage must not prevent startup. Log the degradation and refresh when the
-dependency recovers (background task, health-check hook, or next request).
+At boot, retry the config fetch a bounded number of times **under a total boot deadline**, then start
+in degraded mode on the hardcoded fallback — a config outage must not prevent startup, and must not
+delay it indefinitely either. Log the degradation and refresh when the dependency recovers (background
+task, health-check hook, or next request).
 
 ## Surface failures to the caller
 
 A handler that depends on a downstream call must tell its caller when that call failed — an explicit
 error response or degraded-data marker — never a silent success with stale/empty data. (HTTP: 503 with
-a Problem Details body beats a fabricated 200.)
+an error body beats a fabricated 200.) Serving a last-known-good value is fine **only** when the
+response marks it stale (a `degraded: true` field or a `Warning` header).
+
+Readiness must reflect it too: a service running entirely on fallbacks is degraded, and the detailed
+health endpoint has to say so even while liveness stays green.
 
 ## Concurrency: deduplicate in-flight requests
 
 Guard against duplicate concurrent requests for the same key (single-flight / per-key lock) so N
 concurrent triggers don't spawn N identical downstream calls and overwrite each other out of order.
+This is the same guard the negative cache uses — implement it once, per key, and reuse it.
+
+## What to test (hand to `bug-hunter`)
+
+Every rule above is a test: dependency times out → fallback + one log line + one counter increment;
+dependency returns a partial or wrong-typed body → fallback, not a crash; a real 404 → NOT
+negative-cached; N concurrent callers with the dependency down → exactly one upstream attempt; retry of
+a non-idempotent write → does not double-apply; worst-case latency of the retry policy → asserted
+against the stated deadline.
 
 ## See also
 
@@ -107,3 +224,4 @@ concurrent triggers don't spawn N identical downstream calls and overwrite each 
 - `bug-hunter` — the adversarial-testing rite that validates fallback under "dependency down / partial
   payload / race".
 - `fivem-fallback` — the FiveM/Lua adaptation of this doctrine.
+- `python-rest-api` — the service baseline these outbound calls are made from.

--- a/cursor/rules/fivem-fallback.mdc
+++ b/cursor/rules/fivem-fallback.mdc
@@ -47,14 +47,20 @@ trusting `data` — transport success is not payload validity.
 
 ```lua
 CreateThread(function()
-  for _ = 1, 20 do
+  local deadline = GetGameTimer() + 60000            -- bound the WALL CLOCK, not just the count
+  local wait = 500
+  while GetGameTimer() < deadline do
     local ok = SafeCall(refreshConfig, false)
     if ok then return end
-    Wait(3000)
+    Wait(math.random(wait, wait * 2))                -- jittered, growing backoff
+    wait = math.min(wait * 2, 8000)
   end
   -- still down → run on hardcoded fallback; log it; let a later event refresh
 end)
 ```
+
+The deadline is the point: a fixed `for 1, 20 do ... Wait(3000)` loop wrapped around a client that
+itself retries multiplies out to minutes of boot with no upper bound anyone wrote down.
 
 ## NUI callbacks must signal failure
 
@@ -74,11 +80,23 @@ end)
 
 ## Shared HTTP client (retry only on 5xx)
 
-All Lua→backend traffic goes through ONE shared wrapper: bounded retry (10×) **only on 5xx** — a
-4xx is an answer, not a transport failure (same doctrine as the 404 negative-cache exception) —
-service-token header injected without overwriting the caller's, and a loud-fail placeholder
-hostname so misconfig breaks visibly instead of silently hitting localhost. Production-extracted
-implementation: `references/http-client-retry.md`.
+All Lua→backend traffic goes through ONE shared wrapper: bounded retry **only on 5xx** — a 4xx is an
+answer, not a transport failure (same doctrine as the 404 negative-cache exception) — service-token
+header injected without overwriting the caller's, and a loud-fail placeholder hostname so misconfig
+breaks visibly instead of silently hitting localhost. Production-extracted implementation:
+`references/http-client-retry.md`.
+
+Bound it the way `backend-resilience` requires, because an attempt count alone does not:
+
+- **Give the call a deadline**, not just a retry count. 10 attempts at a 5s timeout is a 50s worst
+  case; the same client under the 20-attempt boot loop below reaches ~18 minutes. Keep the total under
+  what the caller (a player action, a NUI callback) can actually wait for — 3 attempts is the right
+  order of magnitude on a player-facing path.
+- **Jitter the wait** (`Wait(base * 2^n * math.random())`). A fixed ramp puts every FiveM instance on
+  the same retry instant and re-kills the backend as it recovers.
+- **Retry only what is safe to repeat.** A 5xx on a GET is a blip; a 5xx on "buy this item" is
+  ambiguous — the write may already have landed. Retry it only when the backend honors an idempotency
+  key you send on every attempt; otherwise surface the failure to the player.
 
 ## Concurrency
 

--- a/cursor/rules/log-event-collector.mdc
+++ b/cursor/rules/log-event-collector.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Doctrine for building a log-tailing event collector — a sidecar that tails an application or game server's text logs, parses lines into normalized events, and ships them to a backend API. Distilled from a production collector for an Assetto Corsa server, but stack-agnostic. Use when building or reviewing a log tailer, log-to-event parser, file offset persistence, log rotation or truncation handling, multi-line event correlation, shutdown flush, or idempotency/dedup keys for shipped events. Do NOT use for configuring log aggregation stacks (Loki, Fluentd, Filebeat), for the API that receives the events (that is python-rest-api), or for metrics/APM instrumentation.
+  Doctrine for building a log-tailing event collector — a sidecar that tails an application or game server's text logs, parses lines into normalized events, and ships them to a backend API. Distilled from a production collector for an Assetto Corsa server, but stack-agnostic. Use when building or reviewing a log tailer, log-to-event parser, file offset persistence, log rotation or truncation handling, partial-line reads, multi-line event correlation, backpressure, shutdown flush, or idempotency/dedup keys for shipped events. Do NOT use for configuring log aggregation stacks (Loki, Fluentd, Filebeat), for the API that receives the events (that is python-rest-api), or for metrics/APM instrumentation of the monitored application.
 alwaysApply: false
 ---
 
@@ -30,15 +30,35 @@ tests/             # unit tests + golden log fixture
 
 Keep it **dependency-free (stdlib-only) when the deploy target is a bare container** — `urllib`,
 `re`, `json`, `signal` cover everything a collector needs, and the image stays a plain
-`python:3.12-slim` with zero supply chain.
+`python:3.12-slim` with zero supply chain. When the runtime already ships an HTTP client, or the image
+isn't yours to keep minimal, use it: the rule is *no new supply chain for the sake of ergonomics*, not
+*stdlib at any cost*. `urllib` costs you connection pooling, per-phase timeouts and `Retry-After`
+parsing — pay that deliberately, not by default.
 
 ## Tailing — offset in bytes, rotation-proof
 
 - Pick the newest log file by mtime (`sorted(glob("*.txt"), key=mtime)[-1]`) each poll — servers
   start a new file per boot.
 - Persist the **byte offset** together with the file path it belongs to. On read: if the stored
-  path differs from the current file, start at 0; `seek(offset)`; after iterating, store
-  `handle.tell()`.
+  path differs from the current file, start at 0; `seek(offset)`.
+- **Advance the offset only to the last complete line** — never `handle.tell()` after iterating. A
+  poll that lands mid-write consumes a half-line, ships a truncated event, and loses the remainder
+  forever. Measured: one line arriving across two write flushes produced two bogus events and zero
+  correct ones.
+
+  ```python
+  with path.open("rb") as handle:
+      handle.seek(offset)
+      buf = handle.read()
+  cut = buf.rfind(b"\n")
+  if cut < 0:
+      return []                       # nothing complete yet — offset unchanged
+  offset += cut + 1
+  lines = buf[:cut].decode("utf-8", "replace").split("\n")
+  ```
+
+  Cap the held-back remainder (e.g. 1 MiB): a writer that never emits `\n` must not grow the buffer
+  without bound.
 - **Truncation/rotation guard**: `if offset > path.stat().st_size: offset = 0`. Without this, a
   rotated/truncated file silently yields nothing forever.
 - `start_at_end` option (seek to EOF when there is no stored state) so a fresh deploy doesn't
@@ -64,11 +84,21 @@ stale one.
 
 ## Idempotency — deterministic event_key + bounded seen-set
 
-- Every parsed event carries a deterministic `event_key`:
-  `f"player_connected:{steam_id}:{slot}:{line_hash(raw_line)}"` — type + stable ids + a hash of
-  the raw line. Singleton events use a constant key (`"server_started"`).
-- The seen-set is **bounded** (`processed_events[-1000:]`): dedup protects against re-reading the
-  recent window after a restart, not against infinite memory growth.
+- Every parsed event carries a deterministic `event_key` built from type + stable ids + **where the
+  line sits in the log**: `f"player_connected:{steam_id}:{slot}:{log_file}:{line_offset}"`.
+  Singleton events use a constant key (`"server_started"`).
+  Hashing the raw line instead collapses two genuinely distinct occurrences of a byte-identical line
+  into one key and silently drops the second — measured with two identical reconnect lines. The key
+  must be **stable** across a restart that re-reads the same bytes and **distinct** across two real
+  occurrences; the byte offset is both.
+- The seen-set is a **`set` for lookup plus a `deque(maxlen=N)` for the bound** — persist the deque,
+  rebuild the set on load. A plain list is O(n) per check (measured 37x slower at N=1000) and grows
+  unbounded the moment someone forgets the slice.
+- **Size the window against the worst replay, not the happy one.** The rotation guard
+  (`offset > size → offset = 0`) can re-read an entire file, so a file with more lines than N replays
+  straight past the dedup window. Either size N above the largest expected file, or make the backend
+  the idempotency authority (unique index on `event_key`) and treat the local ring as an optimization.
+  State which one the project chose.
 - Dispatch failure is **non-fatal**: log it, do NOT mark the key as seen, let the next scan retry.
   Only mark seen after the backend accepted the event.
 
@@ -103,9 +133,12 @@ Without this, every deploy leaves phantom "online" players in the backend.
 
 ## Backend client — small, honest, testable
 
-- Bounded retry on **connection** errors only (3 attempts, linear backoff `sleep(attempt)`);
-  HTTP errors (4xx/5xx with a response) raise immediately with the body in the message — they are
-  contract problems, not blips.
+- Retry policy follows `backend-resilience` (bounded attempts, exponential backoff + **jitter**, one
+  overall deadline). Collector specifics: retry **connection** errors plus 429/502/503/504, honoring
+  `Retry-After`; every other 4xx raises immediately with the body in the message — it is a contract
+  problem, not a blip. State the worst case next to the config: `attempts x timeout + backoff` must
+  stay under the poll interval, or the tailer falls behind while it retries (a 3x10s policy with
+  linear backoff is already 33s of blocked loop).
 - Service auth = one header (e.g. `X-Drivezone-Token`), added only when configured.
 - Unwrap the backend envelope at the client boundary (`data.get("data", data)`) so the rest of the
   collector never sees transport shape.
@@ -118,6 +151,22 @@ Every payload carries `source` (which collector), `event_version: 1` (forward-co
 `occurred_at` (parsed from the log timestamp, not "now"), and preserves the raw line in
 `payload.raw_line` — when a parser bug is found later, the raw material to re-derive is already
 in the backend. Ship to one generic endpoint (`POST /api/v1/events`); let the backend normalize.
+
+## Backpressure — the backend is the slow part
+
+The poll loop and the dispatcher must not be the same unbounded loop. Keep a **bounded** in-memory
+queue between "lines parsed" and "events shipped"; when it fills, **stop tailing** and leave the offset
+where it is, rather than dropping events or growing memory — the log file on disk is the buffer, and a
+better one than RAM. Batch dispatch when the backend offers a batch endpoint: per-event POSTs cap
+throughput at one round-trip per event and multiply the auth/TLS cost.
+
+## The collector's own observability
+
+A collector that silently falls behind is worse than one that crashes. Expose at minimum: **lag**
+(`file_size - offset`, in bytes), events parsed / shipped / failed since boot, last successful dispatch
+timestamp, and **unparsed-line count**. A rising unparsed-line count is the detector for the top risk
+this skill names below — the upstream changing its log format — and without it that risk is only
+discovered when someone notices missing data.
 
 ## Testing
 

--- a/cursor/rules/python-rest-api.mdc
+++ b/cursor/rules/python-rest-api.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production services. Use when creating or reviewing a Python API service — project layout, response envelope with centralized response codes, exception-handler registry (input errors are never raw 500), Field-constraint validation, tenant-isolation lookups, session-per-request DB access, pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures, testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency with partial unique indexes, JSONB dialect variants, and out-of-process ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
+  Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production services. Use when creating or reviewing a Python API service — project layout, response envelope with centralized response codes, exception-handler registry (input errors are never raw 500), Field-constraint validation, tenant-isolation lookups, session-per-request DB access, pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures, testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency with partial unique indexes, JSONB dialect variants, request size/depth limits, and out-of-process ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 alwaysApply: false
 ---
 
@@ -64,7 +64,7 @@ Register handlers in `main.py`; each maps a failure class to the envelope:
 | `AppException` subclasses | its own | typed business errors raised by services |
 | `RequestValidationError` | 422 | pydantic input rejection |
 | `IntegrityError` (unique/FK/not-null) | 409 | driven by request data, not a server fault |
-| `DataError`, `decimal.InvalidOperation`, `OverflowError` | 400 | bad numeric/literal input |
+| `DataError`, `decimal.InvalidOperation`, `OverflowError`, `RecursionError` | 400 | bad numeric/literal/nesting input |
 | `SQLAlchemyError` | 500 | genuine DB fault |
 | catch-all `Exception` | 500 | message hidden unless `APP_ENV == "dev"` |
 
@@ -78,6 +78,42 @@ Every numeric knob gets an explicit `Field` constraint and a described default:
 `Field(default=None, ge=1, le=128)`, `Decimal = Field(default=Decimal("0"), ge=0)`,
 `str = Field(..., max_length=255)`. Optional tuning fields default to `None` so downstream defaults
 aren't silently overridden.
+
+## Request limits — the framework has none
+
+The stock stack accepts a body of any size and any nesting depth, so "input errors are never a raw
+500" is false until you add two guards. Measured on fastapi 0.141.1 / pydantic 2.13.4:
+
+| Input | Stock behavior | Must be |
+|---|---|---|
+| 2 KB body of nested brackets (`"[" * 1000`) | **500** (`RecursionError`) | 400 |
+| 20 MB flat JSON body | **200** (fully buffered) | 413 |
+
+A 2 KB unauthenticated request that returns a 500 is a denial-of-service primitive, not an edge case.
+Both guards are additive and were verified to leave the happy path at 200:
+
+```python
+class BodyLimit(BaseHTTPMiddleware):                 # -> 413 before anything is parsed
+    async def dispatch(self, request: Request, call_next):
+        cl = request.headers.get("content-length")
+        if cl and int(cl) > settings.MAX_BODY_BYTES:
+            return JSONResponse(error_envelope(RC.PAYLOAD_TOO_LARGE), status_code=413)
+        return await call_next(request)
+
+@app.exception_handler(RecursionError)               # -> 400, not the catch-all 500
+async def too_deep(request: Request, exc: RecursionError): ...
+```
+
+Set `MAX_BODY_BYTES` from the largest legitimate payload, not from a round number, and enforce it at
+the reverse proxy too (`client_max_body_size`) so the app never buffers what it will reject. A
+chunked request has no `Content-Length` — cap the stream read as well when any endpoint accepts one.
+
+## Outbound calls
+
+Every call this service makes to another service, KV store, or third-party API carries an explicit
+timeout and a bounded retry policy. Doctrine, including the deadline budget and the negative-cache
+rules: `backend-resilience`. An outbound call with no timeout inside a request handler converts a
+dependency's slowdown into this service's outage.
 
 ## Tenant isolation (BOLA/IDOR)
 

--- a/openspec/changes/harden-backend-skills/.openspec.yaml
+++ b/openspec/changes/harden-backend-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/harden-backend-skills/design.md
+++ b/openspec/changes/harden-backend-skills/design.md
@@ -1,0 +1,86 @@
+## Context
+
+The backend family (`python-rest-api`, `backend-resilience`, `log-event-collector`,
+`api-resilience-testing`, `bug-hunter`, plus the `fivem-fallback` adaptation) is the most cross-linked
+cluster in the catalog: each skill delegates to the others rather than restating. That makes a defect
+in one of them propagate — `bug-hunter`'s "dependency down" scenario asserts behaviour *defined by*
+`backend-resilience`, so a gap there is a gap in the test rite too.
+
+The skills were written from real production incidents and read as complete. The question this change
+answers is not "are they plausible" but "does the code they prescribe survive the failure it claims to
+handle". That was measured, not argued: a simulation battery re-implemented each prescribed snippet
+verbatim and attacked it, and an A/B trial measured whether the doctrine changes what an agent writes.
+
+## Goals / Non-Goals
+
+**Goals**
+- Every failure-behaviour claim in the backend family is backed by a reproducible run.
+- Remove the two reproduced defects and the cross-skill contradiction on error shape.
+- Close the doctrine gaps the A/B trial proved do not land today (timeouts, deadline, jitter,
+  `Retry-After`, fallback metrics).
+
+**Non-Goals**
+- No migration to RFC 9457. The documented envelope stays canonical (owner decision, 2026-08-06);
+  RFC 9457 is retained only as the greenfield default.
+- No new skill. Observability, async/DB concurrency and background jobs are real gaps in the family
+  but are separate proposals — this change only adds the observability hooks the measured failures
+  require.
+- No changes to services built on these skills; this is catalog-only.
+
+## Decisions
+
+**D1 — Retry doctrine is ordered, not a list.** The skill now prescribes
+timeout → deadline → bounded retry → negative cache + single-flight → fallback → surface, because the
+measured failures were ordering failures: a retry policy with no deadline reached 18 minutes, and a
+negative cache with no single-flight let 38 of 200 concurrent callers through.
+
+**D2 — Fallback observability is a rule, not a principle.** In the A/B trial no arm emitted a metric
+when the rule lived only in a principle bullet, though the arm that saw a named helper reproduced the
+helper. The counter therefore ships inside the prescribed `safe_call` body, where it is copied.
+
+**D3 — Error shape: the documented envelope stays canonical.** `api-resilience-testing` asserted RFC
+9457 while `python-rest-api` prescribes `{status, code, message, path, details}`; the checklist marked
+a compliant service as failing. The checklist item becomes "one documented, machine-readable shape,
+applied to every error path" with RFC 9457 named as the greenfield default. Migration cost for
+`react-api-client` and live services is the reason.
+
+**D4 — Status-code assertions follow the baseline stack.** Measured on fastapi 0.141.1: malformed
+JSON → 422 (not 400), missing/wrong `Content-Type` → 422 (not 415), unknown `Accept` → 200 (no 406),
+wrong path-param type → 422 (not 404). The checklist states the framework-real code, and flags the
+ones worth overriding rather than asserting a code the stack never returns.
+
+**D5 — Request limits belong to `python-rest-api`, not to the testing skill.** The 2 KB → 500 defect
+is a property of the service baseline; `api-resilience-testing` gains the *test case*, the baseline
+gains the *guard*. Single canonical home preserved.
+
+**D6 — `log-event-collector` links retry doctrine instead of restating it.** Per skills-authoring,
+fallback/retry is canonical in `backend-resilience`; the collector keeps only its own specifics
+(what a collector considers retryable, and the poll-interval constraint).
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Timeouts, deadline budget, retry classification, backoff + jitter, retry budget | `backend-resilience` | establish here (new); `fivem-fallback` and `log-event-collector` link |
+| Negative cache + single-flight + fail-TTL jitter | `backend-resilience` | already canonical — corrected in place |
+| Fallback observability (cause-carrying log + counter) | `backend-resilience` | establish here; inside the shared helper |
+| HTTP request limits (max body size, JSON depth) | `python-rest-api` | establish here; `api-resilience-testing` links the test case |
+| Error envelope shape + response codes | `python-rest-api` | already canonical — `api-resilience-testing` stops asserting a rival shape |
+| REST negative-testing checklist | `api-resilience-testing` | already canonical — status codes corrected |
+| Adversarial methodology | `bug-hunter` | link (already canonical, unchanged) |
+| Log tailing, offsets, event dedup | `log-event-collector` | already canonical — defects corrected |
+| Trust boundary (`source`, not client args) | `fivem-lua` | link (already canonical, unchanged) |
+
+## Risks / Trade-offs
+
+- [`backend-resilience` grows past a comfortable skim length] → the retry/timeout mechanics stay in
+  SKILL.md because the A/B trial shows they only land when inline; the production Consul
+  implementation stays in `references/`.
+- [Two new required guards in `python-rest-api` (body size, depth) are breaking for existing services]
+  → both are additive middleware/handler registrations with a verified happy-path pass; the skill
+  states the measured thresholds so adopters can size them.
+- [Corrected status codes could read as "lowering the bar"] → each corrected item names the
+  framework-real code AND whether overriding it is worth doing, so the checklist still drives a
+  decision instead of asserting a false failure.
+- [Version bumps invalidate cached copies for adopters] → intended; `backend-resilience` takes a major
+  (2.0.0) because the retry rules tighten previously permitted policies.

--- a/openspec/changes/harden-backend-skills/proposal.md
+++ b/openspec/changes/harden-backend-skills/proposal.md
@@ -1,0 +1,75 @@
+# Change: Harden the backend skill family against measured failure modes
+
+## Why
+
+A simulation battery run against the code the backend skills actually prescribe (2026-08-06, this
+repo) reproduced three defects and six gaps in doctrine that is presented as production-hardened:
+
+- `log-event-collector` ends its tail loop with `handle.tell()`. A log line arriving across two write
+  flushes is consumed half-read and the offset advances past it: measured, one line produced two
+  bogus events and zero correct ones.
+- `log-event-collector`'s `event_key` hashes the raw line, so two genuinely distinct occurrences of a
+  byte-identical line collapse to one key and the second real event is silently dropped.
+- A stock FastAPI service — the `python-rest-api` baseline — answers **HTTP 500** to a 2 KB request
+  body of nested brackets (`RecursionError`), and **HTTP 200** to a 20 MB body. Both skills declare
+  a 5xx from bad input to be a bug; neither prescribes the body-size or depth limit that prevents it.
+  Verified against fastapi 0.141.1 / pydantic 2.13.4, and the mitigation verified to return 400/413.
+- `backend-resilience`'s negative cache has no single-flight guard: measured, 200 concurrent callers
+  against a down dependency still paid 38 full timeouts. With the guard, 1.
+- No skill states a wall-clock deadline, only attempt counts. The policies as written reach a 50s
+  worst case (`fivem-fallback`, 10 attempts) and ~18 minutes when stacked under its own boot loop.
+- `safe_call` swallows four distinct failure causes into one indistinguishable outcome and emits no
+  log, contradicting its own principle "never silent stale state".
+
+An A/B trial (two arms per side, same task, same reference file) measured what the doctrine actually
+produces: the current `backend-resilience` yielded 10.5/17 of the target behaviours, a revised draft
+yielded 16/17. The five behaviours gained — connect/read timeout split, exponential backoff, retry
+jitter, wall-clock deadline, fail-TTL jitter, `Retry-After` — are exactly the ones the current text
+does not mention. No arm emitted a fallback metric, so that rule needs to be structural, not a
+principle bullet.
+
+`api-resilience-testing` also asserts status codes the baseline stack does not produce (malformed
+JSON → 400; FastAPI returns 422), and prescribes RFC 9457 while `python-rest-api` prescribes a custom
+envelope — the two skills cite each other and disagree.
+
+## What Changes
+
+- `backend-resilience` → 2.0.0: add explicit-timeout and deadline-budget doctrine, retry
+  classification with exponential backoff + full jitter + `Retry-After` + retry budget, the
+  idempotent-only retry rule, single-flight on the negative-cache probe, fail-TTL jitter, an async
+  helper variant, cause-carrying + counted fallbacks, a circuit-breaker escalation note, and a
+  "what to test" handoff to `bug-hunter`.
+- `log-event-collector` → 1.1.0: fix the partial-line offset rule and the `event_key` formula, switch
+  the seen-set to set+deque and state the replay-window interaction with the rotation guard, link
+  retry doctrine to `backend-resilience` instead of restating it, add backpressure and
+  collector-self-observability sections, close the stdlib-only conditional.
+- `python-rest-api` → 1.3.0: add a request-limits rule (max body size + JSON depth, with the measured
+  numbers), map `RecursionError` to 400 in the handler table, define `ValidationException` (named in
+  the doctrine, missing from the reference drop-in), implement the `APP_ENV == "dev"` branch the
+  doctrine promises, flag the `str(exc)` string-sniffing fragility, and require an explicit timeout on
+  every outbound call.
+- `api-resilience-testing` → 1.2.0: correct the asserted status codes to what the baseline stack
+  returns, resolve the error-shape conflict in favour of the documented envelope (RFC 9457 stays as
+  the greenfield default, not a requirement), and add the oversized/deeply-nested body cases with the
+  measured evidence.
+- `fivem-fallback` → 1.3.0: bound the 10-attempt retry with a deadline and jitter, and stop implying
+  a blind retry is safe for non-idempotent calls.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — a skill's claims about runtime failure behaviour SHALL be
+  backed by a reproducible simulation, and prescribed code SHALL be exercised against the failure it
+  claims to handle before publication.
+
+## Impact
+
+- Skills: `backend-resilience`, `log-event-collector`, `python-rest-api`, `api-resilience-testing`,
+  `fivem-fallback` (+ `references/fastapi-envelope.md`), and every regenerated wrapper tree
+  (`claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/`).
+- README skill table rows for the five skills.
+- Consumers: services built on `python-rest-api` gain two new required guards (body-size limit, depth
+  limit); the retry-policy changes tighten previously unbounded attempt counts.

--- a/openspec/changes/harden-backend-skills/specs/skills-authoring/spec.md
+++ b/openspec/changes/harden-backend-skills/specs/skills-authoring/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Simulated failure behaviour
+
+Any claim a skill makes about how prescribed code behaves under failure (timeout, dependency down,
+partial payload, concurrency, replay, hostile input) SHALL be backed by a reproducible run of that
+code against that failure before publication, and the skill SHALL state the measured outcome where it
+motivates a rule.
+
+#### Scenario: Prescribed snippet is exercised against the failure it claims to handle
+
+- **WHEN** a skill ships a code snippet as the recommended handling for a failure mode
+- **THEN** the snippet is run against that failure mode and the observed result is recorded
+- **AND** if the result contradicts the surrounding doctrine, the snippet is corrected before the
+  skill is published
+
+#### Scenario: A quantified claim carries its measurement
+
+- **WHEN** a rule is justified by a cost, a count, or a latency (e.g. "N callers each pay the full
+  timeout", "worst case is X seconds")
+- **THEN** the skill states the measured number and the conditions it was measured under, rather than
+  an unquantified assertion

--- a/openspec/changes/harden-backend-skills/tasks.md
+++ b/openspec/changes/harden-backend-skills/tasks.md
@@ -1,0 +1,82 @@
+## 1. backend-resilience (2.0.0)
+
+- [x] 1.1 Add ordered doctrine line (timeout → deadline → bounded retry → negative cache +
+      single-flight → fallback → surface) and rewrite Principles with: explicit timeout per call,
+      wall-clock deadline, retry only idempotent operations, degradation is an observable event
+- [x] 1.2 Add "Timeouts and the deadline budget" section with the sizing rule
+      (`attempts x timeout + backoff <= deadline <= caller budget`) and the measured worst cases
+- [x] 1.3 Rewrite `safe_call` to carry the cause (`err_type`), log it and increment a counter; add
+      `safe_call_async`; document why `CancelledError` must keep escaping
+- [x] 1.4 Add "Retry: bounded, backed off, jittered" — retryable set (timeouts, resets, 502/503/504,
+      429 honoring `Retry-After`), full jitter, no stacked retry layers, retry budget 10-20%
+- [x] 1.5 Correct the negative-cache section: single-flight probe guard, jittered fail-TTL, per-key
+      cache, with the measured 200-caller numbers; add the circuit-breaker escalation note
+- [x] 1.6 Add stale-with-marker rule to "Surface failures" and the degraded-readiness rule
+- [x] 1.7 Add "What to test" handoff section pointing at `bug-hunter`
+- [x] 1.8 Bump `metadata.version` to 2.0.0 and update the frontmatter description
+
+## 2. log-event-collector (1.1.0)
+
+- [x] 2.1 Replace the `handle.tell()` offset rule with "advance only to the last complete line",
+      including the byte-slice snippet and the held-back-remainder cap
+- [x] 2.2 Replace the `event_key` formula: occurrence discriminator (log file + byte offset) instead
+      of `line_hash(raw_line)`; state the measured collapse
+- [x] 2.3 Seen-set becomes set + `deque(maxlen=N)`; state the rotation-guard/replay-window
+      interaction and require the project to name its idempotency authority
+- [x] 2.4 Backend-client section links `backend-resilience` for retry doctrine; keeps only collector
+      specifics (retryable set incl. 429/`Retry-After`, worst case under the poll interval)
+- [x] 2.5 Add "Backpressure" and "The collector's own observability" sections
+- [x] 2.6 Close the stdlib-only conditional (state the other branch)
+- [x] 2.7 Bump `metadata.version` to 1.1.0 and update the frontmatter description
+
+## 3. python-rest-api (1.3.0)
+
+- [x] 3.1 Add "Request limits" rule: max body size (413) + JSON depth guard (400), with the measured
+      thresholds (2 KB nested body → 500; 20 MB flat body → 200 on the stock stack)
+- [x] 3.2 Add `RecursionError` to the 400 row of the exception-handler table
+- [x] 3.3 Require an explicit timeout on every outbound call; link `backend-resilience`
+- [x] 3.4 Fix `references/fastapi-envelope.md`: define the missing `ValidationException` (422),
+      implement the `APP_ENV == "dev"` branch in the catch-all handler, note the `str(exc)`
+      string-sniffing fragility and that the `HTTPException` code map only serves raw raises
+- [x] 3.5 Bump `metadata.version` to 1.3.0
+
+## 4. api-resilience-testing (1.2.0)
+
+- [x] 4.1 Correct the checklist status codes to the measured baseline behaviour (malformed JSON 422,
+      Content-Type 422, Accept 200, path-param type 422), each noting whether an override is worth it
+- [x] 4.2 Resolve the error-shape conflict: "one documented machine-readable shape applied to every
+      error path"; RFC 9457 named as the greenfield default, not a requirement; remove the rival
+      assertion from step 6 and the "Error standard" bullet
+- [x] 4.3 Add the oversized-body and deep-nesting cases to `references/negative-test-catalog.md` with
+      the measured evidence, linking the guard to `python-rest-api`
+- [x] 4.4 Bump `metadata.version` to 1.2.0
+
+## 5. fivem-fallback (1.3.0)
+
+- [x] 5.1 Bound the shared-client retry: deadline + jitter, and drop the implication that a blind 5xx
+      retry is safe for a non-idempotent call
+- [x] 5.2 Bound the boot loop with a total deadline; state the measured stacked worst case
+- [x] 5.3 Bump `metadata.version` to 1.3.0
+
+## 6. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on all five skills: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [x] Q.2 All touched skill content in English (catalog locale)
+- [x] Q.3 Description triggers still route correctly for each skill and every "Do NOT use for"
+      boundary survives
+- [x] Q.4 No duplicated doctrine: retry/timeout/fallback mechanics live only in `backend-resilience`;
+      request limits only in `python-rest-api`; siblings link per the design.md Canonical Home table
+- [x] Q.5 Every quantified claim added carries its measured number and conditions (skills-authoring:
+      Simulated failure behaviour)
+- [x] Q.6 README skill-table rows updated for the five skills
+
+## 7. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate harden-backend-skills --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green (rite gate incl. this change's own gate groups)
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 CI frontmatter check passes locally (name == dir, semver, category, license on every
+      `skills/*/SKILL.md`)
+- [ ] V.5 `openspec archive harden-backend-skills --yes` after all groups above and after review

--- a/plugins/backend/skills/backend-resilience/SKILL.md
+++ b/plugins/backend/skills/backend-resilience/SKILL.md
@@ -5,12 +5,14 @@ description: >-
   config store (Consul/KV), database, message broker, or another internal service. Use when adding or
   reviewing code that makes network calls that can time out, return 5xx, return partial payloads, or
   hit a dependency that is down — or when adding config fetch, retry logic, caching of failures, or
-  degraded-mode behavior. Enforces safe defaults, one shared fallback helper, response-shape validation,
-  clamping of remote values, bounded retries, negative caching, and in-flight deduplication. Examples in
-  Python; the doctrine is language-agnostic. For the FiveM/Lua adaptation use fivem-fallback instead.
+  degraded-mode behavior. Enforces explicit timeouts and a wall-clock deadline, retries only on
+  idempotent operations with exponential backoff + jitter, safe defaults, one shared fallback helper,
+  response-shape validation, clamping of remote values, negative caching with single-flight, and
+  observable degradation. Examples in Python; the doctrine is language-agnostic. For the FiveM/Lua
+  adaptation use fivem-fallback instead.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 2.0.0
   category: backend
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -22,30 +24,76 @@ Defensive patterns for calling an unreliable dependency. The network boundary is
 5xx, partial payloads, dependency down, races. Every call needs a **safe default** so the service keeps
 working. Doctrine is stack-agnostic; examples are Python.
 
+Apply in this order — it is the order of risk reduction, and each layer assumes the one above it:
+**timeout → deadline → bounded retry (idempotent only) → negative cache + single-flight → fallback
+default → surface the degradation.**
+
 ## Principles
 
-1. **Every external call can fail.** A failed call must produce a safe default — never a crash, and
+1. **Every external call has an explicit timeout.** A call with no timeout is an unbounded outage
+   waiting to happen; a retry on a hung connection waits forever. Set connect and read timeouts
+   separately — never rely on the library default.
+2. **Bound the wall clock, not just the attempt count.** "3 attempts" says nothing about latency.
+   Give the whole operation a **deadline** and check it before each attempt; when the caller is
+   serving an HTTP request, that deadline must be shorter than the request's own budget.
+3. **Retry only what is safe to repeat.** GET/HEAD/PUT/DELETE are retriable. A POST that charges,
+   ships, or writes is retriable **only** with an idempotency key the dependency honors. Otherwise a
+   5xx is a final answer — surface it.
+4. **Every external call can fail.** A failed call must produce a safe default — never a crash, and
    never silent stale state presented as fresh.
-2. **One shared helper, not ad-hoc per module.** Scattered try/except + type-check copies drift.
+5. **One shared helper, not ad-hoc per module.** Scattered try/except + type-check copies drift.
    Provide a single `safe_call`/`with_fallback` utility and use it everywhere.
-3. **Validate the response shape**, not just transport success: check the type, the expected fields,
+6. **Validate the response shape**, not just transport success: check the type, the expected fields,
    and the status/code before trusting the data.
-4. **Clamp untrusted/remote numbers** into a sane range — a bad config value must not break the system.
-5. **Bound retries.** If the HTTP client already retries 5xx, don't stack an unbounded second retry
-   loop on top. Total attempts across all layers must be finite and known.
+7. **Clamp untrusted/remote numbers** into a sane range — a bad config value must not break the system.
+8. **Degradation is an event, not a silence.** Every fallback carries its cause into a log line and a
+   counter. A fallback nobody can see is indistinguishable from correct behavior.
+
+## Timeouts and the deadline budget
+
+```python
+TIMEOUT = httpx.Timeout(connect=1.0, read=2.0, write=2.0, pool=1.0)
+
+deadline = time.monotonic() + 3.0          # the WHOLE operation, retries included
+while time.monotonic() < deadline:
+    ...                                     # attempt; sleep only if it still fits in the deadline
+```
+
+Sizing rule: `attempts x timeout + total backoff <= deadline <= the caller's own budget`. If the
+numbers don't fit, cut the attempts — not the timeout. Worst-case latency must be a number you can
+state; if you can't state it, the policy is unbounded.
+
+Attempt counts above ~3 are almost always wrong on a request path. Measured worst cases for policies
+this catalog used to prescribe: 10 attempts at a 5s timeout = **50s**; the same client stacked under a
+20-attempt/3s boot loop = **~18 minutes** before a caller gets an answer.
 
 ## safe_call / clamp
 
+The helper must report **why** it fell back. Measured: four distinct causes — a dependency timeout, a
+`TypeError` from your own code, malformed JSON, and a `MemoryError` — collapsed into one
+indistinguishable `(False, fallback)` with zero log lines. An operator cannot tell a code bug from an
+outage, and neither can a dashboard.
+
 ```python
-from typing import Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 T = TypeVar("T")
 
-def safe_call(fn: Callable[[], T], fallback: T) -> tuple[bool, T]:
-    """Returns (ok, value). On any failure returns (False, fallback) — never raises."""
+def safe_call(fn: Callable[[], T], fallback: T, *, op: str) -> tuple[bool, T]:
+    """Returns (ok, value). On failure returns (False, fallback) — never raises."""
     try:
         return True, fn()
-    except Exception:
+    except Exception as exc:                       # noqa: BLE001 — boundary helper, by design
+        logger.warning("fallback_used", op=op, err_type=type(exc).__name__, err=str(exc))
+        FALLBACK_TOTAL.labels(op=op, err=type(exc).__name__).inc()
+        return False, fallback
+
+async def safe_call_async(fn: Callable[[], Awaitable[T]], fallback: T, *, op: str) -> tuple[bool, T]:
+    try:
+        return True, await fn()
+    except Exception as exc:                       # noqa: BLE001
+        logger.warning("fallback_used", op=op, err_type=type(exc).__name__, err=str(exc))
+        FALLBACK_TOTAL.labels(op=op, err=type(exc).__name__).inc()
         return False, fallback
 
 def clamp_num(value, lo: float, hi: float, default: float) -> float:
@@ -56,61 +104,132 @@ def clamp_num(value, lo: float, hi: float, default: float) -> float:
     return max(lo, min(hi, v))
 ```
 
-## Config / KV with hardcoded fallback
+The counter is part of the helper, not an afterthought: an alert on `rate(fallback_used)` is the only
+way a permanently-degraded service announces itself.
 
-Remote config (Consul KV, a `/config/*` endpoint) WILL be unavailable sometimes. Always ship a
-hardcoded default and merge field-by-field; clamp ranges.
+`asyncio.CancelledError` is a `BaseException` and correctly escapes `except Exception` — do **not**
+widen the catch to `BaseException`, that swallows shutdown and enclosing timeouts. In an `async def`
+path use `safe_call_async`: the sync helper wrapped around a blocking client blocks the event loop for
+every concurrent request, which is worse than no resilience at all.
+
+## Retry: bounded, backed off, jittered
 
 ```python
-FALLBACK = {"xp_per_level": 100, "max_level": 50}   # hardcoded safe default
-
-ok, cfg = safe_call(lambda: kv_client.get_json("game/config"), None)
-if not ok or not isinstance(cfg, dict):
-    cfg = dict(FALLBACK)                            # degrade, don't crash — and log it
-max_level = clamp_num(cfg.get("max_level"), 1, 999, FALLBACK["max_level"])
+for attempt in range(1, MAX_ATTEMPTS + 1):
+    if time.monotonic() >= deadline:
+        break
+    try:
+        return call()
+    except RetryableError as exc:
+        if attempt == MAX_ATTEMPTS or not is_idempotent:
+            raise
+        delay = min(BASE * 2 ** (attempt - 1), CAP)
+        delay = random.uniform(0, delay)           # full jitter — NOT a fixed ramp
+        if exc.retry_after:                        # 429/503 Retry-After wins over your backoff
+            delay = max(delay, exc.retry_after)
+        if time.monotonic() + delay >= deadline:
+            break
+        time.sleep(delay)
 ```
 
-## Negative cache (avoid timeout cascade)
+- **Retryable**: connect/read timeouts, connection resets, 502/503/504, and 429 (honoring
+  `Retry-After`). **Not retryable**: any other 4xx — a 4xx is an answer.
+- **Jitter is not optional.** Fixed or purely exponential backoff synchronizes every client onto the
+  same retry instants and re-kills the dependency the moment it recovers.
+- **Do not stack retry layers.** If the HTTP client already retries, the caller must not. Total
+  attempts across all layers must be finite, known, and written down next to the config.
+- **Retry budget**: cap retries at ~10-20% of normal traffic (a token bucket per dependency). Past
+  that, shed to the fallback — retries during a broad outage *are* the outage.
 
-When a dependency is unreachable, cache the *failure* briefly (a few seconds) so every subsequent call
-doesn't wait out the full timeout. Re-query after the fail-TTL expires.
+## Negative cache + single-flight (avoid timeout cascade)
 
-**Exception:** a real 404 / "not found" is an answer, not a transport failure — do NOT negative-cache it.
-The same applies to any fast non-200 or a malformed body: only the path that pays the timeout gets
-negative-cached. Full production-extracted implementation (Consul KV, two caches, ACL auto-detect):
-`references/consul-kv-negative-cache.md`.
+When a dependency is unreachable, cache the *failure* briefly so every subsequent call doesn't wait out
+the full timeout — **and** guard the probe with a single-flight lock so a concurrent burst sends one
+probe, not N.
+
+Measured: 200 concurrent callers against a down dependency, negative cache alone → **38** callers still
+paid the full timeout (a burst all misses the cold cache together); with a single-flight guard → **1**.
+A negative cache without single-flight only protects *sequential* callers, which is not the shape an
+outage has.
 
 ```python
 _fail_until = 0.0
+_probe = threading.Lock()
 FAIL_TTL = 15.0
 
 def get_price(item_id: str) -> float | None:
     global _fail_until
     if time.monotonic() < _fail_until:
         return None                                  # known-down: fail fast
+    if not _probe.acquire(blocking=False):
+        return None                                  # someone is already probing — don't pile on
     try:
+        if time.monotonic() < _fail_until:           # re-check under the guard
+            return None
         return pricing_client.get(item_id)           # a 404 here returns None, not an exception
     except TransportError:
-        _fail_until = time.monotonic() + FAIL_TTL    # transport failure: back off
+        _fail_until = time.monotonic() + FAIL_TTL * random.uniform(0.8, 1.2)   # jitter the TTL
         return None
+    finally:
+        _probe.release()
+```
+
+- **Jitter the fail-TTL.** With a fixed TTL every caller retries on the same instant: measured 200
+  simultaneous probes at `t = TTL`. `FAIL_TTL * uniform(0.8, 1.2)` spreads them.
+- **Key the cache per dependency-key**, not one global flag, or one dead key blinds every other.
+- **Exception:** a real 404 / "not found" is an answer, not a transport failure — do NOT
+  negative-cache it. Same for any fast non-200 or a malformed body: only the path that pays the
+  timeout gets negative-cached. Full production-extracted implementation (Consul KV, two caches, ACL
+  auto-detect): `references/consul-kv-negative-cache.md`.
+- **When a fail-flag is not enough**: if the dependency degrades *slowly and partially* (some calls
+  succeed, latency climbs), it never trips. Use a real circuit breaker — open on an error *rate* over
+  a rolling window, half-open with a single trial call — with the same fallback behind it.
+
+## Config / KV with hardcoded fallback
+
+Remote config (Consul KV, a `/config/*` endpoint) WILL be unavailable sometimes. Always ship a
+hardcoded default and merge **field by field** — one bad field must not discard an otherwise valid
+response — and clamp ranges.
+
+```python
+FALLBACK = {"xp_per_level": 100, "max_level": 50}   # hardcoded safe default
+
+ok, cfg = safe_call(lambda: kv_client.get_json("game/config"), None, op="game_config")
+if not ok or not isinstance(cfg, dict):
+    cfg = dict(FALLBACK)                            # degrade, don't crash — already logged + counted
+max_level = clamp_num(cfg.get("max_level"), 1, 999, FALLBACK["max_level"])
 ```
 
 ## Startup config: retry then degrade
 
-At boot, retry the config fetch a bounded number of times, then start in degraded mode on the hardcoded
-fallback — a config outage must not prevent startup. Log the degradation and refresh when the
-dependency recovers (background task, health-check hook, or next request).
+At boot, retry the config fetch a bounded number of times **under a total boot deadline**, then start
+in degraded mode on the hardcoded fallback — a config outage must not prevent startup, and must not
+delay it indefinitely either. Log the degradation and refresh when the dependency recovers (background
+task, health-check hook, or next request).
 
 ## Surface failures to the caller
 
 A handler that depends on a downstream call must tell its caller when that call failed — an explicit
 error response or degraded-data marker — never a silent success with stale/empty data. (HTTP: 503 with
-a Problem Details body beats a fabricated 200.)
+an error body beats a fabricated 200.) Serving a last-known-good value is fine **only** when the
+response marks it stale (a `degraded: true` field or a `Warning` header).
+
+Readiness must reflect it too: a service running entirely on fallbacks is degraded, and the detailed
+health endpoint has to say so even while liveness stays green.
 
 ## Concurrency: deduplicate in-flight requests
 
 Guard against duplicate concurrent requests for the same key (single-flight / per-key lock) so N
 concurrent triggers don't spawn N identical downstream calls and overwrite each other out of order.
+This is the same guard the negative cache uses — implement it once, per key, and reuse it.
+
+## What to test (hand to `bug-hunter`)
+
+Every rule above is a test: dependency times out → fallback + one log line + one counter increment;
+dependency returns a partial or wrong-typed body → fallback, not a crash; a real 404 → NOT
+negative-cached; N concurrent callers with the dependency down → exactly one upstream attempt; retry of
+a non-idempotent write → does not double-apply; worst-case latency of the retry policy → asserted
+against the stated deadline.
 
 ## See also
 
@@ -118,3 +237,4 @@ concurrent triggers don't spawn N identical downstream calls and overwrite each 
 - `bug-hunter` — the adversarial-testing rite that validates fallback under "dependency down / partial
   payload / race".
 - `fivem-fallback` — the FiveM/Lua adaptation of this doctrine.
+- `python-rest-api` — the service baseline these outbound calls are made from.

--- a/plugins/backend/skills/log-event-collector/SKILL.md
+++ b/plugins/backend/skills/log-event-collector/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   server's text logs, parses lines into normalized events, and ships them to a backend API.
   Distilled from a production collector for an Assetto Corsa server, but stack-agnostic. Use when
   building or reviewing a log tailer, log-to-event parser, file offset persistence, log rotation or
-  truncation handling, multi-line event correlation, shutdown flush, or idempotency/dedup keys for
-  shipped events. Do NOT use for configuring log aggregation stacks (Loki, Fluentd, Filebeat), for
-  the API that receives the events (that is python-rest-api), or for metrics/APM instrumentation.
+  truncation handling, partial-line reads, multi-line event correlation, backpressure, shutdown flush,
+  or idempotency/dedup keys for shipped events. Do NOT use for configuring log aggregation stacks
+  (Loki, Fluentd, Filebeat), for the API that receives the events (that is python-rest-api), or for
+  metrics/APM instrumentation of the monitored application.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -41,15 +42,35 @@ tests/             # unit tests + golden log fixture
 
 Keep it **dependency-free (stdlib-only) when the deploy target is a bare container** — `urllib`,
 `re`, `json`, `signal` cover everything a collector needs, and the image stays a plain
-`python:3.12-slim` with zero supply chain.
+`python:3.12-slim` with zero supply chain. When the runtime already ships an HTTP client, or the image
+isn't yours to keep minimal, use it: the rule is *no new supply chain for the sake of ergonomics*, not
+*stdlib at any cost*. `urllib` costs you connection pooling, per-phase timeouts and `Retry-After`
+parsing — pay that deliberately, not by default.
 
 ## Tailing — offset in bytes, rotation-proof
 
 - Pick the newest log file by mtime (`sorted(glob("*.txt"), key=mtime)[-1]`) each poll — servers
   start a new file per boot.
 - Persist the **byte offset** together with the file path it belongs to. On read: if the stored
-  path differs from the current file, start at 0; `seek(offset)`; after iterating, store
-  `handle.tell()`.
+  path differs from the current file, start at 0; `seek(offset)`.
+- **Advance the offset only to the last complete line** — never `handle.tell()` after iterating. A
+  poll that lands mid-write consumes a half-line, ships a truncated event, and loses the remainder
+  forever. Measured: one line arriving across two write flushes produced two bogus events and zero
+  correct ones.
+
+  ```python
+  with path.open("rb") as handle:
+      handle.seek(offset)
+      buf = handle.read()
+  cut = buf.rfind(b"\n")
+  if cut < 0:
+      return []                       # nothing complete yet — offset unchanged
+  offset += cut + 1
+  lines = buf[:cut].decode("utf-8", "replace").split("\n")
+  ```
+
+  Cap the held-back remainder (e.g. 1 MiB): a writer that never emits `\n` must not grow the buffer
+  without bound.
 - **Truncation/rotation guard**: `if offset > path.stat().st_size: offset = 0`. Without this, a
   rotated/truncated file silently yields nothing forever.
 - `start_at_end` option (seek to EOF when there is no stored state) so a fresh deploy doesn't
@@ -75,11 +96,21 @@ stale one.
 
 ## Idempotency — deterministic event_key + bounded seen-set
 
-- Every parsed event carries a deterministic `event_key`:
-  `f"player_connected:{steam_id}:{slot}:{line_hash(raw_line)}"` — type + stable ids + a hash of
-  the raw line. Singleton events use a constant key (`"server_started"`).
-- The seen-set is **bounded** (`processed_events[-1000:]`): dedup protects against re-reading the
-  recent window after a restart, not against infinite memory growth.
+- Every parsed event carries a deterministic `event_key` built from type + stable ids + **where the
+  line sits in the log**: `f"player_connected:{steam_id}:{slot}:{log_file}:{line_offset}"`.
+  Singleton events use a constant key (`"server_started"`).
+  Hashing the raw line instead collapses two genuinely distinct occurrences of a byte-identical line
+  into one key and silently drops the second — measured with two identical reconnect lines. The key
+  must be **stable** across a restart that re-reads the same bytes and **distinct** across two real
+  occurrences; the byte offset is both.
+- The seen-set is a **`set` for lookup plus a `deque(maxlen=N)` for the bound** — persist the deque,
+  rebuild the set on load. A plain list is O(n) per check (measured 37x slower at N=1000) and grows
+  unbounded the moment someone forgets the slice.
+- **Size the window against the worst replay, not the happy one.** The rotation guard
+  (`offset > size → offset = 0`) can re-read an entire file, so a file with more lines than N replays
+  straight past the dedup window. Either size N above the largest expected file, or make the backend
+  the idempotency authority (unique index on `event_key`) and treat the local ring as an optimization.
+  State which one the project chose.
 - Dispatch failure is **non-fatal**: log it, do NOT mark the key as seen, let the next scan retry.
   Only mark seen after the backend accepted the event.
 
@@ -114,9 +145,12 @@ Without this, every deploy leaves phantom "online" players in the backend.
 
 ## Backend client — small, honest, testable
 
-- Bounded retry on **connection** errors only (3 attempts, linear backoff `sleep(attempt)`);
-  HTTP errors (4xx/5xx with a response) raise immediately with the body in the message — they are
-  contract problems, not blips.
+- Retry policy follows `backend-resilience` (bounded attempts, exponential backoff + **jitter**, one
+  overall deadline). Collector specifics: retry **connection** errors plus 429/502/503/504, honoring
+  `Retry-After`; every other 4xx raises immediately with the body in the message — it is a contract
+  problem, not a blip. State the worst case next to the config: `attempts x timeout + backoff` must
+  stay under the poll interval, or the tailer falls behind while it retries (a 3x10s policy with
+  linear backoff is already 33s of blocked loop).
 - Service auth = one header (e.g. `X-Drivezone-Token`), added only when configured.
 - Unwrap the backend envelope at the client boundary (`data.get("data", data)`) so the rest of the
   collector never sees transport shape.
@@ -129,6 +163,22 @@ Every payload carries `source` (which collector), `event_version: 1` (forward-co
 `occurred_at` (parsed from the log timestamp, not "now"), and preserves the raw line in
 `payload.raw_line` — when a parser bug is found later, the raw material to re-derive is already
 in the backend. Ship to one generic endpoint (`POST /api/v1/events`); let the backend normalize.
+
+## Backpressure — the backend is the slow part
+
+The poll loop and the dispatcher must not be the same unbounded loop. Keep a **bounded** in-memory
+queue between "lines parsed" and "events shipped"; when it fills, **stop tailing** and leave the offset
+where it is, rather than dropping events or growing memory — the log file on disk is the buffer, and a
+better one than RAM. Batch dispatch when the backend offers a batch endpoint: per-event POSTs cap
+throughput at one round-trip per event and multiply the auth/TLS cost.
+
+## The collector's own observability
+
+A collector that silently falls behind is worse than one that crashes. Expose at minimum: **lag**
+(`file_size - offset`, in bytes), events parsed / shipped / failed since boot, last successful dispatch
+timestamp, and **unparsed-line count**. A rising unparsed-line count is the detector for the top risk
+this skill names below — the upstream changing its log format — and without it that risk is only
+discovered when someone notices missing data.
 
 ## Testing
 

--- a/plugins/backend/skills/python-rest-api/SKILL.md
+++ b/plugins/backend/skills/python-rest-api/SKILL.md
@@ -8,11 +8,11 @@ description: >-
   pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures,
   testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis
   fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency
-  with partial unique indexes, JSONB dialect variants, and out-of-process ingestion workers (UDP).
-  The baseline that api-resilience-testing and bug-hunter assume.
+  with partial unique indexes, JSONB dialect variants, request size/depth limits, and out-of-process
+  ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -77,7 +77,7 @@ Register handlers in `main.py`; each maps a failure class to the envelope:
 | `AppException` subclasses | its own | typed business errors raised by services |
 | `RequestValidationError` | 422 | pydantic input rejection |
 | `IntegrityError` (unique/FK/not-null) | 409 | driven by request data, not a server fault |
-| `DataError`, `decimal.InvalidOperation`, `OverflowError` | 400 | bad numeric/literal input |
+| `DataError`, `decimal.InvalidOperation`, `OverflowError`, `RecursionError` | 400 | bad numeric/literal/nesting input |
 | `SQLAlchemyError` | 500 | genuine DB fault |
 | catch-all `Exception` | 500 | message hidden unless `APP_ENV == "dev"` |
 
@@ -91,6 +91,42 @@ Every numeric knob gets an explicit `Field` constraint and a described default:
 `Field(default=None, ge=1, le=128)`, `Decimal = Field(default=Decimal("0"), ge=0)`,
 `str = Field(..., max_length=255)`. Optional tuning fields default to `None` so downstream defaults
 aren't silently overridden.
+
+## Request limits — the framework has none
+
+The stock stack accepts a body of any size and any nesting depth, so "input errors are never a raw
+500" is false until you add two guards. Measured on fastapi 0.141.1 / pydantic 2.13.4:
+
+| Input | Stock behavior | Must be |
+|---|---|---|
+| 2 KB body of nested brackets (`"[" * 1000`) | **500** (`RecursionError`) | 400 |
+| 20 MB flat JSON body | **200** (fully buffered) | 413 |
+
+A 2 KB unauthenticated request that returns a 500 is a denial-of-service primitive, not an edge case.
+Both guards are additive and were verified to leave the happy path at 200:
+
+```python
+class BodyLimit(BaseHTTPMiddleware):                 # -> 413 before anything is parsed
+    async def dispatch(self, request: Request, call_next):
+        cl = request.headers.get("content-length")
+        if cl and int(cl) > settings.MAX_BODY_BYTES:
+            return JSONResponse(error_envelope(RC.PAYLOAD_TOO_LARGE), status_code=413)
+        return await call_next(request)
+
+@app.exception_handler(RecursionError)               # -> 400, not the catch-all 500
+async def too_deep(request: Request, exc: RecursionError): ...
+```
+
+Set `MAX_BODY_BYTES` from the largest legitimate payload, not from a round number, and enforce it at
+the reverse proxy too (`client_max_body_size`) so the app never buffers what it will reject. A
+chunked request has no `Content-Length` — cap the stream read as well when any endpoint accepts one.
+
+## Outbound calls
+
+Every call this service makes to another service, KV store, or third-party API carries an explicit
+timeout and a bounded retry policy. Doctrine, including the deadline budget and the negative-cache
+rules: `backend-resilience`. An outbound call with no timeout inside a request handler converts a
+dependency's slowdown into this service's outage.
 
 ## Tenant isolation (BOLA/IDOR)
 

--- a/plugins/backend/skills/python-rest-api/references/fastapi-envelope.md
+++ b/plugins/backend/skills/python-rest-api/references/fastapi-envelope.md
@@ -79,6 +79,13 @@ class ConflictException(AppException):
     def __init__(self, message: str = "Conflict", code: str | None = None) -> None:
         super().__init__(message, status_code=409, code=code or RC.CONFLICT)
 
+class ValidationException(AppException):
+    """Semantic validation a service performs AFTER pydantic accepted the shape
+    (cross-field rules, business invariants). Pydantic's own rejection arrives as
+    RequestValidationError and is handled separately."""
+    def __init__(self, message: str = "Validation error", code: str | None = None, data: Any = None) -> None:
+        super().__init__(message, status_code=422, code=code or RC.VALIDATION_ERROR, data=data)
+
 
 async def app_exception_handler(request: Request, exc: AppException) -> JSONResponse:
     logger.error("app_exception", path=request.url.path, method=request.method,
@@ -103,6 +110,10 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError) -
     logger.error("database_error", path=request.url.path, error=str(exc))
     if isinstance(exc, IntegrityError):
         # Unique/FK violations are driven by request data, not a server fault → 409, not 500.
+        # NOTE: the sniffing below matches Postgres driver text. On another backend, or after a
+        # driver reworded its message, it falls through to the generic integrity code — the 409 is
+        # still correct, only the specific code is lost. Prefer `exc.orig.sqlstate` (23505 unique,
+        # 23503 foreign key) when the driver exposes it, and keep this as the fallback.
         error_message, error_code = "Database integrity violation", RC.DATABASE_INTEGRITY_ERROR
         exc_str = str(exc).lower()
         if "duplicate key" in exc_str:
@@ -117,8 +128,20 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError) -
         "message": "Internal database error", "path": request.url.path})
 
 
+async def too_deep_handler(request: Request, exc: RecursionError) -> JSONResponse:
+    """A deeply-nested JSON body blows the parser's stack. Without this it reaches the
+    catch-all and becomes a 500 — a 5xx caused purely by input. Measured: a 2 KB body of
+    nested brackets returns 500 on a stock service, 400 with this handler registered."""
+    logger.warning("payload_too_deep", path=request.url.path)
+    return JSONResponse(status_code=400, content={
+        "status": "error", "code": RC.PAYLOAD_TOO_DEEP,
+        "message": "Request body nesting is too deep", "path": request.url.path})
+
+
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
-    """Wrap raw HTTPException (404, 405, ...) in the standard envelope."""
+    """Wrap raw HTTPException (404, 405, ...) in the standard envelope. In a service that
+    follows the 'never raise HTTPException directly' rule this only fires for framework-raised
+    ones — 405 from routing, 404 for an unknown path — which is exactly why it must stay."""
     code_map = {404: RC.NOT_FOUND, 405: RC.BAD_REQUEST, 401: RC.UNAUTHORIZED,
                 403: RC.FORBIDDEN, 409: RC.CONFLICT}
     code = code_map.get(exc.status_code, RC.ERROR)
@@ -130,9 +153,12 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     logger.error("unhandled_exception", path=request.url.path,
                  error_type=type(exc).__name__, error=str(exc), exc_info=True)
+    # The real message is exposed ONLY in dev; production gets a fixed string so a stack
+    # trace, SQL fragment or internal path can never leak through the catch-all.
+    message = f"{type(exc).__name__}: {exc}" if settings.APP_ENV == "dev" else "Internal server error"
     return JSONResponse(status_code=500, content={
         "status": "error", "code": RC.INTERNAL_SERVER_ERROR,
-        "message": "Internal server error", "path": request.url.path})
+        "message": message, "path": request.url.path})
 ```
 
 ## main.py registration
@@ -141,9 +167,14 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
 app.add_exception_handler(AppException, app_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(SQLAlchemyError, sqlalchemy_exception_handler)
+app.add_exception_handler(RecursionError, too_deep_handler)
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(Exception, generic_exception_handler)
 ```
+
+`RecursionError` must be registered **before** the `Exception` catch-all reaches it — Starlette
+resolves handlers by walking the exception's MRO, so the more specific class wins regardless of
+registration order, but keeping the order explicit documents the intent.
 
 Services raise the typed hierarchy; endpoints return `success(RC.X_CREATED, "...", data)`. The
 `ResponseCodes` class is a flat registry of UPPER_SNAKE_CASE string constants grouped by domain.

--- a/plugins/fivem/skills/fivem-fallback/SKILL.md
+++ b/plugins/fivem/skills/fivem-fallback/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   services use backend-resilience instead.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -57,14 +57,20 @@ trusting `data` — transport success is not payload validity.
 
 ```lua
 CreateThread(function()
-  for _ = 1, 20 do
+  local deadline = GetGameTimer() + 60000            -- bound the WALL CLOCK, not just the count
+  local wait = 500
+  while GetGameTimer() < deadline do
     local ok = SafeCall(refreshConfig, false)
     if ok then return end
-    Wait(3000)
+    Wait(math.random(wait, wait * 2))                -- jittered, growing backoff
+    wait = math.min(wait * 2, 8000)
   end
   -- still down → run on hardcoded fallback; log it; let a later event refresh
 end)
 ```
+
+The deadline is the point: a fixed `for 1, 20 do ... Wait(3000)` loop wrapped around a client that
+itself retries multiplies out to minutes of boot with no upper bound anyone wrote down.
 
 ## NUI callbacks must signal failure
 
@@ -84,11 +90,23 @@ end)
 
 ## Shared HTTP client (retry only on 5xx)
 
-All Lua→backend traffic goes through ONE shared wrapper: bounded retry (10×) **only on 5xx** — a
-4xx is an answer, not a transport failure (same doctrine as the 404 negative-cache exception) —
-service-token header injected without overwriting the caller's, and a loud-fail placeholder
-hostname so misconfig breaks visibly instead of silently hitting localhost. Production-extracted
-implementation: `references/http-client-retry.md`.
+All Lua→backend traffic goes through ONE shared wrapper: bounded retry **only on 5xx** — a 4xx is an
+answer, not a transport failure (same doctrine as the 404 negative-cache exception) — service-token
+header injected without overwriting the caller's, and a loud-fail placeholder hostname so misconfig
+breaks visibly instead of silently hitting localhost. Production-extracted implementation:
+`references/http-client-retry.md`.
+
+Bound it the way `backend-resilience` requires, because an attempt count alone does not:
+
+- **Give the call a deadline**, not just a retry count. 10 attempts at a 5s timeout is a 50s worst
+  case; the same client under the 20-attempt boot loop below reaches ~18 minutes. Keep the total under
+  what the caller (a player action, a NUI callback) can actually wait for — 3 attempts is the right
+  order of magnitude on a player-facing path.
+- **Jitter the wait** (`Wait(base * 2^n * math.random())`). A fixed ramp puts every FiveM instance on
+  the same retry instant and re-kills the backend as it recovers.
+- **Retry only what is safe to repeat.** A 5xx on a GET is a blip; a 5xx on "buy this item" is
+  ambiguous — the write may already have landed. Retry it only when the backend honors an idempotency
+  key you send on every attempt; otherwise surface the failure to the player.
 
 ## Concurrency
 

--- a/plugins/testing/skills/api-resilience-testing/SKILL.md
+++ b/plugins/testing/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -81,12 +81,19 @@ Run these in order. Produce concrete, runnable tests and a checklist — not pro
    403 authenticated-but-forbidden, 404 unknown resource, 405 wrong method,
    409 conflict, 413 too large, 415 unsupported media type, 422 semantic
    validation, 429 rate limit. A 500 on bad *input* is a bug — input errors must
-   be 4xx.
+   be 4xx. **Assert the code the stack actually returns, then decide whether the
+   difference is worth overriding** — a checklist that demands a code the
+   framework never emits marks a correct service as failing (see the baseline
+   table below).
 
-6. **Validate error responses are safe and useful.** Errors must be a consistent,
-   machine-readable shape (prefer RFC 9457 `application/problem+json`: type,
-   title, status, detail, instance). They must NOT leak stack traces, SQL,
-   internal paths, framework versions, or raw exception text. They MUST say
+6. **Validate error responses are safe and useful.** Errors must use **one
+   documented, machine-readable shape, applied to every error path** — the same
+   body for a 422 from the framework, a 409 from the database, and a 500 from
+   the catch-all. RFC 9457 `application/problem+json` (type, title, status,
+   detail, instance) is the right default for a greenfield API; an existing
+   documented envelope is equally valid and cheaper to keep — consistency is the
+   requirement, the specific shape is not. Errors must NOT leak stack traces,
+   SQL, internal paths, framework versions, or raw exception text. They MUST say
    clearly what was wrong so a client can fix it.
 
 7. **Verify authentication & authorization.** No token → 401. Expired/garbage/
@@ -125,14 +132,15 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 [ ] Over-length strings / oversized payload → 400/413
 [ ] Invalid format (email, uuid, date, enum) → 400/422
 [ ] Unknown/extra fields → ignored or rejected (documented, never crash)
-[ ] Malformed JSON / truncated body → 400 (not 500)
-[ ] Deeply nested / huge array payload → handled, no DoS
+[ ] Malformed JSON / truncated body → 4xx (not 500)
+[ ] Oversized payload → 413 (needs an explicit limit; no framework default)
+[ ] Deeply nested payload → 4xx (needs an explicit guard; 500 by default)
 
 ### Headers & content
-[ ] Missing Content-Type on a body request → 400/415
-[ ] Wrong Content-Type (text/plain for JSON) → 415
+[ ] Missing Content-Type on a body request → 4xx
+[ ] Wrong Content-Type (text/plain for JSON) → 4xx (415 only if you enforce it)
 [ ] Missing required custom headers → handled
-[ ] Unsupported Accept → 406 or sane default
+[ ] Unsupported Accept → 406 or sane default (200 by default — decide explicitly)
 
 ### Auth & authorization
 [ ] No token → 401
@@ -149,7 +157,7 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 
 ### Status codes & errors
 [ ] Input errors are 4xx, never 5xx
-[ ] Error body is consistent & machine-readable (ideally RFC 9457)
+[ ] Error body uses ONE documented shape on every error path (RFC 9457 if greenfield)
 [ ] No stack trace / SQL / internal path / version leaked in any error
 [ ] Error message is actionable (says what to fix)
 
@@ -165,6 +173,29 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 ```
 
 See `references/negative-test-catalog.md` for concrete request/response examples.
+
+## Baseline behavior — assert reality, not folklore
+
+A checklist that asserts a status code the framework never emits produces false failures. Measured on
+FastAPI 0.141.1 / pydantic 2.13.4 (the `python-rest-api` baseline), stock service, no extra handlers:
+
+| Negative case | Often asserted | Actually returned | Worth overriding? |
+|---|---|---|---|
+| Malformed / truncated JSON | 400 | **422** | No — 422 is a fine, consistent rejection |
+| Missing `Content-Type` on a body | 400/415 | **422** | No |
+| Wrong `Content-Type` (`text/plain`) | 415 | **422** | Only if a client contract needs 415 |
+| Unsupported `Accept` | 406 | **200** | Only if you really serve >1 media type |
+| Wrong path-param type (`/users/abc`) | 404 | **422** | No — the route matched, the value didn't |
+| Wrong HTTP method | 405 | **405** (with `Allow`) | Already correct |
+| Extra/unknown body field | rejected | **200**, ignored | Yes if the field is privileged (mass assignment) |
+| **2 KB body of nested brackets** | handled | **500** (`RecursionError`) | **Yes — this is the bug** |
+| **20 MB flat JSON body** | 413 | **200**, fully buffered | **Yes — no default limit exists** |
+
+The last two are not style preferences: a 2 KB unauthenticated request that returns 500 is a
+denial-of-service primitive. The guard belongs to the service baseline — see `python-rest-api`
+("Request limits"), which carries the verified middleware + handler.
+
+Re-run this table against your own stack and version before trusting any row of it.
 
 ---
 
@@ -198,8 +229,10 @@ See `references/negative-test-catalog.md` for concrete request/response examples
   endpoint, ask "what breaks it?" before approving.
 - **Contract as source of truth:** keep the OpenAPI spec accurate; a golden
   snapshot test of the generated schema catches accidental contract drift.
-- **Error standard:** adopt one error shape (RFC 9457) repo-wide so clients and
-  tests can rely on it and nothing leaks.
+- **Error standard:** adopt one error shape repo-wide — RFC 9457 for a greenfield
+  API, or the service's documented envelope where one already exists — so clients
+  and tests can rely on it and nothing leaks. Changing the shape of a live API is
+  a breaking change; consistency beats conformance here.
 
 ---
 

--- a/plugins/testing/skills/api-resilience-testing/references/negative-test-catalog.md
+++ b/plugins/testing/skills/api-resilience-testing/references/negative-test-catalog.md
@@ -78,7 +78,33 @@ Expect: **400/422** with the offending field named.
 ```json
 { "email": "<100 KB string>", "age": 30 }
 ```
-Expect: **400** (length) or **413 Payload Too Large**. Must not hang or OOM.
+Expect: **400** (per-field length) or **413 Payload Too Large** (whole body). Must not hang or OOM.
+
+Run the whole-body case too — not just the long field:
+
+```http
+POST /users
+Content-Type: application/json
+
+{"email":"aaaa…"}          # 20 MB
+```
+Measured on a stock FastAPI 0.141.1 service: **200**, body fully buffered in memory. There is no
+default body-size limit in the framework — a 413 only exists if someone added it. Assert it at the
+app AND at the reverse proxy.
+
+## 7b. Deeply nested payload (stack exhaustion)
+
+```http
+POST /users
+Content-Type: application/json
+
+[[[[[[[[[[ … ]]]]]]]]]]     # 1000 levels — about 2 KB on the wire
+```
+Measured on the same stock service: **500** (`RecursionError`). A 2 KB unauthenticated request that
+returns a 5xx is a denial-of-service primitive, and it violates the "input errors are never 5xx" rule
+that the rest of this catalog assumes. Expect **400** once the guard from `python-rest-api`
+("Request limits") is registered. Test at 1k and 10k levels — 200 levels still returns 422, so a
+shallow probe misses it entirely.
 
 ## 8. Malformed / truncated JSON
 
@@ -88,7 +114,8 @@ Content-Type: application/json
 
 { "email": "a@b.com", "age":
 ```
-Expect: **400** "invalid JSON". A 500 here is a bug.
+Expect: a **4xx** that names invalid JSON — **422** on the FastAPI baseline, 400 on many other stacks.
+A 500 here is a bug; the exact 4xx is the framework's choice, so assert the one yours returns.
 
 ## 9. Unknown / extra fields (and mass assignment)
 

--- a/skills/api-resilience-testing/SKILL.md
+++ b/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -81,12 +81,19 @@ Run these in order. Produce concrete, runnable tests and a checklist — not pro
    403 authenticated-but-forbidden, 404 unknown resource, 405 wrong method,
    409 conflict, 413 too large, 415 unsupported media type, 422 semantic
    validation, 429 rate limit. A 500 on bad *input* is a bug — input errors must
-   be 4xx.
+   be 4xx. **Assert the code the stack actually returns, then decide whether the
+   difference is worth overriding** — a checklist that demands a code the
+   framework never emits marks a correct service as failing (see the baseline
+   table below).
 
-6. **Validate error responses are safe and useful.** Errors must be a consistent,
-   machine-readable shape (prefer RFC 9457 `application/problem+json`: type,
-   title, status, detail, instance). They must NOT leak stack traces, SQL,
-   internal paths, framework versions, or raw exception text. They MUST say
+6. **Validate error responses are safe and useful.** Errors must use **one
+   documented, machine-readable shape, applied to every error path** — the same
+   body for a 422 from the framework, a 409 from the database, and a 500 from
+   the catch-all. RFC 9457 `application/problem+json` (type, title, status,
+   detail, instance) is the right default for a greenfield API; an existing
+   documented envelope is equally valid and cheaper to keep — consistency is the
+   requirement, the specific shape is not. Errors must NOT leak stack traces,
+   SQL, internal paths, framework versions, or raw exception text. They MUST say
    clearly what was wrong so a client can fix it.
 
 7. **Verify authentication & authorization.** No token → 401. Expired/garbage/
@@ -125,14 +132,15 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 [ ] Over-length strings / oversized payload → 400/413
 [ ] Invalid format (email, uuid, date, enum) → 400/422
 [ ] Unknown/extra fields → ignored or rejected (documented, never crash)
-[ ] Malformed JSON / truncated body → 400 (not 500)
-[ ] Deeply nested / huge array payload → handled, no DoS
+[ ] Malformed JSON / truncated body → 4xx (not 500)
+[ ] Oversized payload → 413 (needs an explicit limit; no framework default)
+[ ] Deeply nested payload → 4xx (needs an explicit guard; 500 by default)
 
 ### Headers & content
-[ ] Missing Content-Type on a body request → 400/415
-[ ] Wrong Content-Type (text/plain for JSON) → 415
+[ ] Missing Content-Type on a body request → 4xx
+[ ] Wrong Content-Type (text/plain for JSON) → 4xx (415 only if you enforce it)
 [ ] Missing required custom headers → handled
-[ ] Unsupported Accept → 406 or sane default
+[ ] Unsupported Accept → 406 or sane default (200 by default — decide explicitly)
 
 ### Auth & authorization
 [ ] No token → 401
@@ -149,7 +157,7 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 
 ### Status codes & errors
 [ ] Input errors are 4xx, never 5xx
-[ ] Error body is consistent & machine-readable (ideally RFC 9457)
+[ ] Error body uses ONE documented shape on every error path (RFC 9457 if greenfield)
 [ ] No stack trace / SQL / internal path / version leaked in any error
 [ ] Error message is actionable (says what to fix)
 
@@ -165,6 +173,29 @@ Copy this per API/endpoint and mark `[x]` pass, `[ ]` gap.
 ```
 
 See `references/negative-test-catalog.md` for concrete request/response examples.
+
+## Baseline behavior — assert reality, not folklore
+
+A checklist that asserts a status code the framework never emits produces false failures. Measured on
+FastAPI 0.141.1 / pydantic 2.13.4 (the `python-rest-api` baseline), stock service, no extra handlers:
+
+| Negative case | Often asserted | Actually returned | Worth overriding? |
+|---|---|---|---|
+| Malformed / truncated JSON | 400 | **422** | No — 422 is a fine, consistent rejection |
+| Missing `Content-Type` on a body | 400/415 | **422** | No |
+| Wrong `Content-Type` (`text/plain`) | 415 | **422** | Only if a client contract needs 415 |
+| Unsupported `Accept` | 406 | **200** | Only if you really serve >1 media type |
+| Wrong path-param type (`/users/abc`) | 404 | **422** | No — the route matched, the value didn't |
+| Wrong HTTP method | 405 | **405** (with `Allow`) | Already correct |
+| Extra/unknown body field | rejected | **200**, ignored | Yes if the field is privileged (mass assignment) |
+| **2 KB body of nested brackets** | handled | **500** (`RecursionError`) | **Yes — this is the bug** |
+| **20 MB flat JSON body** | 413 | **200**, fully buffered | **Yes — no default limit exists** |
+
+The last two are not style preferences: a 2 KB unauthenticated request that returns 500 is a
+denial-of-service primitive. The guard belongs to the service baseline — see `python-rest-api`
+("Request limits"), which carries the verified middleware + handler.
+
+Re-run this table against your own stack and version before trusting any row of it.
 
 ---
 
@@ -198,8 +229,10 @@ See `references/negative-test-catalog.md` for concrete request/response examples
   endpoint, ask "what breaks it?" before approving.
 - **Contract as source of truth:** keep the OpenAPI spec accurate; a golden
   snapshot test of the generated schema catches accidental contract drift.
-- **Error standard:** adopt one error shape (RFC 9457) repo-wide so clients and
-  tests can rely on it and nothing leaks.
+- **Error standard:** adopt one error shape repo-wide — RFC 9457 for a greenfield
+  API, or the service's documented envelope where one already exists — so clients
+  and tests can rely on it and nothing leaks. Changing the shape of a live API is
+  a breaking change; consistency beats conformance here.
 
 ---
 

--- a/skills/api-resilience-testing/references/negative-test-catalog.md
+++ b/skills/api-resilience-testing/references/negative-test-catalog.md
@@ -78,7 +78,33 @@ Expect: **400/422** with the offending field named.
 ```json
 { "email": "<100 KB string>", "age": 30 }
 ```
-Expect: **400** (length) or **413 Payload Too Large**. Must not hang or OOM.
+Expect: **400** (per-field length) or **413 Payload Too Large** (whole body). Must not hang or OOM.
+
+Run the whole-body case too — not just the long field:
+
+```http
+POST /users
+Content-Type: application/json
+
+{"email":"aaaa…"}          # 20 MB
+```
+Measured on a stock FastAPI 0.141.1 service: **200**, body fully buffered in memory. There is no
+default body-size limit in the framework — a 413 only exists if someone added it. Assert it at the
+app AND at the reverse proxy.
+
+## 7b. Deeply nested payload (stack exhaustion)
+
+```http
+POST /users
+Content-Type: application/json
+
+[[[[[[[[[[ … ]]]]]]]]]]     # 1000 levels — about 2 KB on the wire
+```
+Measured on the same stock service: **500** (`RecursionError`). A 2 KB unauthenticated request that
+returns a 5xx is a denial-of-service primitive, and it violates the "input errors are never 5xx" rule
+that the rest of this catalog assumes. Expect **400** once the guard from `python-rest-api`
+("Request limits") is registered. Test at 1k and 10k levels — 200 levels still returns 422, so a
+shallow probe misses it entirely.
 
 ## 8. Malformed / truncated JSON
 
@@ -88,7 +114,8 @@ Content-Type: application/json
 
 { "email": "a@b.com", "age":
 ```
-Expect: **400** "invalid JSON". A 500 here is a bug.
+Expect: a **4xx** that names invalid JSON — **422** on the FastAPI baseline, 400 on many other stacks.
+A 500 here is a bug; the exact 4xx is the framework's choice, so assert the one yours returns.
 
 ## 9. Unknown / extra fields (and mass assignment)
 

--- a/skills/backend-resilience/SKILL.md
+++ b/skills/backend-resilience/SKILL.md
@@ -5,12 +5,14 @@ description: >-
   config store (Consul/KV), database, message broker, or another internal service. Use when adding or
   reviewing code that makes network calls that can time out, return 5xx, return partial payloads, or
   hit a dependency that is down — or when adding config fetch, retry logic, caching of failures, or
-  degraded-mode behavior. Enforces safe defaults, one shared fallback helper, response-shape validation,
-  clamping of remote values, bounded retries, negative caching, and in-flight deduplication. Examples in
-  Python; the doctrine is language-agnostic. For the FiveM/Lua adaptation use fivem-fallback instead.
+  degraded-mode behavior. Enforces explicit timeouts and a wall-clock deadline, retries only on
+  idempotent operations with exponential backoff + jitter, safe defaults, one shared fallback helper,
+  response-shape validation, clamping of remote values, negative caching with single-flight, and
+  observable degradation. Examples in Python; the doctrine is language-agnostic. For the FiveM/Lua
+  adaptation use fivem-fallback instead.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 2.0.0
   category: backend
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -22,30 +24,76 @@ Defensive patterns for calling an unreliable dependency. The network boundary is
 5xx, partial payloads, dependency down, races. Every call needs a **safe default** so the service keeps
 working. Doctrine is stack-agnostic; examples are Python.
 
+Apply in this order — it is the order of risk reduction, and each layer assumes the one above it:
+**timeout → deadline → bounded retry (idempotent only) → negative cache + single-flight → fallback
+default → surface the degradation.**
+
 ## Principles
 
-1. **Every external call can fail.** A failed call must produce a safe default — never a crash, and
+1. **Every external call has an explicit timeout.** A call with no timeout is an unbounded outage
+   waiting to happen; a retry on a hung connection waits forever. Set connect and read timeouts
+   separately — never rely on the library default.
+2. **Bound the wall clock, not just the attempt count.** "3 attempts" says nothing about latency.
+   Give the whole operation a **deadline** and check it before each attempt; when the caller is
+   serving an HTTP request, that deadline must be shorter than the request's own budget.
+3. **Retry only what is safe to repeat.** GET/HEAD/PUT/DELETE are retriable. A POST that charges,
+   ships, or writes is retriable **only** with an idempotency key the dependency honors. Otherwise a
+   5xx is a final answer — surface it.
+4. **Every external call can fail.** A failed call must produce a safe default — never a crash, and
    never silent stale state presented as fresh.
-2. **One shared helper, not ad-hoc per module.** Scattered try/except + type-check copies drift.
+5. **One shared helper, not ad-hoc per module.** Scattered try/except + type-check copies drift.
    Provide a single `safe_call`/`with_fallback` utility and use it everywhere.
-3. **Validate the response shape**, not just transport success: check the type, the expected fields,
+6. **Validate the response shape**, not just transport success: check the type, the expected fields,
    and the status/code before trusting the data.
-4. **Clamp untrusted/remote numbers** into a sane range — a bad config value must not break the system.
-5. **Bound retries.** If the HTTP client already retries 5xx, don't stack an unbounded second retry
-   loop on top. Total attempts across all layers must be finite and known.
+7. **Clamp untrusted/remote numbers** into a sane range — a bad config value must not break the system.
+8. **Degradation is an event, not a silence.** Every fallback carries its cause into a log line and a
+   counter. A fallback nobody can see is indistinguishable from correct behavior.
+
+## Timeouts and the deadline budget
+
+```python
+TIMEOUT = httpx.Timeout(connect=1.0, read=2.0, write=2.0, pool=1.0)
+
+deadline = time.monotonic() + 3.0          # the WHOLE operation, retries included
+while time.monotonic() < deadline:
+    ...                                     # attempt; sleep only if it still fits in the deadline
+```
+
+Sizing rule: `attempts x timeout + total backoff <= deadline <= the caller's own budget`. If the
+numbers don't fit, cut the attempts — not the timeout. Worst-case latency must be a number you can
+state; if you can't state it, the policy is unbounded.
+
+Attempt counts above ~3 are almost always wrong on a request path. Measured worst cases for policies
+this catalog used to prescribe: 10 attempts at a 5s timeout = **50s**; the same client stacked under a
+20-attempt/3s boot loop = **~18 minutes** before a caller gets an answer.
 
 ## safe_call / clamp
 
+The helper must report **why** it fell back. Measured: four distinct causes — a dependency timeout, a
+`TypeError` from your own code, malformed JSON, and a `MemoryError` — collapsed into one
+indistinguishable `(False, fallback)` with zero log lines. An operator cannot tell a code bug from an
+outage, and neither can a dashboard.
+
 ```python
-from typing import Callable, TypeVar
+from typing import Awaitable, Callable, TypeVar
 
 T = TypeVar("T")
 
-def safe_call(fn: Callable[[], T], fallback: T) -> tuple[bool, T]:
-    """Returns (ok, value). On any failure returns (False, fallback) — never raises."""
+def safe_call(fn: Callable[[], T], fallback: T, *, op: str) -> tuple[bool, T]:
+    """Returns (ok, value). On failure returns (False, fallback) — never raises."""
     try:
         return True, fn()
-    except Exception:
+    except Exception as exc:                       # noqa: BLE001 — boundary helper, by design
+        logger.warning("fallback_used", op=op, err_type=type(exc).__name__, err=str(exc))
+        FALLBACK_TOTAL.labels(op=op, err=type(exc).__name__).inc()
+        return False, fallback
+
+async def safe_call_async(fn: Callable[[], Awaitable[T]], fallback: T, *, op: str) -> tuple[bool, T]:
+    try:
+        return True, await fn()
+    except Exception as exc:                       # noqa: BLE001
+        logger.warning("fallback_used", op=op, err_type=type(exc).__name__, err=str(exc))
+        FALLBACK_TOTAL.labels(op=op, err=type(exc).__name__).inc()
         return False, fallback
 
 def clamp_num(value, lo: float, hi: float, default: float) -> float:
@@ -56,61 +104,132 @@ def clamp_num(value, lo: float, hi: float, default: float) -> float:
     return max(lo, min(hi, v))
 ```
 
-## Config / KV with hardcoded fallback
+The counter is part of the helper, not an afterthought: an alert on `rate(fallback_used)` is the only
+way a permanently-degraded service announces itself.
 
-Remote config (Consul KV, a `/config/*` endpoint) WILL be unavailable sometimes. Always ship a
-hardcoded default and merge field-by-field; clamp ranges.
+`asyncio.CancelledError` is a `BaseException` and correctly escapes `except Exception` — do **not**
+widen the catch to `BaseException`, that swallows shutdown and enclosing timeouts. In an `async def`
+path use `safe_call_async`: the sync helper wrapped around a blocking client blocks the event loop for
+every concurrent request, which is worse than no resilience at all.
+
+## Retry: bounded, backed off, jittered
 
 ```python
-FALLBACK = {"xp_per_level": 100, "max_level": 50}   # hardcoded safe default
-
-ok, cfg = safe_call(lambda: kv_client.get_json("game/config"), None)
-if not ok or not isinstance(cfg, dict):
-    cfg = dict(FALLBACK)                            # degrade, don't crash — and log it
-max_level = clamp_num(cfg.get("max_level"), 1, 999, FALLBACK["max_level"])
+for attempt in range(1, MAX_ATTEMPTS + 1):
+    if time.monotonic() >= deadline:
+        break
+    try:
+        return call()
+    except RetryableError as exc:
+        if attempt == MAX_ATTEMPTS or not is_idempotent:
+            raise
+        delay = min(BASE * 2 ** (attempt - 1), CAP)
+        delay = random.uniform(0, delay)           # full jitter — NOT a fixed ramp
+        if exc.retry_after:                        # 429/503 Retry-After wins over your backoff
+            delay = max(delay, exc.retry_after)
+        if time.monotonic() + delay >= deadline:
+            break
+        time.sleep(delay)
 ```
 
-## Negative cache (avoid timeout cascade)
+- **Retryable**: connect/read timeouts, connection resets, 502/503/504, and 429 (honoring
+  `Retry-After`). **Not retryable**: any other 4xx — a 4xx is an answer.
+- **Jitter is not optional.** Fixed or purely exponential backoff synchronizes every client onto the
+  same retry instants and re-kills the dependency the moment it recovers.
+- **Do not stack retry layers.** If the HTTP client already retries, the caller must not. Total
+  attempts across all layers must be finite, known, and written down next to the config.
+- **Retry budget**: cap retries at ~10-20% of normal traffic (a token bucket per dependency). Past
+  that, shed to the fallback — retries during a broad outage *are* the outage.
 
-When a dependency is unreachable, cache the *failure* briefly (a few seconds) so every subsequent call
-doesn't wait out the full timeout. Re-query after the fail-TTL expires.
+## Negative cache + single-flight (avoid timeout cascade)
 
-**Exception:** a real 404 / "not found" is an answer, not a transport failure — do NOT negative-cache it.
-The same applies to any fast non-200 or a malformed body: only the path that pays the timeout gets
-negative-cached. Full production-extracted implementation (Consul KV, two caches, ACL auto-detect):
-`references/consul-kv-negative-cache.md`.
+When a dependency is unreachable, cache the *failure* briefly so every subsequent call doesn't wait out
+the full timeout — **and** guard the probe with a single-flight lock so a concurrent burst sends one
+probe, not N.
+
+Measured: 200 concurrent callers against a down dependency, negative cache alone → **38** callers still
+paid the full timeout (a burst all misses the cold cache together); with a single-flight guard → **1**.
+A negative cache without single-flight only protects *sequential* callers, which is not the shape an
+outage has.
 
 ```python
 _fail_until = 0.0
+_probe = threading.Lock()
 FAIL_TTL = 15.0
 
 def get_price(item_id: str) -> float | None:
     global _fail_until
     if time.monotonic() < _fail_until:
         return None                                  # known-down: fail fast
+    if not _probe.acquire(blocking=False):
+        return None                                  # someone is already probing — don't pile on
     try:
+        if time.monotonic() < _fail_until:           # re-check under the guard
+            return None
         return pricing_client.get(item_id)           # a 404 here returns None, not an exception
     except TransportError:
-        _fail_until = time.monotonic() + FAIL_TTL    # transport failure: back off
+        _fail_until = time.monotonic() + FAIL_TTL * random.uniform(0.8, 1.2)   # jitter the TTL
         return None
+    finally:
+        _probe.release()
+```
+
+- **Jitter the fail-TTL.** With a fixed TTL every caller retries on the same instant: measured 200
+  simultaneous probes at `t = TTL`. `FAIL_TTL * uniform(0.8, 1.2)` spreads them.
+- **Key the cache per dependency-key**, not one global flag, or one dead key blinds every other.
+- **Exception:** a real 404 / "not found" is an answer, not a transport failure — do NOT
+  negative-cache it. Same for any fast non-200 or a malformed body: only the path that pays the
+  timeout gets negative-cached. Full production-extracted implementation (Consul KV, two caches, ACL
+  auto-detect): `references/consul-kv-negative-cache.md`.
+- **When a fail-flag is not enough**: if the dependency degrades *slowly and partially* (some calls
+  succeed, latency climbs), it never trips. Use a real circuit breaker — open on an error *rate* over
+  a rolling window, half-open with a single trial call — with the same fallback behind it.
+
+## Config / KV with hardcoded fallback
+
+Remote config (Consul KV, a `/config/*` endpoint) WILL be unavailable sometimes. Always ship a
+hardcoded default and merge **field by field** — one bad field must not discard an otherwise valid
+response — and clamp ranges.
+
+```python
+FALLBACK = {"xp_per_level": 100, "max_level": 50}   # hardcoded safe default
+
+ok, cfg = safe_call(lambda: kv_client.get_json("game/config"), None, op="game_config")
+if not ok or not isinstance(cfg, dict):
+    cfg = dict(FALLBACK)                            # degrade, don't crash — already logged + counted
+max_level = clamp_num(cfg.get("max_level"), 1, 999, FALLBACK["max_level"])
 ```
 
 ## Startup config: retry then degrade
 
-At boot, retry the config fetch a bounded number of times, then start in degraded mode on the hardcoded
-fallback — a config outage must not prevent startup. Log the degradation and refresh when the
-dependency recovers (background task, health-check hook, or next request).
+At boot, retry the config fetch a bounded number of times **under a total boot deadline**, then start
+in degraded mode on the hardcoded fallback — a config outage must not prevent startup, and must not
+delay it indefinitely either. Log the degradation and refresh when the dependency recovers (background
+task, health-check hook, or next request).
 
 ## Surface failures to the caller
 
 A handler that depends on a downstream call must tell its caller when that call failed — an explicit
 error response or degraded-data marker — never a silent success with stale/empty data. (HTTP: 503 with
-a Problem Details body beats a fabricated 200.)
+an error body beats a fabricated 200.) Serving a last-known-good value is fine **only** when the
+response marks it stale (a `degraded: true` field or a `Warning` header).
+
+Readiness must reflect it too: a service running entirely on fallbacks is degraded, and the detailed
+health endpoint has to say so even while liveness stays green.
 
 ## Concurrency: deduplicate in-flight requests
 
 Guard against duplicate concurrent requests for the same key (single-flight / per-key lock) so N
 concurrent triggers don't spawn N identical downstream calls and overwrite each other out of order.
+This is the same guard the negative cache uses — implement it once, per key, and reuse it.
+
+## What to test (hand to `bug-hunter`)
+
+Every rule above is a test: dependency times out → fallback + one log line + one counter increment;
+dependency returns a partial or wrong-typed body → fallback, not a crash; a real 404 → NOT
+negative-cached; N concurrent callers with the dependency down → exactly one upstream attempt; retry of
+a non-idempotent write → does not double-apply; worst-case latency of the retry policy → asserted
+against the stated deadline.
 
 ## See also
 
@@ -118,3 +237,4 @@ concurrent triggers don't spawn N identical downstream calls and overwrite each 
 - `bug-hunter` — the adversarial-testing rite that validates fallback under "dependency down / partial
   payload / race".
 - `fivem-fallback` — the FiveM/Lua adaptation of this doctrine.
+- `python-rest-api` — the service baseline these outbound calls are made from.

--- a/skills/fivem-fallback/SKILL.md
+++ b/skills/fivem-fallback/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   services use backend-resilience instead.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -57,14 +57,20 @@ trusting `data` — transport success is not payload validity.
 
 ```lua
 CreateThread(function()
-  for _ = 1, 20 do
+  local deadline = GetGameTimer() + 60000            -- bound the WALL CLOCK, not just the count
+  local wait = 500
+  while GetGameTimer() < deadline do
     local ok = SafeCall(refreshConfig, false)
     if ok then return end
-    Wait(3000)
+    Wait(math.random(wait, wait * 2))                -- jittered, growing backoff
+    wait = math.min(wait * 2, 8000)
   end
   -- still down → run on hardcoded fallback; log it; let a later event refresh
 end)
 ```
+
+The deadline is the point: a fixed `for 1, 20 do ... Wait(3000)` loop wrapped around a client that
+itself retries multiplies out to minutes of boot with no upper bound anyone wrote down.
 
 ## NUI callbacks must signal failure
 
@@ -84,11 +90,23 @@ end)
 
 ## Shared HTTP client (retry only on 5xx)
 
-All Lua→backend traffic goes through ONE shared wrapper: bounded retry (10×) **only on 5xx** — a
-4xx is an answer, not a transport failure (same doctrine as the 404 negative-cache exception) —
-service-token header injected without overwriting the caller's, and a loud-fail placeholder
-hostname so misconfig breaks visibly instead of silently hitting localhost. Production-extracted
-implementation: `references/http-client-retry.md`.
+All Lua→backend traffic goes through ONE shared wrapper: bounded retry **only on 5xx** — a 4xx is an
+answer, not a transport failure (same doctrine as the 404 negative-cache exception) — service-token
+header injected without overwriting the caller's, and a loud-fail placeholder hostname so misconfig
+breaks visibly instead of silently hitting localhost. Production-extracted implementation:
+`references/http-client-retry.md`.
+
+Bound it the way `backend-resilience` requires, because an attempt count alone does not:
+
+- **Give the call a deadline**, not just a retry count. 10 attempts at a 5s timeout is a 50s worst
+  case; the same client under the 20-attempt boot loop below reaches ~18 minutes. Keep the total under
+  what the caller (a player action, a NUI callback) can actually wait for — 3 attempts is the right
+  order of magnitude on a player-facing path.
+- **Jitter the wait** (`Wait(base * 2^n * math.random())`). A fixed ramp puts every FiveM instance on
+  the same retry instant and re-kills the backend as it recovers.
+- **Retry only what is safe to repeat.** A 5xx on a GET is a blip; a 5xx on "buy this item" is
+  ambiguous — the write may already have landed. Retry it only when the backend honors an idempotency
+  key you send on every attempt; otherwise surface the failure to the player.
 
 ## Concurrency
 

--- a/skills/log-event-collector/SKILL.md
+++ b/skills/log-event-collector/SKILL.md
@@ -5,12 +5,13 @@ description: >-
   server's text logs, parses lines into normalized events, and ships them to a backend API.
   Distilled from a production collector for an Assetto Corsa server, but stack-agnostic. Use when
   building or reviewing a log tailer, log-to-event parser, file offset persistence, log rotation or
-  truncation handling, multi-line event correlation, shutdown flush, or idempotency/dedup keys for
-  shipped events. Do NOT use for configuring log aggregation stacks (Loki, Fluentd, Filebeat), for
-  the API that receives the events (that is python-rest-api), or for metrics/APM instrumentation.
+  truncation handling, partial-line reads, multi-line event correlation, backpressure, shutdown flush,
+  or idempotency/dedup keys for shipped events. Do NOT use for configuring log aggregation stacks
+  (Loki, Fluentd, Filebeat), for the API that receives the events (that is python-rest-api), or for
+  metrics/APM instrumentation of the monitored application.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -41,15 +42,35 @@ tests/             # unit tests + golden log fixture
 
 Keep it **dependency-free (stdlib-only) when the deploy target is a bare container** — `urllib`,
 `re`, `json`, `signal` cover everything a collector needs, and the image stays a plain
-`python:3.12-slim` with zero supply chain.
+`python:3.12-slim` with zero supply chain. When the runtime already ships an HTTP client, or the image
+isn't yours to keep minimal, use it: the rule is *no new supply chain for the sake of ergonomics*, not
+*stdlib at any cost*. `urllib` costs you connection pooling, per-phase timeouts and `Retry-After`
+parsing — pay that deliberately, not by default.
 
 ## Tailing — offset in bytes, rotation-proof
 
 - Pick the newest log file by mtime (`sorted(glob("*.txt"), key=mtime)[-1]`) each poll — servers
   start a new file per boot.
 - Persist the **byte offset** together with the file path it belongs to. On read: if the stored
-  path differs from the current file, start at 0; `seek(offset)`; after iterating, store
-  `handle.tell()`.
+  path differs from the current file, start at 0; `seek(offset)`.
+- **Advance the offset only to the last complete line** — never `handle.tell()` after iterating. A
+  poll that lands mid-write consumes a half-line, ships a truncated event, and loses the remainder
+  forever. Measured: one line arriving across two write flushes produced two bogus events and zero
+  correct ones.
+
+  ```python
+  with path.open("rb") as handle:
+      handle.seek(offset)
+      buf = handle.read()
+  cut = buf.rfind(b"\n")
+  if cut < 0:
+      return []                       # nothing complete yet — offset unchanged
+  offset += cut + 1
+  lines = buf[:cut].decode("utf-8", "replace").split("\n")
+  ```
+
+  Cap the held-back remainder (e.g. 1 MiB): a writer that never emits `\n` must not grow the buffer
+  without bound.
 - **Truncation/rotation guard**: `if offset > path.stat().st_size: offset = 0`. Without this, a
   rotated/truncated file silently yields nothing forever.
 - `start_at_end` option (seek to EOF when there is no stored state) so a fresh deploy doesn't
@@ -75,11 +96,21 @@ stale one.
 
 ## Idempotency — deterministic event_key + bounded seen-set
 
-- Every parsed event carries a deterministic `event_key`:
-  `f"player_connected:{steam_id}:{slot}:{line_hash(raw_line)}"` — type + stable ids + a hash of
-  the raw line. Singleton events use a constant key (`"server_started"`).
-- The seen-set is **bounded** (`processed_events[-1000:]`): dedup protects against re-reading the
-  recent window after a restart, not against infinite memory growth.
+- Every parsed event carries a deterministic `event_key` built from type + stable ids + **where the
+  line sits in the log**: `f"player_connected:{steam_id}:{slot}:{log_file}:{line_offset}"`.
+  Singleton events use a constant key (`"server_started"`).
+  Hashing the raw line instead collapses two genuinely distinct occurrences of a byte-identical line
+  into one key and silently drops the second — measured with two identical reconnect lines. The key
+  must be **stable** across a restart that re-reads the same bytes and **distinct** across two real
+  occurrences; the byte offset is both.
+- The seen-set is a **`set` for lookup plus a `deque(maxlen=N)` for the bound** — persist the deque,
+  rebuild the set on load. A plain list is O(n) per check (measured 37x slower at N=1000) and grows
+  unbounded the moment someone forgets the slice.
+- **Size the window against the worst replay, not the happy one.** The rotation guard
+  (`offset > size → offset = 0`) can re-read an entire file, so a file with more lines than N replays
+  straight past the dedup window. Either size N above the largest expected file, or make the backend
+  the idempotency authority (unique index on `event_key`) and treat the local ring as an optimization.
+  State which one the project chose.
 - Dispatch failure is **non-fatal**: log it, do NOT mark the key as seen, let the next scan retry.
   Only mark seen after the backend accepted the event.
 
@@ -114,9 +145,12 @@ Without this, every deploy leaves phantom "online" players in the backend.
 
 ## Backend client — small, honest, testable
 
-- Bounded retry on **connection** errors only (3 attempts, linear backoff `sleep(attempt)`);
-  HTTP errors (4xx/5xx with a response) raise immediately with the body in the message — they are
-  contract problems, not blips.
+- Retry policy follows `backend-resilience` (bounded attempts, exponential backoff + **jitter**, one
+  overall deadline). Collector specifics: retry **connection** errors plus 429/502/503/504, honoring
+  `Retry-After`; every other 4xx raises immediately with the body in the message — it is a contract
+  problem, not a blip. State the worst case next to the config: `attempts x timeout + backoff` must
+  stay under the poll interval, or the tailer falls behind while it retries (a 3x10s policy with
+  linear backoff is already 33s of blocked loop).
 - Service auth = one header (e.g. `X-Drivezone-Token`), added only when configured.
 - Unwrap the backend envelope at the client boundary (`data.get("data", data)`) so the rest of the
   collector never sees transport shape.
@@ -129,6 +163,22 @@ Every payload carries `source` (which collector), `event_version: 1` (forward-co
 `occurred_at` (parsed from the log timestamp, not "now"), and preserves the raw line in
 `payload.raw_line` — when a parser bug is found later, the raw material to re-derive is already
 in the backend. Ship to one generic endpoint (`POST /api/v1/events`); let the backend normalize.
+
+## Backpressure — the backend is the slow part
+
+The poll loop and the dispatcher must not be the same unbounded loop. Keep a **bounded** in-memory
+queue between "lines parsed" and "events shipped"; when it fills, **stop tailing** and leave the offset
+where it is, rather than dropping events or growing memory — the log file on disk is the buffer, and a
+better one than RAM. Batch dispatch when the backend offers a batch endpoint: per-event POSTs cap
+throughput at one round-trip per event and multiply the auth/TLS cost.
+
+## The collector's own observability
+
+A collector that silently falls behind is worse than one that crashes. Expose at minimum: **lag**
+(`file_size - offset`, in bytes), events parsed / shipped / failed since boot, last successful dispatch
+timestamp, and **unparsed-line count**. A rising unparsed-line count is the detector for the top risk
+this skill names below — the upstream changing its log format — and without it that risk is only
+discovered when someone notices missing data.
 
 ## Testing
 

--- a/skills/python-rest-api/SKILL.md
+++ b/skills/python-rest-api/SKILL.md
@@ -8,11 +8,11 @@ description: >-
   pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures,
   testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis
   fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency
-  with partial unique indexes, JSONB dialect variants, and out-of-process ingestion workers (UDP).
-  The baseline that api-resilience-testing and bug-hunter assume.
+  with partial unique indexes, JSONB dialect variants, request size/depth limits, and out-of-process
+  ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -77,7 +77,7 @@ Register handlers in `main.py`; each maps a failure class to the envelope:
 | `AppException` subclasses | its own | typed business errors raised by services |
 | `RequestValidationError` | 422 | pydantic input rejection |
 | `IntegrityError` (unique/FK/not-null) | 409 | driven by request data, not a server fault |
-| `DataError`, `decimal.InvalidOperation`, `OverflowError` | 400 | bad numeric/literal input |
+| `DataError`, `decimal.InvalidOperation`, `OverflowError`, `RecursionError` | 400 | bad numeric/literal/nesting input |
 | `SQLAlchemyError` | 500 | genuine DB fault |
 | catch-all `Exception` | 500 | message hidden unless `APP_ENV == "dev"` |
 
@@ -91,6 +91,42 @@ Every numeric knob gets an explicit `Field` constraint and a described default:
 `Field(default=None, ge=1, le=128)`, `Decimal = Field(default=Decimal("0"), ge=0)`,
 `str = Field(..., max_length=255)`. Optional tuning fields default to `None` so downstream defaults
 aren't silently overridden.
+
+## Request limits — the framework has none
+
+The stock stack accepts a body of any size and any nesting depth, so "input errors are never a raw
+500" is false until you add two guards. Measured on fastapi 0.141.1 / pydantic 2.13.4:
+
+| Input | Stock behavior | Must be |
+|---|---|---|
+| 2 KB body of nested brackets (`"[" * 1000`) | **500** (`RecursionError`) | 400 |
+| 20 MB flat JSON body | **200** (fully buffered) | 413 |
+
+A 2 KB unauthenticated request that returns a 500 is a denial-of-service primitive, not an edge case.
+Both guards are additive and were verified to leave the happy path at 200:
+
+```python
+class BodyLimit(BaseHTTPMiddleware):                 # -> 413 before anything is parsed
+    async def dispatch(self, request: Request, call_next):
+        cl = request.headers.get("content-length")
+        if cl and int(cl) > settings.MAX_BODY_BYTES:
+            return JSONResponse(error_envelope(RC.PAYLOAD_TOO_LARGE), status_code=413)
+        return await call_next(request)
+
+@app.exception_handler(RecursionError)               # -> 400, not the catch-all 500
+async def too_deep(request: Request, exc: RecursionError): ...
+```
+
+Set `MAX_BODY_BYTES` from the largest legitimate payload, not from a round number, and enforce it at
+the reverse proxy too (`client_max_body_size`) so the app never buffers what it will reject. A
+chunked request has no `Content-Length` — cap the stream read as well when any endpoint accepts one.
+
+## Outbound calls
+
+Every call this service makes to another service, KV store, or third-party API carries an explicit
+timeout and a bounded retry policy. Doctrine, including the deadline budget and the negative-cache
+rules: `backend-resilience`. An outbound call with no timeout inside a request handler converts a
+dependency's slowdown into this service's outage.
 
 ## Tenant isolation (BOLA/IDOR)
 

--- a/skills/python-rest-api/references/fastapi-envelope.md
+++ b/skills/python-rest-api/references/fastapi-envelope.md
@@ -79,6 +79,13 @@ class ConflictException(AppException):
     def __init__(self, message: str = "Conflict", code: str | None = None) -> None:
         super().__init__(message, status_code=409, code=code or RC.CONFLICT)
 
+class ValidationException(AppException):
+    """Semantic validation a service performs AFTER pydantic accepted the shape
+    (cross-field rules, business invariants). Pydantic's own rejection arrives as
+    RequestValidationError and is handled separately."""
+    def __init__(self, message: str = "Validation error", code: str | None = None, data: Any = None) -> None:
+        super().__init__(message, status_code=422, code=code or RC.VALIDATION_ERROR, data=data)
+
 
 async def app_exception_handler(request: Request, exc: AppException) -> JSONResponse:
     logger.error("app_exception", path=request.url.path, method=request.method,
@@ -103,6 +110,10 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError) -
     logger.error("database_error", path=request.url.path, error=str(exc))
     if isinstance(exc, IntegrityError):
         # Unique/FK violations are driven by request data, not a server fault → 409, not 500.
+        # NOTE: the sniffing below matches Postgres driver text. On another backend, or after a
+        # driver reworded its message, it falls through to the generic integrity code — the 409 is
+        # still correct, only the specific code is lost. Prefer `exc.orig.sqlstate` (23505 unique,
+        # 23503 foreign key) when the driver exposes it, and keep this as the fallback.
         error_message, error_code = "Database integrity violation", RC.DATABASE_INTEGRITY_ERROR
         exc_str = str(exc).lower()
         if "duplicate key" in exc_str:
@@ -117,8 +128,20 @@ async def sqlalchemy_exception_handler(request: Request, exc: SQLAlchemyError) -
         "message": "Internal database error", "path": request.url.path})
 
 
+async def too_deep_handler(request: Request, exc: RecursionError) -> JSONResponse:
+    """A deeply-nested JSON body blows the parser's stack. Without this it reaches the
+    catch-all and becomes a 500 — a 5xx caused purely by input. Measured: a 2 KB body of
+    nested brackets returns 500 on a stock service, 400 with this handler registered."""
+    logger.warning("payload_too_deep", path=request.url.path)
+    return JSONResponse(status_code=400, content={
+        "status": "error", "code": RC.PAYLOAD_TOO_DEEP,
+        "message": "Request body nesting is too deep", "path": request.url.path})
+
+
 async def http_exception_handler(request: Request, exc: HTTPException) -> JSONResponse:
-    """Wrap raw HTTPException (404, 405, ...) in the standard envelope."""
+    """Wrap raw HTTPException (404, 405, ...) in the standard envelope. In a service that
+    follows the 'never raise HTTPException directly' rule this only fires for framework-raised
+    ones — 405 from routing, 404 for an unknown path — which is exactly why it must stay."""
     code_map = {404: RC.NOT_FOUND, 405: RC.BAD_REQUEST, 401: RC.UNAUTHORIZED,
                 403: RC.FORBIDDEN, 409: RC.CONFLICT}
     code = code_map.get(exc.status_code, RC.ERROR)
@@ -130,9 +153,12 @@ async def http_exception_handler(request: Request, exc: HTTPException) -> JSONRe
 async def generic_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     logger.error("unhandled_exception", path=request.url.path,
                  error_type=type(exc).__name__, error=str(exc), exc_info=True)
+    # The real message is exposed ONLY in dev; production gets a fixed string so a stack
+    # trace, SQL fragment or internal path can never leak through the catch-all.
+    message = f"{type(exc).__name__}: {exc}" if settings.APP_ENV == "dev" else "Internal server error"
     return JSONResponse(status_code=500, content={
         "status": "error", "code": RC.INTERNAL_SERVER_ERROR,
-        "message": "Internal server error", "path": request.url.path})
+        "message": message, "path": request.url.path})
 ```
 
 ## main.py registration
@@ -141,9 +167,14 @@ async def generic_exception_handler(request: Request, exc: Exception) -> JSONRes
 app.add_exception_handler(AppException, app_exception_handler)
 app.add_exception_handler(RequestValidationError, validation_exception_handler)
 app.add_exception_handler(SQLAlchemyError, sqlalchemy_exception_handler)
+app.add_exception_handler(RecursionError, too_deep_handler)
 app.add_exception_handler(HTTPException, http_exception_handler)
 app.add_exception_handler(Exception, generic_exception_handler)
 ```
+
+`RecursionError` must be registered **before** the `Exception` catch-all reaches it — Starlette
+resolves handlers by walking the exception's MRO, so the more specific class wins regardless of
+registration order, but keeping the order explicit documents the intent.
 
 Services raise the typed hierarchy; endpoints return `success(RC.X_CREATED, "...", data)`. The
 `ResponseCodes` class is a flat registry of UPPER_SNAKE_CASE string constants grouped by domain.


### PR DESCRIPTION
## Why

Audit of the backend skill family (`python-rest-api`, `backend-resilience`, `log-event-collector`, `api-resilience-testing`, `fivem-fallback`). Every change here comes from a run, not from an opinion — per the new `skills-authoring` requirement this PR adds.

## Reproduced defects

**1. `log-event-collector` consumed half-written lines.** The tail loop ended with `handle.tell()`. A log line arriving across two write flushes:

```
pass1 = ['... Player CONNECTED steam=76561 slot=3']
pass2 = ['... Player DISCONNECTED steam=765']      # half-line consumed, offset advanced
pass3 = ['61 slot=3 reason=timeout']               # remainder, never re-joined
```

Two bogus events, zero correct ones. Fixed: the offset advances only to the last `\n`, remainder held back (capped).

**2. `event_key` dropped real events.** `line_hash(raw_line)` de-duplicates the *text*, not the *occurrence*: two distinct reconnects with a byte-identical line collapsed to one key and the second was silently discarded. Fixed: the key carries `log_file:byte_offset`.

**3. A 2 KB request body returns 500 on the `python-rest-api` baseline.** Measured on fastapi 0.141.1 / pydantic 2.13.4, stock service:

| Input | Stock | After the guard |
|---|---|---|
| `"[" * 1000` (~2 KB) | **500** `RecursionError` | 400 |
| 20 MB flat JSON body | **200**, fully buffered | 413 |
| happy path | 200 | 200 |

Both skills declare a 5xx from bad input to be a bug; neither prescribed the limit that prevents it. An unauthenticated 2 KB request returning 5xx is a denial-of-service primitive.

## Measured gaps

| Measurement | Result |
|---|---|
| 200 concurrent callers, dependency down, negative cache alone | **38** still paid the full timeout |
| same burst + single-flight guard | **1** |
| the instant `FAIL_TTL` expires | **200** simultaneous probes (no jitter) |
| worst case of the prescribed 10-attempt / 5s retry | **50s**; stacked under its own boot loop, **~18 min** |
| `safe_call` given 4 distinct failure causes | 1 indistinguishable outcome, **0** log lines |
| seen-set as a list vs a set (N=1000) | **37x** slower |

## Does the doctrine change what an agent writes?

A/B trial, two arms per side, identical task and reference file, scored against 17 target behaviours:

- current `backend-resilience`: **10.5/17**
- revised text: **16/17**

The five behaviours gained — connect/read timeout split, exponential backoff, retry jitter, wall-clock deadline, fail-TTL jitter, `Retry-After` — are exactly the ones the old text never mentioned.

One negative result drove a design decision: **no arm emitted a fallback metric** while the rule lived in a principle bullet. The counter now ships inside the body of the prescribed `safe_call`, where it gets copied.

## Cross-skill conflict resolved

`api-resilience-testing` required RFC 9457 while `python-rest-api` prescribes `{status, code, message, path, details}` — and the two cite each other, so the checklist marked a compliant service as failing. The documented envelope stays canonical; RFC 9457 becomes the greenfield default rather than a requirement.

The checklist also stopped asserting codes the baseline never returns (malformed JSON is **422** not 400; wrong `Content-Type` **422** not 415; unsupported `Accept` **200**, no 406; wrong path-param type **422** not 404) and gained a measured baseline table so each row drives a decision instead of a false failure.

## Versions

`backend-resilience` 2.0.0 (major — tightens previously permitted retry policies) · `python-rest-api` 1.3.0 · `api-resilience-testing` 1.2.0 · `fivem-fallback` 1.3.0 · `log-event-collector` 1.1.0

## Rite

`openspec/changes/harden-backend-skills/` with the mandatory gate groups · spec delta adding **Simulated failure behaviour** to `skills-authoring` · `./generate.sh` run, wrappers in sync · README rows updated · `scripts/validate-rite.sh` green · CI frontmatter check green locally.

`V.5` (`openspec archive`) is intentionally left open — it is the closure step after review.

## Out of scope

Two real gaps in this family, each worth its own proposal: no observability skill (request-id, RED metrics, OpenTelemetry), and no async/DB concurrency doctrine (a sync `Session` inside an `async def` blocks the event loop — `python-rest-api` is silent on it).
