### PR TITLE
🐛 fix(bug-hunter): add the five defect classes it demonstrably missed

### DIFF
--- a/claude/skills/bug-hunter/SKILL.md
+++ b/claude/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 2.2.0
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/cursor/rules/bug-hunter.mdc
+++ b/cursor/rules/bug-hunter.mdc
@@ -19,13 +19,40 @@ happy path. Hunt for the bug before it ships.
 ## Universal checklist (any change, any stack)
 
 - **Boundaries**: zero, negative, max, just-over-max, empty, null/None, wrong type.
+- **Shape, not just size**: a *small* input with a hostile *structure* — 1000 levels of nesting, a
+  deeply recursive object, a self-referencing graph. Size limits do not catch these.
+- **Fragmented input**: the input arrives in pieces — a line still being written, a chunked body, a
+  message split across packets. Does a reader that lands mid-write consume half of it and advance?
 - **Forged input**: ids/owners that belong to someone else; values the client shouldn't be able to set.
 - **Idempotency / replay**: run the same operation twice — does it apply/charge exactly once?
+- **Distinctness** (the inverse, and the one that gets forgotten): two *genuinely different*
+  occurrences that happen to look identical — same payload, same second, same key material. Do they
+  stay two? A dedup key built from content instead of position collapses them and silently drops one.
 - **Partial failure**: make a mid-operation step fail — does everything roll back (no partial effect)?
 - **Dependency down**: external service times out / 5xx / returns garbage — does it degrade safely?
   (Expected behavior is defined by `backend-resilience`: safe default, negative cache, no silent stale.)
-- **Concurrency**: two requests at once on the same target — no dupe, no corruption, no lost update.
+- **Observable degradation**: when it *does* degrade safely — can anyone tell? Assert the log line and
+  the counter, not just the fallback value. A helper that returns the default for a timeout and for a
+  `TypeError` in your own code, with no signal, is indistinguishable from working.
+- **Concurrency at burst, not in pairs**: two requests at once is the *cheapest* case, not the
+  representative one. Fire N (100+) and count how many reached the dependency. Guards like
+  single-flight are invisible at two callers and decisive at two hundred.
 - **Regression**: the related existing suite still passes with the new guard on.
+
+### Why these five were added
+
+Each came from a defect found by other means, that this checklist as written would have missed:
+
+| Added item | The bug it would have caught |
+|---|---|
+| Shape, not just size | a 2 KB body of nested brackets returning **500** from a stock API — every value-boundary case passed |
+| Fragmented input | a log line arriving across two write flushes: the tailer consumed the half-line and advanced past it, producing two bogus events and zero correct ones |
+| Distinctness | two real reconnects with a byte-identical log line collapsing to one dedup key — the second event silently dropped |
+| Observable degradation | a fallback helper folding four distinct failure causes into one silent return, with zero log lines |
+| Burst, not pairs | 200 concurrent callers against a down dependency: **38** still paid the full timeout; at two callers the missing guard is invisible |
+
+When you add a scenario because something escaped, add the row too. A checklist that never grows is a
+checklist that stopped finding things.
 
 ## Stack tracks (read the one that matches what you changed)
 

