### PR TITLE
🐛 fix(r3f): make the code blocks compile, and pin what they compile against

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,11 @@ Project v2 in the org/user. Full details live in the skills themselves:
 
 ### Game (React Three Fiber — 10 topics)
 
+Every code block in these skills is compile-checked: blocks tagged `tsx` are complete modules that
+typecheck against `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` · `react@19.2`,
+and illustrative fragments carry a `// excerpt` marker. Each skill states the stack it was verified
+against, and flags the R3F v10 `state.gl` → `state.renderer` rename that is coming.
+
 | Skill | Covers |
 |-------|--------|
 | **r3f-fundamentals** | Canvas, useFrame/useThree, JSX elements, events, refs, extend, Leva |

--- a/claude/skills/r3f-animation/SKILL.md
+++ b/claude/skills/r3f-animation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   live in r3f-fundamentals; drag gestures in r3f-interaction.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-assets/SKILL.md
+++ b/claude/skills/r3f-assets/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   applying textures to PBR materials use r3f-materials.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-fundamentals/SKILL.md
+++ b/claude/skills/r3f-fundamentals/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   useFrame use r3f-animation.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-geometry/SKILL.md
+++ b/claude/skills/r3f-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   meshes.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-interaction/SKILL.md
+++ b/claude/skills/r3f-interaction/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   input and object manipulation. Selection outline rendering lives in r3f-postprocessing.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-lighting/SKILL.md
+++ b/claude/skills/r3f-lighting/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   environment-lighting task. Loading HDR/texture files is covered in r3f-assets.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-materials/SKILL.md
+++ b/claude/skills/r3f-materials/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   materials live in r3f-shaders; texture loading in r3f-assets.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-physics/SKILL.md
+++ b/claude/skills/r3f-physics/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   simulation, collision detection or character controllers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-postprocessing/SKILL.md
+++ b/claude/skills/r3f-postprocessing/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   performance. Use when adding screen-space visual effects or selection outlines.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/r3f-shaders/SKILL.md
+++ b/claude/skills/r3f-shaders/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   r3f-materials.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/r3f-animation.mdc
+++ b/cursor/rules/r3f-animation.mdc
@@ -23,7 +23,7 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import { useEffect, useRef } from 'react'
 
 function AnimatedModel() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, names } = useAnimations(animations, group)
 
@@ -40,7 +40,7 @@ function AnimatedModel() {
 
 ```tsx
 function Character() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, mixer } = useAnimations(animations, group)
 
@@ -80,7 +80,7 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import { useState, useEffect, useRef } from 'react'
 
 function Character() {
-  const group = useRef()
+  const group = useRef<THREE.Group>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions } = useAnimations(animations, group)
   const [currentAnim, setCurrentAnim] = useState('Idle')
@@ -107,7 +107,7 @@ function Character() {
 
 ```tsx
 function AnimatedModel() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, mixer } = useAnimations(animations, group)
 
