### PR TITLE
🐛 fix(skills): pin what was probed, and fix the pin detector

### DIFF
--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.1
+  version: 1.0.2
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.2.1
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/fivem-nui-react/SKILL.md
+++ b/claude/skills/fivem-nui-react/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   react-api-client.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.0.1
   category: nui
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/react-api-client/SKILL.md
+++ b/claude/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -96,3 +96,6 @@ Should NOT trigger on:
 - "Open a PR for this change"
 - "Create a ticket in Jira"
 - "List my GitHub issues"
+
+> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
+> against that client. `gh project` moves fast — re-probe before trusting a recipe on an older CLI.

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -84,3 +84,6 @@ Should NOT trigger on:
 - "Merge PR #12"
 - "Deploy the fix"
 - "Close issue #9"
+
+> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
+> against that client.

--- a/cursor/rules/fivem-nui-react.mdc
+++ b/cursor/rules/fivem-nui-react.mdc
@@ -89,3 +89,8 @@ Full hook implementations + the Lua counterpart: `references/nui-bridge.md`.
 - `fivem-lua` — the Lua side: SetNuiFocus pairing, callback validation (payload is forgeable),
   disconnect/resource-stop cleanup.
 - `react-api-client` — for standalone (non-CEF) React SPAs talking to a REST API.
+
+> **Verified against**: `vite 8.2.0` + `terser 5.49.2`. The four build rules below were checked by
+> building with them: `base: './'` emits `./assets/…`, the flat `entryFileNames` produce hash-less
+> `assets/index.js` / `assets/index.css` matching `dist/assets/*`, and `drop_console` leaves zero
+> `console.log` in the bundle.

--- a/openspec/changes/pin-probed-skills/.openspec.yaml
+++ b/openspec/changes/pin-probed-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/pin-probed-skills/design.md
+++ b/openspec/changes/pin-probed-skills/design.md
@@ -1,0 +1,62 @@
+## Context
+
+Three audits established that a skill targeting a versioned external surface must say what it was
+checked against, and C5 in `scripts/validate-skills.py` enforces it. Auditing the skills the earlier
+passes had only validated mechanically exposed both halves of the problem: skills that were right but
+unverifiable, and a detector that was wrong in both directions.
+
+## Goals / Non-Goals
+
+**Goals**
+- Pin the skills whose external surface was actually probed, with what the probe produced.
+- Fix the detector's false negatives and state its blind spot rather than paper over it.
+- Leave a written record of the skills that remain unpinned, and why.
+
+**Non-Goals**
+- No pin for a surface that was not probed. That is the failure this requirement exists to prevent.
+- No widening of the C5 trigger to catch prose claims — attempted, and it fires on every skill that
+  merely names a tool. The limit is documented instead.
+- No new doctrine in the pinned skills; only the pin block was added.
+
+## Decisions
+
+**D1 — Probe, then pin; never the reverse.** `fivem-nui-react` was pinned because a Vite build was run
+with its four rules and each output checked. `assettoserver-csp-lua` was not, because nothing was run
+against CSP. The asymmetry is the point.
+
+**D2 — Record what the probe produced, not just the version.** "Verified against vite 8.2.0" is weaker
+than naming the four outputs; the second is falsifiable by a reader in one command.
+
+**D3 — Fix the detector's false negatives before adding pins.** It reported `assettoserver-plugin` and
+`openspec` as unpinned when both carry explicit pins in forms the regex did not match
+(`runtime 0.0.54 ↔ tag v0.0.54`, `Probed on CLI 1.6.0`). Adding pins to already-pinned skills would
+have been noise created by the instrument — the same class of error the validator's first run produced
+at scale.
+
+**D4 — State the blind spot instead of guessing at it.** C5 only fires above 40 fenced lines. Widening
+it to prose was tried and produced false positives on every skill mentioning a tool name. A check that
+silently covers half its rule is worse than one that says which half — so the limit went into the
+check's docstring and into the spec.
+
+**D5 — Mark the fragment, don't rewrite it.** The one non-parsing `ts` block in `react-api-client` is
+a legitimate excerpt (top-level `await` inside a mutation handler). It gets the same marker the `r3f-*`
+family uses, not an invented wrapper that would change what it teaches.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Version-pin requirement and its enforcement | `openspec/specs/skills-authoring` + `scripts/validate-skills.py` | already canonical — detector fixed, limit declared |
+| NUI build for CEF (Vite/terser rules) | `fivem-nui-react` | already canonical — pinned with probe output |
+| `gh` Projects v2 recipes | `backlog/references/gh-projects.md` | already canonical — client version pinned |
+| Executing a backlog item via `gh` | `execute-backlog` | already canonical — client version pinned |
+| Excerpt marking convention for non-module code blocks | `r3f-*` family | convention reused, not restated |
+
+## Risks / Trade-offs
+
+- [Pinned versions age] → they name what was checked and when, which is falsifiable; the previous
+  state was silently unverifiable. Re-probing is the maintenance action.
+- [Four skills stay unpinned] → recorded explicitly in the proposal as a known gap, so the absence is
+  a decision rather than an oversight.
+- [C5 keeps its blind spot] → declared in the check and in the spec; skills below the threshold are
+  hand-reviewed, which is how these three were found.