--- a/openspec/changes/harden-bug-hunter/.openspec.yaml
+++ b/openspec/changes/harden-bug-hunter/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/harden-bug-hunter/design.md
+++ b/openspec/changes/harden-bug-hunter/design.md
@@ -1,0 +1,72 @@
+## Context
+
+`bug-hunter` sits at the centre of the catalog's testing story: `python-rest-api`,
+`backend-resilience`, `api-resilience-testing`, `fivem-fallback` and `openspec-drivezone` all defer to
+it for what "adversarially tested" means. It had never been tested against anything itself.
+
+The audit that ran across the whole catalog produced a rare opportunity: five defects, each found by a
+different instrument (a simulation battery, a FastAPI probe, a TypeScript compile, a live Projects v2
+run), none of them found by following this checklist. That makes the checklist falsifiable — score it
+against the defects and see what it would have caught.
+
+## Goals / Non-Goals
+
+**Goals**
+- Close the classes the checklist provably missed, each traceable to a specific defect.
+- Keep the checklist short enough to actually run — it is a rite, not a taxonomy.
+- Make the growth mechanism explicit so the next escape widens it too.
+
+**Non-Goals**
+- Not turning it into `api-resilience-testing`. That skill owns the exhaustive REST surface audit;
+  this one stays per-change and stack-agnostic.
+- Not adding items that sound rigorous but have no incident behind them. Every added row names its
+  defect; anything without one did not get in.
+- Not rewriting the stack tracks. Only their concurrency scenarios changed, to match the burst rule.
+
+## Decisions
+
+**D1 — Score, don't review.** The improvement came from asking "would this have caught X?" for five
+concrete X's, not from reading the checklist and imagining gaps. Four clean misses and one wrong-scale
+partial is a measurement, and it is the reason each item is here.
+
+**D2 — Distinctness is the item most worth adding.** Idempotency and distinctness are inverses and the
+checklist only had one of them. "Run it twice, does it apply once" and "two different things happen to
+look the same, do they stay two" fail in opposite directions, and dedup code satisfies the first while
+violating the second — which is exactly the bug found in the log collector.
+
+**D3 — Burst replaces pair as the default, pair stays as the floor.** Single-flight, connection-pool
+limits and negative caches are all invisible at two callers. The measured case (38 of 200 reaching a
+down dependency) only exists above a threshold, so the scenario has to name a scale.
+
+**D4 — Observability is a test, not a nice-to-have.** "Degrades safely" was satisfied by a helper that
+also swallowed a `TypeError` from local code with no signal. Asserting the log line and the counter is
+what separates a working fallback from a silent one.
+
+**D5 — The table is part of the doctrine, not commentary.** It gives every item provenance and makes
+the checklist auditable: an item with no defect behind it does not belong. The standing rule to add a
+row when a scenario is added keeps that property.
+
+**D6 — Shape and fragmentation are input-side siblings of existing items.** "Boundaries" covers value
+extremes, "partial failure" covers the operation breaking midway. Neither covers a small input with
+hostile structure, or an input that is itself incomplete when read. They sit next to their siblings
+rather than in a new section.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Per-change adversarial methodology and its universal checklist | `bug-hunter` | already canonical — checklist extended |
+| Stack-specific adversarial depth (Python, FiveM/Lua, .NET plugin) | `bug-hunter/references/track-*.md` | already canonical — concurrency scale raised |
+| Expected behaviour under "dependency down" (safe default, negative cache, observability) | `backend-resilience` | link (already canonical) — the observability item asserts what it defines |
+| Exhaustive REST surface audit | `api-resilience-testing` | link (already canonical, unchanged) |
+| The tasks.md gate that consumes this rite | `openspec-drivezone` | unchanged; inherits the wider checklist |
+
+## Risks / Trade-offs
+
+- [The checklist grows and stops being run] → five items on a seven-item list is a real increase; the
+  provenance table is the counterweight, since an item nobody can trace gets removed rather than
+  tolerated.
+- [Burst testing is harder to write than a pair] → yes, and it is the only way the guard is exercised;
+  the Python track keeps the pair as the documented minimum for cases where a burst is impractical.
+- [The provenance table ages as the defects recede] → it is history, not a claim about the present, and
+  it is what stops the checklist filling with plausible-sounding items.

