### PR TITLE
🐛 fix(backlog): fix what running the flow for real exposed

### DIFF
--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.2
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -43,7 +43,9 @@ to the `backlog` skill; consumes the same config.
    discovery/precedence as `backlog`). Number/search → `gh issue view` in the primary repo (or
    search across workspace repos). Not found → clear error, stop.
 2. **Read fully** — body, comments (later comments may amend scope), linked PRs, labels, board
-   status. Existing open PR for the item → report and ask before duplicating work.
+   status. Existing open PR for the item → report and ask before duplicating work. Resolve linked
+   PRs from the issue's own link graph, never from a text search — recipe and the measured failure
+   of the search approach: `references/board-sync.md` (*Finding the item's PRs*).
 3. **Completeness gate** — the item must have enough to execute: goal, scope, acceptance
    criteria. Also re-check against the *current* codebase (drift since grooming: files renamed,
    feature landed meanwhile). Gaps/contradictions → report and ask: proceed as-is (user accepts

--- a/openspec/changes/harden-backlog-flow/.openspec.yaml
+++ b/openspec/changes/harden-backlog-flow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/harden-backlog-flow/design.md
+++ b/openspec/changes/harden-backlog-flow/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`backlog` and `execute-backlog` are the catalog's only pair meant to be run in sequence as a rite:
+groom an item, then execute it. They are also the pair with the most external surface — a GitHub
+Project board, the issue graph, the PR graph — and therefore the most places where a plausible command
+is subtly the wrong one.
+
+Neither had been exercised. The audit that covered them earlier only probed that their commands
+*exist* (28 subcommand/flag claims against `gh 2.92.0`, all clean). Existing is not the same as
+correct-for-the-purpose, which is what running the flow measures.
+
+## Goals / Non-Goals
+
+**Goals**
+- Run the flow against a real item and fix what the run exposes.
+- Give every step that can be done wrongly the command that does it rightly.
+- Record the suspicion that turned out unfounded, so it is not re-raised.
+
+**Non-Goals**
+- Not executing issue #28's actual work. The run stopped at `execute-backlog`'s own plan-approval
+  gate, which is where the skill says to stop — exercising the skill, not bypassing it.
+- Not redesigning the board-sync model. It was checked and found complete; only its documentation
+  location was wrong.
+- Not adding workspace-mode coverage. Testing multi-repo mode needs a workspace, which this
+  environment does not have; it stays unexercised and is not claimed otherwise.
+
+## Decisions
+
+**D1 — A step without a command is a defect, not a style choice.** *"Existing open PR for the item →
+report and ask"* reads complete, and produced a wrong result the first time it was run, because the
+obvious implementation is a text search. The generalised rule goes into `skills-authoring`: when a
+plausible wrong command exists, name it.
+
+**D2 — Name the forbidden command, not just the correct one.** `gh pr list --search "<n> in:body"`
+will keep looking reasonable to the next reader. Recording that it returned three unrelated PRs for an
+issue with zero linked PRs is what stops it being re-derived.
+
+**D3 — Both failure directions are worth stating.** The text search over-matches (bare number anywhere
+in a body) *and* under-matches (a link that lives only in a commit message). A reader who only knows
+about false positives will still trust a zero result.
+
+**D4 — The duplicate-check trap belongs next to the command.** GitHub dropping punctuation-bearing
+tokens is invisible until it costs a duplicate issue. The measured four-way comparison sits directly
+above the query so it cannot be read without it.
+
+**D5 — Config keys are documented where the config is defined.** `columns:` is read by
+`execute-backlog` and specified in its `board-sync.md`; the schema doc in `backlog` is where someone
+writing `.github/backlog.yml` actually looks. It is cross-referenced rather than duplicated, so
+`board-sync.md` stays canonical.
+
+**D6 — Record the unfounded suspicion.** The three board columns looked undefined because the config
+file carries only `defaults.status`. They are fully specified in `board-sync.md`, with heuristics and
+a warn-and-continue path. Writing that down costs a paragraph and prevents the next reader from
+"fixing" a mechanism that already works.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Grooming an idea into a Project item; duplicate check | `backlog` | already canonical — search trap documented |
+| Config schema for `.github/backlog.yml` / workspace `backlog.yml` | `backlog/references/backlog-config.md` | already canonical — `columns:` cross-referenced |
+| Board transitions and column resolution | `execute-backlog/references/board-sync.md` | already canonical — gains the PR-link recipe |
+| Executing an item to a reviewable PR | `execute-backlog` | already canonical — step 2 given its method |
+| Acceptance criteria verdicts and evidence | `execute-backlog/references/acceptance-tracking.md` | unchanged — reviewed and found sound |
+| Commit/PR message format for the work these skills produce | `conventional-commit` | link (already canonical) |
+
+## Risks / Trade-offs
+
+- [The `closedByPullRequestsReferences` field is a GitHub API surface that can change] → it is pinned
+  to `gh 2.92.0` alongside the rest of the skill's recipes, and the timeline query is given as the
+  second source.
+- [Naming a forbidden command dates the doc if `gh` later fixes the search] → the failure is inherent
+  to matching a bare number in free text, not a `gh` bug.
+- [Workspace mode stays unexercised] → stated in Non-Goals rather than implied by the rest passing.

--- a/openspec/changes/harden-backlog-flow/proposal.md
+++ b/openspec/changes/harden-backlog-flow/proposal.md
@@ -1,0 +1,83 @@
+# Change: Fix what running the backlog → execute-backlog flow for real exposed
+
+## Why
+
+`backlog` and `execute-backlog` are about to be used as a rite — groom an item, then execute it. Of
+the two, `backlog` had received exactly one improvement (a propagation-lag note found by using it) and
+`execute-backlog` had received **no doctrine review at all**: only a cross-skill path correction and a
+version pin. Neither had been exercised end-to-end.
+
+So the flow was run against a real item — issue #28, groomed by `backlog` earlier the same day —
+following `execute-backlog`'s own steps up to its plan-approval gate. Three defects surfaced, and one
+suspicion turned out to be unfounded.
+
+**1. The existing-PR check has no recipe, and the obvious one is wrong in both directions.**
+Step 2 says *"Existing open PR for the item → report and ask before duplicating work."* No reference
+gives a method, so the natural move is a text search. Measured on issue #28, which has **zero** linked
+PRs:
+
+```
+gh pr list --search "28 in:body"  →  #31, #39, #5   (three, none related)
+gh issue view 28 --json closedByPullRequestsReferences  →  0   (correct)
+```
+
+The search matches the bare number anywhere in any PR body — a version string, a line count, an
+unrelated issue number. It also **misses** a real link whose reference lives only in a commit message.
+Following the step literally halts a legitimate run on a false positive.
+
+**2. The duplicate check fails on a verbatim title.** `backlog` step 4 searches for duplicates. Issue
+#28 is titled `refactor(r3f): split the 10 r3f skills into SKILL.md + references/`. Searching its own
+title's leading token returns nothing:
+
+| search | found |
+|---|---|
+| `split r3f skills` | 1 |
+| `r3f references split` | 1 |
+| `r3f` | 1 |
+| **`refactor(r3f)`** | **0** |
+
+GitHub's search drops punctuation-bearing tokens, so a verbatim conventional-commit title reports
+"no duplicate" for an issue that exists.
+
+**3. The `columns:` config extension is undocumented where the config is defined.**
+`execute-backlog/references/board-sync.md` reads `columns.ready`, `columns.in_progress` and
+`columns.review` from the config. `backlog/references/backlog-config.md` — the canonical schema —
+mentions `columns` **zero** times. Someone configuring from the `backlog` skill cannot know the key
+exists.
+
+**Unfounded suspicion, recorded:** the three board columns first looked undefined, since the config
+file carries only `defaults.status`. `board-sync.md` in fact specifies all three, with name heuristics
+as fallback and a warn-and-continue path when a name is not among the board's Status options. The
+defect was only that the schema doc never mentioned them — a documentation gap, not a missing
+mechanism.
+
+## What Changes
+
+- `execute-backlog` → 1.3.0:
+  - Step 2 now resolves linked PRs from the issue's **link graph** and points at the recipe.
+  - New *Finding the item's PRs* section in `references/board-sync.md` with both queries
+    (`closedByPullRequestsReferences` for closing PRs, the timeline's `cross-referenced` events for
+    the rest), and an explicit prohibition on `gh pr list --search "<n> in:body"` carrying the
+    measured failure.
+- `backlog` → 1.1.0:
+  - `references/gh-projects.md`: the duplicate check now says to search key terms, never the
+    candidate title verbatim, with the measured four-way comparison.
+  - `references/backlog-config.md`: the optional `columns:` block documented, marked optional, with
+    the fallback behaviour and a pointer to its canonical definition.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Checklists are scored against field defects** — a skill that
+  prescribes a step SHALL also give the command that performs it when a plausible wrong command
+  exists, and SHALL name the wrong one.
+
+## Impact
+
+- `skills/execute-backlog/SKILL.md` + `references/board-sync.md`;
+  `skills/backlog/references/{gh-projects,backlog-config}.md`; regenerated wrappers.
+- The flow is now safe to run as a rite: the existing-PR gate no longer halts on unrelated PRs, and a
+  verbatim-title duplicate search no longer reports a clean board.

--- a/openspec/changes/harden-backlog-flow/specs/skills-authoring/spec.md
+++ b/openspec/changes/harden-backlog-flow/specs/skills-authoring/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Checklists are scored against field defects
+
+A skill that prescribes a checklist or a rite SHALL be scored against defects actually found in the
+field, and every class the checklist would have missed SHALL be added together with the defect that
+earned it. A checklist item without a traceable origin SHALL NOT be added.
+
+A skill that prescribes a **step** SHALL also give the command that performs it whenever a plausible
+wrong command exists, and SHALL name the wrong one. A step stated without a method is executed by
+whatever command looks obvious, which is how a wrong one becomes the de facto instruction.
+
+#### Scenario: A missed class is added with its provenance
+
+- **WHEN** a defect is found by some means other than the checklist that claims to cover its area
+- **THEN** the class it belongs to is added to the checklist, recorded with the defect that earned it
+- **AND** an item that cannot name the defect behind it is removed rather than kept
+
+#### Scenario: The scoring is stated, not implied
+
+- **WHEN** a checklist is revised after an audit
+- **THEN** the change records which defects were scored against it and which of them it would have
+  caught as previously written
+
+#### Scenario: A prescribed step carries its command
+
+- **WHEN** a step instructs the agent to check, resolve or look something up, and more than one
+  command could plausibly do it
+- **THEN** the correct command is given, and any plausible-but-wrong alternative is named as forbidden
+  with the failure it produces

--- a/openspec/changes/harden-backlog-flow/tasks.md
+++ b/openspec/changes/harden-backlog-flow/tasks.md
@@ -1,0 +1,43 @@
+## 1. Run the flow for real
+
+- [x] 1.1 Execute `execute-backlog` steps 1-3 against issue #28, groomed by `backlog` the same day
+- [x] 1.2 Record each friction point with the command that produced it
+- [x] 1.3 Verify the drift check: the issue's ten line-count claims still hold (0/10 divergent)
+- [x] 1.4 Check the suspicion that the board columns are undefined — found specified in
+      `board-sync.md`; record as unfounded
+
+## 2. execute-backlog (1.3.0)
+
+- [x] 2.1 Step 2 resolves linked PRs from the issue's link graph and points at the recipe
+- [x] 2.2 Add *Finding the item's PRs* to `references/board-sync.md` with both queries
+- [x] 2.3 Forbid `gh pr list --search "<n> in:body"`, with the measured 3-false-positives result and
+      the miss direction
+- [x] 2.4 Bump `metadata.version` to 1.3.0
+
+## 3. backlog (1.1.0)
+
+- [x] 3.1 Document the duplicate-check punctuation trap with the measured four-way comparison
+- [x] 3.2 Document the optional `columns:` block in `references/backlog-config.md`, cross-referencing
+      `board-sync.md` as canonical
+- [x] 3.3 Bump `metadata.version` to 1.1.0
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on both skills
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers and the mutual "Do NOT use for … that is the other skill" boundaries unchanged
+- [x] Q.4 No duplicated doctrine: `columns:` cross-referenced, not restated; PR-link recipe lives only
+      in `board-sync.md`
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 No description promises a policy its body contradicts
+- [x] Q.7 No README change — no skill added, removed or repurposed
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate harden-backlog-flow --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` reports 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` detects 11/11
+- [x] V.6 The corrected PR-link recipe returns the right answer for issue #28 (0 linked PRs)
+- [ ] V.7 `openspec archive harden-backlog-flow --yes` after review

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.2
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-

--- a/plugins/workflow/skills/backlog/references/backlog-config.md
+++ b/plugins/workflow/skills/backlog/references/backlog-config.md
@@ -26,6 +26,14 @@ fields:                # Project field names as shown by gh project field-list
   estimate: Estimate
 defaults:
   status: Backlog      # column for newly created items
+
+# Optional — read by `execute-backlog` when it advances the card. Absent keys fall back to
+# name heuristics; a name that is not among the board's Status options is warned about and
+# skipped, never fatal. Canonical definition: execute-backlog/references/board-sync.md
+columns:
+  ready: Ready
+  in_progress: In progress
+  review: In review
 labels:                # optional: intent → existing repo label
   feature: enhancement
   bug: bug

--- a/plugins/workflow/skills/backlog/references/gh-projects.md
+++ b/plugins/workflow/skills/backlog/references/gh-projects.md
@@ -93,6 +93,12 @@ Only use option names returned by `/orgs/OWNER/issue-fields`. The board mirror m
 
 ## Duplicate check
 
+Search **key terms**, never the candidate title verbatim. GitHub's search drops punctuation-bearing
+tokens, so a conventional-commit style title finds nothing: measured on this catalog, an issue titled
+`refactor(r3f): split the 10 r3f skills into SKILL.md + references/` was found by
+`split r3f skills`, `r3f references split` and `r3f` — and **not** by `refactor(r3f)`, which
+returned zero. A verbatim search reporting "no duplicate" is the failure mode to avoid.
+
 ```bash
 gh issue list -R OWNER/REPO --search "KEY TERMS in:title,body" --state open \
   --json number,title,url --limit 10

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
@@ -61,7 +61,9 @@ to the `backlog` skill; consumes the same config.
    discovery/precedence as `backlog`). Number/search → `gh issue view` in the primary repo (or
    search across workspace repos). Not found → clear error, stop.
 2. **Read fully** — body, comments (later comments may amend scope), linked PRs, labels, board
-   status. Existing open PR for the item → report and ask before duplicating work.
+   status. Existing open PR for the item → report and ask before duplicating work. Resolve linked
+   PRs from the issue's own link graph, never from a text search — recipe and the measured failure
+   of the search approach: `references/board-sync.md` (*Finding the item's PRs*).
 3. **Completeness gate** — the item must have enough to execute: goal, scope, acceptance
    criteria. Also re-check against the *current* codebase (drift since grooming: files renamed,
    feature landed meanwhile). Gaps/contradictions → report and ask: proceed as-is (user accepts

--- a/plugins/workflow/skills/execute-backlog/references/board-sync.md
+++ b/plugins/workflow/skills/execute-backlog/references/board-sync.md
@@ -54,6 +54,26 @@ gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
 - Final issue comment: list every PR, validation summary, the acceptance-criteria verdict table
   (`references/acceptance-tracking.md`), and any approved scope deviations.
 
+## Finding the item's PRs
+
+Resolve them from the issue's **link graph**, never from a text search over PR bodies:
+
+```bash
+# PRs that will close the issue (Closes/Fixes #n) — authoritative
+gh issue view <n> -R OWNER/REPO --json closedByPullRequestsReferences \
+  --jq '.closedByPullRequestsReferences[] | "\(.number) \(.title)"'
+
+# PRs that reference it without closing it
+gh api repos/OWNER/REPO/issues/<n>/timeline \
+  --jq '.[] | select(.event == "cross-referenced")
+             | .source.issue.pull_request.html_url // empty'
+```
+
+**Do NOT use `gh pr list --search "<n> in:body"`.** It matches the bare number anywhere in any PR
+body — a version string, a line count, an unrelated issue number. Measured on this catalog: for an
+issue with **zero** linked PRs, that search returned **three**, none of them related. It also misses
+a real link whose reference lives only in a commit message. Both failure directions at once.
+
 ## Recovery
 
 | Failure | Recovery |

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.0.2
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-

--- a/skills/backlog/references/backlog-config.md
+++ b/skills/backlog/references/backlog-config.md
@@ -26,6 +26,14 @@ fields:                # Project field names as shown by gh project field-list
   estimate: Estimate
 defaults:
   status: Backlog      # column for newly created items
+
+# Optional — read by `execute-backlog` when it advances the card. Absent keys fall back to
+# name heuristics; a name that is not among the board's Status options is warned about and
+# skipped, never fatal. Canonical definition: execute-backlog/references/board-sync.md
+columns:
+  ready: Ready
+  in_progress: In progress
+  review: In review
 labels:                # optional: intent → existing repo label
   feature: enhancement
   bug: bug

--- a/skills/backlog/references/gh-projects.md
+++ b/skills/backlog/references/gh-projects.md
@@ -93,6 +93,12 @@ Only use option names returned by `/orgs/OWNER/issue-fields`. The board mirror m
 
 ## Duplicate check
 
+Search **key terms**, never the candidate title verbatim. GitHub's search drops punctuation-bearing
+tokens, so a conventional-commit style title finds nothing: measured on this catalog, an issue titled
+`refactor(r3f): split the 10 r3f skills into SKILL.md + references/` was found by
+`split r3f skills`, `r3f references split` and `r3f` — and **not** by `refactor(r3f)`, which
+returned zero. A verbatim search reporting "no duplicate" is the failure mode to avoid.
+
 ```bash
 gh issue list -R OWNER/REPO --search "KEY TERMS in:title,body" --state open \
   --json number,title,url --limit 10

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
@@ -61,7 +61,9 @@ to the `backlog` skill; consumes the same config.
    discovery/precedence as `backlog`). Number/search → `gh issue view` in the primary repo (or
    search across workspace repos). Not found → clear error, stop.
 2. **Read fully** — body, comments (later comments may amend scope), linked PRs, labels, board
-   status. Existing open PR for the item → report and ask before duplicating work.
+   status. Existing open PR for the item → report and ask before duplicating work. Resolve linked
+   PRs from the issue's own link graph, never from a text search — recipe and the measured failure
+   of the search approach: `references/board-sync.md` (*Finding the item's PRs*).
 3. **Completeness gate** — the item must have enough to execute: goal, scope, acceptance
    criteria. Also re-check against the *current* codebase (drift since grooming: files renamed,
    feature landed meanwhile). Gaps/contradictions → report and ask: proceed as-is (user accepts

--- a/skills/execute-backlog/references/board-sync.md
+++ b/skills/execute-backlog/references/board-sync.md
@@ -54,6 +54,26 @@ gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
 - Final issue comment: list every PR, validation summary, the acceptance-criteria verdict table
   (`references/acceptance-tracking.md`), and any approved scope deviations.
 
+## Finding the item's PRs
+
+Resolve them from the issue's **link graph**, never from a text search over PR bodies:
+
+```bash
+# PRs that will close the issue (Closes/Fixes #n) — authoritative
+gh issue view <n> -R OWNER/REPO --json closedByPullRequestsReferences \
+  --jq '.closedByPullRequestsReferences[] | "\(.number) \(.title)"'
+
+# PRs that reference it without closing it
+gh api repos/OWNER/REPO/issues/<n>/timeline \
+  --jq '.[] | select(.event == "cross-referenced")
+             | .source.issue.pull_request.html_url // empty'
+```
+
+**Do NOT use `gh pr list --search "<n> in:body"`.** It matches the bare number anywhere in any PR
+body — a version string, a line count, an unrelated issue number. Measured on this catalog: for an
+issue with **zero** linked PRs, that search returned **three**, none of them related. It also misses
+a real link whose reference lives only in a commit message. Both failure directions at once.
+
 ## Recovery
 
 | Failure | Recovery |


### PR DESCRIPTION
## Why

`backlog` and `execute-backlog` are about to be used **as a rite** — groom an item, then execute it. Of the two:

- `backlog` had received **one** improvement (a propagation-lag note, found by using it)
- `execute-backlog` had received **no doctrine review at all** — only a cross-skill path correction and a version pin

Neither had been exercised end-to-end. The earlier audit only probed that their commands *exist* (28 subcommand/flag claims against `gh 2.92.0`, all clean). **Existing is not the same as correct-for-the-purpose.**

So the flow was run against a real item — **issue #28**, groomed by `backlog` the same day — following `execute-backlog`'s own steps up to its plan-approval gate, which is where the skill says to stop.

## 1. The existing-PR check has no recipe, and the obvious one is wrong both ways

Step 2 says *"Existing open PR for the item → report and ask before duplicating work."* No reference gives a method, so the natural move is a text search. Measured on issue #28, which has **zero** linked PRs:

```
gh pr list --search "28 in:body"                       →  #31, #39, #5   (three, none related)
gh issue view 28 --json closedByPullRequestsReferences →  0              (correct)
```

It matches the bare number **anywhere** in any PR body — a version string, a line count, an unrelated issue number. It also **misses** a real link whose reference lives only in a commit message. Following the step literally halts a legitimate run on a false positive.

**Fix:** step 2 now resolves from the issue's link graph, with a new *Finding the item's PRs* section in `references/board-sync.md` carrying both queries — and naming the forbidden one with its measured failure, because it will keep looking reasonable to the next reader.

## 2. The duplicate check fails on a verbatim title

Issue #28 is titled `refactor(r3f): split the 10 r3f skills into SKILL.md + references/`:

| search | found |
|---|---|
| `split r3f skills` | 1 |
| `r3f references split` | 1 |
| `r3f` | 1 |
| **`refactor(r3f)`** | **0** |

GitHub drops punctuation-bearing tokens, so a verbatim conventional-commit title reports **"no duplicate" for an issue that exists**. Documented directly above the query.

## 3. `columns:` is undocumented where the config is defined

`execute-backlog/references/board-sync.md` reads `columns.ready`, `columns.in_progress`, `columns.review`. `backlog/references/backlog-config.md` — the canonical schema — mentions `columns` **zero** times. Cross-referenced now, not duplicated.

## Unfounded suspicion, recorded

The three board columns first looked **undefined**, since the config file carries only `defaults.status`. `board-sync.md` in fact specifies all three, with name heuristics as fallback and a warn-and-continue path when a name is not among the board's Status options. Documentation gap, not a missing mechanism — written down so nobody "fixes" a mechanism that already works.

Also checked and found **sound**: `acceptance-tracking.md` handles unverifiable criteria correctly (`manual` verdict with exact steps, stop-and-ask, Known-gaps section, never implying completeness). And the drift check passed — all ten of #28's line-count claims still hold, 0/10 divergent.

## Spec delta

`skills-authoring` → **MODIFIED** *Checklists are scored against field defects*: a skill that prescribes a **step** must also give the command that performs it whenever a plausible wrong command exists, and must name the wrong one.

> A step stated without a method is executed by whatever command looks obvious, which is how a wrong one becomes the de facto instruction.

## Not claimed

**Workspace (multi-repo) mode stays unexercised** — testing it needs a workspace this environment does not have. Stated in Non-Goals rather than implied by the rest passing.

`execute-backlog` 1.2.1 → 1.3.0 · `backlog` 1.0.2 → 1.1.0. `V.7` intentionally left open.
