### PR TITLE
🐛 fix(process): probe the CLI claims and document what actually ships

### DIFF
--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.0.1
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/conventional-commit/SKILL.md
+++ b/claude/skills/conventional-commit/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: git
 license: MIT
 compatibility: Works in any environment with git access.

--- a/claude/skills/openspec/SKILL.md
+++ b/claude/skills/openspec/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   variant use openspec-drivezone.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/conventional-commit.mdc
+++ b/cursor/rules/conventional-commit.mdc
@@ -26,23 +26,56 @@ the type.
 
 ## Type → icon mapping
 
-| Type | Icon | Use |
-|---|---|---|
-| `feat` | ✨ | new functionality |
-| `fix` | 🐛 | bug fix |
-| `refactor` | ♻️ | refactoring without behavior change |
-| `docs` | 📝 | documentation |
-| `chore` | 🧹 | maintenance tasks, configs, deps |
-| `test` | ✅ | tests |
-| `style` | 🎨 | formatting, style, no logic change |
-| `perf` | ⚡ | performance |
-| `ci` | 👷 | CI/CD |
-| `build` | 📦 | build system, dependencies |
-| `revert` | ⏪ | revert a previous commit |
-| `security` | 🔒 | security fixes |
+| Type | Icon | Use | Cuts a release? |
+|---|---|---|---|
+| `feat` | ✨ | new functionality | **minor** |
+| `fix` | 🐛 | bug fix | **patch** |
+| `perf` | ⚡ | performance | **patch** |
+| `refactor` | ♻️ | refactoring without behavior change | depends on config |
+| `docs` | 📝 | documentation | no |
+| `chore` | 🧹 | maintenance tasks, configs, deps | no |
+| `test` | ✅ | tests | no |
+| `style` | 🎨 | formatting, style, no logic change | no |
+| `ci` | 👷 | CI/CD | no |
+| `build` | 📦 | build system, dependencies | no |
+| `revert` | ⏪ | revert a previous commit | no |
+| `security` | 🔒 | security fixes | **no — see below** |
+
+Any type plus `!` (or a `BREAKING CHANGE:` footer) is a **major**, regardless of the row above.
 
 When the change doesn't cleanly fit one type (e.g. multiple concerns), pick the dominant one — don't
 stack icons.
+
+### The release column is a trap for two types
+
+Under the `conventionalcommits` preset, **only `feat`, `fix` and `perf` cut a release** unless the
+repo overrides it in `releaseRules`. Two consequences worth memorising:
+
+- **`security` ships nothing.** It is not a preset type, so a `🔒 security(auth): rotate leaked
+  token` commit produces no release and no changelog entry — the fix sits on the default branch
+  unreleased. Type a shippable security fix as **`fix`** and put the emphasis in the scope or body:
+  `🔒 fix(auth): rotate leaked service token`. Keep `security` only for changes that genuinely must
+  not trigger a release.
+- **`ci`, `test`, `build`, `style`, `revert` ship nothing either.** That is usually right, but it
+  means a change that users depend on must not be typed `ci` for tidiness.
+
+Verified in this repo: `🐛 fix(r3f): …` cut v2.0.1, while `✅ ci(skills): …` and
+`📝 docs(openspec): …` cut nothing (2026-08-06).
+
+### Repo-specific types override the defaults
+
+A repo can add types and change release levels in `.releaserc.json` → `releaseRules`. **Read that
+file before assuming.** In this catalog, for example:
+
+| Repo rule | Effect |
+|---|---|
+| `refactor` | patch (preset default would be none) |
+| `skill` | **minor** — a catalog-specific type for adding or reworking a skill |
+| `docs`, `chore` | explicitly none |
+
+The gitmoji prefix is optional as far as the release tooling is concerned — this repo's
+`headerPattern` (`^(?:[^\w\s]+\s+)?(\w+)…`) skips a leading non-word prefix — but it is
+mandatory by this convention. Never let the emoji *replace* the type.
 
 ## Hard rules
 