--- a/openspec/changes/pin-probed-skills/proposal.md
+++ b/openspec/changes/pin-probed-skills/proposal.md
@@ -1,0 +1,62 @@
+# Change: Pin the skills whose external surface was actually probed, and widen the pin detector
+
+## Why
+
+`Versioned external APIs are pinned` requires a skill targeting a versioned external surface to state
+what it was verified against. The validator's C5 check enforces it — but only for skills carrying **40+
+lines of fenced code**. A skill that makes the same claims in prose escapes entirely.
+
+`fivem-nui-react` is the clean example: **zero** fenced lines, and four concrete assertions about a
+Vite build for CEF. All four were probed against `vite 8.2.0` + `terser 5.49.2` and **all four hold**:
+
+| claim | result |
+|---|---|
+| `base: './'` — absolute paths 404 in CEF | emits `./assets/index.js`, `./assets/index.css` |
+| flat, hash-less `entryFileNames` so `dist/assets/*` matches | `assets/index.js`, `assets/index.css` |
+| `drop_console: true` | 0 occurrences of `console.log` in the bundle |
+| `dist/index.html` + `dist/assets/*` matches the fxmanifest | both present, nothing else |
+
+Correct doctrine, unverifiable by the reader. That is what a pin fixes.
+
+The pin **detector** was also wrong in both directions:
+
+- **False negatives** — it missed `runtime 0.0.54 ↔ upstream tag v0.0.54` (`assettoserver-plugin`) and
+  `Probed on CLI 1.6.0` (`openspec`), reporting two correctly-pinned skills as unpinned.
+- **Blind spot** — the 40-fenced-line trigger, described above.
+
+## What Changes
+
+- `scripts/validate-skills.py`: PIN regex widened to recognise `Probed on`, and
+  `runtime|tag|CLI|preset <version>` forms. The 40-line trigger stays; its limit is now stated in the
+  check's own docstring rather than implied.
+- Pins added to the three skills whose surface was probed tonight:
+  - `backlog` → 1.0.2 and `execute-backlog` → 1.2.1: `gh 2.92.0`, the client every recipe was probed
+    against (28 subcommand/flag claims across the process skills, all clean).
+  - `fivem-nui-react` → 1.0.1: `vite 8.2.0` + `terser 5.49.2`, with what each build rule produced.
+- `react-api-client` → 1.1.1: one `ts` block in `references/api-client.md` does not parse — top-level
+  `await` and shorthand properties with nothing in scope. Marked as an excerpt, matching the
+  convention used across `r3f-*`. The other three blocks parse.
+
+## Deliberately not done
+
+Four skills target a versioned surface and remain unpinned because **the surface was not probed**:
+`assettoserver-csp-lua` (CSP Lua API), `fivem-lua` and `fivem-fallback` (CitizenFX natives), and
+`react-api-client` (axios/zod — its reference blocks carry no imports, so a compile probe would only
+measure the missing imports). Writing a pin for a version nobody checked would be the exact failure
+this requirement exists to prevent. They are recorded here as a known gap.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Authoring rules are machine-enforced** — a mechanical check that only
+  covers part of its rule SHALL state the uncovered part, so a passing run is not read as full
+  coverage.
+
+## Impact
+
+- `scripts/validate-skills.py`; `skills/{backlog,execute-backlog,fivem-nui-react}/SKILL.md`;
+  `skills/react-api-client/references/api-client.md`; regenerated wrappers.
+- No README change: no skill added, removed or repurposed.

