### PR TITLE
🐛 fix(react-api-client): keep error paths out of the domain parsers

### DIFF
--- a/claude/skills/react-api-client/SKILL.md
+++ b/claude/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/react-api-client.mdc
+++ b/cursor/rules/react-api-client.mdc
@@ -37,10 +37,16 @@ Implementation: `references/api-client.md`.
   message); known body `code` → itself; else status-derived; else `UNKNOWN`.
 - **Callers branch on `err.code` only** — never on HTTP status, never on message strings. Raw
   backend codes outside the enum stay readable on `err.raw.code` for feature-specific handling.
+- **Error paths never reach a domain parser.** Every non-2xx goes through `normalizeError`, which is
+  why an error body that is not the envelope at all still resolves to a code instead of throwing a
+  drift error. That case is real, not hypothetical: a request rejected by the reverse proxy for size
+  (`413`) or by a gateway never reaches the application's exception handlers, so its body is HTML or
+  empty. Handing it to a zod parser would report "payload drift" for what is actually a working
+  guard — see `python-rest-api` ("Request limits").
 
 ## Domain parsers: throw on drift
 
-Every response body goes through a zod schema per domain that validates the envelope AND
+Every **successful** response body goes through a zod schema per domain that validates the envelope AND
 transforms snake_case → camelCase. A missing/wrong-typed field **throws** — a forged or partial
 payload is a failure, never a half-built cache entry. The parser is the only place that knows the
 wire shape.

--- a/plugins/frontend/skills/react-api-client/SKILL.md
+++ b/plugins/frontend/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -47,10 +47,16 @@ Implementation: `references/api-client.md`.
   message); known body `code` → itself; else status-derived; else `UNKNOWN`.
 - **Callers branch on `err.code` only** — never on HTTP status, never on message strings. Raw
   backend codes outside the enum stay readable on `err.raw.code` for feature-specific handling.
+- **Error paths never reach a domain parser.** Every non-2xx goes through `normalizeError`, which is
+  why an error body that is not the envelope at all still resolves to a code instead of throwing a
+  drift error. That case is real, not hypothetical: a request rejected by the reverse proxy for size
+  (`413`) or by a gateway never reaches the application's exception handlers, so its body is HTML or
+  empty. Handing it to a zod parser would report "payload drift" for what is actually a working
+  guard — see `python-rest-api` ("Request limits").
 
 ## Domain parsers: throw on drift
 
-Every response body goes through a zod schema per domain that validates the envelope AND
+Every **successful** response body goes through a zod schema per domain that validates the envelope AND
 transforms snake_case → camelCase. A missing/wrong-typed field **throws** — a forged or partial
 payload is a failure, never a half-built cache entry. The parser is the only place that knows the
 wire shape.

--- a/skills/react-api-client/SKILL.md
+++ b/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -47,10 +47,16 @@ Implementation: `references/api-client.md`.
   message); known body `code` → itself; else status-derived; else `UNKNOWN`.
 - **Callers branch on `err.code` only** — never on HTTP status, never on message strings. Raw
   backend codes outside the enum stay readable on `err.raw.code` for feature-specific handling.
+- **Error paths never reach a domain parser.** Every non-2xx goes through `normalizeError`, which is
+  why an error body that is not the envelope at all still resolves to a code instead of throwing a
+  drift error. That case is real, not hypothetical: a request rejected by the reverse proxy for size
+  (`413`) or by a gateway never reaches the application's exception handlers, so its body is HTML or
+  empty. Handing it to a zod parser would report "payload drift" for what is actually a working
+  guard — see `python-rest-api` ("Request limits").
 
 ## Domain parsers: throw on drift
 
-Every response body goes through a zod schema per domain that validates the envelope AND
+Every **successful** response body goes through a zod schema per domain that validates the envelope AND
 transforms snake_case → camelCase. A missing/wrong-typed field **throws** — a forged or partial
 payload is a failure, never a half-built cache entry. The parser is the only place that knows the
 wire shape.


### PR DESCRIPTION
Found by checking whether **my own change tonight broke a paired skill.**

`react-api-client` is declared "the frontend counterpart of `python-rest-api`". #22 gave the backend a **request-size limit enforced at the reverse proxy** — and a proxy 413 never reaches the application's exception handlers, so its body is HTML or empty, not the envelope.

The skill said:

> Every response body goes through a zod schema per domain…

while its own `references/api-client.md` routes every non-2xx through `normalizeError` and never through a parser. The implementation was already right; the prose was imprecise about a distinction that now has a concrete failure attached to it — handing a proxy 413 to a zod parser reports "payload drift" for what is actually a working guard.

**Fix:** parsers run on *successful* bodies only, stated explicitly, with the proxy/gateway case named and linked to `python-rest-api` ("Request limits").

`react-api-client` 1.0.0 → 1.1.0. No spec delta — a correction, not a new requirement.