### PR TITLE
✅ ci(skills): enforce the authoring rules with a self-tested validator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,15 @@ jobs:
           done
           exit $fail
 
+      - name: Skill content checks (paths, cross-refs, code blocks, pins)
+        run: |
+          python3 -m pip install --quiet pyyaml
+          sudo apt-get install -y -qq lua5.4 >/dev/null 2>&1 || true
+          python3 scripts/validate-skills.py
+
+      - name: Skill validator self-test (the gate is itself gated)
+        run: python3 scripts/selftest-validate-skills.py
+
       - name: OpenSpec rite gate (skills-rite schema)
         run: bash scripts/validate-rite.sh
 

--- a/README.md
+++ b/README.md
@@ -596,6 +596,22 @@ it requires the three gate headings in every active change (closure group last) 
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Run it locally before pushing — CI is the
 backstop, not the first line.
 
+A second gate checks the **content** of the skills themselves.
+[`scripts/validate-skills.py`](scripts/validate-skills.py) runs six checks over every
+`skills/*/SKILL.md` and its references — referenced paths exist, cross-skill references name a real
+skill, code blocks parse (bash/yaml/json/lua/python), the description states no policy the body
+contradicts, versioned external APIs are pinned, and fence tags match their content. It reports any
+check skipped for want of a tool rather than counting it as a pass.
+
+Because a checker that never fails is not a checker,
+[`scripts/selftest-validate-skills.py`](scripts/selftest-validate-skills.py) injects one known defect
+per check into a throwaway copy of the catalog and asserts each one is detected. Both run in CI.
+
+```bash
+python3 scripts/validate-skills.py           # 0 findings expected
+python3 scripts/selftest-validate-skills.py  # 10/10 defect classes detected
+```
+
 ### Per-machine setup
 
 ```bash

--- a/claude/skills/helm-migration/SKILL.md
+++ b/claude/skills/helm-migration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: helm-migration
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates both files when applicable.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
 metadata:
   author: solvelab
   version: 2.1.0

--- a/cursor/rules/assettoserver-csp-lua.mdc
+++ b/cursor/rules/assettoserver-csp-lua.mdc
@@ -102,7 +102,7 @@ Copy-paste helpers for all of these: `references/snippets.lua`.
 
 - The Lua layout (`ac.StructItem.key(...)` + named/sized fields) must match the C# `OnlineEvent<T>`
   **byte-for-byte** — enforce it with a static parity gate over the published DLL (see
-  `bug-hunter` → `references/track-dotnet-plugin.md`), not by review.
+  `bug-hunter` → `bug-hunter/references/track-dotnet-plugin.md`), not by review.
 - **Never name a field `key`.** It collides with the `ac.StructItem.key` mechanism and the packet
   is silently never delivered — while every static gate passes, because the layouts do match.
 - Two scripts that register the **exact same layout both receive the event**. Reuse an existing
@@ -179,6 +179,6 @@ Copy-paste helpers for all of these: `references/snippets.lua`.
   decimals), packet classes and handlers, chat commands, the publish rite.
 - `assettoserver-ops` — operating the server that hosts these scripts; static assets under
   `wwwroot/` are baked into the image (rebuild + recreate, not restart).
-- `bug-hunter` — `references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
+- `bug-hunter` — `bug-hunter/references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
   Lua↔C# packet parity.
 - `conventional-commit` — commit format used by these repos.

--- a/cursor/rules/assettoserver-plugin.mdc
+++ b/cursor/rules/assettoserver-plugin.mdc
@@ -249,7 +249,7 @@ commit) next to the DLL — the deploy side refuses to sync a DLL without a rite
   doctrine, DirectWrite traps, packet layout mirroring, remote assets/audio by URL.
 - `assettoserver-ops` — operating the server that loads this plugin; the deploy/sync gate that
   consumes `plugin-rite-status.json`.
-- `bug-hunter` — the adversarial rite; `references/track-dotnet-plugin.md` is the generalized
+- `bug-hunter` — the adversarial rite; `bug-hunter/references/track-dotnet-plugin.md` is the generalized
   version of the Mono.Cecil published-artifact inspection.
 - `backend-resilience` — the fallback doctrine the backend-call section adapts to this runtime.
 - `conventional-commit` — commit format used by this repo.

--- a/cursor/rules/fivem-lua.mdc
+++ b/cursor/rules/fivem-lua.mdc
@@ -124,7 +124,7 @@ local function stopLoop() active = false end
 ## See also
 
 - `fivem-fallback` — resilience when calling an external backend from Lua.
-- `bug-hunter` — adversarial testing; its `references/track-fivem-lua.md` exercises the trust-boundary
+- `bug-hunter` — adversarial testing; its `bug-hunter/references/track-fivem-lua.md` exercises the trust-boundary
   and lifecycle rules defined here.
 - `backend-resilience` — the stack-agnostic doctrine behind `fivem-fallback`.
 - `fivem-nui-react` — the React/CEF side of NUI (bridge hooks, uiReady handshake, rendering quirks).

--- a/cursor/rules/helm-migration.mdc
+++ b/cursor/rules/helm-migration.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates both files when applicable.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
 alwaysApply: false
 ---
 
@@ -8,6 +8,12 @@ alwaysApply: false
 # Helm Migration Skill
 
 You are a Helm chart expert. When asked to migrate a Kubernetes YAML file to Helm, follow the workflow and conventions below. These are derived from real solvelab production charts and are specific to that chart template.
+
+> **The chart template is the source of truth, not this skill.** The field names below were taken from
+> the solvelab chart template as it stood when this skill was last revised (see `metadata.version`).
+> The template evolves independently, so **read the local copy first** (step 1 of the workflow) and let
+> it win on any disagreement. A field named here but absent from the local `values.yaml` means the
+> template moved — update this skill rather than emitting a field the chart will ignore.
 
 ---
 

--- a/cursor/rules/log-event-collector.mdc
+++ b/cursor/rules/log-event-collector.mdc
@@ -109,6 +109,7 @@ connected" line has the slot and car. Keep a `ParserContext` with maps
 (`attempts_by_steam_id`, `players_by_slot`) that early lines populate and later lines consume:
 
 ```python
+# excerpt — not a complete module; shown inside the parser loop
 if match := patterns.CONNECTED_RE.match(message):
     data = match.groupdict()
     attempt = self.context.attempts_by_steam_id.get(data["steam_id"], {})

--- a/cursor/rules/openspec-drivezone.mdc
+++ b/cursor/rules/openspec-drivezone.mdc
@@ -59,7 +59,7 @@ Dependencies to cover per track:
 **2. `tasks.md` → group `## 3. Tests & Bug-Hunter (MANDATORY)`**
 
 Adversarial QA, not happy-path. → Methodology and per-stack scenarios: **[bug-hunter]**
