### PR TITLE
✨ feat(documentation)!: rebuild around checkable claims and reader need

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ Project v2 in the org/user. Full details live in the skills themselves:
 
 | Skill | Triggers | What It Does |
 |-------|----------|--------------|
-| **documentation** | README, SETUP, TECHNICAL, CHANGELOG, "document this", "write the docs" | Analyzes the project first, then creates the documentation set the project actually needs |
+| **documentation** | README, SETUP, TECHNICAL, CHANGELOG, AGENTS.md, "document this", "write the docs" | Reads the code first, then creates only the documents the project earns — one purpose per page, claims written so a script can verify them (paths as links, trees rooted correctly, env tables from the config module), docs changed in the same commit as the code, and an `AGENTS.md` when a tool-specific instruction file already exists |
 | **helm-migration** | "migrate to helm", "convert yaml to helm", "generate values.yaml" | Converts K8s YAML to Helm values.yaml/env.yaml — **requires the solvelab chart template repository** |
 
 ### Tooling

--- a/claude/skills/documentation/SKILL.md
+++ b/claude/skills/documentation/SKILL.md
@@ -1,9 +1,16 @@
 ---
 name: documentation
-description: Creates and updates complete project documentation following a three-tier model (README.md, docs/SETUP.md, docs/TECHNICAL.md). Use this skill whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, "document this", "write the docs", "update the readme", "explain how this works", "help someone understand this project", or asks to document a codebase for AI tools or new developers. ALWAYS creates all three documentation tiers unless the user explicitly says otherwise. Do NOT use for non-software documentation tasks.
+description: >-
+  Creates and updates project documentation sized to what the project actually is — README.md plus
+  only the deeper docs the code warrants, organized by reader need (tutorial / how-to / reference /
+  explanation). Use whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, AGENTS.md,
+  "document this", "write the docs", "update the readme", "explain how this works", "help someone
+  understand this project", or asks to document a codebase for AI tools or new developers. Enforces
+  read-the-code-first, machine-checkable claims, one purpose per page, and docs that change in the
+  same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 3.0.0
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/documentation.mdc
+++ b/cursor/rules/documentation.mdc
@@ -1,539 +1,163 @@
 ---
 description: >-
-  Creates and updates complete project documentation following a three-tier model (README.md, docs/SETUP.md, docs/TECHNICAL.md). Use this skill whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, "document this", "write the docs", "update the readme", "explain how this works", "help someone understand this project", or asks to document a codebase for AI tools or new developers. ALWAYS creates all three documentation tiers unless the user explicitly says otherwise. Do NOT use for non-software documentation tasks.
+  Creates and updates project documentation sized to what the project actually is — README.md plus only the deeper docs the code warrants, organized by reader need (tutorial / how-to / reference / explanation). Use whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, AGENTS.md, "document this", "write the docs", "update the readme", "explain how this works", "help someone understand this project", or asks to document a codebase for AI tools or new developers. Enforces read-the-code-first, machine-checkable claims, one purpose per page, and docs that change in the same commit as the code. Do NOT use for non-software documentation tasks.
 alwaysApply: false
 ---
 
 
-Reference examples are in `references/examples.md` — read them when generating documentation output.
+# Documentation
 
-## CRITICAL: Always Analyze Before Documenting
+Write documentation a reader can act on and a script can verify. Templates and full worked examples
+live in `references/` — read them when you are about to generate output, not before.
 
-Before writing any documentation, read the codebase and decide which documents are needed based on what the project actually is.
+## Analyze before documenting
 
-### Step 1 — Analyze the project
+Never write a line of documentation before reading the code it describes.
 
-Run these before writing anything:
-- `find . -type f | head -60` — understand the file structure
-- Read the main entry point, config files, and existing docs
-- Identify: language, framework, architecture style, deployment method, integrations
+1. `find . -type f -not -path "*/.git/*" | head -60` — structure.
+2. Read the entry point, the config module, the dependency manifest, and any existing docs.
+3. Identify: language, framework, how it is configured, how it is run, what it integrates with.
+4. **Extract the facts**, don't invent them: env vars from the config module, endpoints from the
+   router, commands from the manifest scripts / Makefile / CI, ports from the compose file.
 
-### Step 2 — Decide which documents to create
+Only document what you read. If a fact matters and you could not verify it, say so in the doc
+("Deployment target: not documented in this repo") instead of guessing. A confident wrong sentence
+costs more than an admitted gap.
 
-Use this decision table:
+## Decide which documents exist
 
-| Condition | Document to create |
+`README.md` is the only unconditional document. Everything else is earned:
+
+| Condition | Document |
 |---|---|