--- a/openspec/changes/harden-bug-hunter/proposal.md
+++ b/openspec/changes/harden-bug-hunter/proposal.md
@@ -1,0 +1,55 @@
+# Change: Add to bug-hunter the five defect classes it demonstrably missed
+
+## Why
+
+`bug-hunter` is the catalog's adversarial-testing rite — the skill every other one defers to for
+"did you try to break it". It was used as the testing doctrine throughout a catalog-wide audit that
+found five real defects by other means. Scoring those defects against its own universal checklist,
+**it would have caught at most one**:
+
+| Defect found | Nearest checklist item | Verdict |
+|---|---|---|
+| A 2 KB body of nested brackets returns **500** from a stock API | *Boundaries: zero, negative, max, just-over-max, empty, null, wrong type* | miss — every item is a **value** boundary; this is a **shape** boundary at trivial size |
+| A log line arriving across two write flushes: the tailer consumed the half-line and advanced past it (2 bogus events, 0 correct) | *Partial failure: make a mid-operation step fail* | miss — that is **your operation** failing midway, not **the input** arriving midway |
+| Two real reconnects with a byte-identical log line collapsed to one dedup key; the second event silently dropped | *Idempotency / replay: run the same operation twice — does it apply exactly once?* | miss — it asks the **opposite** question. Nothing tests that two distinct things stay distinct |
+| A fallback helper folded four distinct failure causes into one silent return, zero log lines | *Dependency down: does it degrade safely?* | miss — it **did** degrade safely; the defect is that nobody could tell |
+| 200 concurrent callers against a down dependency: **38** still paid the full timeout | *Concurrency: **two** requests at once* | partial — right category, wrong scale. At two callers the missing single-flight guard is invisible |
+
+The stack tracks do not close the gap: `track-python-pytest.md` also said "two concurrent requests",
+and `track-fivem-lua.md` "concurrent writers", with nothing on distinctness, fragmented input, shape
+exhaustion or observability.
+
+A rite that misses the defects found while following it is the highest-leverage thing in the catalog
+to fix, because every other skill's testing gate points at it.
+
+## What Changes
+
+- `bug-hunter` → 2.2.0. Five items added to the universal checklist:
+  - **Shape, not just size** — a small input with a hostile structure (deep nesting, recursive graph).
+  - **Fragmented input** — input arriving in pieces; does a reader landing mid-write consume half?
+  - **Distinctness** — the inverse of idempotency: two genuinely different occurrences that look
+    identical must stay two. A dedup key built from content instead of position collapses them.
+  - **Observable degradation** — when it degrades safely, assert the log line and the counter, not
+    only the fallback value.
+  - **Concurrency at burst, not in pairs** — fire N (100+) and count how many reached the dependency.
+- A **"Why these five were added"** table, mapping each new item to the defect that earned it, plus
+  the standing rule: when a scenario is added because something escaped, add its row too.
+- `references/track-python-pytest.md` and `references/track-fivem-lua.md`: concurrency scenarios
+  raised from a pair to a burst, keeping the pair as the minimum case.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — a skill that prescribes a checklist SHALL be scored against
+  defects found in the field, and any class it missed SHALL be added with the defect that earned it.
+
+## Impact
+
+- `skills/bug-hunter/SKILL.md` and both stack-track references; regenerated wrappers.
+- Every skill whose testing gate defers to `bug-hunter` — `python-rest-api`, `backend-resilience`,
+  `api-resilience-testing`, `fivem-fallback`, `openspec-drivezone` — inherits the wider checklist
+  without changing.
+- No README change: the skill's purpose and triggers are unchanged.

--- a/openspec/changes/harden-bug-hunter/specs/skills-authoring/spec.md
+++ b/openspec/changes/harden-bug-hunter/specs/skills-authoring/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Checklists are scored against field defects
+
+A skill that prescribes a checklist or a rite SHALL be scored against defects actually found in the
+field, and every class the checklist would have missed SHALL be added together with the defect that
+earned it. A checklist item without a traceable origin SHALL NOT be added.
+
+#### Scenario: A missed class is added with its provenance
+
+- **WHEN** a defect is found by some means other than the checklist that claims to cover its area
+- **THEN** the class it belongs to is added to the checklist, recorded with the defect that earned it
+- **AND** an item that cannot name the defect behind it is removed rather than kept
+
+#### Scenario: The scoring is stated, not implied
+
+- **WHEN** a checklist is revised after an audit
+- **THEN** the change records which defects were scored against it and which of them it would have
+  caught as previously written

--- a/openspec/changes/harden-bug-hunter/tasks.md
+++ b/openspec/changes/harden-bug-hunter/tasks.md
@@ -1,0 +1,37 @@
+## 1. Score the existing checklist
+
+- [x] 1.1 Take the five defects found in the catalog audit and score each against the universal
+      checklist as written
+- [x] 1.2 Record the verdict per defect (4 clean misses, 1 wrong-scale partial)
+- [x] 1.3 Confirm the stack tracks do not close the gap
+
+## 2. Extend the checklist
+
+- [x] 2.1 Add **Shape, not just size**
+- [x] 2.2 Add **Fragmented input**
+- [x] 2.3 Add **Distinctness** as the stated inverse of idempotency
+- [x] 2.4 Add **Observable degradation**
+- [x] 2.5 Replace pair-concurrency with **burst**, keeping the pair as the minimum case
+- [x] 2.6 Add the provenance table and the standing rule to grow it on the next escape
+- [x] 2.7 Raise the concurrency scenario in `track-python-pytest.md` and `track-fivem-lua.md`
+- [x] 2.8 Bump `metadata.version` to 2.2.0
+
+## 3. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on `bug-hunter`
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers and the "Do NOT use for … that is api-resilience-testing" boundary unchanged
+- [x] Q.4 No duplicated doctrine: fallback behaviour still defined by `backend-resilience`, REST
+      surface audit still owned by `api-resilience-testing`
+- [x] Q.5 Every added item names the defect that earned it, with its measured number
+- [x] Q.6 Description states no policy the body contradicts
+- [x] Q.7 No README change — purpose and triggers unchanged
+
+## 4. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate harden-bug-hunter --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` reports 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` detects 11/11
+- [ ] V.6 `openspec archive harden-bug-hunter --yes` after review