-(`references/track-fivem-lua.md` for the resource, `references/track-python-pytest.md` for the
+(`bug-hunter/references/track-fivem-lua.md` for the resource, `bug-hunter/references/track-python-pytest.md` for the
 backend — pytest E2E runs **before** any in-game validation). For API-surface depth: **[api-resilience-testing]**.
 Trust-boundary rules exercised by the Lua track: **[fivem-lua]**.
 

--- a/cursor/rules/python-rest-api.mdc
+++ b/cursor/rules/python-rest-api.mdc
@@ -259,7 +259,7 @@ Ruff: `target-version` matching the runtime, `line-length = 100`, `select = ["E"
 ## See also
 
 - `api-resilience-testing` — the negative/fuzz/contract methodology this baseline is tested against.
-- `bug-hunter` — per-change adversarial rite (`references/track-python-pytest.md` assumes this stack).
+- `bug-hunter` — per-change adversarial rite (`bug-hunter/references/track-python-pytest.md` assumes this stack).
 - `backend-resilience` — fallback/negative-cache doctrine for calls this service makes to others.
 - `conventional-commit` — commit format used by these services' semantic-release pipelines.
 - `react-api-client` — the frontend counterpart consuming this envelope/code registry.

--- a/openspec/changes/enforce-authoring-checks/.openspec.yaml
+++ b/openspec/changes/enforce-authoring-checks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/enforce-authoring-checks/design.md
+++ b/openspec/changes/enforce-authoring-checks/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`skills-authoring` grew four requirements across three audits, each earned by a measured defect. All
+four were convention: a reviewer could apply them, CI could not. The spec itself already forbids that
+posture — *"Advisory mechanisms are not sold as hard gates"* — so the gap was self-evident once the
+requirements existed.
+
+Roughly half of each requirement is mechanically checkable (does this path exist, does this block
+parse, does this description contradict the body) and half is not (is the simulation meaningful, is
+the rule right). This change automates the first half and leaves the second to review, saying so
+explicitly rather than implying full coverage.
+
+## Goals / Non-Goals
+
+**Goals**
+- Every mechanically checkable authoring rule fails a PR when violated.
+- The validator's own correctness is demonstrated, not asserted.
+- The catalog is at zero findings when the gate lands.
+
+**Non-Goals**
+- No judgement calls automated. C4 and C5 are heuristics; they flag a *shape* for a human to confirm,
+  and both were deliberately narrowed after producing false positives on correct skills.
+- No new doctrine in any skill. Content changes here are corrections the validator found, nothing else.
+- No attempt to check prose quality, teaching value or triggering accuracy.
+
+## Decisions
+
+**D1 — Fix the instrument before trusting it.** The first run produced 31 findings; 22 were the
+validator's bugs. Reporting those as catalog defects would have produced 22 pointless edits and
+damaged trust in every future run. Each false positive was traced to a specific parsing assumption and
+fixed in the validator, not worked around in the skills.
+
+**D2 — The gate is itself gated.** `selftest-validate-skills.py` copies the catalog, injects one known
+defect per check, and asserts the validator fires — currently 10/10. Without it, a regression that
+silently disables a check would look identical to a clean catalog. This is the same discipline the
+`bug-hunter` rite applies to code.
+
+**D3 — Degrade loudly, not silently.** When `luac` or PyYAML is absent the corresponding check is
+skipped and the skip is printed. CI installs both, so the skip path is a local-development
+convenience, never a silent pass.
+
+**D4 — Cross-skill references name their owner.** `references/track-python-pytest.md` written inside
+`python-rest-api` reads as a local file and is not one; it lives in `bug-hunter/references/`. Prefixing
+with the owning skill is both correct and checkable, and it matches how the catalog already links
+sibling skills by name.
+
+**D5 — `jsonc` over splitting the payload variants.** The five negative-test blocks list several
+annotated payloads to be read side by side; splitting them into single documents would lose the
+comparison the section is teaching. The tag was the thing that was wrong.
+
+**D6 — Heuristic checks state their own limits.** C4 fires only when an absolute promise carries no
+condition in the description itself; C5 accepts a stated stack ("pydantic v2, SQLAlchemy 2") as a pin
+and skips skills that explicitly defer to a local source of truth. Both narrowings came from false
+positives on skills that were already correct.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Authoring conventions for skills (frontmatter, locale, canonical home, verified claims) | `openspec/specs/skills-authoring` | already canonical — gains the enforcement requirement |
+| Rite gate structure (mandatory groups per change) | `scripts/validate-rite.sh` | already canonical — the new script sits beside it, same job, different subject |
+| Adversarial testing of a change | `bug-hunter` | link (already canonical) — the self-test applies its discipline to the validator |
+| Per-skill doctrine (backend, docs, r3f, fivem, …) | the skill itself | unchanged; only validator-found corrections applied |
+
+## Risks / Trade-offs
+
+- [A heuristic check false-positives on a future correct skill] → both heuristics were already
+  narrowed by real false positives; when one fires wrongly the fix is to narrow it again, and the
+  self-test guards against narrowing it into uselessness.
+- [Contributors bypass the checks locally] → CI runs them on every PR; local runs are a convenience.
+- [The self-test copies the whole repo ten times] → it runs in seconds and excludes `.git` and
+  `node_modules`; correctness of the gate is worth the cost.
+- [Half the authoring spec stays unenforced] → stated plainly here and in the proposal, rather than
+  letting the green check imply full coverage.

--- a/openspec/changes/enforce-authoring-checks/proposal.md
+++ b/openspec/changes/enforce-authoring-checks/proposal.md
@@ -1,0 +1,64 @@
+# Change: Make the authoring requirements executable, and fix what they catch
+
+## Why
+
+Three audits added four requirements to `skills-authoring` — Simulated failure behaviour, Description
+agrees with body, Code blocks compile or are marked, Versioned external APIs are pinned. All four were
+convention only. Nothing in CI could tell whether a skill obeyed them, which is exactly the failure
+mode `skills-authoring` already names: *"Advisory mechanisms are not sold as hard gates."*
+
+A validator was written for the mechanically checkable half and run over all 30 skills. First pass:
+**31 findings**. Triaging them honestly, **22 were the validator's own bugs**, not the catalog's:
+
+| validator defect | effect |
+|---|---|
+| scanned paths inside fenced blocks | template content counted as broken links |
+| scanned links inside inline-code spans | a rule *showing* link syntax counted as a broken link |
+| resolved `references/x.md` from the file's own directory | reference-to-reference citations counted as missing |
+| did not dedent fences nested in list items | correct Python read as `IndentationError` |
+| "looks like CSS" heuristic matched `import {` | a valid multi-line import counted as mistagged |
+| absolute-promise heuristic matched prohibitions | "never leaks a token" counted as a scope contradiction |
+| version-pin regex missed stated stacks | "pydantic v2 / SQLAlchemy 2" counted as unpinned |
+
+After fixing the instrument: **9 real findings**, all now fixed. The remaining zero is verified by an
+adversarial self-test that injects one known defect per check and asserts the validator fires —
+**10/10 detected**. A checker that never fails is not a checker.
+
+## What Changes
+
+- New `scripts/validate-skills.py` — six checks over every `skills/*/SKILL.md` and its references:
+  C1 referenced repo paths exist · C2 cross-skill references name a real skill · C3 code blocks parse
+  (bash/yaml/json/lua/python) · C4 description agrees with body · C5 versioned APIs are pinned ·
+  C6 fence tags match content. Reports which checks were skipped for want of a tool.
+- New `scripts/selftest-validate-skills.py` — mutates a throwaway copy of the catalog once per check
+  and asserts detection. The gate is itself gated.
+- Both wired into the CI `validate` job.
+- Real defects fixed:
+  - **7 cross-skill reference paths** cited as if local — `references/track-python-pytest.md` from
+    `python-rest-api`, and the same for `assettoserver-csp-lua`, `assettoserver-plugin`, `fivem-lua`,
+    `openspec-drivezone`, `execute-backlog` — now name the owning skill
+    (`bug-hunter/references/…`, `backlog/references/…`).
+  - **helm-migration**: the description promised "Always generates both files when applicable" while
+    the body says *"If the source YAML has no secrets, configmaps or PVCs, do not generate env.yaml."*
+    The description now names the condition. Also states that the local chart template is the source
+    of truth, not the skill, so a field list that drifts is caught by reading the template first.
+  - **5 blocks** in `negative-test-catalog.md` tagged `json` while containing several
+    comment-annotated payload variants — retagged `jsonc`.
+  - **2 fragments** tagged `lua` and `python` marked as excerpts, matching the r3f convention.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — the mechanically checkable authoring rules SHALL be enforced
+  by a script wired into CI, and that script SHALL carry a self-test proving each check fires.
+
+## Impact
+
+- `scripts/validate-skills.py`, `scripts/selftest-validate-skills.py`, `.github/workflows/ci.yml`.
+- Skills corrected: `python-rest-api`, `fivem-lua` (+ reference), `assettoserver-csp-lua`,
+  `assettoserver-plugin`, `openspec-drivezone`, `execute-backlog` (reference), `helm-migration`,
+  `api-resilience-testing` (reference), `log-event-collector`.
+- Every future skill change is now checked for the same six defect classes on every PR.

--- a/openspec/changes/enforce-authoring-checks/specs/skills-authoring/spec.md
+++ b/openspec/changes/enforce-authoring-checks/specs/skills-authoring/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Authoring rules are machine-enforced
+
+The mechanically checkable authoring rules SHALL be enforced by a script wired into CI, and that
+script SHALL carry a self-test that injects one known defect per check and asserts detection. Rules
+that cannot be checked mechanically SHALL be identified as review-only rather than left to imply
+coverage.
+
+#### Scenario: A violation fails the build
+
+- **WHEN** a change introduces a broken reference, an unparseable code block, a mistagged fence, or a
+  description that contradicts its body
+- **THEN** the CI validate job fails and names the skill, the check and the offending content
+
+#### Scenario: A disabled check is caught
+
+- **WHEN** a change to the validator silently stops one of its checks from firing
+- **THEN** the self-test fails, because a catalog with zero findings and a check that cannot fire are
+  otherwise indistinguishable
+
+#### Scenario: A missing tool is reported, not passed over
+
+- **WHEN** a checker dependency is unavailable in the environment
+- **THEN** the affected check is reported as skipped in the output instead of counting as a pass

--- a/openspec/changes/enforce-authoring-checks/tasks.md
+++ b/openspec/changes/enforce-authoring-checks/tasks.md
@@ -1,0 +1,42 @@
+## 1. Validator
+
+- [x] 1.1 Implement C1-C6 over every `skills/*/SKILL.md` and its `references/*.md`
+- [x] 1.2 Handle fences nested in list items (dedent by the fence's own indentation)
+- [x] 1.3 Ignore paths inside fenced blocks and links inside inline-code spans
+- [x] 1.4 Resolve `references/…` from the skill directory, not the citing file's directory
+- [x] 1.5 Narrow C4 (absolute promise carrying its own condition is fine) and C5 (a stated stack is a
+      pin; a skill deferring to a local source of truth is exempt)
+- [x] 1.6 Report checks skipped for want of `luac` or PyYAML; support `luac5.4` naming
+
+## 2. Self-test
+
+- [x] 2.1 Inject one known defect per check into a throwaway copy and assert detection
+- [x] 2.2 All ten defect classes detected
+
+## 3. Catalog corrections found by the validator
+
+- [x] 3.1 Qualify 7 cross-skill reference paths with the owning skill
+- [x] 3.2 helm-migration: description names the env.yaml condition; chart template declared the source
+      of truth
+- [x] 3.3 Retag 5 comment-annotated multi-payload blocks `json` -> `jsonc`
+- [x] 3.4 Mark the `lua` and `python` fragments as excerpts
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on every touched skill
+- [x] Q.2 All touched content in English (catalog locale)
+- [x] Q.3 Triggers and "Do NOT use for" boundaries unchanged on every touched skill
+- [x] Q.4 No duplicated doctrine: the validator enforces `skills-authoring`, it does not restate it
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 No description promises a policy its body contradicts (verified by the validator itself)
+- [x] Q.7 README documents the new scripts
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate enforce-authoring-checks --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 CI frontmatter check passes locally
+- [x] V.5 `scripts/validate-skills.py` reports 0 findings across all 30 skills
+- [x] V.6 `scripts/selftest-validate-skills.py` detects 10/10 injected defect classes
+- [ ] V.7 `openspec archive enforce-authoring-checks --yes` after review

--- a/plugins/backend/skills/log-event-collector/SKILL.md
+++ b/plugins/backend/skills/log-event-collector/SKILL.md
@@ -121,6 +121,7 @@ connected" line has the slot and car. Keep a `ParserContext` with maps
 (`attempts_by_steam_id`, `players_by_slot`) that early lines populate and later lines consume:
 
 ```python
+# excerpt — not a complete module; shown inside the parser loop
 if match := patterns.CONNECTED_RE.match(message):
     data = match.groupdict()
     attempt = self.context.attempts_by_steam_id.get(data["steam_id"], {})

--- a/plugins/backend/skills/python-rest-api/SKILL.md
+++ b/plugins/backend/skills/python-rest-api/SKILL.md
@@ -272,7 +272,7 @@ Ruff: `target-version` matching the runtime, `line-length = 100`, `select = ["E"
 ## See also
 
 - `api-resilience-testing` — the negative/fuzz/contract methodology this baseline is tested against.
-- `bug-hunter` — per-change adversarial rite (`references/track-python-pytest.md` assumes this stack).
+- `bug-hunter` — per-change adversarial rite (`bug-hunter/references/track-python-pytest.md` assumes this stack).
 - `backend-resilience` — fallback/negative-cache doctrine for calls this service makes to others.
 - `conventional-commit` — commit format used by these services' semantic-release pipelines.
 - `react-api-client` — the frontend counterpart consuming this envelope/code registry.

--- a/plugins/devops/skills/helm-migration/SKILL.md
+++ b/plugins/devops/skills/helm-migration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: helm-migration
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates both files when applicable.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
 metadata:
   author: solvelab
   version: 2.1.0
@@ -13,6 +13,12 @@ compatibility: Requires a Helm charts template repository accessible on the loca
 # Helm Migration Skill
 
 You are a Helm chart expert. When asked to migrate a Kubernetes YAML file to Helm, follow the workflow and conventions below. These are derived from real solvelab production charts and are specific to that chart template.
+
+> **The chart template is the source of truth, not this skill.** The field names below were taken from
+> the solvelab chart template as it stood when this skill was last revised (see `metadata.version`).
+> The template evolves independently, so **read the local copy first** (step 1 of the workflow) and let
+> it win on any disagreement. A field named here but absent from the local `values.yaml` means the
+> template moved — update this skill rather than emitting a field the chart will ignore.
 
 ---
 

--- a/plugins/fivem/skills/fivem-lua/SKILL.md
+++ b/plugins/fivem/skills/fivem-lua/SKILL.md
@@ -129,7 +129,7 @@ local function stopLoop() active = false end
 ## See also
 
 - `fivem-fallback` — resilience when calling an external backend from Lua.
-- `bug-hunter` — adversarial testing; its `references/track-fivem-lua.md` exercises the trust-boundary
+- `bug-hunter` — adversarial testing; its `bug-hunter/references/track-fivem-lua.md` exercises the trust-boundary
   and lifecycle rules defined here.
 - `backend-resilience` — the stack-agnostic doctrine behind `fivem-fallback`.
 - `fivem-nui-react` — the React/CEF side of NUI (bridge hooks, uiReady handshake, rendering quirks).

--- a/plugins/fivem/skills/fivem-lua/references/events-registry.md
+++ b/plugins/fivem/skills/fivem-lua/references/events-registry.md
@@ -34,6 +34,7 @@ end
 Consumers:
 
 ```lua
+-- excerpt — not a complete module; `...` stands for your handler body
 local Events = exports["events-catalog"]:GetEventsInstance()
 RegisterNetEvent(Events.serverEvents.MYRES_ACTION, function(payload) ... end)
 TriggerClientEvent(Events.clientEvents.MYRES_STATE, src, data)

--- a/plugins/game/skills/assettoserver-csp-lua/SKILL.md
+++ b/plugins/game/skills/assettoserver-csp-lua/SKILL.md
@@ -118,7 +118,7 @@ Copy-paste helpers for all of these: `references/snippets.lua`.
 
 - The Lua layout (`ac.StructItem.key(...)` + named/sized fields) must match the C# `OnlineEvent<T>`
   **byte-for-byte** — enforce it with a static parity gate over the published DLL (see
-  `bug-hunter` → `references/track-dotnet-plugin.md`), not by review.
+  `bug-hunter` → `bug-hunter/references/track-dotnet-plugin.md`), not by review.
 - **Never name a field `key`.** It collides with the `ac.StructItem.key` mechanism and the packet
   is silently never delivered — while every static gate passes, because the layouts do match.
 - Two scripts that register the **exact same layout both receive the event**. Reuse an existing
@@ -195,6 +195,6 @@ Copy-paste helpers for all of these: `references/snippets.lua`.
   decimals), packet classes and handlers, chat commands, the publish rite.
 - `assettoserver-ops` — operating the server that hosts these scripts; static assets under
   `wwwroot/` are baked into the image (rebuild + recreate, not restart).
-- `bug-hunter` — `references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
+- `bug-hunter` — `bug-hunter/references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
   Lua↔C# packet parity.
 - `conventional-commit` — commit format used by these repos.

--- a/plugins/game/skills/assettoserver-plugin/SKILL.md
+++ b/plugins/game/skills/assettoserver-plugin/SKILL.md
@@ -262,7 +262,7 @@ commit) next to the DLL — the deploy side refuses to sync a DLL without a rite
   doctrine, DirectWrite traps, packet layout mirroring, remote assets/audio by URL.
 - `assettoserver-ops` — operating the server that loads this plugin; the deploy/sync gate that
   consumes `plugin-rite-status.json`.
-- `bug-hunter` — the adversarial rite; `references/track-dotnet-plugin.md` is the generalized
+- `bug-hunter` — the adversarial rite; `bug-hunter/references/track-dotnet-plugin.md` is the generalized
   version of the Mono.Cecil published-artifact inspection.
 - `backend-resilience` — the fallback doctrine the backend-call section adapts to this runtime.
 - `conventional-commit` — commit format used by this repo.

--- a/plugins/testing/skills/api-resilience-testing/references/negative-test-catalog.md
+++ b/plugins/testing/skills/api-resilience-testing/references/negative-test-catalog.md
@@ -30,7 +30,7 @@ Expect: **400/422** (after trim it is empty). Server should trim before storing.
 
 ## 4. Wrong type (type confusion)
 
-```json
+```jsonc
 { "email": 12345, "age": "thirty" }   // number for string, string for number
 { "email": "a@b.com", "age": true }    // boolean where int expected
 { "email": "a@b.com", "age": "30" }    // numeric string — is it coerced or rejected?
@@ -44,7 +44,7 @@ leave it ambiguous.
 
 A money field documented as `XXX.XX` (dot decimal) fed the locale variant:
 
-```json
+```jsonc
 { "amount": "1.234,56" }   // pt-BR thousands "." + decimal ","
 { "amount": "1234,56" }    // comma decimal
 { "amount": "R$ 100,00" }  // currency symbol + comma
@@ -58,7 +58,7 @@ vs `2026-12-31`).
 
 ## 5. Out-of-range / boundary numbers
 
-```json
+```jsonc
 { "email": "a@b.com", "age": -1 }     // below min
 { "email": "a@b.com", "age": 121 }    // above max
 { "email": "a@b.com", "age": 99999999999999999999 }  // overflow
@@ -67,7 +67,7 @@ Expect: **400/422** for each. Test min-1, min, max, max+1 explicitly.
 
 ## 6. Invalid format / enum
 
-```json
+```jsonc
 { "email": "not-an-email", "age": 30 }
 { "email": "a@b.com", "age": 30, "role": "superadmin" }  // not in enum
 ```
@@ -180,7 +180,7 @@ Expect: **404**, consistent error shape, no internal detail.
 
 ## 16. Injection probes
 
-```json
+```jsonc
 { "email": "a@b.com' OR '1'='1", "age": 30 }
 { "email": "<script>alert(1)</script>@b.com", "age": 30 }
 { "email": "../../etc/passwd", "age": 30 }

--- a/plugins/workflow/skills/execute-backlog/references/board-sync.md
+++ b/plugins/workflow/skills/execute-backlog/references/board-sync.md
@@ -2,7 +2,7 @@
 
 Reuses the `backlog` skill's config (`project.owner`, `project.number`, `fields.status`) and the
 same runtime-ID discipline: resolve project/field/option/item IDs fresh each run (see the
-`backlog` skill's `references/gh-projects.md` for the base recipes).
+`backlog` skill's `backlog/references/gh-projects.md` for the base recipes).
 
 ## Find the item for an issue
 

--- a/plugins/workflow/skills/openspec-drivezone/SKILL.md
+++ b/plugins/workflow/skills/openspec-drivezone/SKILL.md
@@ -71,7 +71,7 @@ Dependencies to cover per track:
 **2. `tasks.md` → group `## 3. Tests & Bug-Hunter (MANDATORY)`**
 
 Adversarial QA, not happy-path. → Methodology and per-stack scenarios: **[bug-hunter]**
-(`references/track-fivem-lua.md` for the resource, `references/track-python-pytest.md` for the
+(`bug-hunter/references/track-fivem-lua.md` for the resource, `bug-hunter/references/track-python-pytest.md` for the
 backend — pytest E2E runs **before** any in-game validation). For API-surface depth: **[api-resilience-testing]**.
 Trust-boundary rules exercised by the Lua track: **[fivem-lua]**.
 

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -1,0 +1,45 @@
+"""Adversarial self-test: inject one known defect per check into a copy of the catalog
+and assert the validator fires. A checker that never fails is not a checker."""
+import shutil, subprocess, sys, tempfile, pathlib, re, os
+
+SRC = pathlib.Path(__file__).resolve().parent.parent
+VAL = str(SRC / "scripts" / "validate-skills.py")
+
+MUTATIONS = {
+ "C1 missing path": ("skills/fivem-lua/SKILL.md",
+     lambda s: s + "\n\nSee `references/this-file-does-not-exist.md` for details.\n"),
+ "C2 unknown skill": ("skills/fivem-lua/SKILL.md",
+     lambda s: s + "\n\n- `fivem-teleport` — use this skill for teleport logic.\n"),
+ "C3 bash syntax": ("skills/assettoserver-ops/SKILL.md",
+     lambda s: s + "\n```bash\nif true then echo broken\n```\n"),
+ "C3 yaml parse": ("skills/helm-migration/SKILL.md",
+     lambda s: s + "\n```yaml\nfoo: [1, 2\n  bar: : baz\n```\n"),
+ "C3 json parse": ("skills/claude-statusline/SKILL.md",
+     lambda s: s + '\n```json\n{"a": 1,,}\n```\n'),
+ "C3 python syntax": ("skills/python-rest-api/SKILL.md",
+     lambda s: s + "\n```python\ndef broken(:\n    pass\n```\n"),
+ "C3 lua syntax": ("skills/fivem-lua/SKILL.md",
+     lambda s: s + "\n```lua\nlocal x = = 1\n```\n"),
+ "C4 desc vs body": ("skills/conventional-commit/SKILL.md",
+     lambda s: s.replace("description: >-", "description: >-\n  ALWAYS creates all three tiers.", 1)
+                .replace("\n## ", "\n## Rules\n\nDo not create documents that don't apply.\n\n## ", 1)),
+ "C5 no version pin": ("skills/react-api-client/SKILL.md",
+     lambda s: s + "\n```tsx\n" + "const a = 1\n" * 45 + "```\n\nUses zod and vite.\n"),
+ "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
+     lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
+}
+
+fails = []
+for check, (relpath, mutate) in MUTATIONS.items():
+    with tempfile.TemporaryDirectory() as td:
+        dst = pathlib.Path(td) / "repo"
+        shutil.copytree(SRC, dst, ignore=shutil.ignore_patterns(".git", "node_modules"))
+        p = dst / relpath
+        p.write_text(mutate(p.read_text()))
+        out = subprocess.run([sys.executable, str(dst / "scripts" / "validate-skills.py")], cwd=dst, capture_output=True, text=True).stdout
+        caught = check.split()[0] in out and check in out
+        print(f"  {'CAUGHT ' if caught else 'MISSED '} {check}")
+        if not caught:
+            fails.append(check)
+print(f"\n{len(MUTATIONS)-len(fails)}/{len(MUTATIONS)} defect classes detected")
+sys.exit(1 if fails else 0)

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -1,0 +1,252 @@
+"""Catalog-wide skill validator.
+
+Implements the mechanically checkable half of openspec/specs/skills-authoring:
+
+  C1 referenced repo paths exist            (links + inline paths inside skills/)
+  C2 cross-skill references name a real skill
+  C3 code blocks parse                      (bash -n, yaml, json, lua -p, python)
+  C4 description agrees with body           (heuristic: absolute promise vs qualifying rule)
+  C5 versioned external APIs are pinned     (code-heavy skill without a version statement)
+  C6 fence tags match content               (a block tagged X that is obviously not X)
+
+Exit 1 on any finding. Run from the repo root.
+"""
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path.cwd()
+SKILLS = sorted(p for p in (ROOT / "skills").glob("*/SKILL.md"))
+NAMES = {p.parent.name for p in SKILLS}
+
+# capture the fence's own indentation so a block nested in a list is dedented before parsing
+_FENCE_RE = re.compile(r"^([ \t]*)```(\w*)\n(.*?)^\1```", re.S | re.M)
+
+
+class _Fence:
+    """Yields (lang, dedented_body) pairs, like the old FENCE.findall()."""
+    @staticmethod
+    def findall(text: str):
+        out = []
+        for m in _FENCE_RE.finditer(text):
+            indent, lang, body = m.group(1), m.group(2), m.group(3)
+            if indent:
+                body = "\n".join(l[len(indent):] if l.startswith(indent) else l
+                                  for l in body.splitlines()) + "\n"
+            out.append((lang, body))
+        return out
+
+    @staticmethod
+    def sub(repl, text: str):
+        return _FENCE_RE.sub(repl, text)
+
+
+FENCE = _Fence()
+LINK = re.compile(r"\[[^\]]*\]\(([^)\s]+)\)")
+INLINE = re.compile(r"`([^`\n]+)`")
+PLACEHOLDER = re.compile(r"[*<>{}\[\]]|\.\.\.|YOUR|yourname|example\.com|\$\{")
+
+# Ubuntu ships the compiler as luac5.4; brew/arch ship it as luac.
+LUAC = next((c for c in ("luac", "luac5.4", "luac5.3") if shutil.which(c)), None)
+
+findings: list[tuple[str, str, str]] = []          # (skill, check, message)
+
+
+def add(skill: str, check: str, msg: str) -> None:
+    findings.append((skill, check, msg))
+
+
+def repo_has(rel: str) -> bool:
+    rel = rel.removeprefix("./").strip("/")
+    return (ROOT / rel).exists()
+
+
+# ── C1/C2: references ─────────────────────────────────────────────────────
+def check_refs(skill: str, path: Path, text: str) -> None:
+    # A path inside a fenced block is example content, not a claim about this repo.
+    text = FENCE.sub("", text)
+    # a link inside an inline-code span is being shown AS an example of a link
+    text = INLINE.sub(lambda m: "" if "](" in m.group(1) else m.group(0), text)
+    # references/ is always relative to the skill directory, even when cited from a reference file
+    base = path.parent if path.name == "SKILL.md" else path.parent.parent
+    for m in LINK.finditer(text):
+        t = m.group(1).split("#")[0]
+        if not t or t.startswith(("http", "mailto:", "#")) or PLACEHOLDER.search(t):
+            continue
+        if not ((base / t).exists() or repo_has(t)):
+            add(skill, "C1 missing path", f"link -> {t}")
+
+    for m in INLINE.finditer(text):
+        s = m.group(1).strip()
+        if PLACEHOLDER.search(s) or " " in s or s.startswith(("~", "/", "$", "http")):
+            continue
+        # only judge paths that point inside this skill or into skills/
+        if s.startswith("references/") or s.startswith("skills/"):
+            if not ((base / s).exists() or repo_has(s)):
+                add(skill, "C1 missing path", f"inline -> {s}")
+
+    # cross-skill references: `skill-name` in backticks that looks like a skill slug
+    for m in INLINE.finditer(text):
+        s = m.group(1).strip()
+        if re.fullmatch(r"[a-z][a-z0-9]+(-[a-z0-9]+)+", s) and s not in NAMES:
+            # only flag when it really looks like a sibling reference, not a CLI flag or filename
+            if "." not in s and "/" not in s and s.count("-") <= 3:
+                looks_skillish = any(
+                    s.startswith(p) for p in
+                    ("r3f-", "fivem-", "openspec", "assettoserver-", "python-", "backend-",
+                     "api-", "log-", "react-", "bug-", "helm-", "k8s-", "claude-", "conventional-")
+                )
+                ctx = text[max(0, m.start() - 90):m.end() + 40].lower()
+                cited_as_skill = any(k in ctx for k in ("skill", "see also", "use ", "that is "))
+                is_repo = any(k in ctx for k in ("repo", "repositor", "drivezone ("))
+                if looks_skillish and cited_as_skill and not is_repo:
+                    add(skill, "C2 unknown skill", f"`{s}` is not a skill in the catalog")
+
+
+# ── C3: code blocks parse ─────────────────────────────────────────────────
+def run(cmd: list[str], data: str | None = None) -> tuple[int, str]:
+    try:
+        p = subprocess.run(cmd, input=data, capture_output=True, text=True, timeout=25)
+        return p.returncode, (p.stderr or p.stdout).strip()
+    except Exception as exc:                        # tool missing → skip, not a finding
+        return -1, str(exc)
+
+
+def check_blocks(skill: str, text: str) -> None:
+    for i, (lang, body) in enumerate(FENCE.findall(text)):
+        lang = lang.lower()
+        if re.match(r"\s*(//|#|--)\s*excerpt", body) or PLACEHOLDER.search(body[:400]) and lang in ("bash", "sh"):
+            continue
+        if lang in ("bash", "sh", "shell"):
+            if any(t in body for t in ("<", ">", "$(", "${", "…")):
+                continue                             # templated command, not runnable as-is
+            rc, err = run(["bash", "-n"], body)
+            if rc > 0:
+                add(skill, "C3 bash syntax", f"block#{i}: {err.splitlines()[0][:90]}")
+        elif lang in ("yaml", "yml"):
+            rc, err = run([sys.executable, "-c",
+                           "import sys,yaml;list(yaml.safe_load_all(sys.stdin.read()))"], body)
+            if rc > 0:
+                add(skill, "C3 yaml parse", f"block#{i}: {err.splitlines()[-1][:90]}")
+        elif lang == "json":
+            try:
+                json.loads(body)
+            except Exception as exc:
+                add(skill, "C3 json parse", f"block#{i}: {exc}")
+        elif lang == "lua" and LUAC:
+            with tempfile.NamedTemporaryFile("w", suffix=".lua", delete=False) as fh:
+                fh.write(body); tmp = fh.name
+            rc, err = run([LUAC, "-p", tmp])
+            if rc > 0:
+                add(skill, "C3 lua syntax", f"block#{i}: {err.splitlines()[0][:90]}")
+        elif lang == "python":
+            rc, err = run([sys.executable, "-c",
+                           "import sys,ast;ast.parse(sys.stdin.read())"], body)
+            if rc > 0:
+                add(skill, "C3 python syntax", f"block#{i}: {err.splitlines()[-1][:90]}")
+
+
+# ── C4: description agrees with body ──────────────────────────────────────
+ABSOLUTE = re.compile(r"\b(ALWAYS creates?|ALWAYS generates?|ALWAYS produces?|always creates? all|"
+                      r"all three \w+ tiers|creates? all \w+ (tiers|documents|files))\b", re.I)
+QUALIFIER = re.compile(r"\b(only (when|if|what)|do not create|unless|earned|decision table|"
+                       r"skip|when applicable|if (it |the )?applies)\b", re.I)
+
+
+def check_description(skill: str, text: str) -> None:
+    fm = text.split("---", 2)
+    if len(fm) < 3:
+        add(skill, "C4 frontmatter", "no frontmatter block")
+        return
+    desc = re.search(r"^description:\s*(.*?)(?=^\w+:)", fm[1], re.S | re.M)
+    desc = desc.group(1) if desc else ""
+    body = fm[2]
+    promises = []
+    for m in ABSOLUTE.finditer(desc):
+        tail = desc[m.end():m.end() + 120]           # does the promise carry its own condition?
+        if not re.search(r"\b(only when|only if|unless|when the|if the)\b", tail, re.I):
+            promises.append(m.group(0))
+    if promises and QUALIFIER.search(body):
+        add(skill, "C4 desc vs body",
+            f"description promises {promises[:2]} while the body qualifies it")
+
+
+# ── C5: versioned APIs pinned ─────────────────────────────────────────────
+PIN = re.compile(r"[Vv]erified against|@[\d]+\.[\d]+|version[s]? pinned|targets? v?\d+\.\d+"
+                 r"|[Mm]easured on|pydantic v\d|SQLAlchemy \d|Python .{0,3}\d\.\d+|\b\w+ \d+\.\d+\+")
+API_HINT = re.compile(r"@react-three|@react-spring|fastapi|pydantic|sqlalchemy|helm |kubectl|"
+                      r"citizenfx|Qmmands|AssettoServer|openspec|gh project|zod|vite", re.I)
+
+
+def check_pin(skill: str, text: str) -> None:
+    blocks = FENCE.findall(text)
+    code_lines = sum(len(b.splitlines()) for _, b in blocks)
+    if code_lines < 40:
+        return
+    defers = re.search(r"source of truth, not this skill|read the local copy first", text, re.I)
+    if API_HINT.search(text) and not PIN.search(text) and not defers:
+        add(skill, "C5 no version pin",
+            f"{code_lines} lines of code against a versioned API, no version statement")
+
+
+# ── C6: fence tag matches content ─────────────────────────────────────────
+def check_tags(skill: str, text: str) -> None:
+    for i, (lang, body) in enumerate(FENCE.findall(text)):
+        head = next((l for l in body.splitlines() if l.strip()), "")
+        if lang in ("tsx", "ts", "jsx", "javascript"):
+            if re.match(r"^\s*(varying|uniform|attribute|precision)\s+\w", head):
+                add(skill, "C6 wrong tag", f"block#{i} tagged {lang} but looks like GLSL")
+            if (re.match(r"^[\w\s,#.\-]+\{\s*$", head)
+                    and not re.match(r"^\s*(import|export|const|let|var|return|type|interface)\b", head)
+                    and "function" not in head and "=>" not in head):
+                add(skill, "C6 wrong tag", f"block#{i} tagged {lang} but looks like CSS")
+        if lang in ("yaml", "yml") and head.strip().startswith(("{", "[")):
+            add(skill, "C6 wrong tag", f"block#{i} tagged {lang} but looks like JSON")
+
+
+def main() -> int:
+    for p in SKILLS:
+        skill = p.parent.name
+        text = p.read_text(encoding="utf-8")
+        check_refs(skill, p, text)
+        check_blocks(skill, text)
+        check_description(skill, text)
+        check_pin(skill, text)
+        check_tags(skill, text)
+        for ref in (p.parent / "references").glob("*.md"):
+            rtext = ref.read_text(encoding="utf-8")
+            check_refs(f"{skill}/{ref.name}", ref, rtext)
+            check_blocks(f"{skill}/{ref.name}", rtext)
+
+    by_check: dict[str, int] = {}
+    for _, c, _ in findings:
+        by_check[c] = by_check.get(c, 0) + 1
+    skipped = []
+    if not LUAC:
+        skipped.append("lua syntax (luac not installed)")
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        skipped.append("yaml parse (PyYAML not installed)")
+    print(f"skills checked: {len(SKILLS)}   findings: {len(findings)}")
+    if skipped:
+        print("  checks skipped: " + "; ".join(skipped))
+    for c, n in sorted(by_check.items(), key=lambda x: -x[1]):
+        print(f"  {c:<22} {n}")
+    print()
+    cur = None
+    for skill, check, msg in sorted(findings):
+        if skill != cur:
+            print(f"\n{skill}"); cur = skill
+        print(f"   [{check}] {msg}")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/api-resilience-testing/references/negative-test-catalog.md
+++ b/skills/api-resilience-testing/references/negative-test-catalog.md
@@ -30,7 +30,7 @@ Expect: **400/422** (after trim it is empty). Server should trim before storing.
 
 ## 4. Wrong type (type confusion)
 
-```json
+```jsonc
 { "email": 12345, "age": "thirty" }   // number for string, string for number
 { "email": "a@b.com", "age": true }    // boolean where int expected
 { "email": "a@b.com", "age": "30" }    // numeric string — is it coerced or rejected?
@@ -44,7 +44,7 @@ leave it ambiguous.
 
 A money field documented as `XXX.XX` (dot decimal) fed the locale variant:
 
-```json
+```jsonc
 { "amount": "1.234,56" }   // pt-BR thousands "." + decimal ","
 { "amount": "1234,56" }    // comma decimal
 { "amount": "R$ 100,00" }  // currency symbol + comma
@@ -58,7 +58,7 @@ vs `2026-12-31`).
 
 ## 5. Out-of-range / boundary numbers
 
-```json
+```jsonc
 { "email": "a@b.com", "age": -1 }     // below min
 { "email": "a@b.com", "age": 121 }    // above max
 { "email": "a@b.com", "age": 99999999999999999999 }  // overflow
@@ -67,7 +67,7 @@ Expect: **400/422** for each. Test min-1, min, max, max+1 explicitly.
 
 ## 6. Invalid format / enum
 
-```json
+```jsonc
 { "email": "not-an-email", "age": 30 }
 { "email": "a@b.com", "age": 30, "role": "superadmin" }  // not in enum
 ```
@@ -180,7 +180,7 @@ Expect: **404**, consistent error shape, no internal detail.
 
 ## 16. Injection probes
 
-```json
+```jsonc
 { "email": "a@b.com' OR '1'='1", "age": 30 }
 { "email": "<script>alert(1)</script>@b.com", "age": 30 }
 { "email": "../../etc/passwd", "age": 30 }

--- a/skills/assettoserver-csp-lua/SKILL.md
+++ b/skills/assettoserver-csp-lua/SKILL.md
@@ -118,7 +118,7 @@ Copy-paste helpers for all of these: `references/snippets.lua`.
 
 - The Lua layout (`ac.StructItem.key(...)` + named/sized fields) must match the C# `OnlineEvent<T>`
   **byte-for-byte** — enforce it with a static parity gate over the published DLL (see
-  `bug-hunter` → `references/track-dotnet-plugin.md`), not by review.
+  `bug-hunter` → `bug-hunter/references/track-dotnet-plugin.md`), not by review.
 - **Never name a field `key`.** It collides with the `ac.StructItem.key` mechanism and the packet
   is silently never delivered — while every static gate passes, because the layouts do match.
 - Two scripts that register the **exact same layout both receive the event**. Reuse an existing
@@ -195,6 +195,6 @@ Copy-paste helpers for all of these: `references/snippets.lua`.
   decimals), packet classes and handlers, chat commands, the publish rite.
 - `assettoserver-ops` — operating the server that hosts these scripts; static assets under
   `wwwroot/` are baked into the image (rebuild + recreate, not restart).
-- `bug-hunter` — `references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
+- `bug-hunter` — `bug-hunter/references/track-dotnet-plugin.md`: the published-DLL inspection that enforces
   Lua↔C# packet parity.
 - `conventional-commit` — commit format used by these repos.

--- a/skills/assettoserver-plugin/SKILL.md
+++ b/skills/assettoserver-plugin/SKILL.md
@@ -262,7 +262,7 @@ commit) next to the DLL — the deploy side refuses to sync a DLL without a rite
   doctrine, DirectWrite traps, packet layout mirroring, remote assets/audio by URL.
 - `assettoserver-ops` — operating the server that loads this plugin; the deploy/sync gate that
   consumes `plugin-rite-status.json`.