--- a/openspec/changes/pin-probed-skills/specs/skills-authoring/spec.md
+++ b/openspec/changes/pin-probed-skills/specs/skills-authoring/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Authoring rules are machine-enforced
+
+The mechanically checkable authoring rules SHALL be enforced by a script wired into CI, and that
+script SHALL carry a self-test that injects one known defect per check and asserts detection. Rules
+that cannot be checked mechanically SHALL be identified as review-only rather than left to imply
+coverage. A check that covers only **part** of its rule SHALL state the uncovered part in the check
+itself, so that a passing run is not read as full coverage.
+
+#### Scenario: A violation fails the build
+
+- **WHEN** a change introduces a broken reference, an unparseable code block, a mistagged fence, or a
+  description that contradicts its body
+- **THEN** the CI validate job fails and names the skill, the check and the offending content
+
+#### Scenario: A disabled check is caught
+
+- **WHEN** a change to the validator silently stops one of its checks from firing
+- **THEN** the self-test fails, because a catalog with zero findings and a check that cannot fire are
+  otherwise indistinguishable
+
+#### Scenario: A missing tool is reported, not passed over
+
+- **WHEN** a checker dependency is unavailable in the environment
+- **THEN** the affected check is reported as skipped in the output instead of counting as a pass
+
+#### Scenario: Partial coverage is declared, not implied
+
+- **WHEN** a check enforces its rule only under some condition (a size threshold, a file type, a
+  language it can parse)
+- **THEN** the condition and what escapes it are stated in the check, and skills falling outside it
+  are reviewed by hand rather than assumed compliant

--- a/openspec/changes/pin-probed-skills/tasks.md
+++ b/openspec/changes/pin-probed-skills/tasks.md
@@ -1,0 +1,38 @@
+## 1. Probe
+
+- [x] 1.1 Build a minimal Vite project with the four rules `fivem-nui-react` prescribes and check each
+      output (`vite 8.2.0`, `terser 5.49.2`)
+- [x] 1.2 Extract and syntax-check the `ts` blocks in `react-api-client/references/api-client.md`
+- [x] 1.3 Record the earlier `gh 2.92.0` probe as the pin for the two backlog skills
+
+## 2. Fix the detector
+
+- [x] 2.1 Widen the PIN regex to recognise `Probed on` and `runtime|tag|CLI|preset <version>`
+- [x] 2.2 Confirm `assettoserver-plugin` and `openspec` are no longer reported as unpinned
+- [x] 2.3 Document C5's 40-fenced-line limit in the check's docstring
+
+## 3. Pin and mark
+
+- [x] 3.1 `fivem-nui-react` 1.0.1 — pin with what each build rule produced
+- [x] 3.2 `backlog` 1.0.2 and `execute-backlog` 1.2.1 — pin `gh 2.92.0`
+- [x] 3.3 `react-api-client` 1.1.1 — mark the non-parsing `ts` block as an excerpt
+- [x] 3.4 Record the four skills left unpinned and why
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on every touched skill
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers and "Do NOT use for" boundaries unchanged
+- [x] Q.4 No duplicated doctrine: excerpt convention reused from `r3f-*`, not restated
+- [x] Q.5 Every pin names what was probed and what it produced
+- [x] Q.6 No description promises a policy its body contradicts
+- [x] Q.7 No README change — no skill added, removed or repurposed
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate pin-probed-skills --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` reports 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` detects 11/11
+- [ ] V.6 `openspec archive pin-probed-skills --yes` after review