--- a/plugins/testing/skills/bug-hunter/SKILL.md
+++ b/plugins/testing/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 2.2.0
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -30,13 +30,40 @@ happy path. Hunt for the bug before it ships.
 ## Universal checklist (any change, any stack)
 
 - **Boundaries**: zero, negative, max, just-over-max, empty, null/None, wrong type.
+- **Shape, not just size**: a *small* input with a hostile *structure* — 1000 levels of nesting, a
+  deeply recursive object, a self-referencing graph. Size limits do not catch these.
+- **Fragmented input**: the input arrives in pieces — a line still being written, a chunked body, a
+  message split across packets. Does a reader that lands mid-write consume half of it and advance?
 - **Forged input**: ids/owners that belong to someone else; values the client shouldn't be able to set.
 - **Idempotency / replay**: run the same operation twice — does it apply/charge exactly once?
+- **Distinctness** (the inverse, and the one that gets forgotten): two *genuinely different*
+  occurrences that happen to look identical — same payload, same second, same key material. Do they
+  stay two? A dedup key built from content instead of position collapses them and silently drops one.
 - **Partial failure**: make a mid-operation step fail — does everything roll back (no partial effect)?
 - **Dependency down**: external service times out / 5xx / returns garbage — does it degrade safely?
   (Expected behavior is defined by `backend-resilience`: safe default, negative cache, no silent stale.)
-- **Concurrency**: two requests at once on the same target — no dupe, no corruption, no lost update.
+- **Observable degradation**: when it *does* degrade safely — can anyone tell? Assert the log line and
+  the counter, not just the fallback value. A helper that returns the default for a timeout and for a
+  `TypeError` in your own code, with no signal, is indistinguishable from working.
+- **Concurrency at burst, not in pairs**: two requests at once is the *cheapest* case, not the
+  representative one. Fire N (100+) and count how many reached the dependency. Guards like
+  single-flight are invisible at two callers and decisive at two hundred.
 - **Regression**: the related existing suite still passes with the new guard on.
+
+### Why these five were added
+
+Each came from a defect found by other means, that this checklist as written would have missed:
+
+| Added item | The bug it would have caught |
+|---|---|
+| Shape, not just size | a 2 KB body of nested brackets returning **500** from a stock API — every value-boundary case passed |
+| Fragmented input | a log line arriving across two write flushes: the tailer consumed the half-line and advanced past it, producing two bogus events and zero correct ones |
+| Distinctness | two real reconnects with a byte-identical log line collapsing to one dedup key — the second event silently dropped |
+| Observable degradation | a fallback helper folding four distinct failure causes into one silent return, with zero log lines |
+| Burst, not pairs | 200 concurrent callers against a down dependency: **38** still paid the full timeout; at two callers the missing guard is invisible |
+
+When you add a scenario because something escaped, add the row too. A checklist that never grows is a
+checklist that stopped finding things.
 
 ## Stack tracks (read the one that matches what you changed)
 

--- a/plugins/testing/skills/bug-hunter/references/track-fivem-lua.md
+++ b/plugins/testing/skills/bug-hunter/references/track-fivem-lua.md
@@ -16,7 +16,8 @@ smoke.
   trigger unintended state.
 - **Lifecycle**: disconnect/close mid-flow (ESC included) releases locks/focus and cleans per-player
   state; resource restart doesn't leave orphaned globals.
-- **StateBag races**: concurrent writers to the same networked state don't corrupt it.
+- **StateBag races**: concurrent writers to the same networked state don't corrupt it — drive it with
+  a burst of writers, not a pair.
 
 ## Exit criteria
 