-| Any project | `README.md` — always |
-| Setup requires more than 5 commands | `docs/SETUP.md` |
-| Non-trivial architecture (services, flows, integrations) | `docs/TECHNICAL.md` |
-| REST or GraphQL API exists | `docs/API.md` |
-| Project accepts contributions | `CONTRIBUTING.md` |
-| Multiple environments (dev, staging, prod) | `docs/DEPLOYMENT.md` |
-| Kubernetes or complex infra | `k8s/README.md` or `docs/INFRASTRUCTURE.md` |
-| Version history exists or releases are planned | `CHANGELOG.md` |
-| Background workers or scheduled jobs | `docs/WORKERS.md` |
-| Webhooks or event-driven architecture | `docs/EVENTS.md` |
-| Machine learning models or data pipelines | `docs/MODEL.md` or `docs/PIPELINE.md` |
-| CLI tool or scripts | `docs/CLI.md` |
-| SDK or library for developers | `docs/SDK.md` |
-| Security-sensitive configuration | `docs/SECURITY.md` |
-
-### Step 3 — Create all relevant documents
-
-Do NOT stop after README.md.
-Do NOT create documents that don't apply to this project.
-Read the codebase first. Only document what actually exists in the code.
-
-Before writing README.md:
-- Check for logo/icon files in the repo root (`logo.png`, `logo.svg`, `icon.png`, `favicon.ico`). Include in the header if found.
-- Always include shields/badges relevant to the tech stack detected in the codebase (language, framework, license, Docker, database).
-
----
-
-# Documentation Skill
-
-You are a documentation writer. When asked to create or update project documentation, follow the patterns and principles below. These are derived from real, battle-tested documentation across production codebases.
-
----
-
-## Core Principles
-
-1. **Purpose first** — the very first lines must explain what the software does and why it exists. A reader (human or AI) should understand the project's value in under 10 seconds.
-2. **Simple and human** — write so any developer can understand the solution quickly. Use plain language. Avoid jargon unless it's the project's domain vocabulary.
-3. **Vibe coding friendly** — make documentation context-rich enough for AI tools to understand the codebase and assist effectively. Include architecture diagrams, module trees, data flows, and configuration references.
-4. **Knowledge transfer** — someone new should be able to onboard just by reading the docs. No tribal knowledge required.
-5. **Detail when needed** — simple overview by default, deep-dive sections when complexity demands it. Use a three-tier depth model (see below).
-6. **Living documentation** — structure docs so they're easy to update as the software evolves. Prefer tables and lists over prose paragraphs for things that change frequently (env vars, endpoints, commands).
-
----
-
-## Three-Tier Documentation Model
-
-Organize documentation in three layers of increasing depth:
-
-| Tier | File | Purpose | Audience |
-|------|------|---------|----------|
-| **1. Overview** | `README.md` | What it does, quick start, feature map, architecture at a glance | Everyone — first thing anyone reads |
-| **2. Walkthrough** | `docs/SETUP.md` | Step-by-step first-time setup from zero to running | New developers, DevOps |
-| **3. Deep Reference** | `docs/TECHNICAL.md` | Architecture details, data flows, DTOs, extension points | Contributors, maintainers, AI assistants |
-
-Additional docs as needed:
-- `CHANGELOG.md` — version history (semantic-release format)
-- `ARCHITECTURE.md` — standalone architecture reference (if too large for README)
-- `k8s/README.md` — Kubernetes deployment guide
-- `docs/<feature>.md` — feature-specific deep dives
-
----
-
-## README.md Structure
-
-Follow this skeleton. Every section is optional except the first three — include only what's relevant to the project:
-
-```markdown
-<div align="center">
-  <img src="logo.png" alt="Project Name" width="180" />
-
-  # Project Name
-
-  **One-line description of what the software does and why it exists.**
-
-  [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org)
-  [![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-009688.svg)](https://fastapi.tiangolo.com)
-  [![License](https://img.shields.io/badge/license-MIT-green.svg)]()
-</div>
-
-## Features
-
-- **Feature Name**: Brief description of what it does
-- **Another Feature**: Brief description
-
-## Tech Stack
-
-| Component | Technology |
-|-----------|------------|
-| Framework | FastAPI 0.115+ |
-| Database  | PostgreSQL 16 |
-
-## Quick Start
-
-### Prerequisites
-
-- Docker and Docker Compose
-- Python 3.12+ (for local development)
-
-### Using Docker Compose
-
-\```bash
-docker compose up
-# API available at http://localhost:8000
-\```
-
-### Local Development
-
-\```bash
-python -m venv venv
-source venv/bin/activate
-pip install -e ".[dev]"
-cp .env.example .env
-\```
-
-## Configuration
-
-| Variable | Required | Default | Description |
-|----------|:--------:|---------|-------------|
-| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
-| `LOG_LEVEL` | No | `INFO` | Log verbosity |
-
-## API Endpoints (or Commands)
-
-### Resource Name
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| GET | `/api/v1/items` | Yes | List items |
-| POST | `/api/v1/items` | Yes | Create item |
-
-## Architecture
-
-\```
-ASCII diagram showing component interactions
-\```
-
-## Folder Structure
-
-\```
-project/
-├── app/
-│   ├── api/          # Route handlers
-│   ├── models/       # Database models
-│   ├── services/     # Business logic
-│   └── main.py       # Entry point
-├── tests/
-├── Dockerfile
-└── docker-compose.yml
-\```
-
-## Development
-
-\```bash
-# Run tests
-pytest tests/ -v
-
-# Lint
-ruff check app/
-\```
-
-## Docker Commands
-
-\```bash
-docker compose up -d        # Start
-docker compose logs -f       # Logs
-docker compose down          # Stop
-docker compose up -d --build # Rebuild
-\```
-
-## Troubleshooting
-
-**Problem**: Description of common issue
-**Solution**: How to fix it
-
-## License
-
-MIT
-```
-
-### README Rules
-
-- **Visual header** (default for public/OSS-facing repos): start README.md with a centered header block containing: project logo (if one exists in the repo — look for `logo.png`, `logo.svg`, `icon.png`), project title in H1, one-line description in bold, and shields/badges relevant to the project (language, framework, license). **Audience rule**: for internal services, bots or private tools, skip badges that carry no signal there (no CI badge without public CI, no PyPI badge if unpublished) — a plain H1 + one-line description is correct for that audience. Default structure:
-  ```markdown
-  <div align="center">
-    <img src="logo.png" alt="Project Logo" width="180" />
-
-    # Project Name
-
-    **One-line description**
-
-    [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org)
-    [![Framework](https://img.shields.io/badge/framework-version-blue.svg)](https://framework-url)
-    [![License](https://img.shields.io/badge/license-MIT-green.svg)]()
-  </div>
-  ```
-- **Badges to include** (only when relevant to the project):
-  - Language + version: Python, Node.js, Go, etc.
-  - Main framework + version: FastAPI, Express, Discord.py, etc.
-  - License: MIT, Apache, Proprietary
-  - Docker: if `docker-compose.yml` exists
-  - Database: if a database is configured
-- **Logo detection**: Before writing README.md, search for image files in the repo root (`logo.png`, `logo.svg`, `icon.png`, `favicon.ico`). If found, include it in the header. If not found, skip the `<img>` tag.
-- **No logo, no problem**: If no logo exists, keep the centered div with just the title, description, and badges.
-- **Lead with purpose**: the first line after the header must be a one-sentence description if not already in the header. When badges are used, keep them all inside the header block — none scattered through the body.
-- **Quick Start must be quick**: 3-5 commands maximum. If it takes more, link to `docs/SETUP.md`.
-- **Features as a scannable list**: use bold feature names with concise descriptions. Use emoji sparingly (only if the project already does).
-- **Tables for structured data**: env vars, endpoints, commands, tech stack — always tables, never prose.
-- **ASCII diagrams over images**: text-based diagrams are grep-able, git-diff-friendly, and readable by AI tools.
-- **Folder structure with annotations**: show the directory tree with inline comments explaining each directory's purpose.
-- **Copy-paste ready commands**: every code block should work if pasted directly into a terminal. Include comments for context.
-
----
-
-## docs/SETUP.md Structure
-
-The setup guide takes someone from zero to a running system. Follow this progression:
-
-```markdown
-# Setup Guide
-
-Step-by-step guide to configure [Project Name] from scratch.
-
-## Table of Contents
-
-1. [Prerequisites](#1-prerequisites)
-2. [Configure Environment](#2-configure-environment)
-3. [Deploy with Docker](#3-deploy-with-docker)
-4. [Verify It Works](#4-verify-it-works)
-5. [Troubleshooting](#5-troubleshooting)
-
-## 1. Prerequisites
-
-Before starting, make sure you have:
-
-- Docker and Docker Compose installed
-- [Dependency X] running and accessible
-
-### Verify Dependencies
-
-\```bash
-curl http://localhost:8000/api/v1/health
-# Expected: {"status": "healthy"}
-\```
-
-## 2. Configure Environment
-
-\```bash
-cp .env.example .env
-# Edit .env with your settings
-\```
-
-### Environment Template
-
-\```bash
-# =============================================================================
-# Database
-# =============================================================================
-DATABASE_URL=postgresql://user:pass@db:5432/mydb
-
-# =============================================================================
-# Authentication
-# =============================================================================
-JWT_SECRET_KEY=your-secret-here
-\```
-
-## 3. Deploy with Docker
-
-\```bash
-docker compose build
-docker compose up -d
-docker compose ps  # verify containers are running
-\```
-
-### Verify Logs
-
-\```bash
-docker compose logs -f api
-# Expected: "Application started on port 8000"
-\```
-
-## 4. Verify It Works
-
-\```bash
-curl http://localhost:8000/api/v1/health
-# Expected: {"status": "healthy"}
-\```
-
-## 5. Troubleshooting
-
-**Problem**: Container exits immediately
-**Solution**: Check logs with `docker compose logs api`. Common cause: missing env vars.
-
-## Next Steps
-
-- [ ] Configure production secrets
-- [ ] Set up monitoring
-- [ ] Review security checklist
-```
-
-### Setup Guide Rules
-
-- **Table of contents at the top**: numbered sections with anchor links.
-- **Checkboxes for prerequisites**: `- [ ]` format so readers can mentally check them off.
-- **Verify at every step**: after each major action, show how to confirm it worked. Include expected output.
-- **Environment template with section headers**: group env vars by feature area using comment dividers (`# ====`).
-- **Troubleshooting is mandatory**: at least 5 common problems with solutions.
-- **End with Next Steps**: checklist of follow-up tasks using `- [ ]` format.
-- **Commands include expected output**: show what success looks like so the reader knows they did it right.
-
----
-
-## docs/TECHNICAL.md Structure
-
-The technical reference is for deep understanding. This is where AI tools and new contributors go to understand *how* the system works.
-
-```markdown
-# Technical Documentation
-
-Detailed architecture, components, and data flows for [Project Name].
-
-## Table of Contents
-
-1. [Overview](#1-overview)
-2. [Architecture](#2-architecture)
-3. [Components](#3-components)
-4. [Data Flow](#4-data-flow)
-5. [DTOs and Entities](#5-dtos-and-entities)
-6. [HTTP Clients / External Integrations](#6-http-clients)
-7. [Services](#7-services)
-8. [Logging and Observability](#8-logging-and-observability)
-9. [Testing](#9-testing)
-10. [Extending the System](#10-extending-the-system)
-```
-
-### Technical Doc Rules
-
-- **Table of contents with anchor links**: always at the top, numbered to match sections.
-- **Architecture diagram first**: ASCII box diagram showing how components connect.
-- **Document data flows**: show the path data takes through the system, step by step.
-- **Include code signatures**: for services and clients, show method signatures with types and return values.
-- **DTOs and entities section**: show dataclass/model definitions with field descriptions.
-- **"Extending the System" section**: explain how to add new modules, integrations, or features. This is critical for AI-assisted development.
-- **Tech stack table**: component → technology mapping at the top of the overview.
-
----
-
-## Formatting Conventions
-
-### Tables
-
-Use tables for any structured, repeatable data:
-
-```markdown
-| Variable | Required | Default | Description |
-|----------|:--------:|---------|-------------|
-| `DB_HOST` | Yes | - | Database hostname |
-| `LOG_LEVEL` | No | `INFO` | Log verbosity |
-```
-
-- Center-align boolean/status columns (`:---:`)
-- Use inline code for variable names, commands, values
-- Group rows by category using bold header rows when the table is long
-
-### ASCII Diagrams
-
-Use text-based diagrams for architecture and flows:
-
-```
-┌─────────────┐     HTTP      ┌──────────────┐
-│   Service A │ ─────────────>│  Service B   │
-└─────────────┘               └──────────────┘
-       │                             │
-       │ Events                      │ SQL
-       v                             v
-┌─────────────┐               ┌──────────────┐
-│  Message Q  │               │  PostgreSQL  │
-└─────────────┘               └──────────────┘
-```
-
-Use box-drawing characters (`┌ ─ ┐ └ ┘ │ ├ ┤ ┬ ┴ ┼`) for clean diagrams. Reserve simple arrows (`→ ← ↓ ↑`) for inline flows.
-
-### Code Blocks
-
-- Always specify the language: ` ```bash `, ` ```python `, ` ```yaml `, ` ```json `
-- Include comments explaining non-obvious commands
-- Show expected output when the command produces meaningful results
-
-### Directory Trees
-
-```
-project/
-├── app/
-│   ├── api/          # Route handlers
-│   ├── models/       # Database entities
-│   ├── services/     # Business logic
-│   └── main.py       # Entry point
-├── tests/
-│   ├── test_*.py     # Unit tests
-│   └── conftest.py   # Shared fixtures
-└── docker-compose.yml
-```
-
-Always include inline comments (`# Purpose`) for each directory.
-
-### Section Dividers
-
-Use `---` (horizontal rule) between major sections for visual separation.
-
-### Cross-References
-
-Link between documentation files:
-
-```markdown
-See [Setup Guide](docs/SETUP.md) for first-time configuration.
-See [Technical Documentation](docs/TECHNICAL.md) for architecture details.
-```
-
----
-
-## CHANGELOG.md Format
-
-Use semantic-release format:
-
-```markdown
-## [v1.2.0](https://github.com/org/repo/compare/v1.1.0...v1.2.0) (2026-03-13)
-
-### Features
-
-* **auth**: add OAuth support for Google and GitHub ([abc1234](https://github.com/org/repo/commit/abc1234))
-
-### Bug Fixes
-
-* **orders**: fix fee calculation for products under R$8 ([def5678](https://github.com/org/repo/commit/def5678))
-```
-
-- Reverse chronological order (newest first)
-- Group entries: Features, Bug Fixes, Breaking Changes
-- Include commit hash links
-- Prefix entries with scope in bold: `**module**:`
-
----
-
-## Writing Style Guide
-
-1. **Be direct**: use imperative mood for instructions ("Run the command", "Edit the file"). No hedging.
-2. **Show, don't explain**: a code example is worth a paragraph of prose. When in doubt, add a code block.
-3. **Keep prose minimal**: use sentences for context, tables for data, code blocks for commands.
-4. **Use consistent terminology**: pick one term for each concept and stick with it throughout all docs.
-5. **Document the "why" alongside the "what"**: for non-obvious decisions, add a brief explanation (e.g., "We use Camoufox because standard Playwright gets detected by anti-bot systems").
-6. **Include real examples**: use realistic values, not `foo`/`bar`. Show actual API payloads, real config values, concrete use cases.
-7. **Warn about footguns**: use bold + warning indicator for dangerous operations (e.g., `**Warning**: This deletes all data`).
-
----
-
-## When Creating Documentation
-
-1. **Read the codebase first**: understand the project structure, entry points, configuration, and dependencies before writing anything.
-2. **Start with README.md**: if it doesn't exist, create it. If it exists, update it to match the skeleton above.
-3. **Create docs/SETUP.md** when the project requires more than 5 commands to set up.
-4. **Create docs/TECHNICAL.md** when the project has non-trivial architecture (multiple services, complex data flows, extension points).
-5. **Update CHANGELOG.md** when making significant changes — follow the semantic-release format.
-6. **Never invent features**: only document what actually exists in the code. Read before you write.
-
-## When Updating Documentation
-
-1. **Keep existing structure**: don't reorganize docs unless asked. Add to the existing skeleton.
-2. **Update, don't duplicate**: if information exists in one place, update it there. Don't create parallel docs.
-3. **Reflect code changes**: when code changes (new endpoints, new env vars, new modules), update the corresponding doc sections.
-4. **Preserve the project's voice**: if docs are in Portuguese, keep them in Portuguese. If English, keep English. Match the existing tone.
-
----
-
-## Troubleshooting
-
-**Problem**: Only README.md was updated, SETUP.md and TECHNICAL.md were not created.
-**Solution**: This skill always creates all three tiers. Re-run with: "Document this project following the documentation skill — create README.md, docs/SETUP.md, and docs/TECHNICAL.md."
-
-**Problem**: Documentation describes features that don't exist in the code.
-**Solution**: Always read the codebase before writing. Run `find . -type f` and read key files before starting.
-
-**Problem**: Setup guide is missing expected output for commands.
-**Solution**: Every command block must show what success looks like with a comment like `# Expected: ...`
-
----
-
-## How to Use
-
-### Prompt
-
-Open your project in Claude Code and paste this prompt:
-
-```
-Document this project following the documentation skill.
-Analyze the codebase and create all documentation files this project needs.
-```
-
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Document this project"
-- "Write the docs for this codebase"
-- "Update the README"
-- "Create setup and technical documentation"
-- "Help someone understand this project"
-- "Document this for AI tools"
-
-Should NOT trigger on:
-- "Write a blog post"
-- "Create a presentation"
-- "Fix this bug"
-- "Review my code"
+| Any project | `README.md` |
+| A `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md` or `.clinerules` exists, **or** the user asked to document the repo for AI tools | `AGENTS.md` |
+| Setup takes more than ~5 commands, or has environment prerequisites | `docs/SETUP.md` |
+| Architecture a reader cannot infer from the tree (services, flows, integrations) | `docs/TECHNICAL.md` |
+| REST/GraphQL API with no generated spec published | `docs/API.md` |
+| Project accepts outside contributions | `CONTRIBUTING.md` |
+| More than one deploy environment | `docs/DEPLOYMENT.md` |
+| Releases are tagged | `CHANGELOG.md` (generated, not hand-written) |
+| Background workers, webhooks, ML pipelines, CLI, SDK, security-sensitive config | the matching `docs/<topic>.md` |
+
+**Do not create a document to satisfy the table.** A 200-line project with a 3-command setup needs a
+README and nothing else; splitting it into three tiers produces three files that rot instead of one
+that doesn't. If you create only a README, say so and why.
+
+## One purpose per page
+
+Four reader needs, four kinds of page. Mixing them is the most common reason docs go stale and the
+most common reason readers can't find anything:
+
+| Need | Page kind | In this model |
+|---|---|---|
+| "Get me running for the first time" | **Tutorial** — one happy path, no options | `docs/SETUP.md` |
+| "How do I do X?" | **How-to** — task-oriented, assumes context | `README.md` quick start, `docs/<topic>.md` |
+| "What exactly does Y take?" | **Reference** — exhaustive, dry, generated where possible | config tables, `docs/API.md` |
+| "Why is it like this?" | **Explanation** — design rationale, trade-offs | `docs/TECHNICAL.md`, ADRs |
+
+The practical rule: **how-to content changes far faster than why content.** A page that mixes a
+command sequence with architectural rationale goes stale at the speed of its fastest-changing half.
+Keep them on separate pages, and cross-link.
+
+## Every claim must be checkable
+
+This is the difference between documentation and decoration. Prefer facts a script can verify against
+the repo, and write them so it can:
+
+- **Repo paths are links**, not prose: `[app/main.py](app/main.py)`. A link is checkable; a sentence
+  is not.
+- **Directory trees show the real root.** Measured on a production repo: a README tree written without
+  its `src/` prefix made every path in it unresolvable, and one entry had been renamed months earlier
+  — 9 of 10 entries wrong in a block the reader trusts most.
+- **Directory trees are the highest-rot artifact you can write.** They duplicate the filesystem and
+  break on every refactor. Include one only when the layout is genuinely non-obvious, cap it at the
+  directories that carry meaning (not every file), and annotate each with its purpose. Never paste a
+  full `tree` dump.
+- **Never hand-copy what a tool generates.** Endpoint tables duplicating an OpenAPI spec, flag tables
+  duplicating `--help`, changelogs duplicating the release tool — link or generate them. Hand copies
+  drift silently and there is no signal when they do.
+- **Env var tables come from the config module**, and every row must name a variable that exists in
+  the code. A documented variable the code never reads is a bug report waiting to happen.
+- **Commands are copy-paste runnable.** Run them, or state that you did not. Show expected output for
+  anything whose success is not obvious.
+- Ship the checker. A ~50-line script that resolves every link, every tree path, and every documented
+  env var, wired into CI, turns "the docs are stale" from a discovery into a build failure.
+
+## Keeping it true
+
+Documentation rot is the default outcome; the only reliable fix is process, not diligence:
+
+- **Docs change in the same commit as the code.** A PR that adds an env var and does not touch the
+  config table is incomplete — treat it the way you would treat a missing test.
+- **Every document names an owner** (a person or a team) in its footer or frontmatter. An unowned doc
+  is nobody's job.
+- **Date the volatile parts.** Version numbers, screenshots, benchmark figures and "current status"
+  sections carry the date they were verified.
+- **Delete aggressively.** A section describing a removed feature is worse than no section — it
+  actively misleads. Prune when you touch a page.
+
+## AGENTS.md — the repo's instructions for coding agents
+
+When AI agents work in the repo, the conventions they need live in `AGENTS.md` at the root — an open
+spec (donated to the Linux Foundation's Agentic AI Foundation in December 2025) that most agent tools
+now read. Anthropic's `CLAUDE.md` serves the same role for Claude Code; when both exist, keep one
+canonical and have the other point at it rather than maintaining two.
+
+Content that measurably helps: **architecture overview, where the important files are, and how to
+build/test/run.** Be honest about the ceiling — the published evaluation of repository context files
+on SWE-bench found gains modest and inconsistent across models, with setup and build guidance the most
+valuable part. Write it for that: concrete commands and locations, not aspirational style rules.
+
+`AGENTS.md` is about *contributing to this code*. It is not a substitute for the README, and it is a
+different thing from `llms.txt`, which maps a documentation *site* for retrieval.
+
+**The trigger has to be something you can see.** "This repo is worked on by agents" is not observable
+from a checkout — measured: with that phrasing, no run produced the file. Use the detectable signals
+in the table above: an existing tool-specific instruction file, or the user asking for it. When none
+is present, do not create `AGENTS.md` silently — say it is missing and what it would carry.
+
+## README
+
+Lead with what the software does and why, in one sentence, above everything else. Then only the
+sections this project earns. The full skeleton and a worked example: `references/templates.md` and
+`references/examples.md`.
+
+- **Quick start is 3-5 commands.** More than that means it is a tutorial — move it to `docs/SETUP.md`
+  and link.
+- **Tables for structured data** (env vars, endpoints, commands, tech stack); prose only for context.
+- **Text diagrams over images** — greppable, diff-able, readable by agents.
+- **Badges: signal only.** A badge that cannot fail carries no information — a hardcoded
+  `python-3.12-blue` shield is decoration. Live badges (CI status, coverage, published version) are
+  worth their space; static ones are not. For internal services and private tools a plain H1 plus a
+  one-line description is the correct header. Each badge is also a third-party request served to every
+  reader, so keep the set small.
+- **Include a logo** in a centered header block only if one already exists in the repo.
+
+## Writing style
+
+1. **Imperative for instructions.** "Run the migration", not "you may wish to run".
+2. **Show, don't explain.** A code block beats a paragraph.
+3. **One term per concept**, used consistently across every document.
+4. **Document the why for non-obvious decisions** — the constraint that forced the choice, not the
+   choice alone.
+5. **Real values, never `foo`/`bar`.** Realistic payloads, actual config values.
+6. **Warn about footguns** in bold, at the point of danger, not in a distant section.
+7. **Match the project's existing language and voice.** Portuguese docs stay Portuguese.
+
+## Updating existing documentation
+
+1. **Keep the existing structure** unless asked to reorganize. Add to the skeleton that is there.
+2. **Update in place; never fork a parallel doc.** Two documents describing the same thing means one
+   of them is already wrong.
+3. **Follow the code change.** New endpoint, new env var, new module → the corresponding rows change
+   in the same commit.
+4. **Re-verify what you touch.** If you edit a section, its links, paths and commands are yours now.
+
+## See also
+
+- `references/templates.md` — README / SETUP / TECHNICAL skeletons.
+- `references/examples.md` — worked examples of good output per tier.
+- `conventional-commit` — the commit format that drives generated changelogs.
+- `openspec` — where design rationale lives when a project runs the spec-driven flow; documentation
+  describes what exists, proposals describe what changes.

--- a/openspec/changes/harden-documentation-skill/.openspec.yaml
+++ b/openspec/changes/harden-documentation-skill/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/harden-documentation-skill/design.md
+++ b/openspec/changes/harden-documentation-skill/design.md
@@ -1,0 +1,88 @@
+## Context
+
+`documentation` is the catalog's only `docs`-category skill and one of its most frequently triggered:
+its description fires on README, docs, SETUP, TECHNICAL, CHANGELOG and "explain how this works". It is
+also the skill whose output is hardest to falsify — a wrong sentence in a README looks exactly like a
+right one until someone follows it.
+
+That is why this change was driven by measurement rather than review. Two instruments were built: a
+claim checker that extracts every machine-checkable assertion a markdown doc makes about its repo
+(links, tree paths, inline paths, env vars in tables) and verifies it, and an A/B trial that ran the
+current doctrine and a revised draft over the same real, undocumented codebase and scored the output
+against the source.
+
+## Goals / Non-Goals
+
+**Goals**
+- One policy, stated once, for which documents exist.
+- Rules that produce assertions a script can check, and a way to keep them true over time.
+- Cover the reader-need distinction and the agent context-file convention the skill currently omits.
+
+**Non-Goals**
+- Not adopting Diátaxis wholesale as a file layout. The four needs are used as a *test* for whether a
+  page has one purpose; the repo's README/SETUP/TECHNICAL naming stays.
+- No documentation generator, linter, or CI job shipped in this repo. The skill prescribes shipping a
+  checker in the documented project; building one here is a separate proposal.
+- The `r3f-*` size problem is named in the proposal and left alone.
+
+## Decisions
+
+**D1 — The decision table is the single authority on which files exist.** The
+"ALWAYS three tiers" promise loses, because it is the side that contradicts the body twice and because
+it measurably over-produces: 5 documents for a 1,432-line service, including one the trial's own
+control arm had to justify at length. Owner decision, 2026-08-06.
+
+**D2 — Reader need is a test, not a taxonomy to file under.** Pages keep their existing names; the
+tutorial/how-to/reference/explanation split is applied as "does this page have one purpose?". The
+operative rule is the rot mechanism — how-to content changes faster than why content, so a page
+mixing them decays at the speed of its fastest half.
+
+**D3 — Checkability is the skill's central rule, not a nicety.** The A/B difference was not accuracy
+(both arms got 16/16 env vars and 6/6 endpoints) — it was that the revised arm wrote 131 checkable
+claims where the control wrote 84, and failed fewer of them. Writing a path as a link instead of prose
+converts an unfalsifiable sentence into a testable one at zero cost.
+
+**D4 — Directory trees are demoted, not banned.** They are the highest-rot artifact measured (9 of 10
+entries wrong in a production README, from an omitted root plus one genuine rename). They stay
+available for genuinely non-obvious layouts, with two hard requirements: show the real root, and cap
+at directories that carry meaning.
+
+**D5 — `AGENTS.md` needs a detectable trigger.** The first draft conditioned it on "repo is worked on
+by AI coding agents" and **no trial run produced the file** — the condition is not observable from a
+checkout. It now keys on an existing tool-specific instruction file or an explicit request, and the
+skill is required to *name the gap* rather than create the file silently when neither is present. This
+is a negative result from the simulation, folded back in.
+
+**D6 — Claims about `AGENTS.md` value are stated with their ceiling.** The published SWE-bench
+evaluation of repository context files reports modest and inconsistent gains, with build/setup
+guidance the most useful content. The skill says that, rather than selling the file.
+
+**D7 — Templates leave SKILL.md.** 42% of the file was fenced skeleton. Skeletons are read at
+generation time, not at selection time, which is exactly what `references/` is for.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Which documents a project needs; README/SETUP/TECHNICAL structure | `documentation` | already canonical — decision table becomes the sole authority |
+| One purpose per page (tutorial/how-to/reference/explanation) | `documentation` | establish here (new) |
+| Checkable documentation claims + doc staleness controls | `documentation` | establish here (new) |
+| `AGENTS.md` / agent context files | `documentation` | establish here (new) |
+| Document skeletons and formatting conventions | `documentation/references/templates.md` | move out of SKILL.md |
+| Changelog format and commit types that generate it | `conventional-commit` | link (already canonical) |
+| Design rationale for a *change* (vs documentation of what exists) | `openspec` | link (already canonical) |
+| Frontmatter/authoring conventions for skills themselves | `openspec/specs/skills-authoring` | spec delta, not skill content |
+
+## Risks / Trade-offs
+
+- [Fewer documents by default may read as a regression to anyone relying on the three-tier promise] →
+  the skill must state explicitly when it produced only a README and why; the decision table makes the
+  reasoning inspectable rather than implicit.
+- [Major version bump invalidates cached copies] → intended; the output set changes.
+- [`AGENTS.md` guidance ages fast — the spec is young] → the rule is written against detectable files
+  rather than a spec version, and the value claim carries its published ceiling.
+- [Moving skeletons to `references/` costs a second file read at generation time] → acceptable: they
+  are not needed to decide whether the skill applies, only to produce output.
+- [The claim checker used for the measurements lives outside this repo] → the numbers it produced are
+  recorded in the proposal with their conditions; the skill prescribes shipping such a checker in the
+  documented project, which is where it belongs.

--- a/openspec/changes/harden-documentation-skill/proposal.md
+++ b/openspec/changes/harden-documentation-skill/proposal.md
@@ -1,0 +1,90 @@
+# Change: Rebuild the documentation skill around checkable claims and reader need
+
+## Why
+
+`skills/documentation/SKILL.md` instructs two opposite behaviours in the same file. The frontmatter
+description — the part always in context, and what the model reads when selecting the skill — says
+"**ALWAYS creates all three documentation tiers** unless the user explicitly says otherwise". The body
+says "**Do NOT create documents that don't apply to this project**", and the Troubleshooting section
+restates the first claim ("This skill always creates all three tiers"). Three statements, two
+incompatible policies.
+
+Measured consequences, from an A/B trial on a real undocumented 1,432-line Python service (same task,
+same reference files, output scored against the source code):
+
+| | current skill | revised draft |
+|---|---|---|
+| documents created | 5 | 4 |
+| documentation lines | 873 | 786 |
+| env vars documented / in code | 16/16 | 16/16 |
+| endpoints documented / in code | 6/6 | 6/6 |
+| **machine-checkable claims** | **84** | **131** |
+| claims that fail verification | 13 | 11 |
+| **failure rate** | **15.5%** | **8.4%** |
+| states what it could not verify | no | yes |
+
+The revised text produces 56% more verifiable assertions at roughly half the failure rate, with fewer
+files. Both arms read the code correctly — the current skill is sound on accuracy; it is wrong on
+*scope* and silent on *durability*.
+
+Documentation rot was measured directly with a claim checker over production repos. A README
+directory tree written without its `src/` prefix made every path in the block unresolvable, and one
+entry named a file renamed months earlier — 9 of 10 tree entries wrong, in the artifact the skill
+mandates most insistently ("Folder structure with annotations", "Always include inline comments").
+
+Gaps the current text has no rule for at all:
+
+- **Staleness.** "Living documentation" is listed as a principle with no mechanism — no
+  same-commit rule, no ownership, no verification. Rot is the default outcome of every doc set.
+- **`AGENTS.md`.** The skill triggers on "document this for AI tools" and claims to be "vibe coding
+  friendly", but never mentions the repository context-file convention that agent tooling actually
+  reads (open spec, donated to the Linux Foundation's Agentic AI Foundation in December 2025).
+- **Reader need.** The three tiers conflate tutorial, how-to, reference and explanation. Mixing
+  fast-changing how-to content with slow-changing rationale on one page is the mechanism by which
+  pages go stale.
+
+The file is also 543 lines / ~4.9k tokens — at the ceiling for a SKILL.md — of which 42% is fenced
+template content that belongs in `references/`, plus meta sections ("How to Use", "Trigger Test
+Cases") that cost context on every invocation and instruct nothing.
+
+## What Changes
+
+- `documentation` → 3.0.0 (major: changes which files the skill produces).
+  - Remove the "ALWAYS all three tiers" promise from the description and Troubleshooting. `README.md`
+    is the only unconditional document; the decision table governs the rest, and the skill must say
+    when it deliberately produced only a README.
+  - Add **one purpose per page** (tutorial / how-to / reference / explanation) as the organizing
+    principle behind the tiers, with the fast-how / slow-why rot mechanism stated.
+  - Add **every claim must be checkable**: repo paths as links, directory trees rooted correctly and
+    demoted to "only when the layout is non-obvious", never hand-copy generated sources, env tables
+    sourced from the config module, commands actually run, and ship the checker.
+  - Add **keeping it true**: docs change in the same commit as the code, every document names an
+    owner, volatile facts carry a verification date, delete aggressively.
+  - Add **`AGENTS.md`** with a *detectable* trigger (an existing `CLAUDE.md` / `.cursorrules` /
+    `.github/copilot-instructions.md` / `.clinerules`, or the user asking), and the honest ceiling from
+    the published SWE-bench evaluation of repository context files — gains modest and inconsistent,
+    with build/setup guidance the most valuable part.
+  - Replace the badge/logo material (14 mentions of "badge", 5 of `logo.png`) with a single
+    signal-only rule: a badge that cannot fail carries no information.
+  - Move the README / SETUP / TECHNICAL skeletons and formatting conventions to
+    `references/templates.md`; drop the "How to Use" and "Trigger Test Cases" meta sections.
+- New file `skills/documentation/references/templates.md`.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — a skill's frontmatter description SHALL NOT state a policy
+  its body contradicts, since the description is what drives selection and is always in context.
+
+## Impact
+
+- `skills/documentation/SKILL.md` (rewritten), `skills/documentation/references/templates.md` (new),
+  and every regenerated wrapper tree (`claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/`).
+- README skill-table row for `documentation`.
+- Consumers: projects documented with this skill will get fewer files by default and an `AGENTS.md`
+  where a tool-specific instruction file already exists.
+- Out of scope, noted for a follow-up: the `r3f-*` skills run 732-1,145 lines with 78-86% fenced
+  content and no `references/` at all — the same size problem, larger.

--- a/openspec/changes/harden-documentation-skill/specs/skills-authoring/spec.md
+++ b/openspec/changes/harden-documentation-skill/specs/skills-authoring/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Description agrees with body
+
+A skill's frontmatter `description` SHALL NOT state a policy that its body contradicts. The
+description is loaded into every session and drives skill selection, so a conflict there is resolved
+by the model, not by the author.
+
+#### Scenario: Conflicting policy is caught before publication
+
+- **WHEN** a skill's description asserts a behaviour ("always creates X", "never does Y") that a rule
+  in the body qualifies or reverses
+- **THEN** the conflict is resolved to a single policy and stated once, in the body, with the
+  description summarizing it rather than restating a stronger claim
+
+#### Scenario: Behavioural promises are attributed to the governing rule
+
+- **WHEN** a skill's output set depends on a condition (a decision table, a detected file, a user
+  request)
+- **THEN** the description names the condition rather than promising an unconditional result

--- a/openspec/changes/harden-documentation-skill/tasks.md
+++ b/openspec/changes/harden-documentation-skill/tasks.md
@@ -1,0 +1,55 @@
+## 1. Resolve the scope contradiction
+
+- [x] 1.1 Rewrite the frontmatter `description`: remove "ALWAYS creates all three documentation
+      tiers", name the decision table as the governing condition, add the AGENTS.md trigger
+- [x] 1.2 Rewrite the decision table: `README.md` unconditional, every other document earned; add the
+      "do not create a document to satisfy the table" rule and the requirement to state when only a
+      README was produced
+- [x] 1.3 Delete the Troubleshooting entry that restates "This skill always creates all three tiers"
+
+## 2. New doctrine
+
+- [x] 2.1 Add "One purpose per page" — tutorial / how-to / reference / explanation mapped to the
+      existing file names, with the fast-how / slow-why rot mechanism
+- [x] 2.2 Add "Every claim must be checkable" — repo paths as links, trees rooted correctly and
+      demoted, never hand-copy generated sources, env tables from the config module, commands run or
+      declared unrun, ship the checker; include the measured 9-of-10 tree result
+- [x] 2.3 Add "Keeping it true" — same-commit rule, named owner per document, dated volatile facts,
+      delete aggressively
+- [x] 2.4 Add "AGENTS.md" with the detectable trigger and the published SWE-bench ceiling; state that
+      a missing trigger means naming the gap, not creating the file
+- [x] 2.5 Add the "state what you could not verify" rule to the analysis section
+
+## 3. Removals and size
+
+- [x] 3.1 Move README / SETUP / TECHNICAL skeletons + formatting conventions + changelog format to
+      `skills/documentation/references/templates.md`
+- [x] 3.2 Delete the "How to Use" and "Trigger Test Cases" meta sections
+- [x] 3.3 Collapse the badge/logo material into one signal-only rule
+- [x] 3.4 SKILL.md ends materially shorter than 543 lines with template content in `references/`
+- [x] 3.5 Bump `metadata.version` to 3.0.0
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform: name == directory, folded description, metadata.author solvelab,
+      semver metadata.version, category `docs`, license MIT, compatibility present
+- [x] Q.2 All skill content in English (catalog locale)
+- [x] Q.3 Description triggers still route correctly (README, docs, SETUP, TECHNICAL, CHANGELOG,
+      AGENTS.md, "document this") and the "Do NOT use for non-software documentation" boundary survives
+- [x] Q.4 No duplicated doctrine: skeletons only in `references/templates.md`; changelog format links
+      `conventional-commit`; per the design.md Canonical Home table
+- [x] Q.5 Every quantified claim carries its measured number and conditions (skills-authoring:
+      Simulated failure behaviour)
+- [x] Q.6 Description states no policy the body contradicts (skills-authoring: Description agrees with
+      body) — re-read both after the rewrite
+- [x] Q.7 README skill-table row updated for `documentation`
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate harden-documentation-skill --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 CI frontmatter check passes locally on every `skills/*/SKILL.md`
+- [x] V.5 AGENTS.md trigger re-tested: a run against a checkout containing a `CLAUDE.md` produces or
+      updates `AGENTS.md` (the first draft's unobservable condition produced it in zero runs)
+- [ ] V.6 `openspec archive harden-documentation-skill --yes` after review

--- a/plugins/docs/skills/documentation/SKILL.md
+++ b/plugins/docs/skills/documentation/SKILL.md
@@ -1,543 +1,174 @@
 ---
 name: documentation
-description: Creates and updates complete project documentation following a three-tier model (README.md, docs/SETUP.md, docs/TECHNICAL.md). Use this skill whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, "document this", "write the docs", "update the readme", "explain how this works", "help someone understand this project", or asks to document a codebase for AI tools or new developers. ALWAYS creates all three documentation tiers unless the user explicitly says otherwise. Do NOT use for non-software documentation tasks.
+description: >-
+  Creates and updates project documentation sized to what the project actually is — README.md plus
+  only the deeper docs the code warrants, organized by reader need (tutorial / how-to / reference /
+  explanation). Use whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, AGENTS.md,
+  "document this", "write the docs", "update the readme", "explain how this works", "help someone
+  understand this project", or asks to document a codebase for AI tools or new developers. Enforces
+  read-the-code-first, machine-checkable claims, one purpose per page, and docs that change in the
+  same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 3.0.0
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
-Reference examples are in `references/examples.md` — read them when generating documentation output.
+# Documentation
 
-## CRITICAL: Always Analyze Before Documenting
+Write documentation a reader can act on and a script can verify. Templates and full worked examples
+live in `references/` — read them when you are about to generate output, not before.
 
-Before writing any documentation, read the codebase and decide which documents are needed based on what the project actually is.
+## Analyze before documenting
 
-### Step 1 — Analyze the project
+Never write a line of documentation before reading the code it describes.
 
-Run these before writing anything:
-- `find . -type f | head -60` — understand the file structure
-- Read the main entry point, config files, and existing docs
-- Identify: language, framework, architecture style, deployment method, integrations
+1. `find . -type f -not -path "*/.git/*" | head -60` — structure.
+2. Read the entry point, the config module, the dependency manifest, and any existing docs.
+3. Identify: language, framework, how it is configured, how it is run, what it integrates with.
+4. **Extract the facts**, don't invent them: env vars from the config module, endpoints from the
+   router, commands from the manifest scripts / Makefile / CI, ports from the compose file.
 
-### Step 2 — Decide which documents to create
+Only document what you read. If a fact matters and you could not verify it, say so in the doc
+("Deployment target: not documented in this repo") instead of guessing. A confident wrong sentence
+costs more than an admitted gap.
 
-Use this decision table:
+## Decide which documents exist
 
-| Condition | Document to create |
+`README.md` is the only unconditional document. Everything else is earned:
+
+| Condition | Document |
 |---|---|
-| Any project | `README.md` — always |
-| Setup requires more than 5 commands | `docs/SETUP.md` |
-| Non-trivial architecture (services, flows, integrations) | `docs/TECHNICAL.md` |
-| REST or GraphQL API exists | `docs/API.md` |
-| Project accepts contributions | `CONTRIBUTING.md` |
-| Multiple environments (dev, staging, prod) | `docs/DEPLOYMENT.md` |
-| Kubernetes or complex infra | `k8s/README.md` or `docs/INFRASTRUCTURE.md` |
-| Version history exists or releases are planned | `CHANGELOG.md` |
-| Background workers or scheduled jobs | `docs/WORKERS.md` |
-| Webhooks or event-driven architecture | `docs/EVENTS.md` |
-| Machine learning models or data pipelines | `docs/MODEL.md` or `docs/PIPELINE.md` |
-| CLI tool or scripts | `docs/CLI.md` |
-| SDK or library for developers | `docs/SDK.md` |
-| Security-sensitive configuration | `docs/SECURITY.md` |
-
-### Step 3 — Create all relevant documents
-
-Do NOT stop after README.md.
-Do NOT create documents that don't apply to this project.
-Read the codebase first. Only document what actually exists in the code.
-
-Before writing README.md:
-- Check for logo/icon files in the repo root (`logo.png`, `logo.svg`, `icon.png`, `favicon.ico`). Include in the header if found.
-- Always include shields/badges relevant to the tech stack detected in the codebase (language, framework, license, Docker, database).
-
----
-
-# Documentation Skill
-
-You are a documentation writer. When asked to create or update project documentation, follow the patterns and principles below. These are derived from real, battle-tested documentation across production codebases.
-
----
-
-## Core Principles
-
-1. **Purpose first** — the very first lines must explain what the software does and why it exists. A reader (human or AI) should understand the project's value in under 10 seconds.
-2. **Simple and human** — write so any developer can understand the solution quickly. Use plain language. Avoid jargon unless it's the project's domain vocabulary.
-3. **Vibe coding friendly** — make documentation context-rich enough for AI tools to understand the codebase and assist effectively. Include architecture diagrams, module trees, data flows, and configuration references.
-4. **Knowledge transfer** — someone new should be able to onboard just by reading the docs. No tribal knowledge required.
-5. **Detail when needed** — simple overview by default, deep-dive sections when complexity demands it. Use a three-tier depth model (see below).
-6. **Living documentation** — structure docs so they're easy to update as the software evolves. Prefer tables and lists over prose paragraphs for things that change frequently (env vars, endpoints, commands).
-
----
-
-## Three-Tier Documentation Model
-
-Organize documentation in three layers of increasing depth:
-
-| Tier | File | Purpose | Audience |
-|------|------|---------|----------|
-| **1. Overview** | `README.md` | What it does, quick start, feature map, architecture at a glance | Everyone — first thing anyone reads |
-| **2. Walkthrough** | `docs/SETUP.md` | Step-by-step first-time setup from zero to running | New developers, DevOps |
-| **3. Deep Reference** | `docs/TECHNICAL.md` | Architecture details, data flows, DTOs, extension points | Contributors, maintainers, AI assistants |
-
-Additional docs as needed:
-- `CHANGELOG.md` — version history (semantic-release format)
-- `ARCHITECTURE.md` — standalone architecture reference (if too large for README)
-- `k8s/README.md` — Kubernetes deployment guide
-- `docs/<feature>.md` — feature-specific deep dives
-
----
-
-## README.md Structure
-
-Follow this skeleton. Every section is optional except the first three — include only what's relevant to the project:
-
-```markdown
-<div align="center">
-  <img src="logo.png" alt="Project Name" width="180" />
-
-  # Project Name
-
-  **One-line description of what the software does and why it exists.**
-
-  [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org)
-  [![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-009688.svg)](https://fastapi.tiangolo.com)
-  [![License](https://img.shields.io/badge/license-MIT-green.svg)]()
-</div>
-
-## Features
-
-- **Feature Name**: Brief description of what it does
-- **Another Feature**: Brief description
-
-## Tech Stack
-
-| Component | Technology |
-|-----------|------------|
-| Framework | FastAPI 0.115+ |
-| Database  | PostgreSQL 16 |
-
-## Quick Start
-
-### Prerequisites
-
-- Docker and Docker Compose
-- Python 3.12+ (for local development)
-
-### Using Docker Compose
-
-\```bash
-docker compose up
-# API available at http://localhost:8000
-\```
-
-### Local Development
-
-\```bash
-python -m venv venv
-source venv/bin/activate
-pip install -e ".[dev]"
-cp .env.example .env
-\```
-
-## Configuration
-
-| Variable | Required | Default | Description |
-|----------|:--------:|---------|-------------|
-| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
-| `LOG_LEVEL` | No | `INFO` | Log verbosity |
-
-## API Endpoints (or Commands)
-
-### Resource Name
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| GET | `/api/v1/items` | Yes | List items |
-| POST | `/api/v1/items` | Yes | Create item |
-
-## Architecture
-
-\```
-ASCII diagram showing component interactions
-\```
-
-## Folder Structure
-
-\```
-project/
-├── app/
-│   ├── api/          # Route handlers
-│   ├── models/       # Database models
-│   ├── services/     # Business logic
-│   └── main.py       # Entry point
-├── tests/
-├── Dockerfile
-└── docker-compose.yml
-\```
-
-## Development
-
-\```bash
-# Run tests
-pytest tests/ -v
-
-# Lint
-ruff check app/
-\```
-
-## Docker Commands
-
-\```bash
-docker compose up -d        # Start
-docker compose logs -f       # Logs
-docker compose down          # Stop
-docker compose up -d --build # Rebuild
-\```
-
-## Troubleshooting
-
-**Problem**: Description of common issue
-**Solution**: How to fix it
-
-## License
-
-MIT
-```
-
-### README Rules
-
-- **Visual header** (default for public/OSS-facing repos): start README.md with a centered header block containing: project logo (if one exists in the repo — look for `logo.png`, `logo.svg`, `icon.png`), project title in H1, one-line description in bold, and shields/badges relevant to the project (language, framework, license). **Audience rule**: for internal services, bots or private tools, skip badges that carry no signal there (no CI badge without public CI, no PyPI badge if unpublished) — a plain H1 + one-line description is correct for that audience. Default structure:
-  ```markdown
-  <div align="center">
-    <img src="logo.png" alt="Project Logo" width="180" />
-
-    # Project Name
-
-    **One-line description**
-
-    [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org)
-    [![Framework](https://img.shields.io/badge/framework-version-blue.svg)](https://framework-url)
-    [![License](https://img.shields.io/badge/license-MIT-green.svg)]()
-  </div>
-  ```
-- **Badges to include** (only when relevant to the project):
-  - Language + version: Python, Node.js, Go, etc.
-  - Main framework + version: FastAPI, Express, Discord.py, etc.
-  - License: MIT, Apache, Proprietary
-  - Docker: if `docker-compose.yml` exists
-  - Database: if a database is configured
-- **Logo detection**: Before writing README.md, search for image files in the repo root (`logo.png`, `logo.svg`, `icon.png`, `favicon.ico`). If found, include it in the header. If not found, skip the `<img>` tag.
-- **No logo, no problem**: If no logo exists, keep the centered div with just the title, description, and badges.
-- **Lead with purpose**: the first line after the header must be a one-sentence description if not already in the header. When badges are used, keep them all inside the header block — none scattered through the body.
-- **Quick Start must be quick**: 3-5 commands maximum. If it takes more, link to `docs/SETUP.md`.
-- **Features as a scannable list**: use bold feature names with concise descriptions. Use emoji sparingly (only if the project already does).
-- **Tables for structured data**: env vars, endpoints, commands, tech stack — always tables, never prose.
-- **ASCII diagrams over images**: text-based diagrams are grep-able, git-diff-friendly, and readable by AI tools.
-- **Folder structure with annotations**: show the directory tree with inline comments explaining each directory's purpose.
-- **Copy-paste ready commands**: every code block should work if pasted directly into a terminal. Include comments for context.
-
----
-
-## docs/SETUP.md Structure
-
-The setup guide takes someone from zero to a running system. Follow this progression:
-
-```markdown
-# Setup Guide
-
-Step-by-step guide to configure [Project Name] from scratch.
-
-## Table of Contents
-
-1. [Prerequisites](#1-prerequisites)
-2. [Configure Environment](#2-configure-environment)
-3. [Deploy with Docker](#3-deploy-with-docker)
-4. [Verify It Works](#4-verify-it-works)
-5. [Troubleshooting](#5-troubleshooting)
-
-## 1. Prerequisites
-
-Before starting, make sure you have:
-
-- Docker and Docker Compose installed
-- [Dependency X] running and accessible
-
-### Verify Dependencies
-
-\```bash
-curl http://localhost:8000/api/v1/health
-# Expected: {"status": "healthy"}
-\```
-
-## 2. Configure Environment
-
-\```bash
-cp .env.example .env
-# Edit .env with your settings
-\```
-
-### Environment Template
-
-\```bash
-# =============================================================================
-# Database
-# =============================================================================
-DATABASE_URL=postgresql://user:pass@db:5432/mydb
-
-# =============================================================================
-# Authentication
-# =============================================================================
-JWT_SECRET_KEY=your-secret-here
-\```
-
-## 3. Deploy with Docker
-
-\```bash
-docker compose build
-docker compose up -d
-docker compose ps  # verify containers are running
-\```
-
-### Verify Logs
-
-\```bash
-docker compose logs -f api
-# Expected: "Application started on port 8000"
-\```
-
-## 4. Verify It Works
-
-\```bash
-curl http://localhost:8000/api/v1/health
-# Expected: {"status": "healthy"}
-\```
-
-## 5. Troubleshooting
-
-**Problem**: Container exits immediately
-**Solution**: Check logs with `docker compose logs api`. Common cause: missing env vars.
-
-## Next Steps
-
-- [ ] Configure production secrets
-- [ ] Set up monitoring
-- [ ] Review security checklist
-```
-
-### Setup Guide Rules
-
-- **Table of contents at the top**: numbered sections with anchor links.
-- **Checkboxes for prerequisites**: `- [ ]` format so readers can mentally check them off.
-- **Verify at every step**: after each major action, show how to confirm it worked. Include expected output.
-- **Environment template with section headers**: group env vars by feature area using comment dividers (`# ====`).
-- **Troubleshooting is mandatory**: at least 5 common problems with solutions.
-- **End with Next Steps**: checklist of follow-up tasks using `- [ ]` format.
-- **Commands include expected output**: show what success looks like so the reader knows they did it right.
-
----
-
-## docs/TECHNICAL.md Structure
-
-The technical reference is for deep understanding. This is where AI tools and new contributors go to understand *how* the system works.
-
-```markdown
-# Technical Documentation
-
-Detailed architecture, components, and data flows for [Project Name].
-
-## Table of Contents
-
-1. [Overview](#1-overview)
-2. [Architecture](#2-architecture)
-3. [Components](#3-components)
-4. [Data Flow](#4-data-flow)
-5. [DTOs and Entities](#5-dtos-and-entities)
-6. [HTTP Clients / External Integrations](#6-http-clients)
-7. [Services](#7-services)
-8. [Logging and Observability](#8-logging-and-observability)
-9. [Testing](#9-testing)
-10. [Extending the System](#10-extending-the-system)
-```
-
-### Technical Doc Rules
-
-- **Table of contents with anchor links**: always at the top, numbered to match sections.
-- **Architecture diagram first**: ASCII box diagram showing how components connect.
-- **Document data flows**: show the path data takes through the system, step by step.
-- **Include code signatures**: for services and clients, show method signatures with types and return values.
-- **DTOs and entities section**: show dataclass/model definitions with field descriptions.
-- **"Extending the System" section**: explain how to add new modules, integrations, or features. This is critical for AI-assisted development.
-- **Tech stack table**: component → technology mapping at the top of the overview.
-
----
-
-## Formatting Conventions
-
-### Tables
-
-Use tables for any structured, repeatable data:
-
-```markdown
-| Variable | Required | Default | Description |
-|----------|:--------:|---------|-------------|
-| `DB_HOST` | Yes | - | Database hostname |
-| `LOG_LEVEL` | No | `INFO` | Log verbosity |
-```
-
-- Center-align boolean/status columns (`:---:`)
-- Use inline code for variable names, commands, values
-- Group rows by category using bold header rows when the table is long
-
-### ASCII Diagrams
-
-Use text-based diagrams for architecture and flows:
-
-```
-┌─────────────┐     HTTP      ┌──────────────┐
-│   Service A │ ─────────────>│  Service B   │
-└─────────────┘               └──────────────┘
-       │                             │
-       │ Events                      │ SQL
-       v                             v
-┌─────────────┐               ┌──────────────┐
-│  Message Q  │               │  PostgreSQL  │
-└─────────────┘               └──────────────┘
-```
-
-Use box-drawing characters (`┌ ─ ┐ └ ┘ │ ├ ┤ ┬ ┴ ┼`) for clean diagrams. Reserve simple arrows (`→ ← ↓ ↑`) for inline flows.
-
-### Code Blocks
-
-- Always specify the language: ` ```bash `, ` ```python `, ` ```yaml `, ` ```json `
-- Include comments explaining non-obvious commands
-- Show expected output when the command produces meaningful results
-
-### Directory Trees
-
-```
-project/
-├── app/
-│   ├── api/          # Route handlers
-│   ├── models/       # Database entities
-│   ├── services/     # Business logic
-│   └── main.py       # Entry point
-├── tests/
-│   ├── test_*.py     # Unit tests
-│   └── conftest.py   # Shared fixtures
-└── docker-compose.yml
-```
-
-Always include inline comments (`# Purpose`) for each directory.
-
-### Section Dividers
-
-Use `---` (horizontal rule) between major sections for visual separation.
-
-### Cross-References
-
-Link between documentation files:
-
-```markdown
-See [Setup Guide](docs/SETUP.md) for first-time configuration.
-See [Technical Documentation](docs/TECHNICAL.md) for architecture details.
-```
-
----
-
-## CHANGELOG.md Format
-
-Use semantic-release format:
-
-```markdown
-## [v1.2.0](https://github.com/org/repo/compare/v1.1.0...v1.2.0) (2026-03-13)
-
-### Features
-
-* **auth**: add OAuth support for Google and GitHub ([abc1234](https://github.com/org/repo/commit/abc1234))
-
-### Bug Fixes
-
-* **orders**: fix fee calculation for products under R$8 ([def5678](https://github.com/org/repo/commit/def5678))
-```
-
-- Reverse chronological order (newest first)
-- Group entries: Features, Bug Fixes, Breaking Changes
-- Include commit hash links
-- Prefix entries with scope in bold: `**module**:`
-
----
-
-## Writing Style Guide
-
-1. **Be direct**: use imperative mood for instructions ("Run the command", "Edit the file"). No hedging.
-2. **Show, don't explain**: a code example is worth a paragraph of prose. When in doubt, add a code block.
-3. **Keep prose minimal**: use sentences for context, tables for data, code blocks for commands.
-4. **Use consistent terminology**: pick one term for each concept and stick with it throughout all docs.
-5. **Document the "why" alongside the "what"**: for non-obvious decisions, add a brief explanation (e.g., "We use Camoufox because standard Playwright gets detected by anti-bot systems").
-6. **Include real examples**: use realistic values, not `foo`/`bar`. Show actual API payloads, real config values, concrete use cases.
-7. **Warn about footguns**: use bold + warning indicator for dangerous operations (e.g., `**Warning**: This deletes all data`).
-
----
-
-## When Creating Documentation
-
-1. **Read the codebase first**: understand the project structure, entry points, configuration, and dependencies before writing anything.
-2. **Start with README.md**: if it doesn't exist, create it. If it exists, update it to match the skeleton above.
-3. **Create docs/SETUP.md** when the project requires more than 5 commands to set up.
-4. **Create docs/TECHNICAL.md** when the project has non-trivial architecture (multiple services, complex data flows, extension points).
-5. **Update CHANGELOG.md** when making significant changes — follow the semantic-release format.
-6. **Never invent features**: only document what actually exists in the code. Read before you write.
-
-## When Updating Documentation
-
-1. **Keep existing structure**: don't reorganize docs unless asked. Add to the existing skeleton.
-2. **Update, don't duplicate**: if information exists in one place, update it there. Don't create parallel docs.
-3. **Reflect code changes**: when code changes (new endpoints, new env vars, new modules), update the corresponding doc sections.
-4. **Preserve the project's voice**: if docs are in Portuguese, keep them in Portuguese. If English, keep English. Match the existing tone.
-
----
-
-## Troubleshooting
-
-**Problem**: Only README.md was updated, SETUP.md and TECHNICAL.md were not created.
-**Solution**: This skill always creates all three tiers. Re-run with: "Document this project following the documentation skill — create README.md, docs/SETUP.md, and docs/TECHNICAL.md."
-
-**Problem**: Documentation describes features that don't exist in the code.
-**Solution**: Always read the codebase before writing. Run `find . -type f` and read key files before starting.
-
-**Problem**: Setup guide is missing expected output for commands.
-**Solution**: Every command block must show what success looks like with a comment like `# Expected: ...`
-
----
-
-## How to Use
-
-### Prompt
-
-Open your project in Claude Code and paste this prompt:
-
-```
-Document this project following the documentation skill.
-Analyze the codebase and create all documentation files this project needs.
-```
-
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Document this project"
-- "Write the docs for this codebase"
-- "Update the README"
-- "Create setup and technical documentation"
-- "Help someone understand this project"
-- "Document this for AI tools"
-
-Should NOT trigger on:
-- "Write a blog post"
-- "Create a presentation"
-- "Fix this bug"
-- "Review my code"
+| Any project | `README.md` |
+| A `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md` or `.clinerules` exists, **or** the user asked to document the repo for AI tools | `AGENTS.md` |
+| Setup takes more than ~5 commands, or has environment prerequisites | `docs/SETUP.md` |
+| Architecture a reader cannot infer from the tree (services, flows, integrations) | `docs/TECHNICAL.md` |
+| REST/GraphQL API with no generated spec published | `docs/API.md` |
+| Project accepts outside contributions | `CONTRIBUTING.md` |
+| More than one deploy environment | `docs/DEPLOYMENT.md` |
+| Releases are tagged | `CHANGELOG.md` (generated, not hand-written) |
+| Background workers, webhooks, ML pipelines, CLI, SDK, security-sensitive config | the matching `docs/<topic>.md` |
+
+**Do not create a document to satisfy the table.** A 200-line project with a 3-command setup needs a
+README and nothing else; splitting it into three tiers produces three files that rot instead of one
+that doesn't. If you create only a README, say so and why.
+
+## One purpose per page
+
+Four reader needs, four kinds of page. Mixing them is the most common reason docs go stale and the
+most common reason readers can't find anything:
+
+| Need | Page kind | In this model |
+|---|---|---|
+| "Get me running for the first time" | **Tutorial** — one happy path, no options | `docs/SETUP.md` |
+| "How do I do X?" | **How-to** — task-oriented, assumes context | `README.md` quick start, `docs/<topic>.md` |
+| "What exactly does Y take?" | **Reference** — exhaustive, dry, generated where possible | config tables, `docs/API.md` |
+| "Why is it like this?" | **Explanation** — design rationale, trade-offs | `docs/TECHNICAL.md`, ADRs |
+
+The practical rule: **how-to content changes far faster than why content.** A page that mixes a
+command sequence with architectural rationale goes stale at the speed of its fastest-changing half.
+Keep them on separate pages, and cross-link.
+
+## Every claim must be checkable
+
+This is the difference between documentation and decoration. Prefer facts a script can verify against
+the repo, and write them so it can:
+
+- **Repo paths are links**, not prose: `[app/main.py](app/main.py)`. A link is checkable; a sentence
+  is not.
+- **Directory trees show the real root.** Measured on a production repo: a README tree written without
+  its `src/` prefix made every path in it unresolvable, and one entry had been renamed months earlier
+  — 9 of 10 entries wrong in a block the reader trusts most.
+- **Directory trees are the highest-rot artifact you can write.** They duplicate the filesystem and
+  break on every refactor. Include one only when the layout is genuinely non-obvious, cap it at the
+  directories that carry meaning (not every file), and annotate each with its purpose. Never paste a
+  full `tree` dump.
+- **Never hand-copy what a tool generates.** Endpoint tables duplicating an OpenAPI spec, flag tables
+  duplicating `--help`, changelogs duplicating the release tool — link or generate them. Hand copies
+  drift silently and there is no signal when they do.
+- **Env var tables come from the config module**, and every row must name a variable that exists in
+  the code. A documented variable the code never reads is a bug report waiting to happen.
+- **Commands are copy-paste runnable.** Run them, or state that you did not. Show expected output for
+  anything whose success is not obvious.
+- Ship the checker. A ~50-line script that resolves every link, every tree path, and every documented
+  env var, wired into CI, turns "the docs are stale" from a discovery into a build failure.
+
+## Keeping it true
+
+Documentation rot is the default outcome; the only reliable fix is process, not diligence:
+
+- **Docs change in the same commit as the code.** A PR that adds an env var and does not touch the
+  config table is incomplete — treat it the way you would treat a missing test.
+- **Every document names an owner** (a person or a team) in its footer or frontmatter. An unowned doc
+  is nobody's job.
+- **Date the volatile parts.** Version numbers, screenshots, benchmark figures and "current status"
+  sections carry the date they were verified.
+- **Delete aggressively.** A section describing a removed feature is worse than no section — it
+  actively misleads. Prune when you touch a page.
+
+## AGENTS.md — the repo's instructions for coding agents
+
+When AI agents work in the repo, the conventions they need live in `AGENTS.md` at the root — an open
+spec (donated to the Linux Foundation's Agentic AI Foundation in December 2025) that most agent tools
+now read. Anthropic's `CLAUDE.md` serves the same role for Claude Code; when both exist, keep one
+canonical and have the other point at it rather than maintaining two.
+
+Content that measurably helps: **architecture overview, where the important files are, and how to
+build/test/run.** Be honest about the ceiling — the published evaluation of repository context files
+on SWE-bench found gains modest and inconsistent across models, with setup and build guidance the most
+valuable part. Write it for that: concrete commands and locations, not aspirational style rules.
+
+`AGENTS.md` is about *contributing to this code*. It is not a substitute for the README, and it is a
+different thing from `llms.txt`, which maps a documentation *site* for retrieval.
+
+**The trigger has to be something you can see.** "This repo is worked on by agents" is not observable
+from a checkout — measured: with that phrasing, no run produced the file. Use the detectable signals
+in the table above: an existing tool-specific instruction file, or the user asking for it. When none
+is present, do not create `AGENTS.md` silently — say it is missing and what it would carry.
+
+## README
+
+Lead with what the software does and why, in one sentence, above everything else. Then only the
+sections this project earns. The full skeleton and a worked example: `references/templates.md` and
+`references/examples.md`.
+
+- **Quick start is 3-5 commands.** More than that means it is a tutorial — move it to `docs/SETUP.md`
+  and link.
+- **Tables for structured data** (env vars, endpoints, commands, tech stack); prose only for context.
+- **Text diagrams over images** — greppable, diff-able, readable by agents.
+- **Badges: signal only.** A badge that cannot fail carries no information — a hardcoded
+  `python-3.12-blue` shield is decoration. Live badges (CI status, coverage, published version) are
+  worth their space; static ones are not. For internal services and private tools a plain H1 plus a
+  one-line description is the correct header. Each badge is also a third-party request served to every
+  reader, so keep the set small.
+- **Include a logo** in a centered header block only if one already exists in the repo.
+
+## Writing style
+
+1. **Imperative for instructions.** "Run the migration", not "you may wish to run".
+2. **Show, don't explain.** A code block beats a paragraph.
+3. **One term per concept**, used consistently across every document.
+4. **Document the why for non-obvious decisions** — the constraint that forced the choice, not the
+   choice alone.
+5. **Real values, never `foo`/`bar`.** Realistic payloads, actual config values.
+6. **Warn about footguns** in bold, at the point of danger, not in a distant section.
+7. **Match the project's existing language and voice.** Portuguese docs stay Portuguese.
+
+## Updating existing documentation
+
+1. **Keep the existing structure** unless asked to reorganize. Add to the skeleton that is there.
+2. **Update in place; never fork a parallel doc.** Two documents describing the same thing means one
+   of them is already wrong.
+3. **Follow the code change.** New endpoint, new env var, new module → the corresponding rows change
+   in the same commit.
+4. **Re-verify what you touch.** If you edit a section, its links, paths and commands are yours now.
+
+## See also
+
+- `references/templates.md` — README / SETUP / TECHNICAL skeletons.
+- `references/examples.md` — worked examples of good output per tier.
+- `conventional-commit` — the commit format that drives generated changelogs.
+- `openspec` — where design rationale lives when a project runs the spec-driven flow; documentation
+  describes what exists, proposals describe what changes.

--- a/plugins/docs/skills/documentation/references/templates.md
+++ b/plugins/docs/skills/documentation/references/templates.md
@@ -1,0 +1,366 @@
+# Reference — documentation templates
+
+Skeletons for each document. Every section is optional except the lead: include only what the
+project earns. Fenced blocks below are templates, not claims about any repo.
+
+## README.md skeleton
+
+Only the lead is mandatory — the title and the one-line description of what the software does. Every
+other section below is included only if this project earns it.
+
+The header block is for public/OSS-facing repos. For an internal service or a private tool, a plain
+`# Title` plus the one-line description is the correct header — drop the div and the badges entirely.
+
+Badges follow the signal-only rule from the skill: include the ones that can *fail* (CI status,
+coverage, published version), skip the hardcoded ones that only restate the tech stack the Tech Stack
+table already lists.
+
+```markdown
+<div align="center">
+  <img src="logo.png" alt="Project Name" width="180" />
+
+  # Project Name
+
+  **One-line description of what the software does and why it exists.**
+
+  [![CI](https://github.com/org/repo/actions/workflows/ci.yml/badge.svg)](https://github.com/org/repo/actions/workflows/ci.yml)
+  [![PyPI](https://img.shields.io/pypi/v/package.svg)](https://pypi.org/project/package/)
+</div>
+
+## Features
+
+- **Feature Name**: Brief description of what it does
+- **Another Feature**: Brief description
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Framework | FastAPI 0.115+ |
+| Database  | PostgreSQL 16 |
+
+## Quick Start
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Python 3.12+ (for local development)
+
+### Using Docker Compose
+
+\```bash
+docker compose up
+# API available at http://localhost:8000
+\```
+
+### Local Development
+
+\```bash
+python -m venv venv
+source venv/bin/activate
+pip install -e ".[dev]"
+cp .env.example .env
+\```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|:--------:|---------|-------------|
+| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
+| `LOG_LEVEL` | No | `INFO` | Log verbosity |
+
+## API Endpoints (or Commands)
+
+### Resource Name
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/api/v1/items` | Yes | List items |
+| POST | `/api/v1/items` | Yes | Create item |
+
+## Architecture
+
+\```
+ASCII diagram showing component interactions
+\```
+
+## Folder Structure
+
+\```
+project/
+├── app/
+│   ├── api/          # Route handlers
+│   ├── models/       # Database models
+│   ├── services/     # Business logic
+│   └── main.py       # Entry point
+├── tests/
+├── Dockerfile
+└── docker-compose.yml
+\```
+
+## Development
+
+\```bash
+# Run tests
+pytest tests/ -v
+
+# Lint
+ruff check app/
+\```
+
+## Docker Commands
+
+\```bash
+docker compose up -d        # Start
+docker compose logs -f       # Logs
+docker compose down          # Stop
+docker compose up -d --build # Rebuild
+\```
+
+## Troubleshooting
+
+**Problem**: Description of common issue
+**Solution**: How to fix it
+
+## License
+
+MIT
+```
+
+---
+
+## docs/SETUP.md skeleton
+The setup guide takes someone from zero to a running system. Follow this progression:
+
+```markdown
+# Setup Guide
+
+Step-by-step guide to configure [Project Name] from scratch.
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Configure Environment](#2-configure-environment)
+3. [Deploy with Docker](#3-deploy-with-docker)
+4. [Verify It Works](#4-verify-it-works)
+5. [Troubleshooting](#5-troubleshooting)
+
+## 1. Prerequisites
+
+Before starting, make sure you have:
+
+- Docker and Docker Compose installed
+- [Dependency X] running and accessible
+
+### Verify Dependencies
+
+\```bash
+curl http://localhost:8000/api/v1/health
+# Expected: {"status": "healthy"}
+\```
+
+## 2. Configure Environment
+
+\```bash
+cp .env.example .env
+# Edit .env with your settings
+\```
+
+### Environment Template
+
+\```bash
+# =============================================================================
+# Database
+# =============================================================================
+DATABASE_URL=postgresql://user:pass@db:5432/mydb
+
+# =============================================================================
+# Authentication
+# =============================================================================
+JWT_SECRET_KEY=your-secret-here
+\```
+
+## 3. Deploy with Docker
+
+\```bash
+docker compose build
+docker compose up -d
+docker compose ps  # verify containers are running
+\```
+
+### Verify Logs
+
+\```bash
+docker compose logs -f api
+# Expected: "Application started on port 8000"
+\```
+
+## 4. Verify It Works
+
+\```bash
+curl http://localhost:8000/api/v1/health
+# Expected: {"status": "healthy"}
+\```
+
+## 5. Troubleshooting
+
+**Problem**: Container exits immediately
+**Solution**: Check logs with `docker compose logs api`. Common cause: missing env vars.
+
+## Next Steps
+
+- [ ] Configure production secrets
+- [ ] Set up monitoring
+- [ ] Review security checklist
+```
+
+---
+
+### Setup guide conventions
+
+- Numbered sections with a table of contents at the top, anchors matching the numbers.
+- Prerequisites as `- [ ]` checkboxes so a reader can track them.
+- **Verify after every step.** Each action is followed by the command that confirms it worked and the
+  output it should print. A setup guide with no verification is a list of hopes.
+- Group the environment template by feature area with comment dividers (`# ====`), matching the order
+  of the config module so the two can be diffed.
+- Troubleshooting covers the failures this project actually produces — take them from the exception
+  messages and error paths in the code, not from a generic list, and add one whenever a reader hits a
+  new one.
+- End with a `- [ ]` Next Steps checklist for what comes after "it runs".
+
+---
+
+## docs/TECHNICAL.md skeleton
+The technical reference is for deep understanding. This is where AI tools and new contributors go to understand *how* the system works.
+
+```markdown
+# Technical Documentation
+
+Detailed architecture, components, and data flows for [Project Name].
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Architecture](#2-architecture)
+3. [Components](#3-components)
+4. [Data Flow](#4-data-flow)
+5. [DTOs and Entities](#5-dtos-and-entities)
+6. [HTTP Clients / External Integrations](#6-http-clients)
+7. [Services](#7-services)
+8. [Logging and Observability](#8-logging-and-observability)
+9. [Testing](#9-testing)
+10. [Extending the System](#10-extending-the-system)
+```
+
+---
+
+### Technical doc conventions
+
+- Table of contents with anchors, numbered to match the sections.
+- Architecture diagram first — a text box diagram of how the components connect.
+- Document the **data flows**: the path a request or event takes, step by step, naming the module at
+  each hop so a reader can jump straight to the code.
+- Show real method signatures with types for services and clients, not paraphrases.
+- An **"Extending the system"** section: how to add a module, an integration, an endpoint. This is the
+  section contributors and coding agents use most.
+- This is the explanation tier — put the *why* here (trade-offs, constraints, rejected alternatives)
+  and keep step-by-step commands in the setup guide, so the two decay at their own speeds.
+
+---
+
+## Formatting conventions
+### Tables
+
+Use tables for any structured, repeatable data:
+
+```markdown
+| Variable | Required | Default | Description |
+|----------|:--------:|---------|-------------|
+| `DB_HOST` | Yes | - | Database hostname |
+| `LOG_LEVEL` | No | `INFO` | Log verbosity |
+```
+
+- Center-align boolean/status columns (`:---:`)
+- Use inline code for variable names, commands, values
+- Group rows by category using bold header rows when the table is long
+
+### ASCII Diagrams
+
+Use text-based diagrams for architecture and flows:
+
+```
+┌─────────────┐     HTTP      ┌──────────────┐
+│   Service A │ ─────────────>│  Service B   │
+└─────────────┘               └──────────────┘
+       │                             │
+       │ Events                      │ SQL
+       v                             v
+┌─────────────┐               ┌──────────────┐
+│  Message Q  │               │  PostgreSQL  │
+└─────────────┘               └──────────────┘
+```
+
+Use box-drawing characters (`┌ ─ ┐ └ ┘ │ ├ ┤ ┬ ┴ ┼`) for clean diagrams. Reserve simple arrows (`→ ← ↓ ↑`) for inline flows.
+
+### Code Blocks
+
+- Always specify the language: ` ```bash `, ` ```python `, ` ```yaml `, ` ```json `
+- Include comments explaining non-obvious commands
+- Show expected output when the command produces meaningful results
+
+### Directory Trees
+
+```
+project/
+├── app/
+│   ├── api/          # Route handlers
+│   ├── models/       # Database entities
+│   ├── services/     # Business logic
+│   └── main.py       # Entry point
+├── tests/
+│   ├── test_*.py     # Unit tests
+│   └── conftest.py   # Shared fixtures
+└── docker-compose.yml
+```
+
+Always include inline comments (`# Purpose`) for each directory.
+
+### Section Dividers
+
+Use `---` (horizontal rule) between major sections for visual separation.
+
+### Cross-References
+
+Link between documentation files:
+
+```markdown
+See [Setup Guide](docs/SETUP.md) for first-time configuration.
+See [Technical Documentation](docs/TECHNICAL.md) for architecture details.
+```
+
+---
+
+---
+
+## CHANGELOG.md format (generated by semantic-release — do not hand-write)
+Use semantic-release format:
+
+```markdown
+## [v1.2.0](https://github.com/org/repo/compare/v1.1.0...v1.2.0) (2026-03-13)
+
+### Features
+
+* **auth**: add OAuth support for Google and GitHub ([abc1234](https://github.com/org/repo/commit/abc1234))
+
+### Bug Fixes
+
+* **orders**: fix fee calculation for products under R$8 ([def5678](https://github.com/org/repo/commit/def5678))
+```
+
+- Reverse chronological order (newest first)
+- Group entries: Features, Bug Fixes, Breaking Changes
+- Include commit hash links
+- Prefix entries with scope in bold: `**module**:`
+
+---

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -1,543 +1,174 @@
 ---
 name: documentation
-description: Creates and updates complete project documentation following a three-tier model (README.md, docs/SETUP.md, docs/TECHNICAL.md). Use this skill whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, "document this", "write the docs", "update the readme", "explain how this works", "help someone understand this project", or asks to document a codebase for AI tools or new developers. ALWAYS creates all three documentation tiers unless the user explicitly says otherwise. Do NOT use for non-software documentation tasks.
+description: >-
+  Creates and updates project documentation sized to what the project actually is — README.md plus
+  only the deeper docs the code warrants, organized by reader need (tutorial / how-to / reference /
+  explanation). Use whenever the user mentions README, docs, SETUP, TECHNICAL, CHANGELOG, AGENTS.md,
+  "document this", "write the docs", "update the readme", "explain how this works", "help someone
+  understand this project", or asks to document a codebase for AI tools or new developers. Enforces
+  read-the-code-first, machine-checkable claims, one purpose per page, and docs that change in the
+  same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 3.0.0
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
-Reference examples are in `references/examples.md` — read them when generating documentation output.
+# Documentation
 
-## CRITICAL: Always Analyze Before Documenting
+Write documentation a reader can act on and a script can verify. Templates and full worked examples
+live in `references/` — read them when you are about to generate output, not before.
 
-Before writing any documentation, read the codebase and decide which documents are needed based on what the project actually is.
+## Analyze before documenting
 
-### Step 1 — Analyze the project
+Never write a line of documentation before reading the code it describes.
 
-Run these before writing anything:
-- `find . -type f | head -60` — understand the file structure
-- Read the main entry point, config files, and existing docs
-- Identify: language, framework, architecture style, deployment method, integrations
+1. `find . -type f -not -path "*/.git/*" | head -60` — structure.
+2. Read the entry point, the config module, the dependency manifest, and any existing docs.
+3. Identify: language, framework, how it is configured, how it is run, what it integrates with.
+4. **Extract the facts**, don't invent them: env vars from the config module, endpoints from the
+   router, commands from the manifest scripts / Makefile / CI, ports from the compose file.
 
-### Step 2 — Decide which documents to create
+Only document what you read. If a fact matters and you could not verify it, say so in the doc
+("Deployment target: not documented in this repo") instead of guessing. A confident wrong sentence
+costs more than an admitted gap.
 
-Use this decision table:
+## Decide which documents exist
 
-| Condition | Document to create |
+`README.md` is the only unconditional document. Everything else is earned:
+
+| Condition | Document |
 |---|---|
-| Any project | `README.md` — always |
-| Setup requires more than 5 commands | `docs/SETUP.md` |
-| Non-trivial architecture (services, flows, integrations) | `docs/TECHNICAL.md` |
-| REST or GraphQL API exists | `docs/API.md` |
-| Project accepts contributions | `CONTRIBUTING.md` |
-| Multiple environments (dev, staging, prod) | `docs/DEPLOYMENT.md` |
-| Kubernetes or complex infra | `k8s/README.md` or `docs/INFRASTRUCTURE.md` |
-| Version history exists or releases are planned | `CHANGELOG.md` |
-| Background workers or scheduled jobs | `docs/WORKERS.md` |
-| Webhooks or event-driven architecture | `docs/EVENTS.md` |
-| Machine learning models or data pipelines | `docs/MODEL.md` or `docs/PIPELINE.md` |
-| CLI tool or scripts | `docs/CLI.md` |
-| SDK or library for developers | `docs/SDK.md` |
-| Security-sensitive configuration | `docs/SECURITY.md` |
-
-### Step 3 — Create all relevant documents
-
-Do NOT stop after README.md.
-Do NOT create documents that don't apply to this project.
-Read the codebase first. Only document what actually exists in the code.
-
-Before writing README.md:
-- Check for logo/icon files in the repo root (`logo.png`, `logo.svg`, `icon.png`, `favicon.ico`). Include in the header if found.
-- Always include shields/badges relevant to the tech stack detected in the codebase (language, framework, license, Docker, database).
-
----
-
-# Documentation Skill
-
-You are a documentation writer. When asked to create or update project documentation, follow the patterns and principles below. These are derived from real, battle-tested documentation across production codebases.
-
----
-
-## Core Principles
-
-1. **Purpose first** — the very first lines must explain what the software does and why it exists. A reader (human or AI) should understand the project's value in under 10 seconds.
-2. **Simple and human** — write so any developer can understand the solution quickly. Use plain language. Avoid jargon unless it's the project's domain vocabulary.
-3. **Vibe coding friendly** — make documentation context-rich enough for AI tools to understand the codebase and assist effectively. Include architecture diagrams, module trees, data flows, and configuration references.
-4. **Knowledge transfer** — someone new should be able to onboard just by reading the docs. No tribal knowledge required.
-5. **Detail when needed** — simple overview by default, deep-dive sections when complexity demands it. Use a three-tier depth model (see below).
-6. **Living documentation** — structure docs so they're easy to update as the software evolves. Prefer tables and lists over prose paragraphs for things that change frequently (env vars, endpoints, commands).
-
----
-
-## Three-Tier Documentation Model
-
-Organize documentation in three layers of increasing depth:
-
-| Tier | File | Purpose | Audience |
-|------|------|---------|----------|
-| **1. Overview** | `README.md` | What it does, quick start, feature map, architecture at a glance | Everyone — first thing anyone reads |
-| **2. Walkthrough** | `docs/SETUP.md` | Step-by-step first-time setup from zero to running | New developers, DevOps |
-| **3. Deep Reference** | `docs/TECHNICAL.md` | Architecture details, data flows, DTOs, extension points | Contributors, maintainers, AI assistants |
-
-Additional docs as needed:
-- `CHANGELOG.md` — version history (semantic-release format)
-- `ARCHITECTURE.md` — standalone architecture reference (if too large for README)
-- `k8s/README.md` — Kubernetes deployment guide
-- `docs/<feature>.md` — feature-specific deep dives
-
----
-
-## README.md Structure
-
-Follow this skeleton. Every section is optional except the first three — include only what's relevant to the project:
-
-```markdown
-<div align="center">
-  <img src="logo.png" alt="Project Name" width="180" />
-
-  # Project Name
-
-  **One-line description of what the software does and why it exists.**
-
-  [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org)
-  [![FastAPI](https://img.shields.io/badge/FastAPI-0.115+-009688.svg)](https://fastapi.tiangolo.com)
-  [![License](https://img.shields.io/badge/license-MIT-green.svg)]()
-</div>
-
-## Features
-
-- **Feature Name**: Brief description of what it does
-- **Another Feature**: Brief description
-
-## Tech Stack
-
-| Component | Technology |
-|-----------|------------|
-| Framework | FastAPI 0.115+ |
-| Database  | PostgreSQL 16 |
-
-## Quick Start
-
-### Prerequisites
-
-- Docker and Docker Compose
-- Python 3.12+ (for local development)
-
-### Using Docker Compose
-
-\```bash
-docker compose up
-# API available at http://localhost:8000
-\```
-
-### Local Development
-
-\```bash
-python -m venv venv
-source venv/bin/activate
-pip install -e ".[dev]"
-cp .env.example .env
-\```
-
-## Configuration
-
-| Variable | Required | Default | Description |
-|----------|:--------:|---------|-------------|
-| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
-| `LOG_LEVEL` | No | `INFO` | Log verbosity |
-
-## API Endpoints (or Commands)
-
-### Resource Name
-
-| Method | Endpoint | Auth | Description |
-|--------|----------|------|-------------|
-| GET | `/api/v1/items` | Yes | List items |
-| POST | `/api/v1/items` | Yes | Create item |
-
-## Architecture
-
-\```
-ASCII diagram showing component interactions
-\```
-
-## Folder Structure
-
-\```
-project/
-├── app/
-│   ├── api/          # Route handlers
-│   ├── models/       # Database models
-│   ├── services/     # Business logic
-│   └── main.py       # Entry point
-├── tests/
-├── Dockerfile
-└── docker-compose.yml
-\```
-
-## Development
-
-\```bash
-# Run tests
-pytest tests/ -v
-
-# Lint
-ruff check app/
-\```
-
-## Docker Commands
-
-\```bash
-docker compose up -d        # Start
-docker compose logs -f       # Logs
-docker compose down          # Stop
-docker compose up -d --build # Rebuild
-\```
-
-## Troubleshooting
-
-**Problem**: Description of common issue
-**Solution**: How to fix it
-
-## License
-
-MIT
-```
-
-### README Rules
-
-- **Visual header** (default for public/OSS-facing repos): start README.md with a centered header block containing: project logo (if one exists in the repo — look for `logo.png`, `logo.svg`, `icon.png`), project title in H1, one-line description in bold, and shields/badges relevant to the project (language, framework, license). **Audience rule**: for internal services, bots or private tools, skip badges that carry no signal there (no CI badge without public CI, no PyPI badge if unpublished) — a plain H1 + one-line description is correct for that audience. Default structure:
-  ```markdown
-  <div align="center">
-    <img src="logo.png" alt="Project Logo" width="180" />
-
-    # Project Name
-
-    **One-line description**
-
-    [![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org)
-    [![Framework](https://img.shields.io/badge/framework-version-blue.svg)](https://framework-url)
-    [![License](https://img.shields.io/badge/license-MIT-green.svg)]()
-  </div>
-  ```
-- **Badges to include** (only when relevant to the project):
-  - Language + version: Python, Node.js, Go, etc.
-  - Main framework + version: FastAPI, Express, Discord.py, etc.
-  - License: MIT, Apache, Proprietary
-  - Docker: if `docker-compose.yml` exists
-  - Database: if a database is configured
-- **Logo detection**: Before writing README.md, search for image files in the repo root (`logo.png`, `logo.svg`, `icon.png`, `favicon.ico`). If found, include it in the header. If not found, skip the `<img>` tag.
-- **No logo, no problem**: If no logo exists, keep the centered div with just the title, description, and badges.
-- **Lead with purpose**: the first line after the header must be a one-sentence description if not already in the header. When badges are used, keep them all inside the header block — none scattered through the body.
-- **Quick Start must be quick**: 3-5 commands maximum. If it takes more, link to `docs/SETUP.md`.
-- **Features as a scannable list**: use bold feature names with concise descriptions. Use emoji sparingly (only if the project already does).
-- **Tables for structured data**: env vars, endpoints, commands, tech stack — always tables, never prose.
-- **ASCII diagrams over images**: text-based diagrams are grep-able, git-diff-friendly, and readable by AI tools.
-- **Folder structure with annotations**: show the directory tree with inline comments explaining each directory's purpose.
-- **Copy-paste ready commands**: every code block should work if pasted directly into a terminal. Include comments for context.
-
----
-
-## docs/SETUP.md Structure
-
-The setup guide takes someone from zero to a running system. Follow this progression:
-
-```markdown
-# Setup Guide
-
-Step-by-step guide to configure [Project Name] from scratch.
-
-## Table of Contents
-
-1. [Prerequisites](#1-prerequisites)
-2. [Configure Environment](#2-configure-environment)
-3. [Deploy with Docker](#3-deploy-with-docker)
-4. [Verify It Works](#4-verify-it-works)
-5. [Troubleshooting](#5-troubleshooting)
-
-## 1. Prerequisites
-
-Before starting, make sure you have:
-
-- Docker and Docker Compose installed
-- [Dependency X] running and accessible
-
-### Verify Dependencies
-
-\```bash
-curl http://localhost:8000/api/v1/health
-# Expected: {"status": "healthy"}
-\```
-
-## 2. Configure Environment
-
-\```bash
-cp .env.example .env
-# Edit .env with your settings
-\```
-
-### Environment Template
-
-\```bash
-# =============================================================================
-# Database
-# =============================================================================
-DATABASE_URL=postgresql://user:pass@db:5432/mydb
-
-# =============================================================================
-# Authentication
-# =============================================================================
-JWT_SECRET_KEY=your-secret-here
-\```
-
-## 3. Deploy with Docker
-
-\```bash
-docker compose build
-docker compose up -d
-docker compose ps  # verify containers are running
-\```
-
-### Verify Logs
-
-\```bash
-docker compose logs -f api
-# Expected: "Application started on port 8000"
-\```
-
-## 4. Verify It Works
-
-\```bash
-curl http://localhost:8000/api/v1/health
-# Expected: {"status": "healthy"}
-\```
-
-## 5. Troubleshooting
-
-**Problem**: Container exits immediately
-**Solution**: Check logs with `docker compose logs api`. Common cause: missing env vars.
-
-## Next Steps
-
-- [ ] Configure production secrets
-- [ ] Set up monitoring
-- [ ] Review security checklist
-```
-
-### Setup Guide Rules
-
-- **Table of contents at the top**: numbered sections with anchor links.
-- **Checkboxes for prerequisites**: `- [ ]` format so readers can mentally check them off.
-- **Verify at every step**: after each major action, show how to confirm it worked. Include expected output.
-- **Environment template with section headers**: group env vars by feature area using comment dividers (`# ====`).
-- **Troubleshooting is mandatory**: at least 5 common problems with solutions.
-- **End with Next Steps**: checklist of follow-up tasks using `- [ ]` format.
-- **Commands include expected output**: show what success looks like so the reader knows they did it right.
-
----
-
-## docs/TECHNICAL.md Structure
-
-The technical reference is for deep understanding. This is where AI tools and new contributors go to understand *how* the system works.
-
-```markdown
-# Technical Documentation
-
-Detailed architecture, components, and data flows for [Project Name].
-
-## Table of Contents
-
-1. [Overview](#1-overview)
-2. [Architecture](#2-architecture)
-3. [Components](#3-components)
-4. [Data Flow](#4-data-flow)
-5. [DTOs and Entities](#5-dtos-and-entities)
-6. [HTTP Clients / External Integrations](#6-http-clients)
-7. [Services](#7-services)
-8. [Logging and Observability](#8-logging-and-observability)
-9. [Testing](#9-testing)
-10. [Extending the System](#10-extending-the-system)
-```
-
-### Technical Doc Rules
-
-- **Table of contents with anchor links**: always at the top, numbered to match sections.
-- **Architecture diagram first**: ASCII box diagram showing how components connect.
-- **Document data flows**: show the path data takes through the system, step by step.
-- **Include code signatures**: for services and clients, show method signatures with types and return values.
-- **DTOs and entities section**: show dataclass/model definitions with field descriptions.
-- **"Extending the System" section**: explain how to add new modules, integrations, or features. This is critical for AI-assisted development.
-- **Tech stack table**: component → technology mapping at the top of the overview.
-
----
-
-## Formatting Conventions
-
-### Tables
-
-Use tables for any structured, repeatable data:
-
-```markdown
-| Variable | Required | Default | Description |
-|----------|:--------:|---------|-------------|
-| `DB_HOST` | Yes | - | Database hostname |
-| `LOG_LEVEL` | No | `INFO` | Log verbosity |
-```
-
-- Center-align boolean/status columns (`:---:`)
-- Use inline code for variable names, commands, values
-- Group rows by category using bold header rows when the table is long
-
-### ASCII Diagrams
-
-Use text-based diagrams for architecture and flows:
-
-```
-┌─────────────┐     HTTP      ┌──────────────┐
-│   Service A │ ─────────────>│  Service B   │
-└─────────────┘               └──────────────┘
-       │                             │
-       │ Events                      │ SQL
-       v                             v
-┌─────────────┐               ┌──────────────┐
-│  Message Q  │               │  PostgreSQL  │
-└─────────────┘               └──────────────┘
-```
-
-Use box-drawing characters (`┌ ─ ┐ └ ┘ │ ├ ┤ ┬ ┴ ┼`) for clean diagrams. Reserve simple arrows (`→ ← ↓ ↑`) for inline flows.
-
-### Code Blocks
-
-- Always specify the language: ` ```bash `, ` ```python `, ` ```yaml `, ` ```json `
-- Include comments explaining non-obvious commands
-- Show expected output when the command produces meaningful results
-
-### Directory Trees
-
-```
-project/
-├── app/
-│   ├── api/          # Route handlers
-│   ├── models/       # Database entities
-│   ├── services/     # Business logic
-│   └── main.py       # Entry point
-├── tests/
-│   ├── test_*.py     # Unit tests
-│   └── conftest.py   # Shared fixtures
-└── docker-compose.yml
-```
-
-Always include inline comments (`# Purpose`) for each directory.
-
-### Section Dividers
-
-Use `---` (horizontal rule) between major sections for visual separation.
-
-### Cross-References
-
-Link between documentation files:
-
-```markdown
-See [Setup Guide](docs/SETUP.md) for first-time configuration.
-See [Technical Documentation](docs/TECHNICAL.md) for architecture details.
-```
-
----
-
-## CHANGELOG.md Format
-
-Use semantic-release format:
-
-```markdown
-## [v1.2.0](https://github.com/org/repo/compare/v1.1.0...v1.2.0) (2026-03-13)
-
-### Features
-
-* **auth**: add OAuth support for Google and GitHub ([abc1234](https://github.com/org/repo/commit/abc1234))
-
-### Bug Fixes
-
-* **orders**: fix fee calculation for products under R$8 ([def5678](https://github.com/org/repo/commit/def5678))
-```
-
-- Reverse chronological order (newest first)
-- Group entries: Features, Bug Fixes, Breaking Changes
-- Include commit hash links
-- Prefix entries with scope in bold: `**module**:`
-
----
-
-## Writing Style Guide
-
-1. **Be direct**: use imperative mood for instructions ("Run the command", "Edit the file"). No hedging.
-2. **Show, don't explain**: a code example is worth a paragraph of prose. When in doubt, add a code block.
-3. **Keep prose minimal**: use sentences for context, tables for data, code blocks for commands.
-4. **Use consistent terminology**: pick one term for each concept and stick with it throughout all docs.
-5. **Document the "why" alongside the "what"**: for non-obvious decisions, add a brief explanation (e.g., "We use Camoufox because standard Playwright gets detected by anti-bot systems").
-6. **Include real examples**: use realistic values, not `foo`/`bar`. Show actual API payloads, real config values, concrete use cases.
-7. **Warn about footguns**: use bold + warning indicator for dangerous operations (e.g., `**Warning**: This deletes all data`).
-
----
-
-## When Creating Documentation
-
-1. **Read the codebase first**: understand the project structure, entry points, configuration, and dependencies before writing anything.
-2. **Start with README.md**: if it doesn't exist, create it. If it exists, update it to match the skeleton above.
-3. **Create docs/SETUP.md** when the project requires more than 5 commands to set up.
-4. **Create docs/TECHNICAL.md** when the project has non-trivial architecture (multiple services, complex data flows, extension points).
-5. **Update CHANGELOG.md** when making significant changes — follow the semantic-release format.
-6. **Never invent features**: only document what actually exists in the code. Read before you write.
-
-## When Updating Documentation
-
-1. **Keep existing structure**: don't reorganize docs unless asked. Add to the existing skeleton.
-2. **Update, don't duplicate**: if information exists in one place, update it there. Don't create parallel docs.
-3. **Reflect code changes**: when code changes (new endpoints, new env vars, new modules), update the corresponding doc sections.
-4. **Preserve the project's voice**: if docs are in Portuguese, keep them in Portuguese. If English, keep English. Match the existing tone.
-
----
-
-## Troubleshooting
-
-**Problem**: Only README.md was updated, SETUP.md and TECHNICAL.md were not created.
-**Solution**: This skill always creates all three tiers. Re-run with: "Document this project following the documentation skill — create README.md, docs/SETUP.md, and docs/TECHNICAL.md."
-
-**Problem**: Documentation describes features that don't exist in the code.
-**Solution**: Always read the codebase before writing. Run `find . -type f` and read key files before starting.
-
-**Problem**: Setup guide is missing expected output for commands.
-**Solution**: Every command block must show what success looks like with a comment like `# Expected: ...`
-
----
-
-## How to Use
-
-### Prompt
-
-Open your project in Claude Code and paste this prompt:
-
-```
-Document this project following the documentation skill.
-Analyze the codebase and create all documentation files this project needs.
-```
-
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Document this project"
-- "Write the docs for this codebase"
-- "Update the README"
-- "Create setup and technical documentation"
-- "Help someone understand this project"
-- "Document this for AI tools"
-
-Should NOT trigger on:
-- "Write a blog post"
-- "Create a presentation"
-- "Fix this bug"
-- "Review my code"
+| Any project | `README.md` |
+| A `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md` or `.clinerules` exists, **or** the user asked to document the repo for AI tools | `AGENTS.md` |
+| Setup takes more than ~5 commands, or has environment prerequisites | `docs/SETUP.md` |
+| Architecture a reader cannot infer from the tree (services, flows, integrations) | `docs/TECHNICAL.md` |
+| REST/GraphQL API with no generated spec published | `docs/API.md` |
+| Project accepts outside contributions | `CONTRIBUTING.md` |
+| More than one deploy environment | `docs/DEPLOYMENT.md` |
+| Releases are tagged | `CHANGELOG.md` (generated, not hand-written) |
+| Background workers, webhooks, ML pipelines, CLI, SDK, security-sensitive config | the matching `docs/<topic>.md` |
+
+**Do not create a document to satisfy the table.** A 200-line project with a 3-command setup needs a
+README and nothing else; splitting it into three tiers produces three files that rot instead of one
+that doesn't. If you create only a README, say so and why.
+
+## One purpose per page
+
+Four reader needs, four kinds of page. Mixing them is the most common reason docs go stale and the
+most common reason readers can't find anything:
+
+| Need | Page kind | In this model |
+|---|---|---|
+| "Get me running for the first time" | **Tutorial** — one happy path, no options | `docs/SETUP.md` |
+| "How do I do X?" | **How-to** — task-oriented, assumes context | `README.md` quick start, `docs/<topic>.md` |
+| "What exactly does Y take?" | **Reference** — exhaustive, dry, generated where possible | config tables, `docs/API.md` |
+| "Why is it like this?" | **Explanation** — design rationale, trade-offs | `docs/TECHNICAL.md`, ADRs |
+
+The practical rule: **how-to content changes far faster than why content.** A page that mixes a
+command sequence with architectural rationale goes stale at the speed of its fastest-changing half.
+Keep them on separate pages, and cross-link.
+
+## Every claim must be checkable
+
+This is the difference between documentation and decoration. Prefer facts a script can verify against
+the repo, and write them so it can:
+
+- **Repo paths are links**, not prose: `[app/main.py](app/main.py)`. A link is checkable; a sentence
+  is not.
+- **Directory trees show the real root.** Measured on a production repo: a README tree written without
+  its `src/` prefix made every path in it unresolvable, and one entry had been renamed months earlier
+  — 9 of 10 entries wrong in a block the reader trusts most.
+- **Directory trees are the highest-rot artifact you can write.** They duplicate the filesystem and
+  break on every refactor. Include one only when the layout is genuinely non-obvious, cap it at the
+  directories that carry meaning (not every file), and annotate each with its purpose. Never paste a
+  full `tree` dump.
+- **Never hand-copy what a tool generates.** Endpoint tables duplicating an OpenAPI spec, flag tables
+  duplicating `--help`, changelogs duplicating the release tool — link or generate them. Hand copies
+  drift silently and there is no signal when they do.
+- **Env var tables come from the config module**, and every row must name a variable that exists in
+  the code. A documented variable the code never reads is a bug report waiting to happen.
+- **Commands are copy-paste runnable.** Run them, or state that you did not. Show expected output for
+  anything whose success is not obvious.
+- Ship the checker. A ~50-line script that resolves every link, every tree path, and every documented
+  env var, wired into CI, turns "the docs are stale" from a discovery into a build failure.
+
+## Keeping it true
+
+Documentation rot is the default outcome; the only reliable fix is process, not diligence:
+
+- **Docs change in the same commit as the code.** A PR that adds an env var and does not touch the
+  config table is incomplete — treat it the way you would treat a missing test.
+- **Every document names an owner** (a person or a team) in its footer or frontmatter. An unowned doc
+  is nobody's job.
+- **Date the volatile parts.** Version numbers, screenshots, benchmark figures and "current status"
+  sections carry the date they were verified.
+- **Delete aggressively.** A section describing a removed feature is worse than no section — it
+  actively misleads. Prune when you touch a page.
+
+## AGENTS.md — the repo's instructions for coding agents
+
+When AI agents work in the repo, the conventions they need live in `AGENTS.md` at the root — an open
+spec (donated to the Linux Foundation's Agentic AI Foundation in December 2025) that most agent tools
+now read. Anthropic's `CLAUDE.md` serves the same role for Claude Code; when both exist, keep one
+canonical and have the other point at it rather than maintaining two.
+
+Content that measurably helps: **architecture overview, where the important files are, and how to
+build/test/run.** Be honest about the ceiling — the published evaluation of repository context files
+on SWE-bench found gains modest and inconsistent across models, with setup and build guidance the most
+valuable part. Write it for that: concrete commands and locations, not aspirational style rules.
+
+`AGENTS.md` is about *contributing to this code*. It is not a substitute for the README, and it is a
+different thing from `llms.txt`, which maps a documentation *site* for retrieval.
+
+**The trigger has to be something you can see.** "This repo is worked on by agents" is not observable
+from a checkout — measured: with that phrasing, no run produced the file. Use the detectable signals
+in the table above: an existing tool-specific instruction file, or the user asking for it. When none
+is present, do not create `AGENTS.md` silently — say it is missing and what it would carry.
+
+## README
+
+Lead with what the software does and why, in one sentence, above everything else. Then only the
+sections this project earns. The full skeleton and a worked example: `references/templates.md` and
+`references/examples.md`.
+
+- **Quick start is 3-5 commands.** More than that means it is a tutorial — move it to `docs/SETUP.md`
+  and link.
+- **Tables for structured data** (env vars, endpoints, commands, tech stack); prose only for context.
+- **Text diagrams over images** — greppable, diff-able, readable by agents.
+- **Badges: signal only.** A badge that cannot fail carries no information — a hardcoded
+  `python-3.12-blue` shield is decoration. Live badges (CI status, coverage, published version) are
+  worth their space; static ones are not. For internal services and private tools a plain H1 plus a
+  one-line description is the correct header. Each badge is also a third-party request served to every
+  reader, so keep the set small.
+- **Include a logo** in a centered header block only if one already exists in the repo.
+
+## Writing style
+
+1. **Imperative for instructions.** "Run the migration", not "you may wish to run".
+2. **Show, don't explain.** A code block beats a paragraph.
+3. **One term per concept**, used consistently across every document.
+4. **Document the why for non-obvious decisions** — the constraint that forced the choice, not the
+   choice alone.
+5. **Real values, never `foo`/`bar`.** Realistic payloads, actual config values.
+6. **Warn about footguns** in bold, at the point of danger, not in a distant section.
+7. **Match the project's existing language and voice.** Portuguese docs stay Portuguese.
+
+## Updating existing documentation
+
+1. **Keep the existing structure** unless asked to reorganize. Add to the skeleton that is there.
+2. **Update in place; never fork a parallel doc.** Two documents describing the same thing means one
+   of them is already wrong.
+3. **Follow the code change.** New endpoint, new env var, new module → the corresponding rows change
+   in the same commit.
+4. **Re-verify what you touch.** If you edit a section, its links, paths and commands are yours now.
+
+## See also
+
+- `references/templates.md` — README / SETUP / TECHNICAL skeletons.
+- `references/examples.md` — worked examples of good output per tier.
+- `conventional-commit` — the commit format that drives generated changelogs.
+- `openspec` — where design rationale lives when a project runs the spec-driven flow; documentation
+  describes what exists, proposals describe what changes.

--- a/skills/documentation/references/templates.md
+++ b/skills/documentation/references/templates.md
@@ -1,0 +1,366 @@
+# Reference — documentation templates
+
+Skeletons for each document. Every section is optional except the lead: include only what the
+project earns. Fenced blocks below are templates, not claims about any repo.
+
+## README.md skeleton
+
+Only the lead is mandatory — the title and the one-line description of what the software does. Every
+other section below is included only if this project earns it.
+
+The header block is for public/OSS-facing repos. For an internal service or a private tool, a plain
+`# Title` plus the one-line description is the correct header — drop the div and the badges entirely.
+
+Badges follow the signal-only rule from the skill: include the ones that can *fail* (CI status,
+coverage, published version), skip the hardcoded ones that only restate the tech stack the Tech Stack
+table already lists.
+
+```markdown
+<div align="center">
+  <img src="logo.png" alt="Project Name" width="180" />
+
+  # Project Name
+
+  **One-line description of what the software does and why it exists.**
+
+  [![CI](https://github.com/org/repo/actions/workflows/ci.yml/badge.svg)](https://github.com/org/repo/actions/workflows/ci.yml)
+  [![PyPI](https://img.shields.io/pypi/v/package.svg)](https://pypi.org/project/package/)
+</div>
+
+## Features
+
+- **Feature Name**: Brief description of what it does
+- **Another Feature**: Brief description
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Framework | FastAPI 0.115+ |
+| Database  | PostgreSQL 16 |
+
+## Quick Start
+
+### Prerequisites
+
+- Docker and Docker Compose
+- Python 3.12+ (for local development)
+
+### Using Docker Compose
+
+\```bash
+docker compose up
+# API available at http://localhost:8000
+\```
+
+### Local Development
+
+\```bash
+python -m venv venv
+source venv/bin/activate
+pip install -e ".[dev]"
+cp .env.example .env
+\```
+
+## Configuration
+
+| Variable | Required | Default | Description |
+|----------|:--------:|---------|-------------|
+| `DATABASE_URL` | Yes | - | PostgreSQL connection string |
+| `LOG_LEVEL` | No | `INFO` | Log verbosity |
+
+## API Endpoints (or Commands)
+
+### Resource Name
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| GET | `/api/v1/items` | Yes | List items |
+| POST | `/api/v1/items` | Yes | Create item |
+
+## Architecture
+
+\```
+ASCII diagram showing component interactions
+\```
+
+## Folder Structure
+
+\```
+project/
+├── app/
+│   ├── api/          # Route handlers
+│   ├── models/       # Database models
+│   ├── services/     # Business logic
+│   └── main.py       # Entry point
+├── tests/
+├── Dockerfile
+└── docker-compose.yml
+\```
+
+## Development
+
+\```bash
+# Run tests
+pytest tests/ -v
+
+# Lint
+ruff check app/
+\```
+
+## Docker Commands
+
+\```bash
+docker compose up -d        # Start
+docker compose logs -f       # Logs
+docker compose down          # Stop
+docker compose up -d --build # Rebuild
+\```
+
+## Troubleshooting
+
+**Problem**: Description of common issue
+**Solution**: How to fix it
+
+## License
+
+MIT
+```
+
+---
+
+## docs/SETUP.md skeleton
+The setup guide takes someone from zero to a running system. Follow this progression:
+
+```markdown
+# Setup Guide
+
+Step-by-step guide to configure [Project Name] from scratch.
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [Configure Environment](#2-configure-environment)
+3. [Deploy with Docker](#3-deploy-with-docker)
+4. [Verify It Works](#4-verify-it-works)
+5. [Troubleshooting](#5-troubleshooting)
+
+## 1. Prerequisites
+
+Before starting, make sure you have:
+
+- Docker and Docker Compose installed
+- [Dependency X] running and accessible
+
+### Verify Dependencies
+
+\```bash
+curl http://localhost:8000/api/v1/health
+# Expected: {"status": "healthy"}
+\```
+
+## 2. Configure Environment
+
+\```bash
+cp .env.example .env
+# Edit .env with your settings
+\```
+
+### Environment Template
+
+\```bash
+# =============================================================================
+# Database
+# =============================================================================
+DATABASE_URL=postgresql://user:pass@db:5432/mydb
+
+# =============================================================================
+# Authentication
+# =============================================================================
+JWT_SECRET_KEY=your-secret-here
+\```
+
+## 3. Deploy with Docker
+
+\```bash
+docker compose build
+docker compose up -d
+docker compose ps  # verify containers are running
+\```
+
+### Verify Logs
+
+\```bash
+docker compose logs -f api
+# Expected: "Application started on port 8000"
+\```
+
+## 4. Verify It Works
+
+\```bash
+curl http://localhost:8000/api/v1/health
+# Expected: {"status": "healthy"}
+\```
+
+## 5. Troubleshooting
+
+**Problem**: Container exits immediately
+**Solution**: Check logs with `docker compose logs api`. Common cause: missing env vars.
+
+## Next Steps
+
+- [ ] Configure production secrets
+- [ ] Set up monitoring
+- [ ] Review security checklist
+```
+
+---
+
+### Setup guide conventions
+
+- Numbered sections with a table of contents at the top, anchors matching the numbers.
+- Prerequisites as `- [ ]` checkboxes so a reader can track them.
+- **Verify after every step.** Each action is followed by the command that confirms it worked and the
+  output it should print. A setup guide with no verification is a list of hopes.
+- Group the environment template by feature area with comment dividers (`# ====`), matching the order
+  of the config module so the two can be diffed.
+- Troubleshooting covers the failures this project actually produces — take them from the exception
+  messages and error paths in the code, not from a generic list, and add one whenever a reader hits a
+  new one.
+- End with a `- [ ]` Next Steps checklist for what comes after "it runs".
+
+---
+
+## docs/TECHNICAL.md skeleton
+The technical reference is for deep understanding. This is where AI tools and new contributors go to understand *how* the system works.
+
+```markdown
+# Technical Documentation
+
+Detailed architecture, components, and data flows for [Project Name].
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Architecture](#2-architecture)
+3. [Components](#3-components)
+4. [Data Flow](#4-data-flow)
+5. [DTOs and Entities](#5-dtos-and-entities)
+6. [HTTP Clients / External Integrations](#6-http-clients)
+7. [Services](#7-services)
+8. [Logging and Observability](#8-logging-and-observability)
+9. [Testing](#9-testing)
+10. [Extending the System](#10-extending-the-system)
+```
+
+---
+
+### Technical doc conventions
+
+- Table of contents with anchors, numbered to match the sections.
+- Architecture diagram first — a text box diagram of how the components connect.
+- Document the **data flows**: the path a request or event takes, step by step, naming the module at
+  each hop so a reader can jump straight to the code.
+- Show real method signatures with types for services and clients, not paraphrases.
+- An **"Extending the system"** section: how to add a module, an integration, an endpoint. This is the
+  section contributors and coding agents use most.
+- This is the explanation tier — put the *why* here (trade-offs, constraints, rejected alternatives)
+  and keep step-by-step commands in the setup guide, so the two decay at their own speeds.
+
+---
+
+## Formatting conventions
+### Tables
+
+Use tables for any structured, repeatable data:
+
+```markdown
+| Variable | Required | Default | Description |
+|----------|:--------:|---------|-------------|
+| `DB_HOST` | Yes | - | Database hostname |
+| `LOG_LEVEL` | No | `INFO` | Log verbosity |
+```
+
+- Center-align boolean/status columns (`:---:`)
+- Use inline code for variable names, commands, values
+- Group rows by category using bold header rows when the table is long
+
+### ASCII Diagrams
+
+Use text-based diagrams for architecture and flows:
+
+```
+┌─────────────┐     HTTP      ┌──────────────┐
+│   Service A │ ─────────────>│  Service B   │
+└─────────────┘               └──────────────┘
+       │                             │
+       │ Events                      │ SQL
+       v                             v
+┌─────────────┐               ┌──────────────┐
+│  Message Q  │               │  PostgreSQL  │
+└─────────────┘               └──────────────┘
+```
+
+Use box-drawing characters (`┌ ─ ┐ └ ┘ │ ├ ┤ ┬ ┴ ┼`) for clean diagrams. Reserve simple arrows (`→ ← ↓ ↑`) for inline flows.
+
+### Code Blocks
+
+- Always specify the language: ` ```bash `, ` ```python `, ` ```yaml `, ` ```json `
+- Include comments explaining non-obvious commands
+- Show expected output when the command produces meaningful results
+
+### Directory Trees
+
+```
+project/
+├── app/
+│   ├── api/          # Route handlers
+│   ├── models/       # Database entities
+│   ├── services/     # Business logic
+│   └── main.py       # Entry point
+├── tests/
+│   ├── test_*.py     # Unit tests
+│   └── conftest.py   # Shared fixtures
+└── docker-compose.yml
+```
+
+Always include inline comments (`# Purpose`) for each directory.
+
+### Section Dividers
+
+Use `---` (horizontal rule) between major sections for visual separation.
+
+### Cross-References
+
+Link between documentation files:
+
+```markdown
+See [Setup Guide](docs/SETUP.md) for first-time configuration.
+See [Technical Documentation](docs/TECHNICAL.md) for architecture details.
+```
+
+---
+
+---
+
+## CHANGELOG.md format (generated by semantic-release — do not hand-write)
+Use semantic-release format:
+
+```markdown
+## [v1.2.0](https://github.com/org/repo/compare/v1.1.0...v1.2.0) (2026-03-13)
+
+### Features
+
+* **auth**: add OAuth support for Google and GitHub ([abc1234](https://github.com/org/repo/commit/abc1234))
+
+### Bug Fixes
+
+* **orders**: fix fee calculation for products under R$8 ([def5678](https://github.com/org/repo/commit/def5678))
+```
+
+- Reverse chronological order (newest first)
+- Group entries: Features, Bug Fixes, Breaking Changes
+- Include commit hash links
+- Prefix entries with scope in bold: `**module**:`
+
+---


### PR DESCRIPTION
## Why

`skills/documentation/SKILL.md` instructed two opposite policies in the same file:

- frontmatter description (always in context, drives selection): "**ALWAYS creates all three documentation tiers** unless the user explicitly says otherwise"
- body: "**Do NOT create documents that don't apply to this project**"
- Troubleshooting: "This skill always creates all three tiers"

Three statements, two incompatible policies — and the strongest one lived in the part the model reads first.

## A/B trial

Same task, same reference files, on a real undocumented 1,432-line Python service (OmniVoice TTS add-on: inference, voice registry, schemas, HTTP app, tests). Output scored against the source code, not by opinion.

| | current skill | revised draft |
|---|---|---|
| documents created | 5 | 4 |
| documentation lines | 873 | 786 |
| env vars documented / in code | 16/16 | 16/16 |
| endpoints documented / in code | 6/6 | 6/6 |
| **machine-checkable claims** | **84** | **131** |
| claims that fail verification | 13 | 11 |
| **failure rate** | **15.5%** | **8.4%** |
| states what it could not verify | no | yes |

56% more verifiable assertions at roughly half the failure rate, with fewer files. Both arms got the facts right — the old text was sound on accuracy, wrong on scope, silent on durability.

Fairness note: `binary` claims (depend on the harness PATH) and references to paths outside the checkout were excluded from both arms equally.

## Measured documentation rot

A claim checker was run over production repos, extracting every assertion a doc makes about its repo (links, tree paths, inline paths, env vars in tables) and verifying it. The worst artifact was the one the skill mandated most insistently — "Folder structure with annotations", "Always include inline comments":

> a README directory tree written without its `src/` prefix — **9 of 10 entries unresolvable**, and one entry naming a file renamed months earlier.

Trees are now demoted: only when the layout is genuinely non-obvious, real root required, capped at directories that carry meaning.

## What the file had no rule for at all

- **Staleness.** "Living documentation" was a principle with no mechanism. Now: docs change in the same commit as the code, every document names an owner, volatile facts carry a verification date, delete aggressively.
- **Reader need.** The three tiers conflated tutorial / how-to / reference / explanation. The operative rule is the rot mechanism: how-to content changes faster than why content, so a page mixing them decays at the speed of its fastest half.
- **`AGENTS.md`.** The skill triggers on "document this for AI tools" but never mentioned the repository context-file convention agent tooling actually reads (open spec, donated to the Linux Foundation's Agentic AI Foundation, December 2025).

### A negative result, folded back in

The first draft conditioned `AGENTS.md` on "repo is worked on by AI coding agents" — **zero runs produced the file**, because that is not observable from a checkout. Re-keyed on a detectable signal (an existing `CLAUDE.md` / `.cursorrules` / `.github/copilot-instructions.md` / `.clinerules`, or an explicit request) it fires; the confirmation run also collapsed the duplicate `CLAUDE.md` into a pointer at the canonical file, as the rule requires. When no trigger is present the skill must name the gap rather than create the file silently.

The value claim carries its published ceiling: the SWE-bench evaluation of repository context files reports modest and inconsistent gains, with build/setup guidance the most useful content. The skill says that rather than selling the file.

## Size

543 → 174 lines. 42% of the original was fenced skeleton, which is read at generation time, not selection time — moved to `references/templates.md` (366 lines) alongside the existing `references/examples.md`. Also removed: the "How to Use" and "Trigger Test Cases" meta sections, and 14 badge mentions collapsed into one signal-only rule (a badge that cannot fail carries no information).

## Rite

`openspec/changes/harden-documentation-skill/` with the mandatory gate groups · spec delta adding **Description agrees with body** to `skills-authoring` · `./generate.sh` run, wrappers in sync · README row updated · `scripts/validate-rite.sh` green · CI frontmatter check green locally.

`V.6` (`openspec archive`) is intentionally left open — closure step after review.

## Out of scope

The `r3f-*` skills run 732–1,145 lines with 78–86% fenced content and **no `references/` directory at all** — the same size problem, larger, across 11 skills. Worth its own proposal.
