### PR TITLE
✨ feat(k8s-tune-resources): bring the orphan skill into the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Project v2 in the org/user. Full details live in the skills themselves:
 |-------|----------|--------------|
 | **documentation** | README, SETUP, TECHNICAL, CHANGELOG, AGENTS.md, "document this", "write the docs" | Reads the code first, then creates only the documents the project earns — one purpose per page, claims written so a script can verify them (paths as links, trees rooted correctly, env tables from the config module), docs changed in the same commit as the code, and an `AGENTS.md` when a tool-specific instruction file already exists |
 | **helm-migration** | "migrate to helm", "convert yaml to helm", "generate values.yaml" | Converts K8s YAML to Helm values.yaml/env.yaml — **requires the solvelab chart template repository** |
+| **k8s-tune-resources** | "tune"/"reduce"/"scale down"/"ajustar resources" of pods on nodes with a label, across many repos | Bulk-edits resource requests across every repo behind a node label — discovery from pod images, then clone/patch/commit/push. **Pushes to many repos: runs `DRY_RUN=1` by default** |
 
 ### Tooling
 

--- a/claude/skills/k8s-tune-resources/SKILL.md
+++ b/claude/skills/k8s-tune-resources/SKILL.md
@@ -1,133 +1,19 @@
 ---
 name: k8s-tune-resources
-description: Bulk-edit Kubernetes resources requests/limits across many Bitbucket repos discovered from pods running on nodes with a given label. For each pod, derives the repo name from the image (segment after the last `/`, before `:`), clones `git@bitbucket.org:<ORG>/<REPO>.git`, checks out a target branch (default `deploy`), patches `deploy/dev/values.yaml` and `deploy/hml/values.yaml` with a sed pair, then commits and pushes. Use when the user asks to "tune", "reduce", "scale down" or "ajustar resources" of pods on nodes selected by a label (e.g. `apps=galileos`) across multiple repos.
+description: >-
+  Bulk-edit Kubernetes resource requests/limits across many git repos discovered from the pods running
+  on nodes with a given label. For each pod it derives the repo name from the image, clones it, checks
+  out a target branch, patches the chart values files with a sed pair, then commits and pushes. Use
+  when the user asks to "tune", "reduce", "scale down" or "ajustar resources" of pods on nodes selected
+  by a label across multiple repos. This skill pushes to many repositories at once — it runs dry by
+  default and requires an explicit opt-in to push. Do NOT use for editing a single repo (edit it
+  directly) or for live `kubectl patch` changes that bypass GitOps.
 metadata:
-  author: diegops
-  version: 1.0.0
+  author: solvelab
+  version: 2.0.0
   category: devops
+license: MIT
+compatibility: Requires kubectl with a context on the target cluster, git, and push access to the repos.
 ---
 
-# k8s-tune-resources
-
-Skill for repeating the cluster-wide resources tuning routine across different Kubernetes clusters and label selectors.
-
-## Required inputs (ask the user if missing)
-
-1. **Node label selector** — e.g. `apps=galileos`
-2. **Image-name prefix filter(s)** — substrings to grep on image names to pick which repos to touch (e.g. `galileo`, `ga-`)
-3. **Bitbucket workspace/org** — e.g. `unearsa`
-4. **Target branch** — default `deploy`
-5. **values.yaml relative paths** — default `deploy/dev/values.yaml` and `deploy/hml/values.yaml`
-6. **Patches (sed pairs)** — default:
-   - `memory: "128Mi"` → `memory: "64Mi"`
-   - `cpu: "50m"` → `cpu: "25m"`
-7. **Commit message** — default `chore: reduce resources requests to 64Mi/25m in dev and hml`
-8. **kubeconfig context** — confirm `kubectl config current-context` matches the cluster the user wants
-
-## Workflow
-
-### Step 1 — Discover repos
-
-```bash
-kubectl get nodes -l <LABEL>
-```
-
-For each node, list pods + container images and filter by the prefix(es):
-
-```bash
-for NODE in <node1> <node2> ...; do
-  kubectl get pods -A --field-selector spec.nodeName=$NODE \
-    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.containers[*].image}{"\n"}{end}' \
-    | grep -E '<PREFIX_REGEX>'
-done
-```
-
-Extract repo name from image: segment after the last `/`, before `:` (strip tag). Dedupe.
-Save list to `/tmp/<scope>-repos.txt` (one repo per line).
-
-Show the list to the user and confirm scope before proceeding.
-
-### Step 2 — Mass clone / edit / commit / push
-
-Use `/tmp/<scope>-work/` as workdir.
-
-```bash
-LIST=/tmp/<scope>-repos.txt
-WORK=/tmp/<scope>-work
-ORG=<bitbucket-org>
-BRANCH=<branch>
-COMMIT_MSG="<commit-message>"
-mkdir -p "$WORK"
-LOG=$WORK/run.log
-: > "$LOG"
-
-status() { printf '%-60s %s\n' "$1" "$2" | tee -a "$LOG"; }
-
-while IFS= read -r repo; do
-  [ -z "$repo" ] && continue
-  cd "$WORK" || exit 1
-
-  if [ ! -d "$repo" ]; then
-    if ! git clone --quiet "git@bitbucket.org:${ORG}/${repo}.git" 2>>"$LOG"; then
-      status "$repo" "CLONE_FAIL"; continue
-    fi
-  fi
-
-  cd "$WORK/$repo" || { status "$repo" "CD_FAIL"; continue; }
-  git fetch --quiet origin 2>>"$LOG"
-
-  if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-    status "$repo" "NO_${BRANCH}_BRANCH"; continue
-  fi
-
-  git checkout --quiet "$BRANCH" 2>>"$LOG" || git checkout --quiet -b "$BRANCH" "origin/$BRANCH" 2>>"$LOG"
-  git reset --quiet --hard "origin/$BRANCH" 2>>"$LOG"
-
-  changed=0
-  for f in deploy/dev/values.yaml deploy/hml/values.yaml; do
-    if [ ! -f "$f" ]; then
-      status "$repo:$f" "NO_VALUES_YAML"; continue
-    fi
-    sed -i \
-      -e 's/memory: "128Mi"/memory: "64Mi"/' \
-      -e 's/cpu: "50m"/cpu: "25m"/' \
-      "$f"
-    if ! git diff --quiet -- "$f"; then
-      changed=1
-      git add "$f"
-    fi
-  done
-
-  if [ "$changed" -eq 0 ]; then
-    status "$repo" "NO_CHANGE"; continue
-  fi
-
-  if ! git commit --quiet -m "$COMMIT_MSG" 2>>"$LOG"; then
-    status "$repo" "COMMIT_FAIL"; continue
-  fi
-  if git push --quiet origin "$BRANCH" 2>>"$LOG"; then
-    status "$repo" "PUSHED"
-  else
-    status "$repo" "PUSH_FAIL"
-  fi
-done < "$LIST"
-echo "---DONE---" | tee -a "$LOG"
-```
-
-### Step 3 — Report
-
-Summarize per-repo status from the log: PUSHED / NO_CHANGE / CLONE_FAIL / NO_<BRANCH>_BRANCH / NO_VALUES_YAML / COMMIT_FAIL / PUSH_FAIL.
-
-## Safety notes
-
-- This pushes to many repos. Always confirm scope (cluster context, label, image filter, list of repos) **before** running Step 2.
-- Per global rule (`~/.claude/CLAUDE.md`): commit messages must **not** include any `Co-Authored-By: Claude` line.
-- The sed patterns only match the literal strings `memory: "128Mi"` and `cpu: "50m"`. If a repo already uses other values (e.g. `256Mi`), it falls through as `NO_CHANGE`. Limits (`512Mi`, `1`) are preserved because they don't collide.
-- If `deploy/dev/values.yaml` or `deploy/hml/values.yaml` is missing, the script skips that file but still commits/pushes the env that did change.
-- Some repos store values at the repo root (`dev/values.yaml`) instead of under `deploy/`. Verify path on a sample repo first; adapt the `for f in ...` list if needed.
-
-## Memorized facts
-
-- Bitbucket org used so far: `unearsa`
-- Branch used so far: `deploy`
-- Cluster discovered via label `apps=galileos` had 2 nodes (`10.160.0.164`, `10.160.0.176`) and 51 galileo-related repos (28 `galileo*` + 23 `ga-*`) already patched on 2026-05-18.
+Read and follow all instructions in ~/ai-skills/skills/k8s-tune-resources/SKILL.md