--- a/plugins/frontend/skills/react-api-client/SKILL.md
+++ b/plugins/frontend/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/plugins/frontend/skills/react-api-client/references/api-client.md
+++ b/plugins/frontend/skills/react-api-client/references/api-client.md
@@ -117,6 +117,7 @@ Boot gate (per app): tokens-but-no-user → `GET /auth/me` → `setSession`, els
 ## Dedup nonce for paid mutations
 
 ```ts
+// excerpt — not a complete module; shown inside an async mutation handler
 const dedupKey = typeof crypto !== 'undefined' && crypto.randomUUID
   ? crypto.randomUUID()
   : `${Date.now()}-${Math.random().toString(36).slice(2)}`;  // non-secure context (LAN/IP)

--- a/plugins/nui/skills/fivem-nui-react/SKILL.md
+++ b/plugins/nui/skills/fivem-nui-react/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   react-api-client.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.0.1
   category: nui
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -100,3 +100,8 @@ Full hook implementations + the Lua counterpart: `references/nui-bridge.md`.
 - `fivem-lua` — the Lua side: SetNuiFocus pairing, callback validation (payload is forgeable),
   disconnect/resource-stop cleanup.
 - `react-api-client` — for standalone (non-CEF) React SPAs talking to a REST API.
+
+> **Verified against**: `vite 8.2.0` + `terser 5.49.2`. The four build rules below were checked by
+> building with them: `base: './'` emits `./assets/…`, the flat `entryFileNames` produce hash-less
+> `assets/index.js` / `assets/index.css` matching `dist/assets/*`, and `drop_console` leaves zero
+> `console.log` in the bundle.

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.1
+  version: 1.0.2
   category: process
 license: MIT
 compatibility: >-
@@ -112,3 +112,6 @@ Should NOT trigger on:
 - "Open a PR for this change"
 - "Create a ticket in Jira"
 - "List my GitHub issues"
+
+> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
+> against that client. `gh project` moves fast — re-probe before trusting a recipe on an older CLI.

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.2.1
   category: process
 license: MIT
 compatibility: >-
@@ -102,3 +102,6 @@ Should NOT trigger on:
 - "Merge PR #12"
 - "Deploy the fix"
 - "Close issue #9"
+
+> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
+> against that client.

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -179,13 +179,20 @@ def check_description(skill: str, text: str) -> None:
 
 
 # ── C5: versioned APIs pinned ─────────────────────────────────────────────
-PIN = re.compile(r"[Vv]erified against|@[\d]+\.[\d]+|version[s]? pinned|targets? v?\d+\.\d+"
-                 r"|[Mm]easured on|pydantic v\d|SQLAlchemy \d|Python .{0,3}\d\.\d+|\b\w+ \d+\.\d+\+")
+# A pin is any concrete "this was checked against version X" statement, in prose or in a fence.
+PIN = re.compile(r"[Vv]erified against|[Mm]easured on|[Pp]robed on|version[s]? pinned"
+                 r"|@[\d]+\.[\d]+|targets? v?\d+\.\d+"
+                 r"|\b(?:runtime|tag|CLI|preset)\s+v?\d+\.\d+"
+                 r"|pydantic v\d|SQLAlchemy \d|Python .{0,3}\d\.\d+|\b\w+ \d+\.\d+")
 API_HINT = re.compile(r"@react-three|@react-spring|fastapi|pydantic|sqlalchemy|helm |kubectl|"
                       r"citizenfx|Qmmands|AssettoServer|openspec|gh project|zod|vite", re.I)
 
 
 def check_pin(skill: str, text: str) -> None:
+    """KNOWN LIMIT: only fires on skills carrying 40+ lines of fenced code. A skill that makes
+    the same versioned claims in prose (config keys, CLI flags, API names in bullets) escapes
+    this check and must be reviewed by hand. Widening the trigger produced false positives on
+    every skill that merely names a tool, so the gap is stated instead of guessed at."""
     blocks = FENCE.findall(text)
     code_lines = sum(len(b.splitlines()) for _, b in blocks)
     if code_lines < 40:

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.1
+  version: 1.0.2
   category: process
 license: MIT
 compatibility: >-
@@ -112,3 +112,6 @@ Should NOT trigger on:
 - "Open a PR for this change"
 - "Create a ticket in Jira"
 - "List my GitHub issues"
+
+> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
+> against that client. `gh project` moves fast — re-probe before trusting a recipe on an older CLI.

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.2.1
   category: process
 license: MIT
 compatibility: >-
@@ -102,3 +102,6 @@ Should NOT trigger on:
 - "Merge PR #12"
 - "Deploy the fix"
 - "Close issue #9"
+
+> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
+> against that client.

--- a/skills/fivem-nui-react/SKILL.md
+++ b/skills/fivem-nui-react/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   react-api-client.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.0.1
   category: nui
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -100,3 +100,8 @@ Full hook implementations + the Lua counterpart: `references/nui-bridge.md`.
 - `fivem-lua` — the Lua side: SetNuiFocus pairing, callback validation (payload is forgeable),
   disconnect/resource-stop cleanup.
 - `react-api-client` — for standalone (non-CEF) React SPAs talking to a REST API.
+
+> **Verified against**: `vite 8.2.0` + `terser 5.49.2`. The four build rules below were checked by
+> building with them: `base: './'` emits `./assets/…`, the flat `entryFileNames` produce hash-less
+> `assets/index.js` / `assets/index.css` matching `dist/assets/*`, and `drop_console` leaves zero
+> `console.log` in the bundle.

--- a/skills/react-api-client/SKILL.md
+++ b/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/skills/react-api-client/references/api-client.md
+++ b/skills/react-api-client/references/api-client.md
@@ -117,6 +117,7 @@ Boot gate (per app): tokens-but-no-user → `GET /auth/me` → `setSession`, els
 ## Dedup nonce for paid mutations
 
 ```ts
+// excerpt — not a complete module; shown inside an async mutation handler
 const dedupKey = typeof crypto !== 'undefined' && crypto.randomUUID
   ? crypto.randomUUID()
   : `${Date.now()}-${Math.random().toString(36).slice(2)}`;  // non-secure context (LAN/IP)


### PR DESCRIPTION
## Why

C5 enforces *Versioned external APIs are pinned* — but only for skills carrying **40+ lines of fenced code**. A skill making the same claims in prose escapes entirely.

`fivem-nui-react` is the clean example: **zero** fenced lines, four concrete assertions about a Vite build for CEF. Probed against `vite 8.2.0` + `terser 5.49.2`:

| claim | result |
|---|---|
| `base: './'` — absolute paths 404 in CEF | emits `./assets/index.js`, `./assets/index.css` ✓ |
| flat hash-less `entryFileNames` so `dist/assets/*` matches | `assets/index.js`, `assets/index.css` ✓ |
| `drop_console: true` | **0** occurrences of `console.log` in the bundle ✓ |
| `dist/index.html` + `dist/assets/*` matches the fxmanifest | both present, nothing else ✓ |

Correct doctrine, unverifiable by the reader. That is what a pin fixes.

## The detector was wrong in both directions

- **False negatives** — it missed `runtime 0.0.54 ↔ upstream tag v0.0.54` (`assettoserver-plugin`) and `Probed on CLI 1.6.0` (`openspec`), reporting **two correctly-pinned skills as unpinned**. Adding pins to already-pinned skills would have been noise created by the instrument — the same class of error the validator's first run produced at scale.
- **Blind spot** — the 40-line trigger. Widening it to prose was tried and fires on every skill that merely names a tool, so the limit is now **stated in the check's docstring** rather than papered over.

## What was pinned

- `backlog` → 1.0.2, `execute-backlog` → 1.2.1 — `gh 2.92.0`, the client all 28 subcommand/flag claims were probed against in #31.
- `fivem-nui-react` → 1.0.1 — `vite 8.2.0` + `terser 5.49.2`, recording **what each rule produced**, not just the version. A reader can falsify it in one command.
- `react-api-client` → 1.1.1 — one `ts` block in its reference does not parse (top-level `await`, shorthand properties with nothing in scope). Marked as an excerpt, matching the `r3f-*` convention. The other three parse.

## Deliberately NOT pinned

Four skills target a versioned surface and stay unpinned **because nothing was run against them**: `assettoserver-csp-lua` (CSP Lua API), `fivem-lua` and `fivem-fallback` (CitizenFX natives), `react-api-client` (axios/zod — its reference blocks carry no imports, so a compile probe would only measure the missing imports).

Writing a pin for a version nobody checked is the exact failure this requirement exists to prevent. Recorded in the proposal as a known gap, so the absence is a decision rather than an oversight.

## Spec delta

`skills-authoring` → **MODIFIED** *Authoring rules are machine-enforced*: a check that covers only **part** of its rule must state the uncovered part, so a passing run is not read as full coverage.

`V.6` (`openspec archive`) intentionally left open.