-- `bug-hunter` — the adversarial rite; `references/track-dotnet-plugin.md` is the generalized
+- `bug-hunter` — the adversarial rite; `bug-hunter/references/track-dotnet-plugin.md` is the generalized
   version of the Mono.Cecil published-artifact inspection.
 - `backend-resilience` — the fallback doctrine the backend-call section adapts to this runtime.
 - `conventional-commit` — commit format used by this repo.

--- a/skills/execute-backlog/references/board-sync.md
+++ b/skills/execute-backlog/references/board-sync.md
@@ -2,7 +2,7 @@
 
 Reuses the `backlog` skill's config (`project.owner`, `project.number`, `fields.status`) and the
 same runtime-ID discipline: resolve project/field/option/item IDs fresh each run (see the
-`backlog` skill's `references/gh-projects.md` for the base recipes).
+`backlog` skill's `backlog/references/gh-projects.md` for the base recipes).
 
 ## Find the item for an issue
 

--- a/skills/fivem-lua/SKILL.md
+++ b/skills/fivem-lua/SKILL.md
@@ -129,7 +129,7 @@ local function stopLoop() active = false end
 ## See also
 
 - `fivem-fallback` — resilience when calling an external backend from Lua.
-- `bug-hunter` — adversarial testing; its `references/track-fivem-lua.md` exercises the trust-boundary
+- `bug-hunter` — adversarial testing; its `bug-hunter/references/track-fivem-lua.md` exercises the trust-boundary
   and lifecycle rules defined here.
 - `backend-resilience` — the stack-agnostic doctrine behind `fivem-fallback`.
 - `fivem-nui-react` — the React/CEF side of NUI (bridge hooks, uiReady handshake, rendering quirks).

--- a/skills/fivem-lua/references/events-registry.md
+++ b/skills/fivem-lua/references/events-registry.md
@@ -34,6 +34,7 @@ end
 Consumers:
 
 ```lua
+-- excerpt — not a complete module; `...` stands for your handler body
 local Events = exports["events-catalog"]:GetEventsInstance()
 RegisterNetEvent(Events.serverEvents.MYRES_ACTION, function(payload) ... end)
 TriggerClientEvent(Events.clientEvents.MYRES_STATE, src, data)

--- a/skills/helm-migration/SKILL.md
+++ b/skills/helm-migration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: helm-migration
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates both files when applicable.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
 metadata:
   author: solvelab
   version: 2.1.0
@@ -13,6 +13,12 @@ compatibility: Requires a Helm charts template repository accessible on the loca
 # Helm Migration Skill
 
 You are a Helm chart expert. When asked to migrate a Kubernetes YAML file to Helm, follow the workflow and conventions below. These are derived from real solvelab production charts and are specific to that chart template.
+
+> **The chart template is the source of truth, not this skill.** The field names below were taken from
+> the solvelab chart template as it stood when this skill was last revised (see `metadata.version`).
+> The template evolves independently, so **read the local copy first** (step 1 of the workflow) and let
+> it win on any disagreement. A field named here but absent from the local `values.yaml` means the
+> template moved — update this skill rather than emitting a field the chart will ignore.
 
 ---
 

--- a/skills/log-event-collector/SKILL.md
+++ b/skills/log-event-collector/SKILL.md
@@ -121,6 +121,7 @@ connected" line has the slot and car. Keep a `ParserContext` with maps
 (`attempts_by_steam_id`, `players_by_slot`) that early lines populate and later lines consume:
 
 ```python
+# excerpt — not a complete module; shown inside the parser loop
 if match := patterns.CONNECTED_RE.match(message):
     data = match.groupdict()
     attempt = self.context.attempts_by_steam_id.get(data["steam_id"], {})

--- a/skills/openspec-drivezone/SKILL.md
+++ b/skills/openspec-drivezone/SKILL.md
@@ -71,7 +71,7 @@ Dependencies to cover per track:
 **2. `tasks.md` → group `## 3. Tests & Bug-Hunter (MANDATORY)`**
 
 Adversarial QA, not happy-path. → Methodology and per-stack scenarios: **[bug-hunter]**
-(`references/track-fivem-lua.md` for the resource, `references/track-python-pytest.md` for the
+(`bug-hunter/references/track-fivem-lua.md` for the resource, `bug-hunter/references/track-python-pytest.md` for the
 backend — pytest E2E runs **before** any in-game validation). For API-surface depth: **[api-resilience-testing]**.
 Trust-boundary rules exercised by the Lua track: **[fivem-lua]**.
 

--- a/skills/python-rest-api/SKILL.md
+++ b/skills/python-rest-api/SKILL.md
@@ -272,7 +272,7 @@ Ruff: `target-version` matching the runtime, `line-length = 100`, `select = ["E"
 ## See also
 
 - `api-resilience-testing` — the negative/fuzz/contract methodology this baseline is tested against.
-- `bug-hunter` — per-change adversarial rite (`references/track-python-pytest.md` assumes this stack).
+- `bug-hunter` — per-change adversarial rite (`bug-hunter/references/track-python-pytest.md` assumes this stack).
 - `backend-resilience` — fallback/negative-cache doctrine for calls this service makes to others.
 - `conventional-commit` — commit format used by these services' semantic-release pipelines.
 - `react-api-client` — the frontend counterpart consuming this envelope/code registry.


### PR DESCRIPTION
## Why

Three audits (#22, #24, #26) added four requirements to `skills-authoring`:

- Simulated failure behaviour
- Description agrees with body
- Code blocks compile or are marked
- Versioned external APIs are pinned

All four were **convention only**. Nothing in CI could tell whether a skill obeyed them — the exact posture the same spec forbids: *"Advisory mechanisms are not sold as hard gates."*

## The validator

`scripts/validate-skills.py`, six checks over every `skills/*/SKILL.md` and its references:

| check | what it catches |
|---|---|
| C1 | a referenced repo path that does not exist |
| C2 | a cross-skill reference naming a skill not in the catalog |
| C3 | a code block that does not parse (bash / yaml / json / lua / python) |
| C4 | a description stating a policy the body contradicts |
| C5 | a code-heavy skill targeting a versioned API with no version statement |
| C6 | a fence tag that does not match its content |

## Fixing the instrument before trusting it

First run: **31 findings**. Triaged honestly, **22 were the validator's own bugs**:

| validator defect | effect |
|---|---|
| scanned paths inside fenced blocks | template content counted as broken links |
| scanned links inside inline-code spans | a rule *showing* link syntax counted as a broken link |
| resolved `references/x.md` from the citing file's directory | reference-to-reference citations counted as missing |
| did not dedent fences nested in list items | correct Python read as `IndentationError` |
| "looks like CSS" heuristic matched `import {` | a valid multi-line import counted as mistagged |
| absolute-promise heuristic matched prohibitions | "never leaks a token" counted as a scope contradiction |
| version-pin regex missed stated stacks | "pydantic v2 / SQLAlchemy 2" counted as unpinned |

Every one was fixed **in the validator**, not worked around in the skills. Reporting them as catalog defects would have produced 22 pointless edits and poisoned trust in every future run.

## The 9 real findings, all fixed

- **7 cross-skill reference paths cited as if local.** `references/track-python-pytest.md` written inside `python-rest-api` reads as a local file — it lives in `bug-hunter/references/`. Same in `assettoserver-csp-lua`, `assettoserver-plugin`, `fivem-lua`, `openspec-drivezone`, and `execute-backlog` (→ `backlog/references/gh-projects.md`). All now name the owning skill.
- **`helm-migration` description contradicted its body.** Description: *"Always generates both files when applicable."* Body: *"If the source YAML has no secrets, configmaps or PVCs, do not generate env.yaml."* The description now names the condition. The skill also now declares the **local chart template the source of truth over itself**, so a drifted field list is caught by reading the template rather than by emitting a field the chart ignores.
- **5 blocks tagged `json`** holding several comment-annotated payload variants → retagged `jsonc`. Splitting them would lose the side-by-side comparison the section teaches; the tag was the thing that was wrong.
- **2 fragments** tagged `lua` and `python` marked as excerpts, matching the r3f convention.

## The gate is itself gated

`scripts/selftest-validate-skills.py` copies the catalog, injects one known defect per check, and asserts the validator fires:

```
CAUGHT  C1 missing path      CAUGHT  C3 json parse     CAUGHT  C4 desc vs body
CAUGHT  C2 unknown skill     CAUGHT  C3 python syntax  CAUGHT  C5 no version pin
CAUGHT  C3 bash syntax       CAUGHT  C3 lua syntax     CAUGHT  C6 wrong tag
CAUGHT  C3 yaml parse

10/10 defect classes detected
```

Without it, a catalog with zero findings and a check that cannot fire are indistinguishable — the same discipline `bug-hunter` applies to code.

## Honest limits

- **C4 and C5 are heuristics.** They flag a shape for a human to confirm. Both were narrowed after producing false positives on skills that were already correct, and the design notes say so rather than implying they are decidable.
- **Half of `skills-authoring` stays review-only** — whether a simulation is meaningful, whether a rule is right. Stated plainly so a green check does not imply full coverage.
- **Missing tools are reported as skipped**, never counted as a pass. CI installs PyYAML and lua5.4.

## Result

**0 findings across all 30 skills.** Both scripts wired into the CI `validate` job, so every future skill change is checked for the same six defect classes on every PR.

`V.7` (`openspec archive`) intentionally left open — closure step after review.