--- a/codex/AGENTS.md
+++ b/codex/AGENTS.md
@@ -23,6 +23,7 @@ Each skill @-includes the canonical skill from `skills/<name>/SKILL.md` — no d
 | `fivem-lua` | `codex/skills/fivem-lua/AGENTS.md` |
 | `fivem-nui-react` | `codex/skills/fivem-nui-react/AGENTS.md` |
 | `helm-migration` | `codex/skills/helm-migration/AGENTS.md` |
+| `k8s-tune-resources` | `codex/skills/k8s-tune-resources/AGENTS.md` |
 | `log-event-collector` | `codex/skills/log-event-collector/AGENTS.md` |
 | `openspec-drivezone` | `codex/skills/openspec-drivezone/AGENTS.md` |
 | `openspec` | `codex/skills/openspec/AGENTS.md` |

--- a/codex/skills/k8s-tune-resources/AGENTS.md
+++ b/codex/skills/k8s-tune-resources/AGENTS.md
@@ -1,0 +1,3 @@
+# k8s-tune-resources
+
+@../../skills/k8s-tune-resources/SKILL.md

--- a/copilot/instructions/k8s-tune-resources.instructions.md
+++ b/copilot/instructions/k8s-tune-resources.instructions.md
@@ -1,0 +1,3 @@
+# k8s-tune-resources
+
+Follow the instructions in [SKILL.md](../../skills/k8s-tune-resources/SKILL.md)