--- a/plugins/testing/skills/bug-hunter/references/track-python-pytest.md
+++ b/plugins/testing/skills/bug-hunter/references/track-python-pytest.md
@@ -15,7 +15,9 @@ Run the E2E suite **before** any manual validation. Mirror existing `test_*_adve
 - **Dependency resilience**: mock the config/KV client to raise (timeout/connect error) → assert the
   fallback path and the negative cache (one attempt per fail-TTL); assert a real 404 is NOT
   negative-cached. (Definitions in `backend-resilience`.)
-- **Concurrency**: two concurrent requests on the same row/target. Note the fixture limit: SQLite test
+- **Concurrency**: fire N concurrent requests (100+, not two) on the same row/target and count how
+  many reached the dependency — a single-flight or lock guard is invisible at two callers.
+  Two concurrent requests on the same row/target remain the minimum case. Note the fixture limit: SQLite test
   fixtures don't enforce row locks — `SELECT ... FOR UPDATE` serialization is only truly validated
   against the real database (e.g. Postgres). State this limit in the test docstring.
 - **Rate-limit / reconnect persistence** where the change touches them.

--- a/skills/bug-hunter/SKILL.md
+++ b/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 2.2.0
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -30,13 +30,40 @@ happy path. Hunt for the bug before it ships.
 ## Universal checklist (any change, any stack)
 
 - **Boundaries**: zero, negative, max, just-over-max, empty, null/None, wrong type.
+- **Shape, not just size**: a *small* input with a hostile *structure* — 1000 levels of nesting, a
+  deeply recursive object, a self-referencing graph. Size limits do not catch these.
+- **Fragmented input**: the input arrives in pieces — a line still being written, a chunked body, a
+  message split across packets. Does a reader that lands mid-write consume half of it and advance?
 - **Forged input**: ids/owners that belong to someone else; values the client shouldn't be able to set.
 - **Idempotency / replay**: run the same operation twice — does it apply/charge exactly once?
+- **Distinctness** (the inverse, and the one that gets forgotten): two *genuinely different*
+  occurrences that happen to look identical — same payload, same second, same key material. Do they
+  stay two? A dedup key built from content instead of position collapses them and silently drops one.
 - **Partial failure**: make a mid-operation step fail — does everything roll back (no partial effect)?
 - **Dependency down**: external service times out / 5xx / returns garbage — does it degrade safely?
   (Expected behavior is defined by `backend-resilience`: safe default, negative cache, no silent stale.)
-- **Concurrency**: two requests at once on the same target — no dupe, no corruption, no lost update.
+- **Observable degradation**: when it *does* degrade safely — can anyone tell? Assert the log line and
+  the counter, not just the fallback value. A helper that returns the default for a timeout and for a
+  `TypeError` in your own code, with no signal, is indistinguishable from working.
+- **Concurrency at burst, not in pairs**: two requests at once is the *cheapest* case, not the
+  representative one. Fire N (100+) and count how many reached the dependency. Guards like
+  single-flight are invisible at two callers and decisive at two hundred.
 - **Regression**: the related existing suite still passes with the new guard on.
+
+### Why these five were added
+
+Each came from a defect found by other means, that this checklist as written would have missed:
+
+| Added item | The bug it would have caught |
+|---|---|
+| Shape, not just size | a 2 KB body of nested brackets returning **500** from a stock API — every value-boundary case passed |
+| Fragmented input | a log line arriving across two write flushes: the tailer consumed the half-line and advanced past it, producing two bogus events and zero correct ones |
+| Distinctness | two real reconnects with a byte-identical log line collapsing to one dedup key — the second event silently dropped |
+| Observable degradation | a fallback helper folding four distinct failure causes into one silent return, with zero log lines |
+| Burst, not pairs | 200 concurrent callers against a down dependency: **38** still paid the full timeout; at two callers the missing guard is invisible |
+
+When you add a scenario because something escaped, add the row too. A checklist that never grows is a
+checklist that stopped finding things.
 
 ## Stack tracks (read the one that matches what you changed)
 

--- a/skills/bug-hunter/references/track-fivem-lua.md
+++ b/skills/bug-hunter/references/track-fivem-lua.md
@@ -16,7 +16,8 @@ smoke.
   trigger unintended state.
 - **Lifecycle**: disconnect/close mid-flow (ESC included) releases locks/focus and cleans per-player
   state; resource restart doesn't leave orphaned globals.
-- **StateBag races**: concurrent writers to the same networked state don't corrupt it.
+- **StateBag races**: concurrent writers to the same networked state don't corrupt it — drive it with
+  a burst of writers, not a pair.
 
 ## Exit criteria
 

--- a/skills/bug-hunter/references/track-python-pytest.md
+++ b/skills/bug-hunter/references/track-python-pytest.md
@@ -15,7 +15,9 @@ Run the E2E suite **before** any manual validation. Mirror existing `test_*_adve
 - **Dependency resilience**: mock the config/KV client to raise (timeout/connect error) → assert the
   fallback path and the negative cache (one attempt per fail-TTL); assert a real 404 is NOT
   negative-cached. (Definitions in `backend-resilience`.)