--- a/cursor/rules/openspec.mdc
+++ b/cursor/rules/openspec.mdc
@@ -18,6 +18,14 @@ are deltas against them.
 - Pick a unique change-id: kebab-case, **verb-led** (`add-`, `update-`, `remove-`, `refactor-`).
 - Scaffold `proposal.md`, `tasks.md`, `design.md` (only if needed), and one delta spec per affected
   capability.
+- **Every change needs at least one delta.** A change with no `specs/<capability>/spec.md` fails
+  validation, strict or not. When the work genuinely changes no requirement (a correction, a tooling
+  change), do not invent a new requirement to satisfy the tool — express the change as
+  `## MODIFIED Requirements` on the requirement it refines, restating it in full with its scenarios.
+  A near-duplicate `## ADDED` requirement is the wrong answer: it splits the doctrine.
+  - Probed on CLI **1.6.0**: the validator's own error message suggests setting `skip_specs: true` in
+    the change's `.openspec.yaml` for a change that touches no specs. **It has no effect** — neither
+    `skip_specs` nor `skipSpecs` suppresses the error. Treat the delta as mandatory.
 - Validate: `openspec validate <change-id> --strict` — fix until it passes.
 - **Do not start implementation until the proposal is approved.**
 

--- a/openspec/changes/verify-process-skill-claims/.openspec.yaml
+++ b/openspec/changes/verify-process-skill-claims/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/verify-process-skill-claims/design.md
+++ b/openspec/changes/verify-process-skill-claims/design.md
@@ -1,0 +1,59 @@
+## Context
+
+The process skills are the ones that *act* — they run `gh`, `git` and `openspec` on the user's behalf.
+A wrong flag in a code-heavy reference skill wastes a reader's minute; a wrong flag here fails
+mid-operation, sometimes after a write has already landed. They are also the easiest family to verify,
+because the tools are installed and self-documenting.
+
+## Goals / Non-Goals
+
+**Goals**
+- Every CLI claim these skills make is probed against the installed tool.
+- The two defects found by using the skills are fixed at the point of use.
+- A negative result is reported as a negative result.
+
+**Non-Goals**
+- No new doctrine. The `backlog` recipe was already correct; only its rationale was missing.
+- No commit-message linting. The gitmoji↔type mapping is convention; adding a CI check for it is a
+  separate proposal, and history is immutable anyway.
+- Not probing `claude-statusline`'s JSON field list against a live Claude Code session — that needs a
+  running harness, not a CLI, and is out of scope here.
+
+## Decisions
+
+**D1 — Probe by `--help`, not by execution.** Running `gh issue create` to check it exists would file
+an issue. Resolving the subcommand and grepping its help output for each flag is non-destructive and
+catches exactly the failure that matters: a renamed subcommand or a removed flag.
+
+**D2 — Report the clean result.** 28 of 28 claims held. Writing edits anyway to justify the audit
+would be the same dishonesty the catalog's other audits were built to remove.
+
+**D3 — Ground the release table in this repo's history, not the preset docs.** Three commits merged on
+2026-08-06 give a direct reading: `fix` released, `ci` and `docs` did not. That is falsifiable by
+anyone with `git log`; a citation of the preset's README is not.
+
+**D4 — Tell people to type security fixes as `fix`.** The honest alternative — adding `security` to
+`releaseRules` — is a repo-by-repo change this skill cannot make. The rule that works everywhere is to
+use a shipping type and carry the emphasis in the scope, body and emoji.
+
+**D5 — Put the lag warning next to the recipe, not in a troubleshooting section.** The failure happens
+in the seconds between two commands; the warning is only useful where the id is captured.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Commit and PR message format, type→icon mapping, release impact | `conventional-commit` | already canonical — release impact added |
+| `gh` Projects v2 recipes (ids, item-add/edit, org issue fields, recovery) | `backlog/references/gh-projects.md` | already canonical — lag warning added |
+| Executing an existing backlog item | `execute-backlog` | unchanged; it links the recipes above |
+| OpenSpec lifecycle and `validate --strict` semantics | `openspec` | unchanged; claims probed clean |
+| Rite gates and their enforcement layer | `openspec-drivezone` | unchanged; claims probed clean |
+
+## Risks / Trade-offs
+
+- [The release table hardcodes this repo's `releaseRules` as an example] → it is labelled as this
+  catalog's config and the rule above it says to read `.releaserc.json` before assuming.
+- [Advising `fix` for security changes loses the `security` type's signal] → the emoji, scope and body
+  carry it; shipping the fix matters more than the taxonomy.
+- [The probe is a point-in-time result] → it names the tool versions it ran against, so a future
+  reader can tell whether it still applies.

--- a/openspec/changes/verify-process-skill-claims/proposal.md
+++ b/openspec/changes/verify-process-skill-claims/proposal.md
@@ -1,0 +1,77 @@
+# Change: Probe the process skills' CLI claims, and document what release types actually ship
+
+## Why
+
+Six skills (`openspec`, `openspec-drivezone`, `backlog`, `execute-backlog`, `conventional-commit`,
+`claude-statusline`) instruct the agent to run external CLIs. `skills-authoring` requires those claims
+to be verified, and they never had been.
+
+Every command and flag was extracted from their code blocks and inline code and probed against the
+installed tools — **28 distinct claims against `gh 2.92.0` and `openspec 1.6.0`: all subcommands exist
+and every flag appears in its help output. Zero problems.** That is a negative result and it is
+reported as one; no edits were manufactured from it.
+
+Two real defects surfaced from actually *using* these skills, not from reading them:
+
+**1. `conventional-commit` lists twelve types and never says which ones ship.** Under the
+`conventionalcommits` preset only `feat`, `fix` and `perf` cut a release. The table's `security` row
+is the trap: it is not a preset type, so `🔒 security(auth): rotate leaked token` produces **no
+release and no changelog entry** — a security fix sits unreleased on the default branch while the
+author believes it shipped.
+
+Verified against this repo's own history rather than the preset docs:
+
+| commit | release |
+|---|---|
+| `🐛 fix(r3f): make the code blocks compile…` (#26) | v2.0.1 |
+| `✅ ci(skills): enforce the authoring rules…` (#29) | none |
+| `📝 docs(openspec): archive…` (#27, #30) | none |
+
+The skill also omits the repo's own `releaseRules` overrides — `refactor` → patch and a catalog-
+specific `skill` type → minor — so a contributor following the skill cannot predict the outcome.
+
+**2. `backlog` has the right recipe but not the reason.** Its `gh-projects.md` already says to capture
+the item id from `item-add --format json --jq .id`. It does not say what happens if you look it up
+again instead: a freshly added item is **not yet visible to `gh project item-list`**, so the follow-up
+`item-edit` fails with `Could not resolve to a node with the global id of ''`. The identical id
+resolves fine once the board catches up. Hit live while filing #28.
+
+## What Changes
+
+- `conventional-commit` → 1.3.0:
+  - Type table gains a **release impact** column, with `!`/`BREAKING CHANGE` called out as major.
+  - New section on the two traps: `security` ships nothing (type a shippable security fix as `fix`),
+    and `ci`/`test`/`build`/`style`/`revert` ship nothing either.
+  - New section on repo-specific `releaseRules` overrides, with this catalog's as the worked example
+    (`refactor` → patch, `skill` → minor, `docs`/`chore` → none).
+  - Notes that the release tooling treats the gitmoji as optional (`headerPattern` skips a leading
+    non-word prefix) while this convention still requires it — the emoji never replaces the type.
+- `backlog` → 1.0.1: `references/gh-projects.md` states the propagation lag and the exact error it
+  produces, next to the recipe that avoids it.
+- `openspec` → 1.1.0: states that every change needs a delta, that a correction should be expressed as
+  `## MODIFIED Requirements` rather than a near-duplicate `## ADDED` one, and that the `skip_specs`
+  escape hatch the CLI advertises does not work on 1.6.0.
+
+**3. `openspec` repeats a CLI escape hatch that the CLI does not honour.** A change with no spec
+delta fails validation. The validator's own error message suggests setting `skip_specs: true` in the
+change's `.openspec.yaml`; probed on CLI 1.6.0, **neither `skip_specs` nor `skipSpecs` has any
+effect**. Hit while writing this very change.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Versioned external APIs are pinned** — extended to command-line
+  tools, requiring prescribed subcommands and flags to be probed against the installed tool and the
+  probed version recorded, and requiring tool guidance contradicted by the tool itself to be corrected
+  rather than repeated.
+
+## Impact
+
+- `skills/conventional-commit/SKILL.md`, `skills/backlog/references/gh-projects.md`, regenerated
+  wrappers.
+- Anyone typing a security fix as `security` in a semantic-release repo now learns it will not ship.
+- No change to the other three probed skills (`openspec-drivezone`, `execute-backlog`,
+  `claude-statusline`): their CLI claims verified clean.

--- a/openspec/changes/verify-process-skill-claims/specs/skills-authoring/spec.md
+++ b/openspec/changes/verify-process-skill-claims/specs/skills-authoring/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Versioned external APIs are pinned
+
+A skill whose content targets an external API **or command-line tool** with breaking releases SHALL
+state the exact versions it was verified against, and SHALL name any known upcoming rename or removal
+that will invalidate it. For a skill that instructs the agent to run a CLI, the commands and flags it
+prescribes SHALL be probed against that tool before publication.
+
+#### Scenario: Reader can tell which era the code targets
+
+- **WHEN** a skill documents a library API
+- **THEN** the skill names the library versions its examples were verified against, rather than
+  leaving the reader to infer it
+
+#### Scenario: A known breaking change is disclosed, not silently absorbed
+
+- **WHEN** the upstream has announced a rename or removal affecting the skill's examples
+- **THEN** the skill names it and where it applies, instead of presenting the current form as timeless
+
+#### Scenario: Prescribed CLI commands are probed, not assumed
+
+- **WHEN** a skill instructs the agent to run a command with specific subcommands and flags
+- **THEN** each subcommand and flag is checked against the installed tool before publication, and the
+  tool version the check ran against is recorded
+
+#### Scenario: Tool guidance contradicted by the tool is corrected, not repeated
+
+- **WHEN** a tool's own output advertises behaviour its implementation does not deliver
+- **THEN** the skill states the probed behaviour and the version it holds for, rather than repeating
+  the tool's claim

--- a/openspec/changes/verify-process-skill-claims/tasks.md
+++ b/openspec/changes/verify-process-skill-claims/tasks.md
@@ -1,0 +1,39 @@
+## 1. Probe
+
+- [x] 1.1 Extract every `gh`/`openspec` command and flag from the six process skills' code blocks and
+      inline code
+- [x] 1.2 Probe each subcommand and flag against the installed tool via `--help` (non-destructive)
+- [x] 1.3 Record the result: 28/28 claims clean against gh 2.92.0 and openspec 1.6.0
+
+## 2. conventional-commit (1.3.0)
+
+- [x] 2.1 Add a release-impact column to the type table; call out `!`/`BREAKING CHANGE` as major
+- [x] 2.2 Document the `security` trap and the non-shipping types, with the repo-history evidence
+- [x] 2.3 Document repo-specific `releaseRules` overrides using this catalog's config as the example
+- [x] 2.4 Note that the release tooling treats the gitmoji as optional while this convention does not
+- [x] 2.5 Bump `metadata.version` to 1.3.0
+
+## 3. backlog (1.0.1)
+
+- [x] 3.1 State the item-add propagation lag and its exact error next to the id-capture recipe
+- [x] 3.2 Bump `metadata.version` to 1.0.1
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on both touched skills
+- [x] Q.2 All touched content in English (catalog locale)
+- [x] Q.3 Triggers and "Do NOT use for" boundaries unchanged
+- [x] Q.4 No duplicated doctrine: release impact lives only in `conventional-commit`; Projects v2
+      recipes only in `backlog/references/gh-projects.md`
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 No description promises a policy its body contradicts
+- [x] Q.7 No README change needed — no skill added, removed or repurposed
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate verify-process-skill-claims --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` reports 0 findings
+- [x] V.5 `scripts/selftest-validate-skills.py` detects 10/10
+- [ ] V.6 `openspec archive verify-process-skill-claims --yes` after review

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.0.1
   category: process
 license: MIT
 compatibility: >-

--- a/plugins/workflow/skills/backlog/references/gh-projects.md
+++ b/plugins/workflow/skills/backlog/references/gh-projects.md
@@ -38,6 +38,12 @@ gh project item-add NUM --owner OWNER --url ISSUE_URL --format json --jq .id
 # → ITEM_ID (PVTI_…)
 ```
 
+**Capture that id — do not look it up again.** A freshly added item is not immediately visible to
+`gh project item-list`: querying it right after `item-add` returns an empty result, and the
+`item-edit` call then fails with `Could not resolve to a node with the global id of ''`. The same
+query returns the item (with the identical id) once the board catches up. Observed 2026-08-06 on
+Projects v2 with gh 2.92.0.
+
 ## Set fields (one call per field)
 
 ```bash

--- a/plugins/workflow/skills/conventional-commit/SKILL.md
+++ b/plugins/workflow/skills/conventional-commit/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: git
 license: MIT
 compatibility: Works in any environment with git access.
@@ -35,23 +35,56 @@ the type.
 
 ## Type → icon mapping
 
-| Type | Icon | Use |
-|---|---|---|
-| `feat` | ✨ | new functionality |
-| `fix` | 🐛 | bug fix |
-| `refactor` | ♻️ | refactoring without behavior change |
-| `docs` | 📝 | documentation |
-| `chore` | 🧹 | maintenance tasks, configs, deps |
-| `test` | ✅ | tests |
-| `style` | 🎨 | formatting, style, no logic change |
-| `perf` | ⚡ | performance |
-| `ci` | 👷 | CI/CD |
-| `build` | 📦 | build system, dependencies |
-| `revert` | ⏪ | revert a previous commit |
-| `security` | 🔒 | security fixes |
+| Type | Icon | Use | Cuts a release? |
+|---|---|---|---|
+| `feat` | ✨ | new functionality | **minor** |
+| `fix` | 🐛 | bug fix | **patch** |
+| `perf` | ⚡ | performance | **patch** |
+| `refactor` | ♻️ | refactoring without behavior change | depends on config |
+| `docs` | 📝 | documentation | no |
+| `chore` | 🧹 | maintenance tasks, configs, deps | no |
+| `test` | ✅ | tests | no |
+| `style` | 🎨 | formatting, style, no logic change | no |
+| `ci` | 👷 | CI/CD | no |
+| `build` | 📦 | build system, dependencies | no |
+| `revert` | ⏪ | revert a previous commit | no |
+| `security` | 🔒 | security fixes | **no — see below** |
+
+Any type plus `!` (or a `BREAKING CHANGE:` footer) is a **major**, regardless of the row above.
 
 When the change doesn't cleanly fit one type (e.g. multiple concerns), pick the dominant one — don't
 stack icons.
+
+### The release column is a trap for two types
+
+Under the `conventionalcommits` preset, **only `feat`, `fix` and `perf` cut a release** unless the
+repo overrides it in `releaseRules`. Two consequences worth memorising:
+
+- **`security` ships nothing.** It is not a preset type, so a `🔒 security(auth): rotate leaked
+  token` commit produces no release and no changelog entry — the fix sits on the default branch
+  unreleased. Type a shippable security fix as **`fix`** and put the emphasis in the scope or body:
+  `🔒 fix(auth): rotate leaked service token`. Keep `security` only for changes that genuinely must
+  not trigger a release.
+- **`ci`, `test`, `build`, `style`, `revert` ship nothing either.** That is usually right, but it
+  means a change that users depend on must not be typed `ci` for tidiness.
+
+Verified in this repo: `🐛 fix(r3f): …` cut v2.0.1, while `✅ ci(skills): …` and
+`📝 docs(openspec): …` cut nothing (2026-08-06).
+
+### Repo-specific types override the defaults
+
+A repo can add types and change release levels in `.releaserc.json` → `releaseRules`. **Read that
+file before assuming.** In this catalog, for example:
+
+| Repo rule | Effect |
+|---|---|
+| `refactor` | patch (preset default would be none) |
+| `skill` | **minor** — a catalog-specific type for adding or reworking a skill |
+| `docs`, `chore` | explicitly none |
+
+The gitmoji prefix is optional as far as the release tooling is concerned — this repo's
+`headerPattern` (`^(?:[^\w\s]+\s+)?(\w+)…`) skips a leading non-word prefix — but it is
+mandatory by this convention. Never let the emoji *replace* the type.
 
 ## Hard rules
 

--- a/plugins/workflow/skills/openspec/SKILL.md
+++ b/plugins/workflow/skills/openspec/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   variant use openspec-drivezone.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -28,6 +28,14 @@ are deltas against them.
 - Pick a unique change-id: kebab-case, **verb-led** (`add-`, `update-`, `remove-`, `refactor-`).
 - Scaffold `proposal.md`, `tasks.md`, `design.md` (only if needed), and one delta spec per affected
   capability.
+- **Every change needs at least one delta.** A change with no `specs/<capability>/spec.md` fails
+  validation, strict or not. When the work genuinely changes no requirement (a correction, a tooling
+  change), do not invent a new requirement to satisfy the tool — express the change as
+  `## MODIFIED Requirements` on the requirement it refines, restating it in full with its scenarios.
+  A near-duplicate `## ADDED` requirement is the wrong answer: it splits the doctrine.
+  - Probed on CLI **1.6.0**: the validator's own error message suggests setting `skip_specs: true` in
+    the change's `.openspec.yaml` for a change that touches no specs. **It has no effect** — neither
+    `skip_specs` nor `skipSpecs` suppresses the error. Treat the delta as mandatory.
 - Validate: `openspec validate <change-id> --strict` — fix until it passes.
 - **Do not start implementation until the proposal is approved.**
 

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.0.1
   category: process
 license: MIT
 compatibility: >-

--- a/skills/backlog/references/gh-projects.md
+++ b/skills/backlog/references/gh-projects.md
@@ -38,6 +38,12 @@ gh project item-add NUM --owner OWNER --url ISSUE_URL --format json --jq .id
 # → ITEM_ID (PVTI_…)
 ```
 
+**Capture that id — do not look it up again.** A freshly added item is not immediately visible to
+`gh project item-list`: querying it right after `item-add` returns an empty result, and the
+`item-edit` call then fails with `Could not resolve to a node with the global id of ''`. The same
+query returns the item (with the identical id) once the board catches up. Observed 2026-08-06 on
+Projects v2 with gh 2.92.0.
+
 ## Set fields (one call per field)
 
 ```bash

--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   co-author reference in commits, PR titles, PR bodies, or PR descriptions.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: git
 license: MIT
 compatibility: Works in any environment with git access.
@@ -35,23 +35,56 @@ the type.
 
 ## Type → icon mapping
 
-| Type | Icon | Use |
-|---|---|---|
-| `feat` | ✨ | new functionality |
-| `fix` | 🐛 | bug fix |
-| `refactor` | ♻️ | refactoring without behavior change |
-| `docs` | 📝 | documentation |
-| `chore` | 🧹 | maintenance tasks, configs, deps |
-| `test` | ✅ | tests |
-| `style` | 🎨 | formatting, style, no logic change |
-| `perf` | ⚡ | performance |
-| `ci` | 👷 | CI/CD |
-| `build` | 📦 | build system, dependencies |
-| `revert` | ⏪ | revert a previous commit |
-| `security` | 🔒 | security fixes |
+| Type | Icon | Use | Cuts a release? |
+|---|---|---|---|
+| `feat` | ✨ | new functionality | **minor** |
+| `fix` | 🐛 | bug fix | **patch** |
+| `perf` | ⚡ | performance | **patch** |
+| `refactor` | ♻️ | refactoring without behavior change | depends on config |
+| `docs` | 📝 | documentation | no |
+| `chore` | 🧹 | maintenance tasks, configs, deps | no |
+| `test` | ✅ | tests | no |
+| `style` | 🎨 | formatting, style, no logic change | no |
+| `ci` | 👷 | CI/CD | no |
+| `build` | 📦 | build system, dependencies | no |
+| `revert` | ⏪ | revert a previous commit | no |
+| `security` | 🔒 | security fixes | **no — see below** |
+
+Any type plus `!` (or a `BREAKING CHANGE:` footer) is a **major**, regardless of the row above.
 
 When the change doesn't cleanly fit one type (e.g. multiple concerns), pick the dominant one — don't
 stack icons.
+
+### The release column is a trap for two types
+
+Under the `conventionalcommits` preset, **only `feat`, `fix` and `perf` cut a release** unless the
+repo overrides it in `releaseRules`. Two consequences worth memorising:
+
+- **`security` ships nothing.** It is not a preset type, so a `🔒 security(auth): rotate leaked
+  token` commit produces no release and no changelog entry — the fix sits on the default branch
+  unreleased. Type a shippable security fix as **`fix`** and put the emphasis in the scope or body:
+  `🔒 fix(auth): rotate leaked service token`. Keep `security` only for changes that genuinely must
+  not trigger a release.
+- **`ci`, `test`, `build`, `style`, `revert` ship nothing either.** That is usually right, but it
+  means a change that users depend on must not be typed `ci` for tidiness.
+
+Verified in this repo: `🐛 fix(r3f): …` cut v2.0.1, while `✅ ci(skills): …` and
+`📝 docs(openspec): …` cut nothing (2026-08-06).
+
+### Repo-specific types override the defaults
+
+A repo can add types and change release levels in `.releaserc.json` → `releaseRules`. **Read that
+file before assuming.** In this catalog, for example:
+
+| Repo rule | Effect |
+|---|---|
+| `refactor` | patch (preset default would be none) |
+| `skill` | **minor** — a catalog-specific type for adding or reworking a skill |
+| `docs`, `chore` | explicitly none |
+
+The gitmoji prefix is optional as far as the release tooling is concerned — this repo's
+`headerPattern` (`^(?:[^\w\s]+\s+)?(\w+)…`) skips a leading non-word prefix — but it is
+mandatory by this convention. Never let the emoji *replace* the type.
 
 ## Hard rules
 

--- a/skills/openspec/SKILL.md
+++ b/skills/openspec/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   variant use openspec-drivezone.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -28,6 +28,14 @@ are deltas against them.
 - Pick a unique change-id: kebab-case, **verb-led** (`add-`, `update-`, `remove-`, `refactor-`).
 - Scaffold `proposal.md`, `tasks.md`, `design.md` (only if needed), and one delta spec per affected
   capability.
+- **Every change needs at least one delta.** A change with no `specs/<capability>/spec.md` fails
+  validation, strict or not. When the work genuinely changes no requirement (a correction, a tooling
+  change), do not invent a new requirement to satisfy the tool — express the change as
+  `## MODIFIED Requirements` on the requirement it refines, restating it in full with its scenarios.
+  A near-duplicate `## ADDED` requirement is the wrong answer: it splits the doctrine.
+  - Probed on CLI **1.6.0**: the validator's own error message suggests setting `skip_specs: true` in
+    the change's `.openspec.yaml` for a change that touches no specs. **It has no effect** — neither
+    `skip_specs` nor `skipSpecs` suppresses the error. Treat the delta as mandatory.
 - Validate: `openspec validate <change-id> --strict` — fix until it passes.
 - **Do not start implementation until the proposal is approved.**
 


### PR DESCRIPTION
## Why

Six skills — `openspec`, `openspec-drivezone`, `backlog`, `execute-backlog`, `conventional-commit`, `claude-statusline` — instruct the agent to run external CLIs. `skills-authoring` requires those claims to be verified. They never had been.

## The probe

Every command and flag extracted from their code blocks and inline code, then probed via `--help` (non-destructive — running `gh issue create` to check it exists would file an issue):

**28 distinct claims against `gh 2.92.0` and `openspec 1.6.0`. Every subcommand exists, every flag appears in its help output. Zero problems.**

That is a negative result and it is reported as one. No edits were manufactured from it.

## Three defects found by *using* the skills, not reading them

### 1. `conventional-commit` never says which types ship

Twelve types listed, no release impact. Under the `conventionalcommits` preset only `feat`, `fix` and `perf` cut a release — so the table's `security` row is a trap:

> `🔒 security(auth): rotate leaked token` → **no release, no changelog entry.** The fix sits unreleased on the default branch while the author believes it shipped.

Verified against this repo's own history rather than the preset docs:

| commit | release |
|---|---|
| `🐛 fix(r3f): make the code blocks compile…` (#26) | **v2.0.1** |
| `✅ ci(skills): enforce the authoring rules…` (#29) | none |
| `📝 docs(openspec): archive…` (#27, #30) | none |

The skill also omitted this repo's own `releaseRules` overrides — `refactor` → patch, and a catalog-specific `skill` type → minor.

**Fix:** release-impact column, the two traps (`security` ships nothing; so do `ci`/`test`/`build`/`style`/`revert`), the rule to type a shippable security fix as `fix` and carry the emphasis in scope/body/emoji, and a section on reading `.releaserc.json` before assuming.

### 2. `backlog` had the right recipe without the reason

`gh-projects.md` already said to capture the item id from `item-add --format json --jq .id`. It did not say what happens if you look it up again:

> A freshly added item is **not yet visible to `gh project item-list`**. The follow-up `item-edit` fails with `Could not resolve to a node with the global id of ''`. The identical id resolves fine once the board catches up.

Hit live while filing #28. The warning now sits next to the recipe that avoids it, because the failure happens in the seconds between two commands.

### 3. `openspec` repeated an escape hatch the CLI does not honour

A change with no spec delta fails validation. The validator's own error message suggests setting `skip_specs: true` in the change's `.openspec.yaml`. Probed on 1.6.0:

```
skip_specs: true  -> errors=1
skipSpecs: true   -> errors=1
```

**Neither has any effect.** Hit while writing this very change. The skill now states that the delta is mandatory, and that a correction touching no requirement should be expressed as `## MODIFIED Requirements` on the requirement it refines — never as a near-duplicate `## ADDED` one, which splits the doctrine.

## Spec delta

`skills-authoring` → **MODIFIED** *Versioned external APIs are pinned*, extended to command-line tools: prescribed subcommands and flags must be probed against the installed tool with the version recorded, and tool guidance contradicted by the tool itself must be corrected rather than repeated.

Expressed as MODIFIED rather than a new requirement — the same rule this PR adds to the `openspec` skill, applied to itself.

## Versions

`conventional-commit` 1.3.0 · `openspec` 1.1.0 · `backlog` 1.0.1

No change to `openspec-drivezone`, `execute-backlog` or `claude-statusline`: their CLI claims verified clean.

`V.6` (`openspec archive`) intentionally left open — closure step after review.