--- a/cursor/rules/k8s-tune-resources.mdc
+++ b/cursor/rules/k8s-tune-resources.mdc
@@ -1,0 +1,172 @@
+---
+description: >-
+  Bulk-edit Kubernetes resource requests/limits across many git repos discovered from the pods running on nodes with a given label. For each pod it derives the repo name from the image, clones it, checks out a target branch, patches the chart values files with a sed pair, then commits and pushes. Use when the user asks to "tune", "reduce", "scale down" or "ajustar resources" of pods on nodes selected by a label across multiple repos. This skill pushes to many repositories at once — it runs dry by default and requires an explicit opt-in to push. Do NOT use for editing a single repo (edit it directly) or for live `kubectl patch` changes that bypass GitOps.
+alwaysApply: false
+---
+
+
+# k8s-tune-resources
+
+Skill for repeating the cluster-wide resources tuning routine across different Kubernetes clusters and label selectors.
+
+> **Verified against**: `kubectl v1.36.1` · `git 2.47.3`. Every flag the workflow uses — `-l`,
+> `-A`, `--field-selector`, `-o jsonpath` — was probed against that client. The clone URL template
+> assumes Bitbucket over SSH; adapt the host for any other forge.
+>
+> **This skill pushes to many repositories.** The Step 2 loop runs with `DRY_RUN=1` by default and
+> never pushes until you set it to `0`. Read the dry-run report first — see *Safety notes*.
+
+## Required inputs (ask the user if missing)
+
+1. **Node label selector** — e.g. `apps=<group>`
+2. **Image-name prefix filter(s)** — substrings to grep on image names to pick which repos to
+   touch (e.g. `myapp`, `ma-`)
+3. **Git host workspace/org** — the org the repos live under (the clone URL template is
+   `git@bitbucket.org:<ORG>/<REPO>.git`; adapt the host if you are not on Bitbucket)
+4. **Target branch** — default `deploy`
+5. **values.yaml relative paths** — default `deploy/dev/values.yaml` and `deploy/hml/values.yaml`
+6. **Patches (sed pairs)** — default:
+   - `memory: "128Mi"` → `memory: "64Mi"`
+   - `cpu: "50m"` → `cpu: "25m"`
+7. **Commit message** — default `chore: reduce resources requests to 64Mi/25m in dev and hml`
+8. **kubeconfig context** — confirm `kubectl config current-context` matches the cluster the user wants
+
+## Workflow
+
+### Step 1 — Discover repos
+
+```bash
+kubectl get nodes -l <LABEL>
+```
+
+For each node, list pods + container images and filter by the prefix(es):
+
+```bash
+for NODE in <node1> <node2> ...; do
+  kubectl get pods -A --field-selector spec.nodeName=$NODE \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.containers[*].image}{"\n"}{end}' \
+    | grep -E '<PREFIX_REGEX>'
+done
+```
+
+Extract repo name from image: segment after the last `/`, before `:` (strip tag). Dedupe.
+Save list to `/tmp/<scope>-repos.txt` (one repo per line).
+
+Show the list to the user and confirm scope before proceeding.
+
+### Step 2 — Mass clone / edit / commit / push
+
+Use `/tmp/<scope>-work/` as workdir.
+
+```bash
+LIST=/tmp/<scope>-repos.txt
+WORK=/tmp/<scope>-work
+ORG=<bitbucket-org>
+BRANCH=<branch>
+COMMIT_MSG="<commit-message>"
+DRY_RUN=${DRY_RUN:-1}          # 1 = clone, patch and report; never push. Flip to 0 only after review.
+mkdir -p "$WORK"
+LOG=$WORK/run.log
+: > "$LOG"
+
+status() { printf '%-60s %s\n' "$1" "$2" | tee -a "$LOG"; }
+
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  cd "$WORK" || exit 1
+
+  if [ ! -d "$repo" ]; then
+    if ! git clone --quiet "git@bitbucket.org:${ORG}/${repo}.git" 2>>"$LOG"; then
+      status "$repo" "CLONE_FAIL"; continue
+    fi
+  fi
+
+  cd "$WORK/$repo" || { status "$repo" "CD_FAIL"; continue; }
+  git fetch --quiet origin 2>>"$LOG"
+
+  if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    status "$repo" "NO_${BRANCH}_BRANCH"; continue
+  fi
+
+  git checkout --quiet "$BRANCH" 2>>"$LOG" || git checkout --quiet -b "$BRANCH" "origin/$BRANCH" 2>>"$LOG"
+  git reset --quiet --hard "origin/$BRANCH" 2>>"$LOG"
+
+  changed=0
+  for f in deploy/dev/values.yaml deploy/hml/values.yaml; do
+    if [ ! -f "$f" ]; then
+      status "$repo:$f" "NO_VALUES_YAML"; continue
+    fi
+    sed -i \
+      -e 's/memory: "128Mi"/memory: "64Mi"/' \
+      -e 's/cpu: "50m"/cpu: "25m"/' \
+      "$f"
+    if ! git diff --quiet -- "$f"; then
+      changed=1
+      git add "$f"
+    fi
+  done
+
+  if [ "$changed" -eq 0 ]; then
+    status "$repo" "NO_CHANGE"; continue
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    status "$repo" "WOULD_CHANGE"; git --no-pager diff --cached --stat >>"$LOG"; continue
+  fi
+
+  if ! git commit --quiet -m "$COMMIT_MSG" 2>>"$LOG"; then
+    status "$repo" "COMMIT_FAIL"; continue
+  fi
+  if git push --quiet origin "$BRANCH" 2>>"$LOG"; then
+    status "$repo" "PUSHED"
+  else
+    status "$repo" "PUSH_FAIL"
+  fi
+done < "$LIST"
+echo "---DONE---" | tee -a "$LOG"
+```
+
+### Step 3 — Report
+
+Summarize per-repo status from the log: WOULD_CHANGE (dry run) / PUSHED / NO_CHANGE / CLONE_FAIL / NO_<BRANCH>_BRANCH / NO_VALUES_YAML / COMMIT_FAIL / PUSH_FAIL.
+
+## Safety notes
+
+- **Dry run first, always.** The loop above honours `DRY_RUN`; leave it at `1` for the first pass,
+  read the report, and only then re-run with `DRY_RUN=0`. A prose instruction to "confirm scope" is
+  not a safety mechanism — the flag is.
+- **Rollback plan before the push, not after.** Every repo lands exactly one commit, so the revert is
+  mechanical — but write it down before you start:
+
+  ```bash
+  # per repo, from the same workdir, AFTER a bad run
+  cd "$WORK/$repo" && git revert --no-edit HEAD && git push origin "$BRANCH"
+  ```
+
+  If the branch is protected or shared, revert instead of force-pushing; never `push --force` across
+  a fleet.
+- `git reset --hard "origin/$BRANCH"` discards anything already in a reused workdir. That is
+  deliberate (it guarantees a clean base) but it means the workdir is disposable — never point
+  `$WORK` at a directory you are also working in.
+- This pushes to many repos. Always confirm scope (cluster context, label, image filter, list of repos) **before** running Step 2.
+- Per global rule (`~/.claude/CLAUDE.md`): commit messages must **not** include any `Co-Authored-By: Claude` line.
+- The sed patterns only match the literal strings `memory: "128Mi"` and `cpu: "50m"`. If a repo already uses other values (e.g. `256Mi`), it falls through as `NO_CHANGE`. Limits (`512Mi`, `1`) are preserved because they don't collide.
+- If `deploy/dev/values.yaml` or `deploy/hml/values.yaml` is missing, the script skips that file but still commits/pushes the env that did change.
+- Some repos store values at the repo root (`dev/values.yaml`) instead of under `deploy/`. Verify path on a sample repo first; adapt the `for f in ...` list if needed.
+
+## Blast radius — what this has actually done
+
+A real run touched **51 repositories** from a single label selector (2 nodes, two image-name
+prefixes). That is the scale to plan for: a wrong sed pair is 51 bad commits pushed to a shared
+branch, and there is no undo button.
+
+Sizing the run before you make it:
+
+```bash
+wc -l "$LIST"                      # how many repos will be pushed to
+head -20 "$LIST"                   # do these names look like what you expect?
+```
+
+Do not record cluster addresses, customer names or org slugs in this skill. They belong to the run,
+not to the doctrine — the run asks for them as inputs (see *Required inputs*), and this file is
+published.

