### PR TITLE
📝 docs(readme): correct the statusline script line count

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ Project v2 in the org/user. Full details live in the skills themselves:
 
 | Skill | Triggers | What It Does |
 |-------|----------|--------------|
-| **claude-statusline** | "configure my Claude Code status line", statusLine in settings.json, statusline.sh, "add context/cost/git to my statusline", install a statusline gist | Sets up or customizes the Claude Code status bar — ships a ready-made 4-line script (model/context/git/cost/rate-limits/cache) plus the full JSON-field reference; safe install, custom-build rules, and gist sharing |
+| **claude-statusline** | "configure my Claude Code status line", statusLine in settings.json, statusline.sh, "add context/cost/git to my statusline", install a statusline gist | Sets up or customizes the Claude Code status bar — ships a ready-made 3-line script (model/effort/thinking/cost · repo/branch/diff/token-cost · context/rate-limits) plus the full JSON-field reference; safe install, custom-build rules, and gist sharing |
 
 ### Game (React Three Fiber — 10 topics)
 


### PR DESCRIPTION
Audited `claude-statusline` by **running** what it ships.

`references/statusline.sh` was executed against a synthetic payload built from the fields `references/fields.md` documents:

```
🤖 Opus 5 | 🚀 xhigh | 🧠 thinking enabled | ⏱️ 15m 0s | 💰 $1.23
🔗 ai-skills | 🌱 master | 📝 +420 -69 | ↑ In 341k $0.41 · ♻️ 87% · ↓ Out 800 $0.02
📊 ctx ▓▓░░░░░░ 37% | 🚦 5h ▓░░░░░░░ 22% | 7d ▓▓▓░░░░░ 48%
```

**3 lines, exit 0.** The README said "ready-made 4-line script"; the skill's own description already said 3. README corrected, and its vague segment list replaced with what the three lines actually carry.

## Negative result worth recording

My first pass also reported three fields the script reads but `fields.md` did not document — `model.display_name`, `workspace.current_dir`, `cost.total_lines_removed`. That was **my extractor's bug**: it captured only the first backticked field per table row, and all three share a row with a sibling field.

Re-checked properly: **34 fields documented, 15 read by the script, 0 undocumented.** `fields.md` is complete. No skill change needed — reporting it rather than manufacturing an edit.

No version bump: no skill content changed.