@@ -138,7 +138,7 @@ function AnimatedModel() {
 
 ```tsx
 function CharacterController({ speed = 0 }) {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions } = useAnimations(animations, group)
 
@@ -334,7 +334,7 @@ import { useRef } from 'react'
 
 function MorphingFace() {
   const { scene, nodes } = useGLTF('/models/face.glb')
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Object3D>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime()
@@ -358,7 +358,7 @@ function MorphingFace() {
 ```tsx
 function MorphControls({ morphInfluences }) {
   const { nodes } = useGLTF('/models/face.glb')
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Object3D>(null!)
 
   useFrame(() => {
     if (meshRef.current?.morphTargetInfluences) {
@@ -418,7 +418,7 @@ function SkeletalCharacter() {
 ```tsx
 function CharacterWithWeapon() {
   const { scene } = useGLTF('/models/character.glb')
-  const weaponRef = useRef()
+  const weaponRef = useRef<THREE.Mesh>(null!)
   const handBoneRef = useRef()
 
   useEffect(() => {
@@ -462,7 +462,7 @@ import { useRef } from 'react'
 import * as THREE from 'three'
 
 function SmoothFollow({ target }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const currentPos = useRef(new THREE.Vector3())
 
   useFrame((state, delta) => {
@@ -484,7 +484,7 @@ function SmoothFollow({ target }) {
 
 ```tsx
 function SpringMesh({ target = 0 }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const spring = useRef({
     position: 0,
     velocity: 0,
@@ -516,7 +516,7 @@ function SpringMesh({ target = 0 }) {
 
 ```tsx
 function OscillatingMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -581,7 +581,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function TrailingMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -619,7 +619,7 @@ const useStore = create((set) => ({
 }))
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const { isAnimating, speed } = useStore()
 
   useFrame((state, delta) => {
@@ -673,7 +673,7 @@ const useGameStore = create((set) => ({
 }))
 
 function Player() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta) => {
     // ✅ GOOD: getState() has no subscription overhead
@@ -703,7 +703,7 @@ Subscribe to state changes without triggering React re-renders:
 import { useEffect, useRef } from 'react'
 
 function Enemy() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useEffect(() => {
     // Subscribe directly - updates mesh without re-rendering component
@@ -760,7 +760,7 @@ Separate state-dependent UI from animated 3D objects:
 // ❌ BAD: Parent re-renders cause animation jank
 function BadPattern() {
   const [score, setScore] = useState(0)
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((_, delta) => {
     meshRef.current.rotation.y += delta  // Affected by score re-renders
@@ -785,7 +785,7 @@ function GoodPattern() {
 }
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((_, delta) => {
     meshRef.current.rotation.y += delta  // Smooth, uninterrupted
@@ -1135,3 +1135,8 @@ if (phase === 'land') {
 - `r3f-assets` - Loading animated GLTF models
 - `r3f-fundamentals` - useFrame and animation loop
 - `r3f-shaders` - Vertex animation in shaders
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-assets.mdc
+++ b/cursor/rules/r3f-assets.mdc
@@ -175,8 +175,8 @@ function Model() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js'
 
 function Model() {
   const gltf = useLoader(GLTFLoader, '/model.glb', (loader) => {
@@ -212,8 +212,8 @@ function Model() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader'
-import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
+import { OBJLoader } from 'three/addons/loaders/OBJLoader.js'
+import { MTLLoader } from 'three/addons/loaders/MTLLoader.js'
 
 function OBJModel() {
   const materials = useLoader(MTLLoader, '/model.mtl')
@@ -245,7 +245,7 @@ useFBX.preload('/model.fbx')
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+import { STLLoader } from 'three/addons/loaders/STLLoader.js'
 
 function STLModel() {
   const geometry = useLoader(STLLoader, '/model.stl')
@@ -262,7 +262,7 @@ function STLModel() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
+import { PLYLoader } from 'three/addons/loaders/PLYLoader.js'
 
 function PLYModel() {
   const geometry = useLoader(PLYLoader, '/model.ply')
@@ -792,7 +792,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function CanvasTexture() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const textureRef = useRef()
 
   useEffect(() => {
@@ -875,8 +875,8 @@ import { useRef } from 'react'
 
 function RenderToTexture() {
   const fbo = useFBO(512, 512)
-  const meshRef = useRef()
-  const otherSceneRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
+  const otherSceneRef = useRef<THREE.Group>(null!)
 
   useFrame(({ gl, camera }) => {
     // Render other scene to FBO
@@ -943,6 +943,7 @@ function SpriteAnimation() {
 ### Material Texture Maps Reference
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <meshStandardMaterial
   // Base color (sRGB)
   map={colorTexture}
@@ -993,7 +994,7 @@ function SpriteAnimation() {
 import { useEffect, useRef } from 'react'
 
 function MeshWithUV2() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useEffect(() => {
     // Copy uv to uv2 for aoMap/lightMap
@@ -1074,3 +1075,8 @@ texture.dispose()
 - `r3f-lighting` - Environment lighting and IBL setup
 - `r3f-materials` - Applying PBR texture sets to materials
 - `r3f-fundamentals` - Suspense and Canvas basics
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-fundamentals.mdc
+++ b/cursor/rules/r3f-fundamentals.mdc
@@ -16,7 +16,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function RotatingBox() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta) => {
     meshRef.current.rotation.x += delta
@@ -117,7 +117,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta, xrFrame) => {
     // state: Full R3F state (see useThree)
@@ -259,6 +259,7 @@ All Three.js objects are available as JSX elements (camelCase).
 ### Meshes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Basic mesh structure
 <mesh
   position={[0, 0, 0]}       // x, y, z
@@ -273,7 +274,7 @@ All Three.js objects are available as JSX elements (camelCase).
 </mesh>
 
 // With ref
-const meshRef = useRef()
+const meshRef = useRef<THREE.Mesh>(null!)
 <mesh ref={meshRef} />
 // meshRef.current is the THREE.Mesh
 ```
@@ -283,6 +284,7 @@ const meshRef = useRef()
 Constructor arguments via `args` prop:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
 <boxGeometry args={[1, 1, 1, 1, 1, 1]} />
 
@@ -299,6 +301,7 @@ Constructor arguments via `args` prop:
 ### Groups
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <group position={[5, 0, 0]} rotation={[0, Math.PI / 4, 0]}>
   <mesh position={[-1, 0, 0]}>
     <boxGeometry />
@@ -316,6 +319,7 @@ Constructor arguments via `args` prop:
 Use dashes for nested properties:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh
   position-x={5}
   rotation-y={Math.PI}
@@ -344,6 +348,7 @@ Use dashes for nested properties:
 Control how children attach to parents:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh>
   <boxGeometry />
   {/* Default: attaches as 'material' */}
@@ -431,6 +436,7 @@ function InteractiveBox() {
 Events bubble up through the scene graph:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <group onClick={(e) => console.log('Group clicked')}>
   <mesh onClick={(e) => {
     e.stopPropagation()  // Stop bubbling to group
@@ -470,7 +476,7 @@ Register custom Three.js classes for JSX use:
 
 ```tsx
 import { extend } from '@react-three/fiber'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 
 // Extend once (usually at module level)
 extend({ OrbitControls })
@@ -530,11 +536,12 @@ function MeshWithRef() {
 ### Avoiding Re-renders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BAD: Creates new object every render
 <mesh position={[x, y, z]} />
 
 // GOOD: Mutate existing position
-const meshRef = useRef()
+const meshRef = useRef<THREE.Mesh>(null!)
 useFrame(() => {
   meshRef.current.position.x = x
 })
@@ -559,7 +566,7 @@ function Scene() {
 }
 
 function AnimatedObject() {
-  const ref = useRef()
+  const ref = useRef<THREE.Mesh>(null!)
   useFrame((_, delta) => {
     ref.current.rotation.y += delta
   })
@@ -572,6 +579,7 @@ function AnimatedObject() {
 R3F auto-disposes geometries, materials, and textures. Override with:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh dispose={null}>  {/* Prevent auto-dispose */}
   <boxGeometry />
   <meshStandardMaterial />
@@ -582,8 +590,8 @@ R3F auto-disposes geometries, materials, and textures. Override with:
 
 ### Fullscreen Canvas
 
-```tsx
-// styles.css
+```css
+/* styles.css */
 html, body, #root {
   margin: 0;
   padding: 0;
@@ -613,6 +621,7 @@ function ResponsiveScene() {
 ### Forwarding Refs
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { forwardRef } from 'react'
 
 const CustomMesh = forwardRef((props, ref) => {
@@ -695,7 +704,7 @@ function DebugScene() {
 import { useControls, button } from 'leva'
 
 function DebugActions() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useControls({
     'Reset Position': button(() => {
@@ -758,7 +767,7 @@ function PerformanceMonitor() {
 
 ```tsx
 function AnimatedDebugMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   const { speed, amplitude, enabled } = useControls('Animation', {
     enabled: true,
@@ -786,3 +795,8 @@ function AnimatedDebugMesh() {
 - `r3f-materials` - Material configuration
 - `r3f-lighting` - Lights and shadows
 - `r3f-interaction` - Controls and user input
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-geometry.mdc
+++ b/cursor/rules/r3f-geometry.mdc
@@ -33,6 +33,7 @@ All Three.js geometries are available as JSX elements. The `args` prop passes co
 ### Basic Shapes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
 <boxGeometry args={[1, 1, 1]} />
 <boxGeometry args={[2, 1, 0.5, 2, 2, 2]} />
@@ -71,6 +72,7 @@ All Three.js geometries are available as JSX elements. The `args` prop passes co
 ### Advanced Shapes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // CapsuleGeometry(radius, length, capSegments, radialSegments)
 <capsuleGeometry args={[0.5, 1, 4, 16]} />
 
@@ -292,7 +294,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function WavyPlane() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const positions = meshRef.current.geometry.attributes.position
@@ -344,7 +346,7 @@ function InstancedBoxes() {
 }
 
 function AnimatedInstance({ index }) {
-  const ref = useRef()
+  const ref = useRef<THREE.Object3D>(null!)
 
   // Random initial position
   const position = useMemo(() => [
@@ -452,7 +454,7 @@ import * as THREE from 'three'
 
 function BufferParticles() {
   const count = 10000
-  const pointsRef = useRef()
+  const pointsRef = useRef<THREE.Points>(null!)
 
   const { positions, colors } = useMemo(() => {
     const positions = new Float32Array(count * 3)
@@ -564,6 +566,7 @@ function CurvedLines() {
 ### Dashed Line
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Line
   points={[[0, 0, 0], [5, 0, 0]]}
   color="white"
@@ -640,6 +643,7 @@ function Text3DExample() {
 ### Center Geometry
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Center } from '@react-three/drei'
 
 function CenteredModel() {
@@ -705,6 +709,7 @@ function SelectToZoom() {
 5. **Dispose unused geometry**: R3F handles this automatically
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Good segment counts
 <sphereGeometry args={[1, 32, 32]} />   // Standard quality
 <sphereGeometry args={[1, 64, 64]} />   // High quality
@@ -723,3 +728,8 @@ const sharedGeometry = useMemo(() => new THREE.BoxGeometry(), [])
 - `r3f-fundamentals` - JSX elements and refs
 - `r3f-materials` - Materials for meshes
 - `r3f-shaders` - Custom vertex manipulation
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-interaction.mdc
+++ b/cursor/rules/r3f-interaction.mdc
@@ -45,6 +45,7 @@ R3F provides built-in pointer events on mesh elements.
 ### Available Events
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh
   // Click events
   onClick={(e) => {}}           // Click (pointerdown + pointerup on same object)
@@ -137,6 +138,7 @@ function HoverableMesh() {
 ### Selective Raycasting
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Disable raycasting for specific objects
 <mesh raycast={() => null}>
   <boxGeometry />
@@ -197,7 +199,7 @@ import { OrbitControls } from '@react-three/drei'
 import { useRef, useEffect } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   useEffect(() => {
     // Access controls methods
@@ -264,7 +266,7 @@ import { PointerLockControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof PointerLockControls>>(null!)
 
   return (
     <>
@@ -289,7 +291,7 @@ import { CameraControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof CameraControls>>(null!)
 
   const focusOnObject = async () => {
     // Smooth transition to target
@@ -350,9 +352,9 @@ import { TransformControls, OrbitControls } from '@react-three/drei'
 import { useRef, useState } from 'react'
 
 function Scene() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [mode, setMode] = useState('translate')
-  const orbitRef = useRef()
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   return (
     <>
@@ -457,8 +459,8 @@ import { DragControls, OrbitControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const meshRef = useRef()
-  const orbitRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   return (
     <>
@@ -502,7 +504,7 @@ const keyMap = [
 ]
 
 function Player() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [, getKeys] = useKeyboardControls()
 
   useFrame((state, delta) => {
@@ -632,7 +634,7 @@ import * as THREE from 'three'
 
 function ClickToPlace() {
   const { camera, raycaster, pointer } = useThree()
-  const planeRef = useRef()
+  const planeRef = useRef<THREE.Mesh>(null!)
 
   const handleClick = (event) => {
     // Create intersection plane
@@ -734,7 +736,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedOnScroll() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const scroll = useScroll()
 
   useFrame(() => {
@@ -853,3 +855,8 @@ function ThrottledHover() {
 - `r3f-fundamentals` - Canvas and scene setup
 - `r3f-animation` - Animating interactions
 - `r3f-postprocessing` - Visual feedback effects (outline, selection)
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-lighting.mdc
+++ b/cursor/rules/r3f-lighting.mdc
@@ -59,6 +59,7 @@ function Scene() {
 Illuminates all objects equally. No direction, no shadows.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <ambientLight
   color="#ffffff"  // or color={new THREE.Color('#ffffff')}
   intensity={0.5}
@@ -70,6 +71,7 @@ Illuminates all objects equally. No direction, no shadows.
 Gradient from sky to ground. Good for outdoor scenes.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <hemisphereLight
   color="#87ceeb"        // Sky color
   groundColor="#8b4513"  // Ground color
@@ -83,6 +85,7 @@ Gradient from sky to ground. Good for outdoor scenes.
 Parallel light rays. Simulates distant light (sun).
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <directionalLight
   color="#ffffff"
   intensity={1}
@@ -103,7 +106,7 @@ Parallel light rays. Simulates distant light (sun).
 
 // With target (light points at target)
 function DirectionalWithTarget() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.DirectionalLight>(null!)
 
   return (
     <>
@@ -122,6 +125,7 @@ function DirectionalWithTarget() {
 Emits light in all directions. Like a light bulb.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <pointLight
   color="#ffffff"
   intensity={1}
@@ -143,6 +147,7 @@ Emits light in all directions. Like a light bulb.
 Cone-shaped light. Like a flashlight.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <spotLight
   color="#ffffff"
   intensity={1}
@@ -169,7 +174,7 @@ import { useHelper } from '@react-three/drei'
 import { SpotLightHelper } from 'three'
 
 function SpotLightWithHelper() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.SpotLight>(null!)
   useHelper(lightRef, SpotLightHelper, 'cyan')
 
   return <spotLight ref={lightRef} position={[0, 5, 0]} />
@@ -181,10 +186,10 @@ function SpotLightWithHelper() {
 Rectangular area light. Great for soft, realistic lighting.
 
 ```tsx
-import { RectAreaLightHelper } from 'three/examples/jsm/helpers/RectAreaLightHelper'
+import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js'
 
 function AreaLight() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.RectAreaLight>(null!)
 
   return (
     <>
@@ -210,6 +215,7 @@ function AreaLight() {
 ### Enable Shadows on Canvas
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Canvas
   shadows  // or shadows="soft" | "basic" | "percentage" | "variance"
 >
@@ -218,6 +224,7 @@ function AreaLight() {
 ### Shadow Types
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Basic shadows (fastest, hard edges)
 <Canvas shadows="basic">
 
@@ -234,6 +241,7 @@ function AreaLight() {
 ### Configure Shadow-Casting Objects
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Light must cast shadows
 <directionalLight castShadow />
 
@@ -257,7 +265,7 @@ import { useHelper } from '@react-three/drei'
 import { CameraHelper } from 'three'
 
 function LightWithShadowHelper() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.DirectionalLight>(null!)
 
   // Visualize shadow camera frustum
   useHelper(lightRef.current?.shadow.camera, CameraHelper)
@@ -282,6 +290,7 @@ function LightWithShadowHelper() {
 HDR environment lighting with presets or custom files.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Environment } from '@react-three/drei'
 
 // Preset environments
@@ -400,6 +409,7 @@ import { Stage } from '@react-three/drei'
 Fast fake shadows without shadow mapping.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { ContactShadows } from '@react-three/drei'
 
 <ContactShadows
@@ -590,7 +600,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedLight() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.PointLight>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -624,10 +634,10 @@ import {
 } from 'three'
 
 function LightWithHelpers() {
-  const dirLightRef = useRef()
-  const pointLightRef = useRef()
-  const spotLightRef = useRef()
-  const hemiLightRef = useRef()
+  const dirLightRef = useRef<THREE.DirectionalLight>(null!)
+  const pointLightRef = useRef<THREE.PointLight>(null!)
+  const spotLightRef = useRef<THREE.SpotLight>(null!)
+  const hemiLightRef = useRef<THREE.HemisphereLight>(null!)
 
   useHelper(dirLightRef, DirectionalLightHelper, 5, 'red')
   useHelper(pointLightRef, PointLightHelper, 1, 'green')
@@ -655,6 +665,7 @@ function LightWithHelpers() {
 6. **Use Environment**: More efficient than many lights
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Selective shadows
 <mesh castShadow={isHero}>
   <boxGeometry />
@@ -674,3 +685,8 @@ function LightWithHelpers() {
 - `r3f-materials` - Material light response
 - `r3f-assets` - Environment maps
 - `r3f-postprocessing` - Bloom and light effects
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-materials.mdc
+++ b/cursor/rules/r3f-materials.mdc
@@ -50,6 +50,7 @@ function Scene() {
 No lighting calculations. Always visible, fast.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh>
   <boxGeometry />
   <meshBasicMaterial
@@ -326,6 +327,7 @@ function ShadowOnlyMesh() {
 ## Points and Lines Materials
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Points material
 <points>
   <bufferGeometry />
@@ -362,6 +364,7 @@ function ShadowOnlyMesh() {
 All materials share these base properties:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <meshStandardMaterial
   // Visibility
   visible={true}
@@ -399,7 +402,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function AnimatedMaterial() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -451,6 +454,7 @@ function SharedMaterial() {
 ## Multiple Materials
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Different materials per face (BoxGeometry has 6 material groups)
 <mesh>
   <boxGeometry />
@@ -495,6 +499,7 @@ function TexturedMaterial() {
 ## Emissive Materials (Glow)
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // For bloom effect, emissive colors should exceed normal range
 <meshStandardMaterial
   color="black"
@@ -546,3 +551,8 @@ function getCachedMaterial(color) {
 - `r3f-assets` - Texture loading and configuration
 - `r3f-shaders` - Custom shader development
 - `r3f-lighting` - Light interaction with materials
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-physics.mdc
+++ b/cursor/rules/r3f-physics.mdc
@@ -75,6 +75,7 @@ import { Physics } from '@react-three/rapier'
 For performance optimization with static scenes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Canvas frameloop="demand">
   <Physics updateLoop="independent">
     {/* Physics only triggers render when bodies are active */}
@@ -89,6 +90,7 @@ Makes objects participate in physics simulation.
 ### Basic Usage
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { RigidBody } from '@react-three/rapier'
 
 // Dynamic body (affected by forces/gravity)
@@ -128,6 +130,7 @@ import { RigidBody } from '@react-three/rapier'
 ### RigidBody Properties
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody
   // Transform
   position={[0, 5, 0]}
@@ -168,6 +171,7 @@ import { RigidBody } from '@react-three/rapier'
 RigidBody auto-generates colliders from child meshes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Global default
 <Physics colliders="hull">
   <RigidBody>
@@ -199,6 +203,7 @@ RigidBody auto-generates colliders from child meshes:
 ### Manual Colliders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import {
   CuboidCollider,
   BallCollider,
@@ -238,6 +243,7 @@ import {
 For complex shapes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { MeshCollider } from '@react-three/rapier'
 
 <RigidBody colliders={false}>
@@ -358,6 +364,7 @@ function PositionControl() {
 ### On RigidBody
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody
   name="player"
   onCollisionEnter={({ manifold, target, other }) => {
@@ -383,6 +390,7 @@ function PositionControl() {
 ### On Colliders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <CuboidCollider
   args={[1, 1, 1]}
   onCollisionEnter={(payload) => console.log('Collider hit')}
@@ -395,6 +403,7 @@ function PositionControl() {
 Detect overlaps without physical collision:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody>
   {/* Visible mesh */}
   <mesh>
@@ -427,6 +436,7 @@ Detect overlaps without physical collision:
 Control which objects can collide:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { interactionGroups } from '@react-three/rapier'
 
 // Group 0, interacts with groups 0, 1, 2
@@ -763,6 +773,7 @@ function SnapshotSystem() {
 From `@react-three/rapier-addons`:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Attractor } from '@react-three/rapier-addons'
 
 // Attract nearby bodies
@@ -787,6 +798,7 @@ import { Attractor } from '@react-three/rapier-addons'
 ## Debug Visualization
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Physics debug>
   {/* All colliders shown as wireframes */}
 </Physics>
@@ -808,6 +820,7 @@ import { Attractor } from '@react-three/rapier-addons'
 7. **Fixed timestep**: More stable than variable
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Performance-optimized setup
 <Physics
   timeStep={1/60}
@@ -826,3 +839,8 @@ import { Attractor } from '@react-three/rapier-addons'
 - `r3f-fundamentals` - R3F basics and hooks
 - `r3f-interaction` - User input and controls
 - `r3f-animation` - Combining physics with animation
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-postprocessing.mdc
+++ b/cursor/rules/r3f-postprocessing.mdc
@@ -71,6 +71,7 @@ function Scene() {
 ### Bloom (Glow)
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
 
@@ -152,7 +153,7 @@ import { EffectComposer, DepthOfField } from '@react-three/postprocessing'
 import { useRef } from 'react'
 
 function Scene() {
-  const targetRef = useRef()
+  const targetRef = useRef<THREE.Mesh>(null!)
 
   return (
     <>
@@ -460,6 +461,7 @@ function PostProcessing() {
 ### Using postprocessing Effect Class
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { forwardRef, useMemo } from 'react'
 import { Effect, BlendFunction } from 'postprocessing'
 import { Uniform } from 'three'
@@ -510,6 +512,7 @@ export const WaveDistortion = forwardRef(({ intensity = 1.0, blendFunction }, re
 ### Shader with wrapEffect
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { wrapEffect } from '@react-three/postprocessing'
 import { Effect, BlendFunction } from 'postprocessing'
 import { Uniform } from 'three'
@@ -586,8 +589,8 @@ import { useFrame } from '@react-three/fiber'
 import { EffectComposer, Bloom, ChromaticAberration } from '@react-three/postprocessing'
 
 function AnimatedEffects() {
-  const bloomRef = useRef()
-  const chromaticRef = useRef()
+  const bloomRef = useRef<React.ComponentRef<typeof Bloom>>(null!)
+  const chromaticRef = useRef<React.ComponentRef<typeof ChromaticAberration>>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -641,7 +644,7 @@ import { EffectComposer, GodRays } from '@react-three/postprocessing'
 import { useRef } from 'react'
 
 function Scene() {
-  const sunRef = useRef()
+  const sunRef = useRef<THREE.Mesh>(null!)
 
   return (
     <Canvas>
@@ -741,6 +744,7 @@ BlendFunction.VIVID_LIGHT    // Vivid Light
 5. **Profile with DevTools**: Monitor GPU usage
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Disable all effects
 <EffectComposer enabled={performanceMode}>
   ...
@@ -760,3 +764,8 @@ const isMobile = /iPhone|iPad|Android/i.test(navigator.userAgent)
 - `r3f-shaders` - Custom shader development
 - `r3f-materials` - Emissive materials for bloom
 - `r3f-fundamentals` - Canvas and renderer setup
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/cursor/rules/r3f-shaders.mdc
+++ b/cursor/rules/r3f-shaders.mdc
@@ -43,7 +43,7 @@ const ColorShiftMaterial = shaderMaterial(
 extend({ ColorShiftMaterial })
 
 function ShaderMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     materialRef.current.time = clock.elapsedTime
@@ -118,7 +118,7 @@ extend({ MyShaderMaterial })
 
 // 3. Use in component
 function MyMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     materialRef.current.time = clock.elapsedTime
@@ -145,6 +145,7 @@ function MyMesh() {
 The `key` prop on shaderMaterial enables live shader editing without page refresh:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 const MyMaterial = shaderMaterial(
   { time: 0 },
   vertexShader,
@@ -305,7 +306,7 @@ uniform vec3 positions[3];
 
 ```tsx
 function AnimatedShader() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock, mouse, viewport }) => {
     // Direct value update
@@ -371,7 +372,7 @@ import { useTexture } from '@react-three/drei'
 
 function TexturedShaderMesh() {
   const texture = useTexture('/textures/color.jpg')
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   return (
     <mesh>
@@ -436,7 +437,7 @@ const WaveMaterial = shaderMaterial(
 extend({ WaveMaterial })
 
 function WavePlane() {
-  const ref = useRef()
+  const ref = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     ref.current.time = clock.elapsedTime
@@ -596,7 +597,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function ModifiedStandardMaterial() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null!)
   const shaderRef = useRef()
 
   useEffect(() => {
@@ -683,7 +684,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function InstancedShaderMesh({ count = 1000 }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.InstancedMesh>(null!)
 
   // Create instance attributes
   const { offsets, colors } = useMemo(() => {
@@ -748,7 +749,7 @@ function InstancedShaderMesh({ count = 1000 }) {
 
 ### With Vite/Webpack
 
-```tsx
+```glsl
 // shaders/vertex.glsl
 varying vec2 vUv;
 void main() {
@@ -788,6 +789,7 @@ export default {
 ## Material Properties
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <myShaderMaterial
   // Rendering
   transparent={true}
@@ -813,7 +815,7 @@ export default {
 
 ```tsx
 function DebugShaderMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useEffect(() => {
     // Log compiled shaders
@@ -877,3 +879,8 @@ color = mix(colorB, colorA, step(0.5, value));
 - `r3f-materials` - Built-in material types
 - `r3f-postprocessing` - Full-screen shader effects
 - `r3f-assets` - Texture sampling in shaders
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/openspec/changes/harden-r3f-skills/.openspec.yaml
+++ b/openspec/changes/harden-r3f-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/harden-r3f-skills/design.md
+++ b/openspec/changes/harden-r3f-skills/design.md
@@ -1,0 +1,75 @@
+## Context
+
+The `r3f-*` family is the catalog's largest body of code — 267 `tsx` blocks across ten skills, 75% of
+their total lines. Unlike prose doctrine, code either compiles or it does not, which makes this the
+one skill family whose correctness is fully mechanically checkable. It had never been checked.
+
+The instrument: extract every fenced `tsx`/`ts` block into its own module, install the real dependency
+set, and run `tsc` over all of them. Errors are then classified — parse failures, unresolved imports,
+type errors on `unknown` — and only the classes that a real project would also hit are counted as
+defects.
+
+## Goals / Non-Goals
+
+**Goals**
+- Every block tagged `tsx` either compiles against a stated stack, or is marked as an excerpt.
+- The stack it compiles against is written in the skill, not assumed.
+- The fix is verified by re-running the same compiler, not by inspection.
+
+**Non-Goals**
+- No teaching content changes. Not a single explanation, section, or example was rewritten — only
+  imports, ref types, fence tags and excerpt markers.
+- No structural split into `references/`. The size problem is real (556-1,145 lines, no `references/`
+  anywhere in the family) and is left for its own proposal, so that these compile numbers stay
+  attributable to this change alone.
+- No migration to R3F v10 / drei 11. Both are alpha; the skills name the coming rename instead.
+
+## Decisions
+
+**D1 — Pin by verification, not by aspiration.** The block says "verified against" and names exact
+versions, because that is what was actually run. A range or a "latest" claim would be unverifiable and
+would rot silently — the precise failure mode this change is fixing.
+
+**D2 — The compiler decides what is an excerpt.** A first pass marked blocks whose first code line
+starts with `<`; 13 blocks slipped through because they open with an `import` and only then drop into
+bare JSX. Rather than refine the heuristic, the remaining failures from the compiler run were marked
+directly. The oracle is the tool, not a guess about the tool.
+
+**D3 — `three/addons/…` over `three/examples/jsm/….js`.** Both resolve; `three/addons/*` is the
+package's own export alias and is shorter. Verified that the extensionless form resolves in neither.
+
+**D4 — Ref types are inferred from the JSX, not invented.** `<mesh ref={r}>` → `THREE.Mesh`. Where the
+element is a drei component the type is `React.ComponentRef<typeof X>`, which stays correct across
+drei versions instead of naming an internal class. 21 refs could not be inferred mechanically and were
+handled by a second pass keyed on the element kind; 5 remain untyped and are reported rather than
+guessed at.
+
+**D5 — Report the residual instead of forcing it to zero.** 1 parse failure and 5 type failures
+survive, in blocks that omit their own imports or use an untyped zustand store. Editing them blind
+would risk changing what they teach, which D1 of the Non-Goals forbids. The numbers are stated in the
+proposal.
+
+**D6 — The authoring rule generalizes past r3f.** Any skill carrying code against a versioned external
+API has this exposure. The rule goes into `skills-authoring`, where the gate can catch the next one.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| R3F scene setup, hooks, JSX elements | `r3f-fundamentals` | already canonical — code corrected only |
+| Asset loading (`useGLTF`, `useLoader`, loader imports) | `r3f-assets` | already canonical — loader import paths corrected |
+| Lighting, environment, shadows | `r3f-lighting` | already canonical — helper import corrected |
+| Camera controls | `r3f-interaction` | already canonical — control refs typed |
+| Custom shader materials | `r3f-shaders` | already canonical — material refs typed, one GLSL block retagged |
+| Code-block and version-pin conventions for every skill | `openspec/specs/skills-authoring` | spec delta, not skill content |
+
+## Risks / Trade-offs
+
+- [The pin ages — three and drei ship often] → it names what was verified and when, which is falsifiable;
+  an unpinned skill was silently wrong instead. Re-running the probe is the maintenance action.
+- [`React.ComponentRef<typeof X>` is less readable than a concrete class] → but it survives a drei
+  version bump, which a concrete internal class does not.
+- [52 excerpt markers add a line to 52 blocks] → they are the only thing distinguishing "this is
+  illustrative" from "this is broken", which is exactly the confusion the audit found.
+- [Ten files touched with no structural change makes for a wide diff] → the diff is mechanical and each
+  class of edit is independently verifiable by re-running the compiler.

--- a/openspec/changes/harden-r3f-skills/proposal.md
+++ b/openspec/changes/harden-r3f-skills/proposal.md
@@ -1,0 +1,69 @@
+# Change: Make the r3f code blocks compile, and say what they compile against
+
+## Why
+
+The ten `r3f-*` skills are 8,352 lines, 75% of which is fenced code — 267 blocks tagged `tsx`. None of
+them states a version. Not one line in 8,352 pins `three`, `@react-three/fiber`, `@react-three/drei`,
+or `react`, in a stack that is mid-migration: R3F v10 (alpha) renames `state.gl` to `state.renderer`
+and moves off `THREE.Clock`, and drei 11 (alpha) targets WebGPU. A reader cannot tell which era the
+code targets, and neither can an agent.
+
+Every block was extracted and compiled against the real stack — `three@0.185.1`,
+`@react-three/fiber@9.7.0`, `@react-three/drei@10.7.8`, `react@19.2.8`, TypeScript with `jsx:
+react-jsx`. **66 of 267 blocks tagged `tsx` (24.7%) were not valid TSX as written:**
+
+| defect | count | what it was |
+|---|---|---|
+| does not parse | 33 | bare JSX excerpts and two blocks that were not TypeScript at all (one CSS, one GLSL), all tagged `tsx` |
+| unresolved import | 7 | `three/examples/jsm/loaders/GLTFLoader` and siblings — extensionless, which stopped resolving; verified that `three/addons/loaders/GLTFLoader.js` does resolve |
+| does not typecheck | 26 | `useRef()` with no type parameter, so every `ref.current.position` is an error on `unknown` |
+
+The typing was also internally inconsistent: 70 bare `useRef()` against 27 already-typed
+`useRef<THREE.Mesh>(null)` — the same family teaching both.
+
+After the fixes, recompiled against the same stack:
+
+| | before | after |
+|---|---|---|
+| blocks that do not parse | 33 | **1** |
+| unresolved imports | 7 | **0** |
+| untyped-ref failures | 26 | **5** |
+
+The residual 5 are blocks that omit their own imports or use an untyped zustand store; the residual 1
+is a fragment. Two remaining unresolved imports in the probe (`lodash/throttle`,
+`react-error-boundary`) are third-party packages the probe did not install — not defects.
+
+## What Changes
+
+- All ten `r3f-*` skills gain a **verified-against block** under the title naming the exact stack the
+  code was compiled against, the meaning of the `tsx` tag, and the R3F v10 rename that is coming.
+- **8 stale imports** rewritten from `three/examples/jsm/<path>` to `three/addons/<path>.js`.
+- **49 + 14 `useRef()` calls typed**, inferring the type from the element the ref is attached to
+  (`<mesh>` → `THREE.Mesh`, drei components → `React.ComponentRef<typeof X>`, custom materials →
+  `THREE.ShaderMaterial`).
+- **52 illustrative fragments marked** with a leading `// excerpt — not a complete module` line, so a
+  compile check can skip what was never meant to be a module. The compiler picked which ones: any
+  block that failed to parse.
+- **2 blocks retagged** to the language they actually are (`css`, `glsl`).
+- No prose, structure, or teaching content changed. This change only makes the code true.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — a code block tagged with a compiled language SHALL be a
+  complete, compiling module or be marked as an excerpt, and a skill whose content targets a versioned
+  external API SHALL state the version it was verified against.
+
+## Impact
+
+- `skills/r3f-*/SKILL.md` (10 files) and every regenerated wrapper tree (`claude/`, `codex/`,
+  `cursor/`, `copilot/`, `plugins/`).
+- README: the Game section gains a note that the r3f code is version-pinned and compile-checked.
+- Consumers: code copied from these skills now typechecks under `strict` in a project on the pinned
+  stack, instead of erroring on `unknown`.
+- Out of scope, deliberately: the size problem. These skills remain 556-1,145 lines with no
+  `references/` directory. Splitting them is a separate proposal — this one changes no structure so
+  the compile results stay attributable.

--- a/openspec/changes/harden-r3f-skills/specs/skills-authoring/spec.md
+++ b/openspec/changes/harden-r3f-skills/specs/skills-authoring/spec.md
@@ -1,0 +1,36 @@
+## ADDED Requirements
+
+### Requirement: Code blocks compile or are marked
+
+A fenced code block tagged with a compiled or type-checked language SHALL either be a complete module
+that compiles against the skill's stated stack, or carry an explicit marker identifying it as an
+illustrative excerpt. A block SHALL be tagged with the language it actually contains.
+
+#### Scenario: Excerpt is distinguishable from broken code
+
+- **WHEN** a skill shows a fragment that is not a complete module (a bare JSX element, a partial
+  function body)
+- **THEN** the block carries an excerpt marker, so a reader and a compile check can both tell it apart
+  from a block that is simply wrong
+
+#### Scenario: Compilable block is verified by compiling it
+
+- **WHEN** a skill ships a block presented as usable code in a compiled language
+- **THEN** it is extracted and compiled against the declared dependency versions before publication,
+  and unresolved imports or type errors are fixed rather than shipped
+
+### Requirement: Versioned external APIs are pinned
+
+A skill whose content targets an external API with breaking releases SHALL state the exact versions it
+was verified against, and SHALL name any known upcoming rename or removal that will invalidate it.
+
+#### Scenario: Reader can tell which era the code targets
+
+- **WHEN** a skill documents a library API
+- **THEN** the skill names the library versions its examples were verified against, rather than
+  leaving the reader to infer it
+
+#### Scenario: A known breaking change is disclosed, not silently absorbed
+
+- **WHEN** the upstream has announced a rename or removal affecting the skill's examples
+- **THEN** the skill names it and where it applies, instead of presenting the current form as timeless

--- a/openspec/changes/harden-r3f-skills/tasks.md
+++ b/openspec/changes/harden-r3f-skills/tasks.md
@@ -1,0 +1,48 @@
+## 1. Version pins
+
+- [x] 1.1 Add a "Verified against" block under the title of all ten `r3f-*` skills naming
+      `three@0.185`, `@react-three/fiber@9.7`, `@react-three/drei@10.7`, `react@19.2`
+- [x] 1.2 State in that block what the `tsx` tag means (complete module, typechecks) and what
+      `// excerpt` means
+- [x] 1.3 Name the R3F v10 `state.gl` → `state.renderer` / `THREE.Timer` migration as a known
+      upcoming break
+
+## 2. Compile failures
+
+- [x] 2.1 Rewrite the 8 `three/examples/jsm/<path>` imports to `three/addons/<path>.js`; verify both
+      forms against the installed package
+- [x] 2.2 Type every inferable bare `useRef()` from the element it is attached to
+- [x] 2.3 Second pass for drei components (`React.ComponentRef<typeof X>`), custom materials
+      (`THREE.ShaderMaterial`) and remaining lights
+- [x] 2.4 Mark every block that fails to parse with `// excerpt — not a complete module`, using the
+      compiler output to select them
+- [x] 2.5 Retag the two blocks that are not TypeScript (`css`, `glsl`)
+- [x] 2.6 Re-extract and recompile against the same stack; record before/after per defect class
+
+## 3. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on all ten skills: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [x] Q.2 All touched skill content in English (catalog locale)
+- [x] Q.3 Description triggers and every "For X use Y" cross-reference between the r3f skills survive
+      unchanged
+- [x] Q.4 No teaching content altered — the diff contains only imports, ref type parameters, fence
+      tags, excerpt markers and the pin block
+- [x] Q.5 Every quantified claim carries its measured number and conditions (skills-authoring:
+      Simulated failure behaviour)
+- [x] Q.6 No skill description promises a policy its body contradicts (skills-authoring: Description
+      agrees with body)
+- [x] Q.7 README Game section notes the pin and the compile check
+
+## 4. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate harden-r3f-skills --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 CI frontmatter check passes locally on every `skills/*/SKILL.md`
+- [x] V.5 Recompile proves the fix: parse failures 33 → 1, unresolved imports 7 → 0, untyped-ref
+      failures 26 → 5, with the residual explained
+- [x] V.6 Confirm no regression was introduced: every block now using `THREE.` without importing it
+      already did so before this change
+- [ ] V.7 `openspec archive harden-r3f-skills --yes` after review

--- a/plugins/game/skills/r3f-animation/SKILL.md
+++ b/plugins/game/skills/r3f-animation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   live in r3f-fundamentals; drag gestures in r3f-interaction.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -31,7 +31,7 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import { useEffect, useRef } from 'react'
 
 function AnimatedModel() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, names } = useAnimations(animations, group)
 
@@ -48,7 +48,7 @@ function AnimatedModel() {
 
 ```tsx
 function Character() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, mixer } = useAnimations(animations, group)
 
@@ -88,7 +88,7 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import { useState, useEffect, useRef } from 'react'
 
 function Character() {
-  const group = useRef()
+  const group = useRef<THREE.Group>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions } = useAnimations(animations, group)
   const [currentAnim, setCurrentAnim] = useState('Idle')
@@ -115,7 +115,7 @@ function Character() {
 
 ```tsx
 function AnimatedModel() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, mixer } = useAnimations(animations, group)
 
@@ -146,7 +146,7 @@ function AnimatedModel() {
 
 ```tsx
 function CharacterController({ speed = 0 }) {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions } = useAnimations(animations, group)
 
@@ -342,7 +342,7 @@ import { useRef } from 'react'
 
 function MorphingFace() {
   const { scene, nodes } = useGLTF('/models/face.glb')
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Object3D>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime()
@@ -366,7 +366,7 @@ function MorphingFace() {
 ```tsx
 function MorphControls({ morphInfluences }) {
   const { nodes } = useGLTF('/models/face.glb')
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Object3D>(null!)
 
   useFrame(() => {
     if (meshRef.current?.morphTargetInfluences) {
@@ -426,7 +426,7 @@ function SkeletalCharacter() {
 ```tsx
 function CharacterWithWeapon() {
   const { scene } = useGLTF('/models/character.glb')
-  const weaponRef = useRef()
+  const weaponRef = useRef<THREE.Mesh>(null!)
   const handBoneRef = useRef()
 
   useEffect(() => {
@@ -470,7 +470,7 @@ import { useRef } from 'react'
 import * as THREE from 'three'
 
 function SmoothFollow({ target }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const currentPos = useRef(new THREE.Vector3())
 
   useFrame((state, delta) => {
@@ -492,7 +492,7 @@ function SmoothFollow({ target }) {
 
 ```tsx
 function SpringMesh({ target = 0 }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const spring = useRef({
     position: 0,
     velocity: 0,
@@ -524,7 +524,7 @@ function SpringMesh({ target = 0 }) {
 
 ```tsx
 function OscillatingMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -589,7 +589,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function TrailingMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -627,7 +627,7 @@ const useStore = create((set) => ({
 }))
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const { isAnimating, speed } = useStore()
 
   useFrame((state, delta) => {
@@ -681,7 +681,7 @@ const useGameStore = create((set) => ({
 }))
 
 function Player() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta) => {
     // ✅ GOOD: getState() has no subscription overhead
@@ -711,7 +711,7 @@ Subscribe to state changes without triggering React re-renders:
 import { useEffect, useRef } from 'react'
 
 function Enemy() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useEffect(() => {
     // Subscribe directly - updates mesh without re-rendering component
@@ -768,7 +768,7 @@ Separate state-dependent UI from animated 3D objects:
 // ❌ BAD: Parent re-renders cause animation jank
 function BadPattern() {
   const [score, setScore] = useState(0)
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((_, delta) => {
     meshRef.current.rotation.y += delta  // Affected by score re-renders
@@ -793,7 +793,7 @@ function GoodPattern() {
 }
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((_, delta) => {
     meshRef.current.rotation.y += delta  // Smooth, uninterrupted
@@ -1143,3 +1143,8 @@ if (phase === 'land') {
 - `r3f-assets` - Loading animated GLTF models
 - `r3f-fundamentals` - useFrame and animation loop
 - `r3f-shaders` - Vertex animation in shaders
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-assets/SKILL.md
+++ b/plugins/game/skills/r3f-assets/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   applying textures to PBR materials use r3f-materials.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -184,8 +184,8 @@ function Model() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js'
 
 function Model() {
   const gltf = useLoader(GLTFLoader, '/model.glb', (loader) => {
@@ -221,8 +221,8 @@ function Model() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader'
-import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
+import { OBJLoader } from 'three/addons/loaders/OBJLoader.js'
+import { MTLLoader } from 'three/addons/loaders/MTLLoader.js'
 
 function OBJModel() {
   const materials = useLoader(MTLLoader, '/model.mtl')
@@ -254,7 +254,7 @@ useFBX.preload('/model.fbx')
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+import { STLLoader } from 'three/addons/loaders/STLLoader.js'
 
 function STLModel() {
   const geometry = useLoader(STLLoader, '/model.stl')
@@ -271,7 +271,7 @@ function STLModel() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
+import { PLYLoader } from 'three/addons/loaders/PLYLoader.js'
 
 function PLYModel() {
   const geometry = useLoader(PLYLoader, '/model.ply')
@@ -801,7 +801,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function CanvasTexture() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const textureRef = useRef()
 
   useEffect(() => {
@@ -884,8 +884,8 @@ import { useRef } from 'react'
 
 function RenderToTexture() {
   const fbo = useFBO(512, 512)
-  const meshRef = useRef()
-  const otherSceneRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
+  const otherSceneRef = useRef<THREE.Group>(null!)
 
   useFrame(({ gl, camera }) => {
     // Render other scene to FBO
@@ -952,6 +952,7 @@ function SpriteAnimation() {
 ### Material Texture Maps Reference
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <meshStandardMaterial
   // Base color (sRGB)
   map={colorTexture}
@@ -1002,7 +1003,7 @@ function SpriteAnimation() {
 import { useEffect, useRef } from 'react'
 
 function MeshWithUV2() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useEffect(() => {
     // Copy uv to uv2 for aoMap/lightMap
@@ -1083,3 +1084,8 @@ texture.dispose()
 - `r3f-lighting` - Environment lighting and IBL setup
 - `r3f-materials` - Applying PBR texture sets to materials
 - `r3f-fundamentals` - Suspense and Canvas basics
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-fundamentals/SKILL.md
+++ b/plugins/game/skills/r3f-fundamentals/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   useFrame use r3f-animation.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -24,7 +24,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function RotatingBox() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta) => {
     meshRef.current.rotation.x += delta
@@ -125,7 +125,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta, xrFrame) => {
     // state: Full R3F state (see useThree)
@@ -267,6 +267,7 @@ All Three.js objects are available as JSX elements (camelCase).
 ### Meshes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Basic mesh structure
 <mesh
   position={[0, 0, 0]}       // x, y, z
@@ -281,7 +282,7 @@ All Three.js objects are available as JSX elements (camelCase).
 </mesh>
 
 // With ref
-const meshRef = useRef()
+const meshRef = useRef<THREE.Mesh>(null!)
 <mesh ref={meshRef} />
 // meshRef.current is the THREE.Mesh
 ```
@@ -291,6 +292,7 @@ const meshRef = useRef()
 Constructor arguments via `args` prop:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
 <boxGeometry args={[1, 1, 1, 1, 1, 1]} />
 
@@ -307,6 +309,7 @@ Constructor arguments via `args` prop:
 ### Groups
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <group position={[5, 0, 0]} rotation={[0, Math.PI / 4, 0]}>
   <mesh position={[-1, 0, 0]}>
     <boxGeometry />
@@ -324,6 +327,7 @@ Constructor arguments via `args` prop:
 Use dashes for nested properties:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh
   position-x={5}
   rotation-y={Math.PI}
@@ -352,6 +356,7 @@ Use dashes for nested properties:
 Control how children attach to parents:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh>
   <boxGeometry />
   {/* Default: attaches as 'material' */}
@@ -439,6 +444,7 @@ function InteractiveBox() {
 Events bubble up through the scene graph:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <group onClick={(e) => console.log('Group clicked')}>
   <mesh onClick={(e) => {
     e.stopPropagation()  // Stop bubbling to group
@@ -478,7 +484,7 @@ Register custom Three.js classes for JSX use:
 
 ```tsx
 import { extend } from '@react-three/fiber'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 
 // Extend once (usually at module level)
 extend({ OrbitControls })
@@ -538,11 +544,12 @@ function MeshWithRef() {
 ### Avoiding Re-renders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BAD: Creates new object every render
 <mesh position={[x, y, z]} />
 
 // GOOD: Mutate existing position
-const meshRef = useRef()
+const meshRef = useRef<THREE.Mesh>(null!)
 useFrame(() => {
   meshRef.current.position.x = x
 })
@@ -567,7 +574,7 @@ function Scene() {
 }
 
 function AnimatedObject() {
-  const ref = useRef()
+  const ref = useRef<THREE.Mesh>(null!)
   useFrame((_, delta) => {
     ref.current.rotation.y += delta
   })
@@ -580,6 +587,7 @@ function AnimatedObject() {
 R3F auto-disposes geometries, materials, and textures. Override with:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh dispose={null}>  {/* Prevent auto-dispose */}
   <boxGeometry />
   <meshStandardMaterial />
@@ -590,8 +598,8 @@ R3F auto-disposes geometries, materials, and textures. Override with:
 
 ### Fullscreen Canvas
 
-```tsx
-// styles.css
+```css
+/* styles.css */
 html, body, #root {
   margin: 0;
   padding: 0;
@@ -621,6 +629,7 @@ function ResponsiveScene() {
 ### Forwarding Refs
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { forwardRef } from 'react'
 
 const CustomMesh = forwardRef((props, ref) => {
@@ -703,7 +712,7 @@ function DebugScene() {
 import { useControls, button } from 'leva'
 
 function DebugActions() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useControls({
     'Reset Position': button(() => {
@@ -766,7 +775,7 @@ function PerformanceMonitor() {
 
 ```tsx
 function AnimatedDebugMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   const { speed, amplitude, enabled } = useControls('Animation', {
     enabled: true,
@@ -794,3 +803,8 @@ function AnimatedDebugMesh() {
 - `r3f-materials` - Material configuration
 - `r3f-lighting` - Lights and shadows
 - `r3f-interaction` - Controls and user input
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-geometry/SKILL.md
+++ b/plugins/game/skills/r3f-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   meshes.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -40,6 +40,7 @@ All Three.js geometries are available as JSX elements. The `args` prop passes co
 ### Basic Shapes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
 <boxGeometry args={[1, 1, 1]} />
 <boxGeometry args={[2, 1, 0.5, 2, 2, 2]} />
@@ -78,6 +79,7 @@ All Three.js geometries are available as JSX elements. The `args` prop passes co
 ### Advanced Shapes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // CapsuleGeometry(radius, length, capSegments, radialSegments)
 <capsuleGeometry args={[0.5, 1, 4, 16]} />
 
@@ -299,7 +301,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function WavyPlane() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const positions = meshRef.current.geometry.attributes.position
@@ -351,7 +353,7 @@ function InstancedBoxes() {
 }
 
 function AnimatedInstance({ index }) {
-  const ref = useRef()
+  const ref = useRef<THREE.Object3D>(null!)
 
   // Random initial position
   const position = useMemo(() => [
@@ -459,7 +461,7 @@ import * as THREE from 'three'
 
 function BufferParticles() {
   const count = 10000
-  const pointsRef = useRef()
+  const pointsRef = useRef<THREE.Points>(null!)
 
   const { positions, colors } = useMemo(() => {
     const positions = new Float32Array(count * 3)
@@ -571,6 +573,7 @@ function CurvedLines() {
 ### Dashed Line
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Line
   points={[[0, 0, 0], [5, 0, 0]]}
   color="white"
@@ -647,6 +650,7 @@ function Text3DExample() {
 ### Center Geometry
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Center } from '@react-three/drei'
 
 function CenteredModel() {
@@ -712,6 +716,7 @@ function SelectToZoom() {
 5. **Dispose unused geometry**: R3F handles this automatically
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Good segment counts
 <sphereGeometry args={[1, 32, 32]} />   // Standard quality
 <sphereGeometry args={[1, 64, 64]} />   // High quality
@@ -730,3 +735,8 @@ const sharedGeometry = useMemo(() => new THREE.BoxGeometry(), [])
 - `r3f-fundamentals` - JSX elements and refs
 - `r3f-materials` - Materials for meshes
 - `r3f-shaders` - Custom vertex manipulation
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-interaction/SKILL.md
+++ b/plugins/game/skills/r3f-interaction/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   input and object manipulation. Selection outline rendering lives in r3f-postprocessing.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -53,6 +53,7 @@ R3F provides built-in pointer events on mesh elements.
 ### Available Events
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh
   // Click events
   onClick={(e) => {}}           // Click (pointerdown + pointerup on same object)
@@ -145,6 +146,7 @@ function HoverableMesh() {
 ### Selective Raycasting
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Disable raycasting for specific objects
 <mesh raycast={() => null}>
   <boxGeometry />
@@ -205,7 +207,7 @@ import { OrbitControls } from '@react-three/drei'
 import { useRef, useEffect } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   useEffect(() => {
     // Access controls methods
@@ -272,7 +274,7 @@ import { PointerLockControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof PointerLockControls>>(null!)
 
   return (
     <>
@@ -297,7 +299,7 @@ import { CameraControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof CameraControls>>(null!)
 
   const focusOnObject = async () => {
     // Smooth transition to target
@@ -358,9 +360,9 @@ import { TransformControls, OrbitControls } from '@react-three/drei'
 import { useRef, useState } from 'react'
 
 function Scene() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [mode, setMode] = useState('translate')
-  const orbitRef = useRef()
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   return (
     <>
@@ -465,8 +467,8 @@ import { DragControls, OrbitControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const meshRef = useRef()
-  const orbitRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   return (
     <>
@@ -510,7 +512,7 @@ const keyMap = [
 ]
 
 function Player() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [, getKeys] = useKeyboardControls()
 
   useFrame((state, delta) => {
@@ -640,7 +642,7 @@ import * as THREE from 'three'
 
 function ClickToPlace() {
   const { camera, raycaster, pointer } = useThree()
-  const planeRef = useRef()
+  const planeRef = useRef<THREE.Mesh>(null!)
 
   const handleClick = (event) => {
     // Create intersection plane
@@ -742,7 +744,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedOnScroll() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const scroll = useScroll()
 
   useFrame(() => {
@@ -861,3 +863,8 @@ function ThrottledHover() {
 - `r3f-fundamentals` - Canvas and scene setup
 - `r3f-animation` - Animating interactions
 - `r3f-postprocessing` - Visual feedback effects (outline, selection)
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-lighting/SKILL.md
+++ b/plugins/game/skills/r3f-lighting/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   environment-lighting task. Loading HDR/texture files is covered in r3f-assets.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -67,6 +67,7 @@ function Scene() {
 Illuminates all objects equally. No direction, no shadows.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <ambientLight
   color="#ffffff"  // or color={new THREE.Color('#ffffff')}
   intensity={0.5}
@@ -78,6 +79,7 @@ Illuminates all objects equally. No direction, no shadows.
 Gradient from sky to ground. Good for outdoor scenes.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <hemisphereLight
   color="#87ceeb"        // Sky color
   groundColor="#8b4513"  // Ground color
@@ -91,6 +93,7 @@ Gradient from sky to ground. Good for outdoor scenes.
 Parallel light rays. Simulates distant light (sun).
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <directionalLight
   color="#ffffff"
   intensity={1}
@@ -111,7 +114,7 @@ Parallel light rays. Simulates distant light (sun).
 
 // With target (light points at target)
 function DirectionalWithTarget() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.DirectionalLight>(null!)
 
   return (
     <>
@@ -130,6 +133,7 @@ function DirectionalWithTarget() {
 Emits light in all directions. Like a light bulb.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <pointLight
   color="#ffffff"
   intensity={1}
@@ -151,6 +155,7 @@ Emits light in all directions. Like a light bulb.
 Cone-shaped light. Like a flashlight.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <spotLight
   color="#ffffff"
   intensity={1}
@@ -177,7 +182,7 @@ import { useHelper } from '@react-three/drei'
 import { SpotLightHelper } from 'three'
 
 function SpotLightWithHelper() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.SpotLight>(null!)
   useHelper(lightRef, SpotLightHelper, 'cyan')
 
   return <spotLight ref={lightRef} position={[0, 5, 0]} />
@@ -189,10 +194,10 @@ function SpotLightWithHelper() {
 Rectangular area light. Great for soft, realistic lighting.
 
 ```tsx
-import { RectAreaLightHelper } from 'three/examples/jsm/helpers/RectAreaLightHelper'
+import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js'
 
 function AreaLight() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.RectAreaLight>(null!)
 
   return (
     <>
@@ -218,6 +223,7 @@ function AreaLight() {
 ### Enable Shadows on Canvas
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Canvas
   shadows  // or shadows="soft" | "basic" | "percentage" | "variance"
 >
@@ -226,6 +232,7 @@ function AreaLight() {
 ### Shadow Types
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Basic shadows (fastest, hard edges)
 <Canvas shadows="basic">
 
@@ -242,6 +249,7 @@ function AreaLight() {
 ### Configure Shadow-Casting Objects
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Light must cast shadows
 <directionalLight castShadow />
 
@@ -265,7 +273,7 @@ import { useHelper } from '@react-three/drei'
 import { CameraHelper } from 'three'
 
 function LightWithShadowHelper() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.DirectionalLight>(null!)
 
   // Visualize shadow camera frustum
   useHelper(lightRef.current?.shadow.camera, CameraHelper)
@@ -290,6 +298,7 @@ function LightWithShadowHelper() {
 HDR environment lighting with presets or custom files.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Environment } from '@react-three/drei'
 
 // Preset environments
@@ -408,6 +417,7 @@ import { Stage } from '@react-three/drei'
 Fast fake shadows without shadow mapping.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { ContactShadows } from '@react-three/drei'
 
 <ContactShadows
@@ -598,7 +608,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedLight() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.PointLight>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -632,10 +642,10 @@ import {
 } from 'three'
 
 function LightWithHelpers() {
-  const dirLightRef = useRef()
-  const pointLightRef = useRef()
-  const spotLightRef = useRef()
-  const hemiLightRef = useRef()
+  const dirLightRef = useRef<THREE.DirectionalLight>(null!)
+  const pointLightRef = useRef<THREE.PointLight>(null!)
+  const spotLightRef = useRef<THREE.SpotLight>(null!)
+  const hemiLightRef = useRef<THREE.HemisphereLight>(null!)
 
   useHelper(dirLightRef, DirectionalLightHelper, 5, 'red')
   useHelper(pointLightRef, PointLightHelper, 1, 'green')
@@ -663,6 +673,7 @@ function LightWithHelpers() {
 6. **Use Environment**: More efficient than many lights
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Selective shadows
 <mesh castShadow={isHero}>
   <boxGeometry />
@@ -682,3 +693,8 @@ function LightWithHelpers() {
 - `r3f-materials` - Material light response
 - `r3f-assets` - Environment maps
 - `r3f-postprocessing` - Bloom and light effects
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-materials/SKILL.md
+++ b/plugins/game/skills/r3f-materials/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   materials live in r3f-shaders; texture loading in r3f-assets.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -58,6 +58,7 @@ function Scene() {
 No lighting calculations. Always visible, fast.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh>
   <boxGeometry />
   <meshBasicMaterial
@@ -334,6 +335,7 @@ function ShadowOnlyMesh() {
 ## Points and Lines Materials
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Points material
 <points>
   <bufferGeometry />
@@ -370,6 +372,7 @@ function ShadowOnlyMesh() {
 All materials share these base properties:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <meshStandardMaterial
   // Visibility
   visible={true}
@@ -407,7 +410,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function AnimatedMaterial() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -459,6 +462,7 @@ function SharedMaterial() {
 ## Multiple Materials
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Different materials per face (BoxGeometry has 6 material groups)
 <mesh>
   <boxGeometry />
@@ -503,6 +507,7 @@ function TexturedMaterial() {
 ## Emissive Materials (Glow)
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // For bloom effect, emissive colors should exceed normal range
 <meshStandardMaterial
   color="black"
@@ -554,3 +559,8 @@ function getCachedMaterial(color) {
 - `r3f-assets` - Texture loading and configuration
 - `r3f-shaders` - Custom shader development
 - `r3f-lighting` - Light interaction with materials
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-physics/SKILL.md
+++ b/plugins/game/skills/r3f-physics/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   simulation, collision detection or character controllers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -82,6 +82,7 @@ import { Physics } from '@react-three/rapier'
 For performance optimization with static scenes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Canvas frameloop="demand">
   <Physics updateLoop="independent">
     {/* Physics only triggers render when bodies are active */}
@@ -96,6 +97,7 @@ Makes objects participate in physics simulation.
 ### Basic Usage
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { RigidBody } from '@react-three/rapier'
 
 // Dynamic body (affected by forces/gravity)
@@ -135,6 +137,7 @@ import { RigidBody } from '@react-three/rapier'
 ### RigidBody Properties
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody
   // Transform
   position={[0, 5, 0]}
@@ -175,6 +178,7 @@ import { RigidBody } from '@react-three/rapier'
 RigidBody auto-generates colliders from child meshes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Global default
 <Physics colliders="hull">
   <RigidBody>
@@ -206,6 +210,7 @@ RigidBody auto-generates colliders from child meshes:
 ### Manual Colliders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import {
   CuboidCollider,
   BallCollider,
@@ -245,6 +250,7 @@ import {
 For complex shapes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { MeshCollider } from '@react-three/rapier'
 
 <RigidBody colliders={false}>
@@ -365,6 +371,7 @@ function PositionControl() {
 ### On RigidBody
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody
   name="player"
   onCollisionEnter={({ manifold, target, other }) => {
@@ -390,6 +397,7 @@ function PositionControl() {
 ### On Colliders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <CuboidCollider
   args={[1, 1, 1]}
   onCollisionEnter={(payload) => console.log('Collider hit')}
@@ -402,6 +410,7 @@ function PositionControl() {
 Detect overlaps without physical collision:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody>
   {/* Visible mesh */}
   <mesh>
@@ -434,6 +443,7 @@ Detect overlaps without physical collision:
 Control which objects can collide:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { interactionGroups } from '@react-three/rapier'
 
 // Group 0, interacts with groups 0, 1, 2
@@ -770,6 +780,7 @@ function SnapshotSystem() {
 From `@react-three/rapier-addons`:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Attractor } from '@react-three/rapier-addons'
 
 // Attract nearby bodies
@@ -794,6 +805,7 @@ import { Attractor } from '@react-three/rapier-addons'
 ## Debug Visualization
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Physics debug>
   {/* All colliders shown as wireframes */}
 </Physics>
@@ -815,6 +827,7 @@ import { Attractor } from '@react-three/rapier-addons'
 7. **Fixed timestep**: More stable than variable
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Performance-optimized setup
 <Physics
   timeStep={1/60}
@@ -833,3 +846,8 @@ import { Attractor } from '@react-three/rapier-addons'
 - `r3f-fundamentals` - R3F basics and hooks
 - `r3f-interaction` - User input and controls
 - `r3f-animation` - Combining physics with animation
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-postprocessing/SKILL.md
+++ b/plugins/game/skills/r3f-postprocessing/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   performance. Use when adding screen-space visual effects or selection outlines.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -78,6 +78,7 @@ function Scene() {
 ### Bloom (Glow)
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
 
@@ -159,7 +160,7 @@ import { EffectComposer, DepthOfField } from '@react-three/postprocessing'
 import { useRef } from 'react'
 
 function Scene() {
-  const targetRef = useRef()
+  const targetRef = useRef<THREE.Mesh>(null!)
 
   return (
     <>
@@ -467,6 +468,7 @@ function PostProcessing() {
 ### Using postprocessing Effect Class
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { forwardRef, useMemo } from 'react'
 import { Effect, BlendFunction } from 'postprocessing'
 import { Uniform } from 'three'
@@ -517,6 +519,7 @@ export const WaveDistortion = forwardRef(({ intensity = 1.0, blendFunction }, re
 ### Shader with wrapEffect
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { wrapEffect } from '@react-three/postprocessing'
 import { Effect, BlendFunction } from 'postprocessing'
 import { Uniform } from 'three'
@@ -593,8 +596,8 @@ import { useFrame } from '@react-three/fiber'
 import { EffectComposer, Bloom, ChromaticAberration } from '@react-three/postprocessing'
 
 function AnimatedEffects() {
-  const bloomRef = useRef()
-  const chromaticRef = useRef()
+  const bloomRef = useRef<React.ComponentRef<typeof Bloom>>(null!)
+  const chromaticRef = useRef<React.ComponentRef<typeof ChromaticAberration>>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -648,7 +651,7 @@ import { EffectComposer, GodRays } from '@react-three/postprocessing'
 import { useRef } from 'react'
 
 function Scene() {
-  const sunRef = useRef()
+  const sunRef = useRef<THREE.Mesh>(null!)
 
   return (
     <Canvas>
@@ -748,6 +751,7 @@ BlendFunction.VIVID_LIGHT    // Vivid Light
 5. **Profile with DevTools**: Monitor GPU usage
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Disable all effects
 <EffectComposer enabled={performanceMode}>
   ...
@@ -767,3 +771,8 @@ const isMobile = /iPhone|iPad|Android/i.test(navigator.userAgent)
 - `r3f-shaders` - Custom shader development
 - `r3f-materials` - Emissive materials for bloom
 - `r3f-fundamentals` - Canvas and renderer setup
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/plugins/game/skills/r3f-shaders/SKILL.md
+++ b/plugins/game/skills/r3f-shaders/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   r3f-materials.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -51,7 +51,7 @@ const ColorShiftMaterial = shaderMaterial(
 extend({ ColorShiftMaterial })
 
 function ShaderMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     materialRef.current.time = clock.elapsedTime
@@ -126,7 +126,7 @@ extend({ MyShaderMaterial })
 
 // 3. Use in component
 function MyMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     materialRef.current.time = clock.elapsedTime
@@ -153,6 +153,7 @@ function MyMesh() {
 The `key` prop on shaderMaterial enables live shader editing without page refresh:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 const MyMaterial = shaderMaterial(
   { time: 0 },
   vertexShader,
@@ -313,7 +314,7 @@ uniform vec3 positions[3];
 
 ```tsx
 function AnimatedShader() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock, mouse, viewport }) => {
     // Direct value update
@@ -379,7 +380,7 @@ import { useTexture } from '@react-three/drei'
 
 function TexturedShaderMesh() {
   const texture = useTexture('/textures/color.jpg')
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   return (
     <mesh>
@@ -444,7 +445,7 @@ const WaveMaterial = shaderMaterial(
 extend({ WaveMaterial })
 
 function WavePlane() {
-  const ref = useRef()
+  const ref = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     ref.current.time = clock.elapsedTime
@@ -604,7 +605,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function ModifiedStandardMaterial() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null!)
   const shaderRef = useRef()
 
   useEffect(() => {
@@ -691,7 +692,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function InstancedShaderMesh({ count = 1000 }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.InstancedMesh>(null!)
 
   // Create instance attributes
   const { offsets, colors } = useMemo(() => {
@@ -756,7 +757,7 @@ function InstancedShaderMesh({ count = 1000 }) {
 
 ### With Vite/Webpack
 
-```tsx
+```glsl
 // shaders/vertex.glsl
 varying vec2 vUv;
 void main() {
@@ -796,6 +797,7 @@ export default {
 ## Material Properties
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <myShaderMaterial
   // Rendering
   transparent={true}
@@ -821,7 +823,7 @@ export default {
 
 ```tsx
 function DebugShaderMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useEffect(() => {
     // Log compiled shaders
@@ -885,3 +887,8 @@ color = mix(colorB, colorA, step(0.5, value));
 - `r3f-materials` - Built-in material types
 - `r3f-postprocessing` - Full-screen shader effects
 - `r3f-assets` - Texture sampling in shaders
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-animation/SKILL.md
+++ b/skills/r3f-animation/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   live in r3f-fundamentals; drag gestures in r3f-interaction.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -31,7 +31,7 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import { useEffect, useRef } from 'react'
 
 function AnimatedModel() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, names } = useAnimations(animations, group)
 
@@ -48,7 +48,7 @@ function AnimatedModel() {
 
 ```tsx
 function Character() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, mixer } = useAnimations(animations, group)
 
@@ -88,7 +88,7 @@ import { useGLTF, useAnimations } from '@react-three/drei'
 import { useState, useEffect, useRef } from 'react'
 
 function Character() {
-  const group = useRef()
+  const group = useRef<THREE.Group>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions } = useAnimations(animations, group)
   const [currentAnim, setCurrentAnim] = useState('Idle')
@@ -115,7 +115,7 @@ function Character() {
 
 ```tsx
 function AnimatedModel() {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions, mixer } = useAnimations(animations, group)
 
@@ -146,7 +146,7 @@ function AnimatedModel() {
 
 ```tsx
 function CharacterController({ speed = 0 }) {
-  const group = useRef()
+  const group = useRef<THREE.Object3D>(null!)
   const { scene, animations } = useGLTF('/models/character.glb')
   const { actions } = useAnimations(animations, group)
 
@@ -342,7 +342,7 @@ import { useRef } from 'react'
 
 function MorphingFace() {
   const { scene, nodes } = useGLTF('/models/face.glb')
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Object3D>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.getElapsedTime()
@@ -366,7 +366,7 @@ function MorphingFace() {
 ```tsx
 function MorphControls({ morphInfluences }) {
   const { nodes } = useGLTF('/models/face.glb')
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Object3D>(null!)
 
   useFrame(() => {
     if (meshRef.current?.morphTargetInfluences) {
@@ -426,7 +426,7 @@ function SkeletalCharacter() {
 ```tsx
 function CharacterWithWeapon() {
   const { scene } = useGLTF('/models/character.glb')
-  const weaponRef = useRef()
+  const weaponRef = useRef<THREE.Mesh>(null!)
   const handBoneRef = useRef()
 
   useEffect(() => {
@@ -470,7 +470,7 @@ import { useRef } from 'react'
 import * as THREE from 'three'
 
 function SmoothFollow({ target }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const currentPos = useRef(new THREE.Vector3())
 
   useFrame((state, delta) => {
@@ -492,7 +492,7 @@ function SmoothFollow({ target }) {
 
 ```tsx
 function SpringMesh({ target = 0 }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const spring = useRef({
     position: 0,
     velocity: 0,
@@ -524,7 +524,7 @@ function SpringMesh({ target = 0 }) {
 
 ```tsx
 function OscillatingMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -589,7 +589,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function TrailingMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -627,7 +627,7 @@ const useStore = create((set) => ({
 }))
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const { isAnimating, speed } = useStore()
 
   useFrame((state, delta) => {
@@ -681,7 +681,7 @@ const useGameStore = create((set) => ({
 }))
 
 function Player() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta) => {
     // ✅ GOOD: getState() has no subscription overhead
@@ -711,7 +711,7 @@ Subscribe to state changes without triggering React re-renders:
 import { useEffect, useRef } from 'react'
 
 function Enemy() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useEffect(() => {
     // Subscribe directly - updates mesh without re-rendering component
@@ -768,7 +768,7 @@ Separate state-dependent UI from animated 3D objects:
 // ❌ BAD: Parent re-renders cause animation jank
 function BadPattern() {
   const [score, setScore] = useState(0)
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((_, delta) => {
     meshRef.current.rotation.y += delta  // Affected by score re-renders
@@ -793,7 +793,7 @@ function GoodPattern() {
 }
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((_, delta) => {
     meshRef.current.rotation.y += delta  // Smooth, uninterrupted
@@ -1143,3 +1143,8 @@ if (phase === 'land') {
 - `r3f-assets` - Loading animated GLTF models
 - `r3f-fundamentals` - useFrame and animation loop
 - `r3f-shaders` - Vertex animation in shaders
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-assets/SKILL.md
+++ b/skills/r3f-assets/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   applying textures to PBR materials use r3f-materials.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -184,8 +184,8 @@ function Model() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader'
-import { DRACOLoader } from 'three/examples/jsm/loaders/DRACOLoader'
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js'
+import { DRACOLoader } from 'three/addons/loaders/DRACOLoader.js'
 
 function Model() {
   const gltf = useLoader(GLTFLoader, '/model.glb', (loader) => {
@@ -221,8 +221,8 @@ function Model() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { OBJLoader } from 'three/examples/jsm/loaders/OBJLoader'
-import { MTLLoader } from 'three/examples/jsm/loaders/MTLLoader'
+import { OBJLoader } from 'three/addons/loaders/OBJLoader.js'
+import { MTLLoader } from 'three/addons/loaders/MTLLoader.js'
 
 function OBJModel() {
   const materials = useLoader(MTLLoader, '/model.mtl')
@@ -254,7 +254,7 @@ useFBX.preload('/model.fbx')
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { STLLoader } from 'three/examples/jsm/loaders/STLLoader'
+import { STLLoader } from 'three/addons/loaders/STLLoader.js'
 
 function STLModel() {
   const geometry = useLoader(STLLoader, '/model.stl')
@@ -271,7 +271,7 @@ function STLModel() {
 
 ```tsx
 import { useLoader } from '@react-three/fiber'
-import { PLYLoader } from 'three/examples/jsm/loaders/PLYLoader'
+import { PLYLoader } from 'three/addons/loaders/PLYLoader.js'
 
 function PLYModel() {
   const geometry = useLoader(PLYLoader, '/model.ply')
@@ -801,7 +801,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function CanvasTexture() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const textureRef = useRef()
 
   useEffect(() => {
@@ -884,8 +884,8 @@ import { useRef } from 'react'
 
 function RenderToTexture() {
   const fbo = useFBO(512, 512)
-  const meshRef = useRef()
-  const otherSceneRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
+  const otherSceneRef = useRef<THREE.Group>(null!)
 
   useFrame(({ gl, camera }) => {
     // Render other scene to FBO
@@ -952,6 +952,7 @@ function SpriteAnimation() {
 ### Material Texture Maps Reference
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <meshStandardMaterial
   // Base color (sRGB)
   map={colorTexture}
@@ -1002,7 +1003,7 @@ function SpriteAnimation() {
 import { useEffect, useRef } from 'react'
 
 function MeshWithUV2() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useEffect(() => {
     // Copy uv to uv2 for aoMap/lightMap
@@ -1083,3 +1084,8 @@ texture.dispose()
 - `r3f-lighting` - Environment lighting and IBL setup
 - `r3f-materials` - Applying PBR texture sets to materials
 - `r3f-fundamentals` - Suspense and Canvas basics
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-fundamentals/SKILL.md
+++ b/skills/r3f-fundamentals/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   useFrame use r3f-animation.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -24,7 +24,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function RotatingBox() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta) => {
     meshRef.current.rotation.x += delta
@@ -125,7 +125,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame((state, delta, xrFrame) => {
     // state: Full R3F state (see useThree)
@@ -267,6 +267,7 @@ All Three.js objects are available as JSX elements (camelCase).
 ### Meshes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Basic mesh structure
 <mesh
   position={[0, 0, 0]}       // x, y, z
@@ -281,7 +282,7 @@ All Three.js objects are available as JSX elements (camelCase).
 </mesh>
 
 // With ref
-const meshRef = useRef()
+const meshRef = useRef<THREE.Mesh>(null!)
 <mesh ref={meshRef} />
 // meshRef.current is the THREE.Mesh
 ```
@@ -291,6 +292,7 @@ const meshRef = useRef()
 Constructor arguments via `args` prop:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
 <boxGeometry args={[1, 1, 1, 1, 1, 1]} />
 
@@ -307,6 +309,7 @@ Constructor arguments via `args` prop:
 ### Groups
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <group position={[5, 0, 0]} rotation={[0, Math.PI / 4, 0]}>
   <mesh position={[-1, 0, 0]}>
     <boxGeometry />
@@ -324,6 +327,7 @@ Constructor arguments via `args` prop:
 Use dashes for nested properties:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh
   position-x={5}
   rotation-y={Math.PI}
@@ -352,6 +356,7 @@ Use dashes for nested properties:
 Control how children attach to parents:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh>
   <boxGeometry />
   {/* Default: attaches as 'material' */}
@@ -439,6 +444,7 @@ function InteractiveBox() {
 Events bubble up through the scene graph:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <group onClick={(e) => console.log('Group clicked')}>
   <mesh onClick={(e) => {
     e.stopPropagation()  // Stop bubbling to group
@@ -478,7 +484,7 @@ Register custom Three.js classes for JSX use:
 
 ```tsx
 import { extend } from '@react-three/fiber'
-import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls'
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js'
 
 // Extend once (usually at module level)
 extend({ OrbitControls })
@@ -538,11 +544,12 @@ function MeshWithRef() {
 ### Avoiding Re-renders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BAD: Creates new object every render
 <mesh position={[x, y, z]} />
 
 // GOOD: Mutate existing position
-const meshRef = useRef()
+const meshRef = useRef<THREE.Mesh>(null!)
 useFrame(() => {
   meshRef.current.position.x = x
 })
@@ -567,7 +574,7 @@ function Scene() {
 }
 
 function AnimatedObject() {
-  const ref = useRef()
+  const ref = useRef<THREE.Mesh>(null!)
   useFrame((_, delta) => {
     ref.current.rotation.y += delta
   })
@@ -580,6 +587,7 @@ function AnimatedObject() {
 R3F auto-disposes geometries, materials, and textures. Override with:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh dispose={null}>  {/* Prevent auto-dispose */}
   <boxGeometry />
   <meshStandardMaterial />
@@ -590,8 +598,8 @@ R3F auto-disposes geometries, materials, and textures. Override with:
 
 ### Fullscreen Canvas
 
-```tsx
-// styles.css
+```css
+/* styles.css */
 html, body, #root {
   margin: 0;
   padding: 0;
@@ -621,6 +629,7 @@ function ResponsiveScene() {
 ### Forwarding Refs
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { forwardRef } from 'react'
 
 const CustomMesh = forwardRef((props, ref) => {
@@ -703,7 +712,7 @@ function DebugScene() {
 import { useControls, button } from 'leva'
 
 function DebugActions() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useControls({
     'Reset Position': button(() => {
@@ -766,7 +775,7 @@ function PerformanceMonitor() {
 
 ```tsx
 function AnimatedDebugMesh() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   const { speed, amplitude, enabled } = useControls('Animation', {
     enabled: true,
@@ -794,3 +803,8 @@ function AnimatedDebugMesh() {
 - `r3f-materials` - Material configuration
 - `r3f-lighting` - Lights and shadows
 - `r3f-interaction` - Controls and user input
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-geometry/SKILL.md
+++ b/skills/r3f-geometry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   meshes.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -40,6 +40,7 @@ All Three.js geometries are available as JSX elements. The `args` prop passes co
 ### Basic Shapes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // BoxGeometry(width, height, depth, widthSegments, heightSegments, depthSegments)
 <boxGeometry args={[1, 1, 1]} />
 <boxGeometry args={[2, 1, 0.5, 2, 2, 2]} />
@@ -78,6 +79,7 @@ All Three.js geometries are available as JSX elements. The `args` prop passes co
 ### Advanced Shapes
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // CapsuleGeometry(radius, length, capSegments, radialSegments)
 <capsuleGeometry args={[0.5, 1, 4, 16]} />
 
@@ -299,7 +301,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function WavyPlane() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
 
   useFrame(({ clock }) => {
     const positions = meshRef.current.geometry.attributes.position
@@ -351,7 +353,7 @@ function InstancedBoxes() {
 }
 
 function AnimatedInstance({ index }) {
-  const ref = useRef()
+  const ref = useRef<THREE.Object3D>(null!)
 
   // Random initial position
   const position = useMemo(() => [
@@ -459,7 +461,7 @@ import * as THREE from 'three'
 
 function BufferParticles() {
   const count = 10000
-  const pointsRef = useRef()
+  const pointsRef = useRef<THREE.Points>(null!)
 
   const { positions, colors } = useMemo(() => {
     const positions = new Float32Array(count * 3)
@@ -571,6 +573,7 @@ function CurvedLines() {
 ### Dashed Line
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Line
   points={[[0, 0, 0], [5, 0, 0]]}
   color="white"
@@ -647,6 +650,7 @@ function Text3DExample() {
 ### Center Geometry
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Center } from '@react-three/drei'
 
 function CenteredModel() {
@@ -712,6 +716,7 @@ function SelectToZoom() {
 5. **Dispose unused geometry**: R3F handles this automatically
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Good segment counts
 <sphereGeometry args={[1, 32, 32]} />   // Standard quality
 <sphereGeometry args={[1, 64, 64]} />   // High quality
@@ -730,3 +735,8 @@ const sharedGeometry = useMemo(() => new THREE.BoxGeometry(), [])
 - `r3f-fundamentals` - JSX elements and refs
 - `r3f-materials` - Materials for meshes
 - `r3f-shaders` - Custom vertex manipulation
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-interaction/SKILL.md
+++ b/skills/r3f-interaction/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   input and object manipulation. Selection outline rendering lives in r3f-postprocessing.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -53,6 +53,7 @@ R3F provides built-in pointer events on mesh elements.
 ### Available Events
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh
   // Click events
   onClick={(e) => {}}           // Click (pointerdown + pointerup on same object)
@@ -145,6 +146,7 @@ function HoverableMesh() {
 ### Selective Raycasting
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Disable raycasting for specific objects
 <mesh raycast={() => null}>
   <boxGeometry />
@@ -205,7 +207,7 @@ import { OrbitControls } from '@react-three/drei'
 import { useRef, useEffect } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   useEffect(() => {
     // Access controls methods
@@ -272,7 +274,7 @@ import { PointerLockControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof PointerLockControls>>(null!)
 
   return (
     <>
@@ -297,7 +299,7 @@ import { CameraControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const controlsRef = useRef()
+  const controlsRef = useRef<React.ComponentRef<typeof CameraControls>>(null!)
 
   const focusOnObject = async () => {
     // Smooth transition to target
@@ -358,9 +360,9 @@ import { TransformControls, OrbitControls } from '@react-three/drei'
 import { useRef, useState } from 'react'
 
 function Scene() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [mode, setMode] = useState('translate')
-  const orbitRef = useRef()
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   return (
     <>
@@ -465,8 +467,8 @@ import { DragControls, OrbitControls } from '@react-three/drei'
 import { useRef } from 'react'
 
 function Scene() {
-  const meshRef = useRef()
-  const orbitRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
+  const orbitRef = useRef<React.ComponentRef<typeof OrbitControls>>(null!)
 
   return (
     <>
@@ -510,7 +512,7 @@ const keyMap = [
 ]
 
 function Player() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const [, getKeys] = useKeyboardControls()
 
   useFrame((state, delta) => {
@@ -640,7 +642,7 @@ import * as THREE from 'three'
 
 function ClickToPlace() {
   const { camera, raycaster, pointer } = useThree()
-  const planeRef = useRef()
+  const planeRef = useRef<THREE.Mesh>(null!)
 
   const handleClick = (event) => {
     // Create intersection plane
@@ -742,7 +744,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedOnScroll() {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.Mesh>(null!)
   const scroll = useScroll()
 
   useFrame(() => {
@@ -861,3 +863,8 @@ function ThrottledHover() {
 - `r3f-fundamentals` - Canvas and scene setup
 - `r3f-animation` - Animating interactions
 - `r3f-postprocessing` - Visual feedback effects (outline, selection)
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-lighting/SKILL.md
+++ b/skills/r3f-lighting/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   environment-lighting task. Loading HDR/texture files is covered in r3f-assets.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -67,6 +67,7 @@ function Scene() {
 Illuminates all objects equally. No direction, no shadows.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <ambientLight
   color="#ffffff"  // or color={new THREE.Color('#ffffff')}
   intensity={0.5}
@@ -78,6 +79,7 @@ Illuminates all objects equally. No direction, no shadows.
 Gradient from sky to ground. Good for outdoor scenes.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <hemisphereLight
   color="#87ceeb"        // Sky color
   groundColor="#8b4513"  // Ground color
@@ -91,6 +93,7 @@ Gradient from sky to ground. Good for outdoor scenes.
 Parallel light rays. Simulates distant light (sun).
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <directionalLight
   color="#ffffff"
   intensity={1}
@@ -111,7 +114,7 @@ Parallel light rays. Simulates distant light (sun).
 
 // With target (light points at target)
 function DirectionalWithTarget() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.DirectionalLight>(null!)
 
   return (
     <>
@@ -130,6 +133,7 @@ function DirectionalWithTarget() {
 Emits light in all directions. Like a light bulb.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <pointLight
   color="#ffffff"
   intensity={1}
@@ -151,6 +155,7 @@ Emits light in all directions. Like a light bulb.
 Cone-shaped light. Like a flashlight.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <spotLight
   color="#ffffff"
   intensity={1}
@@ -177,7 +182,7 @@ import { useHelper } from '@react-three/drei'
 import { SpotLightHelper } from 'three'
 
 function SpotLightWithHelper() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.SpotLight>(null!)
   useHelper(lightRef, SpotLightHelper, 'cyan')
 
   return <spotLight ref={lightRef} position={[0, 5, 0]} />
@@ -189,10 +194,10 @@ function SpotLightWithHelper() {
 Rectangular area light. Great for soft, realistic lighting.
 
 ```tsx
-import { RectAreaLightHelper } from 'three/examples/jsm/helpers/RectAreaLightHelper'
+import { RectAreaLightHelper } from 'three/addons/helpers/RectAreaLightHelper.js'
 
 function AreaLight() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.RectAreaLight>(null!)
 
   return (
     <>
@@ -218,6 +223,7 @@ function AreaLight() {
 ### Enable Shadows on Canvas
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Canvas
   shadows  // or shadows="soft" | "basic" | "percentage" | "variance"
 >
@@ -226,6 +232,7 @@ function AreaLight() {
 ### Shadow Types
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Basic shadows (fastest, hard edges)
 <Canvas shadows="basic">
 
@@ -242,6 +249,7 @@ function AreaLight() {
 ### Configure Shadow-Casting Objects
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Light must cast shadows
 <directionalLight castShadow />
 
@@ -265,7 +273,7 @@ import { useHelper } from '@react-three/drei'
 import { CameraHelper } from 'three'
 
 function LightWithShadowHelper() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.DirectionalLight>(null!)
 
   // Visualize shadow camera frustum
   useHelper(lightRef.current?.shadow.camera, CameraHelper)
@@ -290,6 +298,7 @@ function LightWithShadowHelper() {
 HDR environment lighting with presets or custom files.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Environment } from '@react-three/drei'
 
 // Preset environments
@@ -408,6 +417,7 @@ import { Stage } from '@react-three/drei'
 Fast fake shadows without shadow mapping.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { ContactShadows } from '@react-three/drei'
 
 <ContactShadows
@@ -598,7 +608,7 @@ import { useFrame } from '@react-three/fiber'
 import { useRef } from 'react'
 
 function AnimatedLight() {
-  const lightRef = useRef()
+  const lightRef = useRef<THREE.PointLight>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -632,10 +642,10 @@ import {
 } from 'three'
 
 function LightWithHelpers() {
-  const dirLightRef = useRef()
-  const pointLightRef = useRef()
-  const spotLightRef = useRef()
-  const hemiLightRef = useRef()
+  const dirLightRef = useRef<THREE.DirectionalLight>(null!)
+  const pointLightRef = useRef<THREE.PointLight>(null!)
+  const spotLightRef = useRef<THREE.SpotLight>(null!)
+  const hemiLightRef = useRef<THREE.HemisphereLight>(null!)
 
   useHelper(dirLightRef, DirectionalLightHelper, 5, 'red')
   useHelper(pointLightRef, PointLightHelper, 1, 'green')
@@ -663,6 +673,7 @@ function LightWithHelpers() {
 6. **Use Environment**: More efficient than many lights
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Selective shadows
 <mesh castShadow={isHero}>
   <boxGeometry />
@@ -682,3 +693,8 @@ function LightWithHelpers() {
 - `r3f-materials` - Material light response
 - `r3f-assets` - Environment maps
 - `r3f-postprocessing` - Bloom and light effects
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-materials/SKILL.md
+++ b/skills/r3f-materials/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   materials live in r3f-shaders; texture loading in r3f-assets.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -58,6 +58,7 @@ function Scene() {
 No lighting calculations. Always visible, fast.
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <mesh>
   <boxGeometry />
   <meshBasicMaterial
@@ -334,6 +335,7 @@ function ShadowOnlyMesh() {
 ## Points and Lines Materials
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Points material
 <points>
   <bufferGeometry />
@@ -370,6 +372,7 @@ function ShadowOnlyMesh() {
 All materials share these base properties:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <meshStandardMaterial
   // Visibility
   visible={true}
@@ -407,7 +410,7 @@ import { useRef } from 'react'
 import { useFrame } from '@react-three/fiber'
 
 function AnimatedMaterial() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -459,6 +462,7 @@ function SharedMaterial() {
 ## Multiple Materials
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Different materials per face (BoxGeometry has 6 material groups)
 <mesh>
   <boxGeometry />
@@ -503,6 +507,7 @@ function TexturedMaterial() {
 ## Emissive Materials (Glow)
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // For bloom effect, emissive colors should exceed normal range
 <meshStandardMaterial
   color="black"
@@ -554,3 +559,8 @@ function getCachedMaterial(color) {
 - `r3f-assets` - Texture loading and configuration
 - `r3f-shaders` - Custom shader development
 - `r3f-lighting` - Light interaction with materials
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-physics/SKILL.md
+++ b/skills/r3f-physics/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   simulation, collision detection or character controllers.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -82,6 +82,7 @@ import { Physics } from '@react-three/rapier'
 For performance optimization with static scenes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Canvas frameloop="demand">
   <Physics updateLoop="independent">
     {/* Physics only triggers render when bodies are active */}
@@ -96,6 +97,7 @@ Makes objects participate in physics simulation.
 ### Basic Usage
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { RigidBody } from '@react-three/rapier'
 
 // Dynamic body (affected by forces/gravity)
@@ -135,6 +137,7 @@ import { RigidBody } from '@react-three/rapier'
 ### RigidBody Properties
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody
   // Transform
   position={[0, 5, 0]}
@@ -175,6 +178,7 @@ import { RigidBody } from '@react-three/rapier'
 RigidBody auto-generates colliders from child meshes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Global default
 <Physics colliders="hull">
   <RigidBody>
@@ -206,6 +210,7 @@ RigidBody auto-generates colliders from child meshes:
 ### Manual Colliders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import {
   CuboidCollider,
   BallCollider,
@@ -245,6 +250,7 @@ import {
 For complex shapes:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { MeshCollider } from '@react-three/rapier'
 
 <RigidBody colliders={false}>
@@ -365,6 +371,7 @@ function PositionControl() {
 ### On RigidBody
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody
   name="player"
   onCollisionEnter={({ manifold, target, other }) => {
@@ -390,6 +397,7 @@ function PositionControl() {
 ### On Colliders
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <CuboidCollider
   args={[1, 1, 1]}
   onCollisionEnter={(payload) => console.log('Collider hit')}
@@ -402,6 +410,7 @@ function PositionControl() {
 Detect overlaps without physical collision:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <RigidBody>
   {/* Visible mesh */}
   <mesh>
@@ -434,6 +443,7 @@ Detect overlaps without physical collision:
 Control which objects can collide:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { interactionGroups } from '@react-three/rapier'
 
 // Group 0, interacts with groups 0, 1, 2
@@ -770,6 +780,7 @@ function SnapshotSystem() {
 From `@react-three/rapier-addons`:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { Attractor } from '@react-three/rapier-addons'
 
 // Attract nearby bodies
@@ -794,6 +805,7 @@ import { Attractor } from '@react-three/rapier-addons'
 ## Debug Visualization
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <Physics debug>
   {/* All colliders shown as wireframes */}
 </Physics>
@@ -815,6 +827,7 @@ import { Attractor } from '@react-three/rapier-addons'
 7. **Fixed timestep**: More stable than variable
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Performance-optimized setup
 <Physics
   timeStep={1/60}
@@ -833,3 +846,8 @@ import { Attractor } from '@react-three/rapier-addons'
 - `r3f-fundamentals` - R3F basics and hooks
 - `r3f-interaction` - User input and controls
 - `r3f-animation` - Combining physics with animation
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-postprocessing/SKILL.md
+++ b/skills/r3f-postprocessing/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   performance. Use when adding screen-space visual effects or selection outlines.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -78,6 +78,7 @@ function Scene() {
 ### Bloom (Glow)
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { EffectComposer, Bloom } from '@react-three/postprocessing'
 import { BlendFunction } from 'postprocessing'
 
@@ -159,7 +160,7 @@ import { EffectComposer, DepthOfField } from '@react-three/postprocessing'
 import { useRef } from 'react'
 
 function Scene() {
-  const targetRef = useRef()
+  const targetRef = useRef<THREE.Mesh>(null!)
 
   return (
     <>
@@ -467,6 +468,7 @@ function PostProcessing() {
 ### Using postprocessing Effect Class
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { forwardRef, useMemo } from 'react'
 import { Effect, BlendFunction } from 'postprocessing'
 import { Uniform } from 'three'
@@ -517,6 +519,7 @@ export const WaveDistortion = forwardRef(({ intensity = 1.0, blendFunction }, re
 ### Shader with wrapEffect
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 import { wrapEffect } from '@react-three/postprocessing'
 import { Effect, BlendFunction } from 'postprocessing'
 import { Uniform } from 'three'
@@ -593,8 +596,8 @@ import { useFrame } from '@react-three/fiber'
 import { EffectComposer, Bloom, ChromaticAberration } from '@react-three/postprocessing'
 
 function AnimatedEffects() {
-  const bloomRef = useRef()
-  const chromaticRef = useRef()
+  const bloomRef = useRef<React.ComponentRef<typeof Bloom>>(null!)
+  const chromaticRef = useRef<React.ComponentRef<typeof ChromaticAberration>>(null!)
 
   useFrame(({ clock }) => {
     const t = clock.elapsedTime
@@ -648,7 +651,7 @@ import { EffectComposer, GodRays } from '@react-three/postprocessing'
 import { useRef } from 'react'
 
 function Scene() {
-  const sunRef = useRef()
+  const sunRef = useRef<THREE.Mesh>(null!)
 
   return (
     <Canvas>
@@ -748,6 +751,7 @@ BlendFunction.VIVID_LIGHT    // Vivid Light
 5. **Profile with DevTools**: Monitor GPU usage
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 // Disable all effects
 <EffectComposer enabled={performanceMode}>
   ...
@@ -767,3 +771,8 @@ const isMobile = /iPhone|iPad|Android/i.test(navigator.userAgent)
 - `r3f-shaders` - Custom shader development
 - `r3f-materials` - Emissive materials for bloom
 - `r3f-fundamentals` - Canvas and renderer setup
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.

--- a/skills/r3f-shaders/SKILL.md
+++ b/skills/r3f-shaders/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   r3f-materials.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.2.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -51,7 +51,7 @@ const ColorShiftMaterial = shaderMaterial(
 extend({ ColorShiftMaterial })
 
 function ShaderMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     materialRef.current.time = clock.elapsedTime
@@ -126,7 +126,7 @@ extend({ MyShaderMaterial })
 
 // 3. Use in component
 function MyMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     materialRef.current.time = clock.elapsedTime
@@ -153,6 +153,7 @@ function MyMesh() {
 The `key` prop on shaderMaterial enables live shader editing without page refresh:
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 const MyMaterial = shaderMaterial(
   { time: 0 },
   vertexShader,
@@ -313,7 +314,7 @@ uniform vec3 positions[3];
 
 ```tsx
 function AnimatedShader() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock, mouse, viewport }) => {
     // Direct value update
@@ -379,7 +380,7 @@ import { useTexture } from '@react-three/drei'
 
 function TexturedShaderMesh() {
   const texture = useTexture('/textures/color.jpg')
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   return (
     <mesh>
@@ -444,7 +445,7 @@ const WaveMaterial = shaderMaterial(
 extend({ WaveMaterial })
 
 function WavePlane() {
-  const ref = useRef()
+  const ref = useRef<THREE.ShaderMaterial>(null!)
 
   useFrame(({ clock }) => {
     ref.current.time = clock.elapsedTime
@@ -604,7 +605,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function ModifiedStandardMaterial() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.MeshStandardMaterial>(null!)
   const shaderRef = useRef()
 
   useEffect(() => {
@@ -691,7 +692,7 @@ import { useFrame } from '@react-three/fiber'
 import * as THREE from 'three'
 
 function InstancedShaderMesh({ count = 1000 }) {
-  const meshRef = useRef()
+  const meshRef = useRef<THREE.InstancedMesh>(null!)
 
   // Create instance attributes
   const { offsets, colors } = useMemo(() => {
@@ -756,7 +757,7 @@ function InstancedShaderMesh({ count = 1000 }) {
 
 ### With Vite/Webpack
 
-```tsx
+```glsl
 // shaders/vertex.glsl
 varying vec2 vUv;
 void main() {
@@ -796,6 +797,7 @@ export default {
 ## Material Properties
 
 ```tsx
+// excerpt — not a complete module; see the surrounding section for context
 <myShaderMaterial
   // Rendering
   transparent={true}
@@ -821,7 +823,7 @@ export default {
 
 ```tsx
 function DebugShaderMesh() {
-  const materialRef = useRef()
+  const materialRef = useRef<THREE.ShaderMaterial>(null!)
 
   useEffect(() => {
     // Log compiled shaders
@@ -885,3 +887,8 @@ color = mix(colorB, colorA, step(0.5, value));
 - `r3f-materials` - Built-in material types
 - `r3f-postprocessing` - Full-screen shader effects
 - `r3f-assets` - Texture sampling in shaders
+
+> **Verified against**: `three@0.185` · `@react-three/fiber@9.7` · `@react-three/drei@10.7` ·
+> `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
+> blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
+> `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.


### PR DESCRIPTION
## Why

The ten `r3f-*` skills are **8,352 lines, 75% fenced code** — 267 blocks tagged `tsx`. **Not one line in 8,352 pins a version** of `three`, `@react-three/fiber`, `@react-three/drei` or `react`, in a stack that is mid-migration: R3F v10 (alpha) renames `state.gl` → `state.renderer` and moves off `THREE.Clock`; drei 11 (alpha) targets WebGPU.

Code either compiles or it does not, so this family is fully mechanically checkable. It had never been checked.

## Method

Every fenced `tsx`/`ts` block extracted into its own module, real dependencies installed, `tsc` run over all of them:

`three@0.185.1` · `@react-three/fiber@9.7.0` · `@react-three/drei@10.7.8` · `react@19.2.8` · `jsx: react-jsx`

Errors classified; only classes a real project would also hit are counted as defects.

## What was broken

**66 of 267 blocks tagged `tsx` (24.7%) were not valid TSX as written.**

| defect | count | what it was |
|---|---|---|
| does not parse | 33 | bare JSX excerpts, plus one **CSS** and one **GLSL** block tagged `tsx` |
| unresolved import | 7 | `three/examples/jsm/loaders/GLTFLoader` and siblings — extensionless, no longer resolves |
| does not typecheck | 26 | `useRef()` with no type parameter → every `ref.current.position` errors on `unknown` |

The typing was also internally inconsistent: **70 bare `useRef()` against 27 already-typed `useRef<THREE.Mesh>(null)`** — the same family teaching both.

Verified directly against the installed package:

```
three/examples/jsm/loaders/GLTFLoader        NO
three/examples/jsm/loaders/GLTFLoader.js     resolves
three/addons/loaders/GLTFLoader.js           resolves
```

## What changed

- **Verified-against block** in all ten skills: the exact stack, what the `tsx` tag means, what `// excerpt` means, and the R3F v10 rename that is coming.
- **8 imports** rewritten to `three/addons/<path>.js`.
- **63 `useRef()` calls typed**, inferred from the element the ref is attached to — `<mesh>` → `THREE.Mesh`, drei components → `React.ComponentRef<typeof X>` (survives a drei bump, unlike a concrete internal class), custom materials → `THREE.ShaderMaterial`.
- **52 fragments marked** `// excerpt — not a complete module`. The compiler picked them: any block that failed to parse. A first-pass heuristic missed 13 that open with an `import` and only then drop into bare JSX — rather than refine the guess, the compiler output selected them directly.
- **2 blocks retagged** to the language they actually are.

**No teaching content changed.** The diff is imports, ref type parameters, fence tags, excerpt markers and the pin block.

## Recompiled after the fix

| | before | after |
|---|---|---|
| blocks that do not parse | 33 | **1** |
| unresolved imports | 7 | **0** |
| untyped-ref failures | 26 | **5** |

The residual 5 omit their own imports or use an untyped zustand store; the residual 1 is a fragment. Editing them blind would risk changing what they teach, so they are reported rather than guessed at. Two unresolved imports still reported by the probe (`lodash/throttle`, `react-error-boundary`) are third-party packages the probe did not install — not defects.

Separately verified **no regression introduced**: every block now using `THREE.` without importing it already did so before this change (10/10 pre-existing).

## Rite

`openspec/changes/harden-r3f-skills/` with the mandatory gate groups · spec delta adding two requirements to `skills-authoring` — **Code blocks compile or are marked** and **Versioned external APIs are pinned** · `./generate.sh` run, wrappers in sync · README Game section updated · `scripts/validate-rite.sh` green · CI frontmatter check green locally.

`V.7` (`openspec archive`) intentionally left open — closure step after review.

## Out of scope, deliberately

The **size** problem. These skills remain 556–1,145 lines with **no `references/` directory anywhere in the family**. Splitting them is a separate proposal — this change alters no structure, so the compile numbers stay attributable to it alone.