--- a/openspec/changes/onboard-k8s-tune-resources/.openspec.yaml
+++ b/openspec/changes/onboard-k8s-tune-resources/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/onboard-k8s-tune-resources/design.md
+++ b/openspec/changes/onboard-k8s-tune-resources/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`k8s-tune-resources` shipped to every Claude Code user of this repo while sitting outside every
+control the catalog has. It was found by cross-checking the wrapper trees against the canonical one
+during a catalog-wide audit — not by any gate, because no gate looked there.
+
+It is also the most destructive skill in the catalog: it clones a fleet of repositories, rewrites
+their chart values with `sed`, commits and pushes. A real run touched 51 repositories.
+
+## Goals / Non-Goals
+
+**Goals**
+- Bring the skill under the same rules as every other one.
+- Give an operation of this blast radius a dry run and a rollback path.
+- Make the orphan state impossible to reach again silently.
+
+**Non-Goals**
+- Not rewriting the skill's approach. The discovery-from-pod-images workflow is sound and stays.
+- Not rewriting git history to purge the values already published. That is the repository owner's
+  decision; this change stops the leak going forward and says so.
+- Not generalising the skill beyond Bitbucket/SSH. The clone template is called out as an assumption
+  instead.
+
+## Decisions
+
+**D1 — Promote, do not delete.** The skill does real work and its workflow is battle-tested at 51
+repos. Deleting it would lose that; leaving it orphaned would keep it unchecked. Promotion is the only
+option that ends with it governed.
+
+**D2 — `DRY_RUN=1` is the default, not a documented option.** The previous safety was a sentence
+asking the operator to confirm scope. For an operation with no undo, the guard has to be in the code
+path: the loop now stops after staging and reports `WOULD_CHANGE` with a diffstat unless `DRY_RUN=0`
+is passed deliberately.
+
+**D3 — Rollback is written before the run, not after.** Every repo lands exactly one commit, so a
+`git revert HEAD` per repo is sufficient and safe on shared branches. The skill says to prepare it up
+front, and forbids fleet-wide force-pushing.
+
+**D4 — Operational values are inputs, never doctrine.** Cluster addresses, org slugs and app-name
+prefixes belong to a run. The skill already collects them in *Required inputs*; recording them a
+second time as "memorized facts" gained nothing and published internal detail from a public repo. The
+blast-radius figure is kept because the *number* is the lesson; the addresses are not.
+
+**D5 — The catalog requirement becomes structural, not numeric.** The existing requirement asserted
+"exactly 20 skills" and had been wrong for some time — the catalog is at 31. A count in a spec is a
+guaranteed future falsehood; the rule that matters is that the canonical tree defines the set.
+
+**D6 — C7 checks generated trees, not just the canonical one.** The whole failure was that every check
+looked only where the file was not. The new check inverts the direction: walk the generated trees and
+demand a source for each entry.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Bulk resource tuning across repos discovered from a cluster | `k8s-tune-resources` | establish here (promoted from an orphan wrapper) |
+| Kubernetes YAML → Helm chart conversion | `helm-migration` | unchanged; different job, no overlap |
+| Commit message format for the commits this skill creates | `conventional-commit` | link (already canonical) |
+| What the catalog is, and how a skill is added | `openspec/specs/skills-catalog` | spec delta |
+| Mechanical enforcement of authoring rules | `scripts/validate-skills.py` | already canonical — gains C7 |
+
+## Risks / Trade-offs
+
+- [`DRY_RUN` defaulting to 1 breaks anyone who copy-pasted the old loop into automation] → intended;
+  the failure mode is "nothing was pushed", which is the safe direction, and the report says why.
+- [Promoting the skill makes an org-specific workflow more visible] → the org-specific values are
+  removed and the remaining workflow is generic; it was already public.
+- [C7 only walks `claude/` and `codex/`] → those are the two trees that install as skills; `cursor/`
+  and `copilot/` emit flat files, and `plugins/` is assembled from the canonical set by `generate.sh`.
+- [Removed values persist in git history] → stated in the proposal as out of scope and left to the
+  repository owner.

--- a/openspec/changes/onboard-k8s-tune-resources/proposal.md
+++ b/openspec/changes/onboard-k8s-tune-resources/proposal.md
@@ -1,0 +1,63 @@
+# Change: Bring k8s-tune-resources into the catalog, and stop orphan skills recurring
+
+## Why
+
+`k8s-tune-resources` existed only as `claude/skills/k8s-tune-resources/SKILL.md` — 133 lines of real
+content in a **generated** tree, with no `skills/k8s-tune-resources/` source behind it. Everything
+that governs a catalog skill therefore skipped it:
+
+- `generate.sh` never produced its `codex/`, `cursor/`, `copilot/` or `plugins/` variants
+- the CI frontmatter check globs `skills/*/SKILL.md`, so its missing `license` and `compatibility`
+  were never caught, and its `metadata.author: diegops` never reconciled with the catalog's `solvelab`
+- `scripts/validate-skills.py` never checked it — the catalog reported 30 skills; there were 31
+- the README never listed it, so nobody browsing the catalog knew it shipped
+
+It was still installed for every Claude Code user of this repo.
+
+Reviewing it surfaced three further problems:
+
+1. **It published internal infrastructure to a public repo.** A "Memorized facts" section carried two
+   cluster node addresses (RFC1918), a customer org slug and an application-name prefix. No
+   credentials, so the severity is low — but the skill works without any of it, and the run already
+   asks for those values as inputs.
+2. **No dry run.** Step 2 clones, patches, commits *and pushes* in one loop. Its only guard was a
+   prose line saying to confirm scope first. A real run pushed to **51 repositories**.
+3. **No rollback path**, for an operation whose blast radius is 51 shared branches.
+
+## What Changes
+
+- `skills/k8s-tune-resources/SKILL.md` created (2.0.0) from the orphan, with catalog-conformant
+  frontmatter (`solvelab`, MIT, `compatibility`, folded description), and the orphan
+  `claude/skills/k8s-tune-resources/` deleted so `generate.sh` owns every tree.
+- **`DRY_RUN` wired into the loop, defaulting to `1`** — it clones, patches and reports
+  `WOULD_CHANGE` with a diffstat, and never pushes until explicitly set to `0`. Verified with
+  `bash -n` after substituting the placeholders.
+- **Rollback documented before the push**: the per-repo `git revert` command, and the rule to revert
+  rather than force-push across a fleet.
+- **Blast radius stated**: 51 repositories from one label selector, with the two commands that size a
+  run before you make it.
+- Cluster addresses, customer org and app-name prefixes removed; the required-inputs list already
+  collects them per run. A standing instruction not to record them here was added.
+- **Verified against** `kubectl v1.36.1` and `git 2.47.3` — every flag the workflow uses (`-l`, `-A`,
+  `--field-selector`, `-o jsonpath`) probed against that client.
+- New validator check **C7 — no orphan wrapper skills**: every directory under a generated tree must
+  have a canonical `skills/<name>/SKILL.md`. Self-test extended to 11 defect classes.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: MODIFIED **Catalog composition after the quality review** — the catalog is the set
+  of `skills/*/SKILL.md`; a skill present only in a generated tree is not a catalog skill and is
+  rejected by CI.
+
+## Impact
+
+- New `skills/k8s-tune-resources/SKILL.md`; `claude/skills/k8s-tune-resources/` replaced by the
+  generated wrapper; new `codex/`, `cursor/`, `copilot/`, `plugins/devops/` variants.
+- `scripts/validate-skills.py` (+C7), `scripts/selftest-validate-skills.py` (11 classes), README row.
+- Catalog count goes 30 → 31.
+- **Not done here:** the removed values remain in git history. Rewriting published history is the
+  repository owner's call, not this change's.