-- **Concurrency**: two concurrent requests on the same row/target. Note the fixture limit: SQLite test
+- **Concurrency**: fire N concurrent requests (100+, not two) on the same row/target and count how
+  many reached the dependency — a single-flight or lock guard is invisible at two callers.
+  Two concurrent requests on the same row/target remain the minimum case. Note the fixture limit: SQLite test
   fixtures don't enforce row locks — `SELECT ... FOR UPDATE` serialization is only truly validated
   against the real database (e.g. Postgres). State this limit in the test docstring.
 - **Rate-limit / reconnect persistence** where the change touches them.


### PR DESCRIPTION
## Why

`bug-hunter` is the rite every other skill defers to for *"did you try to break it"* — `python-rest-api`, `backend-resilience`, `api-resilience-testing`, `fivem-fallback` and `openspec-drivezone` all point at it. It had never been tested against anything itself.

The catalog-wide audit produced a rare chance to falsify it: **five defects, each found by a different instrument** (a simulation battery, a FastAPI probe, a TypeScript compile, a live Projects v2 run) — **none of them found by following this checklist**. So: score it.

## The scoring

| Defect found | Nearest checklist item | Verdict |
|---|---|---|
| A **2 KB** body of nested brackets returns **500** from a stock API | *Boundaries: zero, negative, max, just-over-max, empty, null, wrong type* | **miss** — every item is a **value** boundary; this is a **shape** boundary at trivial size |
| A log line arriving across two write flushes: the tailer consumed the half-line and advanced past it (2 bogus events, 0 correct) | *Partial failure: make a mid-operation step fail* | **miss** — that is **your operation** failing midway, not **the input** arriving midway |
| Two real reconnects with a byte-identical log line collapsed to one dedup key; the second event silently dropped | *Idempotency / replay: run the same operation twice — does it apply exactly once?* | **miss** — asks the **opposite** question. Nothing tested that two distinct things stay distinct |
| A fallback helper folded four distinct failure causes into one silent return, zero log lines | *Dependency down: does it degrade safely?* | **miss** — it **did** degrade safely; the defect is that nobody could tell |
| 200 concurrent callers against a down dependency: **38** still paid the full timeout | *Concurrency: **two** requests at once* | **partial** — right category, wrong scale. At two callers the missing single-flight guard is invisible |

**At most 1 of 5.** The stack tracks did not close the gap either: `track-python-pytest.md` also said "two concurrent requests", `track-fivem-lua.md` "concurrent writers", with nothing on distinctness, fragmented input, shape exhaustion or observability.

A rite that misses the defects found *while following it* is the highest-leverage thing in the catalog to fix.

## What was added

- **Shape, not just size** — a small input with a hostile structure (deep nesting, recursive graph). Size limits do not catch these.
- **Fragmented input** — input arriving in pieces; does a reader landing mid-write consume half and advance?
- **Distinctness** — the stated inverse of idempotency. Dedup code satisfies "run it twice, apply once" while violating "two different things stay two" — which is exactly the collector bug.
- **Observable degradation** — assert the log line and the counter, not only the fallback value.
- **Concurrency at burst, not in pairs** — fire N (100+) and count how many reached the dependency. Pair stays as the documented minimum where a burst is impractical.

Plus a **provenance table** mapping each item to the defect that earned it, and the standing rule:

> When you add a scenario because something escaped, add the row too. A checklist that never grows is a checklist that stopped finding things.

An item that cannot name the defect behind it gets removed rather than tolerated — that is what stops the checklist filling with plausible-sounding entries.

## Spec delta

`skills-authoring` → **ADDED** *Checklists are scored against field defects*: a skill prescribing a checklist must be scored against real defects, every missed class added with its provenance, and the scoring recorded rather than implied.

## Blast radius

Every skill whose testing gate defers to `bug-hunter` inherits the wider checklist without changing a line.

`bug-hunter` 2.1.0 → 2.2.0. `V.6` (`openspec archive`) intentionally left open.