--- a/openspec/changes/onboard-k8s-tune-resources/specs/skills-catalog/spec.md
+++ b/openspec/changes/onboard-k8s-tune-resources/specs/skills-catalog/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: Catalog composition after the quality review
+
+The catalog SHALL be exactly the set of `skills/<name>/SKILL.md` files. A skill present only in a
+generated tree (`claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/`) is not a catalog skill: it
+escapes `generate.sh`, the CI frontmatter check, the content validator and the README index, while
+still installing for users. CI SHALL reject that state.
+
+The composition is not a frozen count. It changes by proposal, and the README index is the
+human-readable view of it.
+
+#### Scenario: npx discovery lists the full catalog
+
+- **WHEN** `npx skills add <repo> --list` runs against the repository root
+- **THEN** every `skills/<name>/SKILL.md` is discovered
+- **AND** the set matches the README skill index
+
+#### Scenario: A skill in a generated tree without a source is rejected
+
+- **WHEN** a directory exists under `claude/skills/` or `codex/skills/` with no matching
+  `skills/<name>/SKILL.md`
+- **THEN** `scripts/validate-skills.py` reports it as an orphan wrapper and CI fails
+
+#### Scenario: Adding a skill goes through the canonical tree
+
+- **WHEN** a new skill is added
+- **THEN** it is written to `skills/<name>/SKILL.md`, its wrappers are produced by `./generate.sh`,
+  and it gains a README row — never hand-written into a generated tree

--- a/openspec/changes/onboard-k8s-tune-resources/tasks.md
+++ b/openspec/changes/onboard-k8s-tune-resources/tasks.md
@@ -1,0 +1,49 @@
+## 1. Promote the orphan
+
+- [x] 1.1 Create `skills/k8s-tune-resources/SKILL.md` from the orphan wrapper
+- [x] 1.2 Catalog-conformant frontmatter: folded description, `solvelab`, semver, `devops`, MIT,
+      `compatibility`
+- [x] 1.3 Delete `claude/skills/k8s-tune-resources/` so `generate.sh` owns every tree
+- [x] 1.4 Run `./generate.sh`; confirm the claude/codex/cursor/copilot/plugins variants appear
+
+## 2. Make the operation survivable
+
+- [x] 2.1 Wire `DRY_RUN` into the Step 2 loop, defaulting to `1`, reporting `WOULD_CHANGE` + diffstat
+- [x] 2.2 Verify the loop with `bash -n` after substituting the placeholders
+- [x] 2.3 Document the per-repo rollback and forbid fleet-wide force-push
+- [x] 2.4 State the blast radius (51 repos from one label) and the two commands that size a run
+- [x] 2.5 Add the dry-run banner to the header
+
+## 3. Remove published operational detail
+
+- [x] 3.1 Delete the cluster node addresses, customer org slug and app-name prefixes
+- [x] 3.2 Genericise the remaining examples in *Required inputs*
+- [x] 3.3 Add the standing rule that run values are inputs, not doctrine
+- [x] 3.4 Grep every tree to confirm none of the removed values survive
+
+## 4. Prevent recurrence
+
+- [x] 4.1 Add validator check C7: every directory under `claude/skills/` and `codex/skills/` has a
+      canonical `skills/<name>/SKILL.md`
+- [x] 4.2 Extend the self-test to inject an orphan wrapper; 11/11 classes detected
+- [x] 4.3 Probe and pin the tools the skill prescribes (`kubectl v1.36.1`, `git 2.47.3`)
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on the new skill
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Description carries its triggers and a "Do NOT use for" boundary
+- [x] Q.4 No duplicated doctrine: no overlap with `helm-migration`; commit format links
+      `conventional-commit`
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 Description states no policy the body contradicts
+- [x] Q.7 README gains the `k8s-tune-resources` row in the devops section
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate onboard-k8s-tune-resources --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` reports 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` detects 11/11 injected defect classes
+- [ ] V.6 `openspec archive onboard-k8s-tune-resources --yes` after review

--- a/plugins/devops/skills/k8s-tune-resources/SKILL.md
+++ b/plugins/devops/skills/k8s-tune-resources/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: k8s-tune-resources
+description: >-
+  Bulk-edit Kubernetes resource requests/limits across many git repos discovered from the pods running
+  on nodes with a given label. For each pod it derives the repo name from the image, clones it, checks
+  out a target branch, patches the chart values files with a sed pair, then commits and pushes. Use
+  when the user asks to "tune", "reduce", "scale down" or "ajustar resources" of pods on nodes selected
+  by a label across multiple repos. This skill pushes to many repositories at once — it runs dry by
+  default and requires an explicit opt-in to push. Do NOT use for editing a single repo (edit it
+  directly) or for live `kubectl patch` changes that bypass GitOps.
+metadata:
+  author: solvelab
+  version: 2.0.0
+  category: devops
+license: MIT
+compatibility: Requires kubectl with a context on the target cluster, git, and push access to the repos.
+---
+
+# k8s-tune-resources
+
+Skill for repeating the cluster-wide resources tuning routine across different Kubernetes clusters and label selectors.
+
+> **Verified against**: `kubectl v1.36.1` · `git 2.47.3`. Every flag the workflow uses — `-l`,
+> `-A`, `--field-selector`, `-o jsonpath` — was probed against that client. The clone URL template
+> assumes Bitbucket over SSH; adapt the host for any other forge.
+>
+> **This skill pushes to many repositories.** The Step 2 loop runs with `DRY_RUN=1` by default and
+> never pushes until you set it to `0`. Read the dry-run report first — see *Safety notes*.
+
+## Required inputs (ask the user if missing)
+
+1. **Node label selector** — e.g. `apps=<group>`
+2. **Image-name prefix filter(s)** — substrings to grep on image names to pick which repos to
+   touch (e.g. `myapp`, `ma-`)
+3. **Git host workspace/org** — the org the repos live under (the clone URL template is
+   `git@bitbucket.org:<ORG>/<REPO>.git`; adapt the host if you are not on Bitbucket)
+4. **Target branch** — default `deploy`
+5. **values.yaml relative paths** — default `deploy/dev/values.yaml` and `deploy/hml/values.yaml`
+6. **Patches (sed pairs)** — default:
+   - `memory: "128Mi"` → `memory: "64Mi"`
+   - `cpu: "50m"` → `cpu: "25m"`
+7. **Commit message** — default `chore: reduce resources requests to 64Mi/25m in dev and hml`
+8. **kubeconfig context** — confirm `kubectl config current-context` matches the cluster the user wants
+
+## Workflow
+
+### Step 1 — Discover repos
+
+```bash
+kubectl get nodes -l <LABEL>
+```
+
+For each node, list pods + container images and filter by the prefix(es):
+
+```bash
+for NODE in <node1> <node2> ...; do
+  kubectl get pods -A --field-selector spec.nodeName=$NODE \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.containers[*].image}{"\n"}{end}' \
+    | grep -E '<PREFIX_REGEX>'
+done
+```
+
+Extract repo name from image: segment after the last `/`, before `:` (strip tag). Dedupe.
+Save list to `/tmp/<scope>-repos.txt` (one repo per line).
+
+Show the list to the user and confirm scope before proceeding.
+
+### Step 2 — Mass clone / edit / commit / push
+
+Use `/tmp/<scope>-work/` as workdir.
+
+```bash
+LIST=/tmp/<scope>-repos.txt
+WORK=/tmp/<scope>-work
+ORG=<bitbucket-org>
+BRANCH=<branch>
+COMMIT_MSG="<commit-message>"
+DRY_RUN=${DRY_RUN:-1}          # 1 = clone, patch and report; never push. Flip to 0 only after review.
+mkdir -p "$WORK"
+LOG=$WORK/run.log
+: > "$LOG"
+
+status() { printf '%-60s %s\n' "$1" "$2" | tee -a "$LOG"; }
+
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  cd "$WORK" || exit 1
+
+  if [ ! -d "$repo" ]; then
+    if ! git clone --quiet "git@bitbucket.org:${ORG}/${repo}.git" 2>>"$LOG"; then
+      status "$repo" "CLONE_FAIL"; continue
+    fi
+  fi
+
+  cd "$WORK/$repo" || { status "$repo" "CD_FAIL"; continue; }
+  git fetch --quiet origin 2>>"$LOG"
+
+  if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    status "$repo" "NO_${BRANCH}_BRANCH"; continue
+  fi
+
+  git checkout --quiet "$BRANCH" 2>>"$LOG" || git checkout --quiet -b "$BRANCH" "origin/$BRANCH" 2>>"$LOG"
+  git reset --quiet --hard "origin/$BRANCH" 2>>"$LOG"
+
+  changed=0
+  for f in deploy/dev/values.yaml deploy/hml/values.yaml; do
+    if [ ! -f "$f" ]; then
+      status "$repo:$f" "NO_VALUES_YAML"; continue
+    fi
+    sed -i \
+      -e 's/memory: "128Mi"/memory: "64Mi"/' \
+      -e 's/cpu: "50m"/cpu: "25m"/' \
+      "$f"
+    if ! git diff --quiet -- "$f"; then
+      changed=1
+      git add "$f"
+    fi
+  done
+
+  if [ "$changed" -eq 0 ]; then
+    status "$repo" "NO_CHANGE"; continue
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    status "$repo" "WOULD_CHANGE"; git --no-pager diff --cached --stat >>"$LOG"; continue
+  fi
+
+  if ! git commit --quiet -m "$COMMIT_MSG" 2>>"$LOG"; then
+    status "$repo" "COMMIT_FAIL"; continue
+  fi
+  if git push --quiet origin "$BRANCH" 2>>"$LOG"; then
+    status "$repo" "PUSHED"
+  else
+    status "$repo" "PUSH_FAIL"
+  fi
+done < "$LIST"
+echo "---DONE---" | tee -a "$LOG"
+```
+
+### Step 3 — Report
+
+Summarize per-repo status from the log: WOULD_CHANGE (dry run) / PUSHED / NO_CHANGE / CLONE_FAIL / NO_<BRANCH>_BRANCH / NO_VALUES_YAML / COMMIT_FAIL / PUSH_FAIL.
+
+## Safety notes
+
+- **Dry run first, always.** The loop above honours `DRY_RUN`; leave it at `1` for the first pass,
+  read the report, and only then re-run with `DRY_RUN=0`. A prose instruction to "confirm scope" is
+  not a safety mechanism — the flag is.
+- **Rollback plan before the push, not after.** Every repo lands exactly one commit, so the revert is
+  mechanical — but write it down before you start:
+
+  ```bash
+  # per repo, from the same workdir, AFTER a bad run
+  cd "$WORK/$repo" && git revert --no-edit HEAD && git push origin "$BRANCH"
+  ```
+
+  If the branch is protected or shared, revert instead of force-pushing; never `push --force` across
+  a fleet.
+- `git reset --hard "origin/$BRANCH"` discards anything already in a reused workdir. That is
+  deliberate (it guarantees a clean base) but it means the workdir is disposable — never point
+  `$WORK` at a directory you are also working in.
+- This pushes to many repos. Always confirm scope (cluster context, label, image filter, list of repos) **before** running Step 2.
+- Per global rule (`~/.claude/CLAUDE.md`): commit messages must **not** include any `Co-Authored-By: Claude` line.
+- The sed patterns only match the literal strings `memory: "128Mi"` and `cpu: "50m"`. If a repo already uses other values (e.g. `256Mi`), it falls through as `NO_CHANGE`. Limits (`512Mi`, `1`) are preserved because they don't collide.
+- If `deploy/dev/values.yaml` or `deploy/hml/values.yaml` is missing, the script skips that file but still commits/pushes the env that did change.
+- Some repos store values at the repo root (`dev/values.yaml`) instead of under `deploy/`. Verify path on a sample repo first; adapt the `for f in ...` list if needed.
+
+## Blast radius — what this has actually done
+
+A real run touched **51 repositories** from a single label selector (2 nodes, two image-name
+prefixes). That is the scale to plan for: a wrong sed pair is 51 bad commits pushed to a shared
+branch, and there is no undo button.
+
+Sizing the run before you make it:
+
+```bash
+wc -l "$LIST"                      # how many repos will be pushed to
+head -20 "$LIST"                   # do these names look like what you expect?
+```
+
+Do not record cluster addresses, customer names or org slugs in this skill. They belong to the run,
+not to the doctrine — the run asks for them as inputs (see *Required inputs*), and this file is
+published.

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -27,6 +27,7 @@ MUTATIONS = {
      lambda s: s + "\n```tsx\n" + "const a = 1\n" * 45 + "```\n\nUses zod and vite.\n"),
  "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
      lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
+ "C7 orphan wrapper": (None, None),
 }
 
 fails = []
@@ -34,8 +35,12 @@ for check, (relpath, mutate) in MUTATIONS.items():
     with tempfile.TemporaryDirectory() as td:
         dst = pathlib.Path(td) / "repo"
         shutil.copytree(SRC, dst, ignore=shutil.ignore_patterns(".git", "node_modules"))
-        p = dst / relpath
-        p.write_text(mutate(p.read_text()))
+        if relpath is None:                       # C7: a wrapper skill with no canonical source
+            (dst / "claude" / "skills" / "ghost-skill").mkdir(parents=True)
+            (dst / "claude" / "skills" / "ghost-skill" / "SKILL.md").write_text("---\nname: ghost-skill\n---\n")
+        else:
+            p = dst / relpath
+            p.write_text(mutate(p.read_text()))
         out = subprocess.run([sys.executable, str(dst / "scripts" / "validate-skills.py")], cwd=dst, capture_output=True, text=True).stdout
         caught = check.split()[0] in out and check in out
         print(f"  {'CAUGHT ' if caught else 'MISSED '} {check}")

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -8,6 +8,7 @@ Implements the mechanically checkable half of openspec/specs/skills-authoring:
   C4 description agrees with body           (heuristic: absolute promise vs qualifying rule)
   C5 versioned external APIs are pinned     (code-heavy skill without a version statement)
   C6 fence tags match content               (a block tagged X that is obviously not X)
+  C7 no orphan wrapper skills               (every generated skill has a canonical source)
 
 Exit 1 on any finding. Run from the repo root.
 """
@@ -210,7 +211,22 @@ def check_tags(skill: str, text: str) -> None:
             add(skill, "C6 wrong tag", f"block#{i} tagged {lang} but looks like JSON")
 
 
+# ── C7: no orphan wrapper skills ──────────────────────────────────────────
+def check_orphans() -> None:
+    """A skill living only in a generated tree is outside generate.sh, outside the
+    frontmatter check, outside this validator, and absent from the README."""
+    for tree in ("claude/skills", "codex/skills"):
+        base = ROOT / tree
+        if not base.is_dir():
+            continue
+        for d in sorted(base.iterdir()):
+            if d.is_dir() and d.name not in NAMES:
+                add(d.name, "C7 orphan wrapper",
+                    f"{tree}/{d.name} has no canonical skills/{d.name}/SKILL.md")
+
+
 def main() -> int:
+    check_orphans()
     for p in SKILLS:
         skill = p.parent.name
         text = p.read_text(encoding="utf-8")

--- a/skills/k8s-tune-resources/SKILL.md
+++ b/skills/k8s-tune-resources/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: k8s-tune-resources
+description: >-
+  Bulk-edit Kubernetes resource requests/limits across many git repos discovered from the pods running
+  on nodes with a given label. For each pod it derives the repo name from the image, clones it, checks
+  out a target branch, patches the chart values files with a sed pair, then commits and pushes. Use
+  when the user asks to "tune", "reduce", "scale down" or "ajustar resources" of pods on nodes selected
+  by a label across multiple repos. This skill pushes to many repositories at once — it runs dry by
+  default and requires an explicit opt-in to push. Do NOT use for editing a single repo (edit it
+  directly) or for live `kubectl patch` changes that bypass GitOps.
+metadata:
+  author: solvelab
+  version: 2.0.0
+  category: devops
+license: MIT
+compatibility: Requires kubectl with a context on the target cluster, git, and push access to the repos.
+---
+
+# k8s-tune-resources
+
+Skill for repeating the cluster-wide resources tuning routine across different Kubernetes clusters and label selectors.
+
+> **Verified against**: `kubectl v1.36.1` · `git 2.47.3`. Every flag the workflow uses — `-l`,
+> `-A`, `--field-selector`, `-o jsonpath` — was probed against that client. The clone URL template
+> assumes Bitbucket over SSH; adapt the host for any other forge.
+>
+> **This skill pushes to many repositories.** The Step 2 loop runs with `DRY_RUN=1` by default and
+> never pushes until you set it to `0`. Read the dry-run report first — see *Safety notes*.
+
+## Required inputs (ask the user if missing)
+
+1. **Node label selector** — e.g. `apps=<group>`
+2. **Image-name prefix filter(s)** — substrings to grep on image names to pick which repos to
+   touch (e.g. `myapp`, `ma-`)
+3. **Git host workspace/org** — the org the repos live under (the clone URL template is
+   `git@bitbucket.org:<ORG>/<REPO>.git`; adapt the host if you are not on Bitbucket)
+4. **Target branch** — default `deploy`
+5. **values.yaml relative paths** — default `deploy/dev/values.yaml` and `deploy/hml/values.yaml`
+6. **Patches (sed pairs)** — default:
+   - `memory: "128Mi"` → `memory: "64Mi"`
+   - `cpu: "50m"` → `cpu: "25m"`
+7. **Commit message** — default `chore: reduce resources requests to 64Mi/25m in dev and hml`
+8. **kubeconfig context** — confirm `kubectl config current-context` matches the cluster the user wants
+
+## Workflow
+
+### Step 1 — Discover repos
+
+```bash
+kubectl get nodes -l <LABEL>
+```
+
+For each node, list pods + container images and filter by the prefix(es):
+
+```bash
+for NODE in <node1> <node2> ...; do
+  kubectl get pods -A --field-selector spec.nodeName=$NODE \
+    -o jsonpath='{range .items[*]}{.metadata.namespace}{" "}{.metadata.name}{" "}{.spec.containers[*].image}{"\n"}{end}' \
+    | grep -E '<PREFIX_REGEX>'
+done
+```
+
+Extract repo name from image: segment after the last `/`, before `:` (strip tag). Dedupe.
+Save list to `/tmp/<scope>-repos.txt` (one repo per line).
+
+Show the list to the user and confirm scope before proceeding.
+
+### Step 2 — Mass clone / edit / commit / push
+
+Use `/tmp/<scope>-work/` as workdir.
+
+```bash
+LIST=/tmp/<scope>-repos.txt
+WORK=/tmp/<scope>-work
+ORG=<bitbucket-org>
+BRANCH=<branch>
+COMMIT_MSG="<commit-message>"
+DRY_RUN=${DRY_RUN:-1}          # 1 = clone, patch and report; never push. Flip to 0 only after review.
+mkdir -p "$WORK"
+LOG=$WORK/run.log
+: > "$LOG"
+
+status() { printf '%-60s %s\n' "$1" "$2" | tee -a "$LOG"; }
+
+while IFS= read -r repo; do
+  [ -z "$repo" ] && continue
+  cd "$WORK" || exit 1
+
+  if [ ! -d "$repo" ]; then
+    if ! git clone --quiet "git@bitbucket.org:${ORG}/${repo}.git" 2>>"$LOG"; then
+      status "$repo" "CLONE_FAIL"; continue
+    fi
+  fi
+
+  cd "$WORK/$repo" || { status "$repo" "CD_FAIL"; continue; }
+  git fetch --quiet origin 2>>"$LOG"
+
+  if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+    status "$repo" "NO_${BRANCH}_BRANCH"; continue
+  fi
+
+  git checkout --quiet "$BRANCH" 2>>"$LOG" || git checkout --quiet -b "$BRANCH" "origin/$BRANCH" 2>>"$LOG"
+  git reset --quiet --hard "origin/$BRANCH" 2>>"$LOG"
+
+  changed=0
+  for f in deploy/dev/values.yaml deploy/hml/values.yaml; do
+    if [ ! -f "$f" ]; then
+      status "$repo:$f" "NO_VALUES_YAML"; continue
+    fi
+    sed -i \
+      -e 's/memory: "128Mi"/memory: "64Mi"/' \
+      -e 's/cpu: "50m"/cpu: "25m"/' \
+      "$f"
+    if ! git diff --quiet -- "$f"; then
+      changed=1
+      git add "$f"
+    fi
+  done
+
+  if [ "$changed" -eq 0 ]; then
+    status "$repo" "NO_CHANGE"; continue
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    status "$repo" "WOULD_CHANGE"; git --no-pager diff --cached --stat >>"$LOG"; continue
+  fi
+
+  if ! git commit --quiet -m "$COMMIT_MSG" 2>>"$LOG"; then
+    status "$repo" "COMMIT_FAIL"; continue
+  fi
+  if git push --quiet origin "$BRANCH" 2>>"$LOG"; then
+    status "$repo" "PUSHED"
+  else
+    status "$repo" "PUSH_FAIL"
+  fi
+done < "$LIST"
+echo "---DONE---" | tee -a "$LOG"
+```
+
+### Step 3 — Report
+
+Summarize per-repo status from the log: WOULD_CHANGE (dry run) / PUSHED / NO_CHANGE / CLONE_FAIL / NO_<BRANCH>_BRANCH / NO_VALUES_YAML / COMMIT_FAIL / PUSH_FAIL.
+
+## Safety notes
+
+- **Dry run first, always.** The loop above honours `DRY_RUN`; leave it at `1` for the first pass,
+  read the report, and only then re-run with `DRY_RUN=0`. A prose instruction to "confirm scope" is
+  not a safety mechanism — the flag is.
+- **Rollback plan before the push, not after.** Every repo lands exactly one commit, so the revert is
+  mechanical — but write it down before you start:
+
+  ```bash
+  # per repo, from the same workdir, AFTER a bad run
+  cd "$WORK/$repo" && git revert --no-edit HEAD && git push origin "$BRANCH"
+  ```
+
+  If the branch is protected or shared, revert instead of force-pushing; never `push --force` across
+  a fleet.
+- `git reset --hard "origin/$BRANCH"` discards anything already in a reused workdir. That is
+  deliberate (it guarantees a clean base) but it means the workdir is disposable — never point
+  `$WORK` at a directory you are also working in.
+- This pushes to many repos. Always confirm scope (cluster context, label, image filter, list of repos) **before** running Step 2.
+- Per global rule (`~/.claude/CLAUDE.md`): commit messages must **not** include any `Co-Authored-By: Claude` line.
+- The sed patterns only match the literal strings `memory: "128Mi"` and `cpu: "50m"`. If a repo already uses other values (e.g. `256Mi`), it falls through as `NO_CHANGE`. Limits (`512Mi`, `1`) are preserved because they don't collide.
+- If `deploy/dev/values.yaml` or `deploy/hml/values.yaml` is missing, the script skips that file but still commits/pushes the env that did change.
+- Some repos store values at the repo root (`dev/values.yaml`) instead of under `deploy/`. Verify path on a sample repo first; adapt the `for f in ...` list if needed.
+
+## Blast radius — what this has actually done
+
+A real run touched **51 repositories** from a single label selector (2 nodes, two image-name
+prefixes). That is the scale to plan for: a wrong sed pair is 51 bad commits pushed to a shared
+branch, and there is no undo button.
+
+Sizing the run before you make it:
+
+```bash
+wc -l "$LIST"                      # how many repos will be pushed to
+head -20 "$LIST"                   # do these names look like what you expect?
+```
+
+Do not record cluster addresses, customer names or org slugs in this skill. They belong to the run,
+not to the doctrine — the run asks for them as inputs (see *Required inputs*), and this file is
+published.


### PR DESCRIPTION
## Why

`k8s-tune-resources` existed **only** as `claude/skills/k8s-tune-resources/SKILL.md` — 133 lines of real content in a **generated** tree, with no `skills/` source behind it.

Everything that governs a catalog skill skipped it:

| control | why it missed |
|---|---|
| `generate.sh` | never produced its `codex/`, `cursor/`, `copilot/`, `plugins/` variants |
| CI frontmatter check | globs `skills/*/SKILL.md` — its missing `license` and `compatibility` went unseen, and `metadata.author: diegops` never reconciled with the catalog's `solvelab` |
| `scripts/validate-skills.py` | never read it — the catalog reported 30 skills; there were **31** |
| README index | never listed it |

It installed for every Claude Code user of this repo regardless. Found by cross-checking the wrapper trees against the canonical one — no gate looked there, which is the whole defect.

## Three more problems, found on review

**1. It published internal detail from a public repo.** A "Memorized facts" section carried two cluster node addresses (RFC1918), a customer org slug, and an app-name prefix. No credentials, so severity is low — but the run already collects those as *Required inputs*, so the skill works without any of it.

**2. No dry run.** Step 2 cloned, patched, committed **and pushed** in one loop. Its only guard was a prose line asking the operator to confirm scope. A real run pushed to **51 repositories**.

**3. No rollback path**, for an operation with that blast radius.

## What changed

- **Promoted** to `skills/k8s-tune-resources/SKILL.md` (2.0.0) with catalog-conformant frontmatter; orphan deleted so `generate.sh` owns every tree.
- **`DRY_RUN=1` by default**, wired into the loop — stages, reports `WOULD_CHANGE` with a diffstat, never pushes until explicitly set to `0`. Verified with `bash -n` after substituting the placeholders.

  > The previous safety was a sentence asking the operator to be careful. For an operation with no undo, the guard has to be in the code path.

- **Rollback documented before the run** (`git revert HEAD` per repo), fleet-wide force-push forbidden.
- **Blast radius stated** — 51 repos from one label selector — with the two commands that size a run before you make it.
- **Operational values removed**, plus a standing rule that they are inputs, not doctrine. Grepped every tree to confirm none survive.
- **Verified against `kubectl v1.36.1` and `git 2.47.3`** — every flag the workflow uses (`-l`, `-A`, `--field-selector`, `-o jsonpath`) probed against that client.

## Preventing recurrence

New validator check **C7 — no orphan wrapper skills**: every directory under `claude/skills/` or `codex/skills/` must have a canonical `skills/<name>/SKILL.md`. The whole failure was that every check looked only where the file was *not*; C7 inverts the direction.

Self-test extended — **11/11 defect classes detected**, including an injected orphan.

## Spec delta

`skills-catalog` → **MODIFIED** *Catalog composition after the quality review*. The requirement asserted **"exactly 20 skills"** and had been wrong for some time (the catalog is at 31). A count in a spec is a guaranteed future falsehood; it now states the structural rule — the catalog *is* the set of `skills/*/SKILL.md`, and a skill present only in a generated tree is rejected by CI.

## Not done here

The removed values remain in **git history**. Rewriting published history is the repository owner's call, not this change's — flagging it rather than deciding it.

`V.6` (`openspec archive`) intentionally left open — closure step after review.
