### PR TITLE
♻️ refactor(skills): apply the meta-section rule to the whole catalog

### DIFF
--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/claude-statusline/SKILL.md
+++ b/claude/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/helm-migration/SKILL.md
+++ b/claude/skills/helm-migration/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: helm-migration
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 2.2.0
   category: devops
 license: MIT
 compatibility: Requires a Helm charts template repository accessible on the local filesystem. Works best in Claude Code.

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -83,19 +83,3 @@ codebase.
 | Select option not found for a proposed value | Show available options; ask instead of guessing. |
 | Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
 
-## Trigger Test Cases
-
-Should trigger on:
-- "/backlog add social login authentication"
-- "Create a backlog item for rate limiting"
-- "Turn this idea into an issue on our board"
-- "Add this to the backlog of the project"
-
-Should NOT trigger on:
-- "Implement issue #123" (execute-backlog)
-- "Open a PR for this change"
-- "Create a ticket in Jira"
-- "List my GitHub issues"
-
-> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
-> against that client. `gh project` moves fast — re-probe before trusting a recipe on an older CLI.

--- a/cursor/rules/claude-statusline.mdc
+++ b/cursor/rules/claude-statusline.mdc
@@ -160,20 +160,3 @@ for a secret (unlisted-but-linkable) gist. Manage with `gh gist edit|view|delete
   run. Cache slow git calls (keyed by `session_id`).
 - **Windows** — write the `command` path with forward slashes; Git Bash eats backslashes.
 
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Configure my Claude Code status line"
-- "Add context / cost / git to my statusline"
-- "My statusline.sh isn't showing up"
-- "Make the status bar show cache usage"
-- "My friend sent me this statusline gist, install it"
-- "Share my status line with someone"
-
-Should NOT trigger on:
-- "Customize my shell prompt / PS1 / starship / powerlevel10k"
-- "Set up a tmux status bar"
-- "Change the VS Code status bar"
-- "Write documentation for this project"

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -73,19 +73,3 @@ to the `backlog` skill; consumes the same config.
     to the PR(s); present summary: what changed, validation evidence, the criteria table with
     every verdict, deviations (if any, pre-approved), next human step (review/merge).
 
-## Trigger Test Cases
-
-Should trigger on:
-- "/execute-backlog 123"
-- "Implement issue #42"
-- "Pick up the backlog item about push notifications"
-- "Execute https://github.com/org/repo/issues/7"
-
-Should NOT trigger on:
-- "Create a backlog item for X" (backlog)
-- "Merge PR #12"
-- "Deploy the fix"
-- "Close issue #9"
-
-> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
-> against that client.

--- a/cursor/rules/helm-migration.mdc
+++ b/cursor/rules/helm-migration.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 alwaysApply: false
 ---
 
@@ -253,30 +253,6 @@ Rules:
 
 ---
 
-## How to Use
-
-Use this prompt to trigger the skill:
-```
-Migrate this YAML-file to Helm following the helm-migration skill.
-Charts template path: [PATH_TO_CHARTS_TEMPLATE]
-Source YAML-file: [PATH_TO_YAML_FILE]
-Save files to: [DESTINATION_PATH]
-```
-
-Claude will generate:
-- `values.yaml` — workload definition
-- `env.yaml` — secrets, configmaps and PVCs (only if present in source YAML)
-
-### Example
-```
-Migrate this YAML-file to Helm following the helm-migration skill.
-Charts template path: /path/to/charts-template
-Source YAML-file: /path/to/source/deployment.yaml
-Save files to: /path/to/output/helm/
-```
-
----
-
 ## Troubleshooting
 
 **Problem**: Field exists in YAML but not in charts template.
@@ -318,19 +294,3 @@ See `references/examples.md` for complete before/after examples of:
 - Deployment with secretKeyRef and commented resource limits
 - Deployment with PVC
 
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Migrate this YAML to Helm"
-- "Convert this manifest to values.yaml"
-- "Generate values.yaml for this deployment"
-- "I need to helm-migrate this file"
-- "Create env.yaml from this YAML"
-
-Should NOT trigger on:
-- "Update the README"
-- "Fix this Python bug"
-- "Create a docker-compose file"
-- "Write documentation for this project"

--- a/openspec/changes/prune-meta-sections/.openspec.yaml
+++ b/openspec/changes/prune-meta-sections/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/prune-meta-sections/design.md
+++ b/openspec/changes/prune-meta-sections/design.md
@@ -1,0 +1,55 @@
+## Context
+
+A rule accepted for one skill and never applied to the rest is not a rule — it is an exception that
+happens to be documented. #24 established that trigger blocks in a skill body cost context and cannot
+affect routing. This applies it to the four skills that still carried them, and puts it behind a check
+so the next one is caught rather than argued again.
+
+## Goals / Non-Goals
+
+**Goals**
+- The rule holds across the whole catalog, not the skill it was written for.
+- No routing information is lost — cases the description misses get folded in first.
+- The rule is enforced mechanically, like the other authoring rules.
+
+**Non-Goals**
+- Not touching doctrine. Only meta sections were removed; every rule, example and reference stays.
+- Not rewriting descriptions wholesale. `helm-migration` gains a clause because it had none; the other
+  three already routed correctly and were left alone.
+
+## Decisions
+
+**D1 — Check each block against its description before deleting it.** Assuming redundancy would have
+thrown away `helm-migration`'s four anti-triggers, which were the only routing guidance that skill had
+anywhere. Three of the four skills were pure duplication; one was not, and only checking told them
+apart.
+
+**D2 — Anti-triggers belong in the description because that is where they act.** A `Should NOT trigger
+on` list inside the body is evaluated after selection already happened. Moving those four cases into
+`helm-migration`'s description is the difference between documenting a routing rule and having one.
+
+**D3 — Redirects count as routing guidance.** A first sweep flagged 17 skills for lacking a `Do NOT
+use` clause; most of them route via a redirect instead (`for X use r3f-animation`, `see fivem-lua`),
+which serves the same purpose. The requirement accepts either form, so the check does not manufacture
+17 edits for a phrasing preference.
+
+**D4 — Put the reasoning inside the check.** C8's docstring carries *why* a meta section is a defect,
+so a contributor who hits it gets the argument rather than a rule number.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Where triggers and anti-triggers live | `openspec/specs/skills-authoring` | establish here (new requirement) |
+| Mechanical enforcement of authoring rules | `scripts/validate-skills.py` | already canonical — gains C8 |
+| Helm migration workflow and chart conventions | `helm-migration` | already canonical — description gains routing, body unchanged |
+| Grooming and executing backlog items | `backlog`, `execute-backlog` | already canonical — meta blocks removed only |
+| Claude Code status line setup | `claude-statusline` | already canonical — meta block removed only |
+
+## Risks / Trade-offs
+
+- [Trigger cases had value as author-facing test material] → the ones carrying information moved into
+  the description; the rest were duplicates. Nothing that affected behaviour was lost.
+- [C8 fires on a future skill that wants a usage example] → an example belongs in `references/`, where
+  it loads on demand; the check names that in its message.
+- [Descriptions grow] → `helm-migration`'s grew by one sentence and replaced 38 body lines.

--- a/openspec/changes/prune-meta-sections/proposal.md
+++ b/openspec/changes/prune-meta-sections/proposal.md
@@ -1,0 +1,58 @@
+# Change: Remove the meta sections the catalog kept after ruling against them
+
+## Why
+
+#24 removed `How to Use` and `Trigger Test Cases` from `documentation`, arguing they are read only
+*after* the skill has already been selected — so they cannot influence routing, and they cost context
+on every invocation. The argument was accepted and the sections were deleted.
+
+**It was applied to exactly one skill.** Four others kept theirs:
+
+| skill | meta lines | % of file | sections |
+|---|---|---|---|
+| `helm-migration` | 38 | 11% | How to Use, Trigger Test Cases |
+| `backlog` | 16 | 14% | Trigger Test Cases |
+| `execute-backlog` | 16 | 15% | Trigger Test Cases |
+| `claude-statusline` | 15 | 8% | Trigger Test Cases |
+
+**85 lines loaded on every invocation that instruct nothing about the task.**
+
+Before deleting, each block was checked against its own description rather than assumed redundant:
+
+- `backlog`, `execute-backlog`, `claude-statusline` — every case already covered. `claude-statusline`'s
+  "tmux status bar" is its description's "non-Claude-Code status bars"; `execute-backlog`'s
+  "Merge PR #12" is its "Do NOT use … for merging PRs".
+- `helm-migration` — **four cases were not covered**, all anti-triggers (README, a Python bug, a
+  docker-compose file, project documentation), because its description carries **no routing guidance at
+  all**: no `Do NOT use` clause and no redirect to a sibling skill. Those four are the reason it needed
+  one.
+
+`helm-migration`'s `How to Use` was separately redundant: 24 lines telling the user which prompt to
+type — read after they typed — listing three inputs its own workflow step 1 already asks for.
+
+## What Changes
+
+- `helm-migration` → 2.2.0: description gains a `Do NOT use for …` clause built from the four real
+  anti-triggers; `How to Use` and `Trigger Test Cases` removed (−38 lines).
+- `backlog` → 1.1.1, `execute-backlog` → 1.3.1, `claude-statusline` → 1.1.1: `Trigger Test Cases`
+  removed (−47 lines), descriptions already carrying every case.
+- New validator check **C8 — no meta sections in SKILL.md**, with the reasoning in the check itself.
+  Self-test extended to **12/12** defect classes.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — triggers live in the description, not the body; a case the
+  description does not cover is folded in rather than filed away, and every skill states where it does
+  not apply.
+
+## Impact
+
+- `skills/{helm-migration,backlog,execute-backlog,claude-statusline}/SKILL.md`;
+  `scripts/validate-skills.py` (+C8); `scripts/selftest-validate-skills.py` (12 classes); regenerated
+  wrappers.
+- 85 fewer lines of per-invocation context across four skills, and `helm-migration` gains routing
+  guidance it never had.

--- a/openspec/changes/prune-meta-sections/specs/skills-authoring/spec.md
+++ b/openspec/changes/prune-meta-sections/specs/skills-authoring/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Triggers live in the description, not the body
+
+A skill SHALL NOT carry a `How to Use`, `Trigger Test Cases`, `Prompt` or `Usage` section in its
+`SKILL.md`. Such a section is read only after the skill has already been selected, so it cannot
+influence routing, and it costs context on every invocation. Trigger and anti-trigger information
+SHALL live in the frontmatter `description`, which is what the model reads when choosing a skill.
+
+#### Scenario: A trigger case not present in the description is folded in, not filed away
+
+- **WHEN** a skill's body lists a trigger or anti-trigger case that its description does not cover
+- **THEN** the case is added to the description, where it can affect selection
+- **AND** the body section is removed rather than kept as a duplicate
+
+#### Scenario: Every skill states where it does not apply
+
+- **WHEN** another skill in the catalog covers an adjacent area
+- **THEN** the description names it, either as an explicit "Do NOT use for … (that is `<skill>`)"
+  clause or as a redirect ("for X use `<skill>`"), so the two do not compete for the same prompt

--- a/openspec/changes/prune-meta-sections/tasks.md
+++ b/openspec/changes/prune-meta-sections/tasks.md
@@ -1,0 +1,40 @@
+## 1. Measure
+
+- [x] 1.1 Find every `How to Use` / `Trigger Test Cases` / `Prompt` / `Usage` section in the catalog
+- [x] 1.2 Measure the per-invocation cost of each (85 lines across four skills)
+- [x] 1.3 Check every trigger case against its own skill's description before deleting anything
+
+## 2. Preserve what carried information
+
+- [x] 2.1 `helm-migration`: fold the four uncovered anti-triggers into the description as a
+      `Do NOT use for …` clause — the skill had no routing guidance of any kind
+- [x] 2.2 Confirm `backlog`, `execute-backlog` and `claude-statusline` descriptions already cover
+      every case in their blocks
+
+## 3. Remove and enforce
+
+- [x] 3.1 Delete the meta sections from all four skills
+- [x] 3.2 Add validator check C8 with its reasoning in the check itself
+- [x] 3.3 Extend the self-test to inject a meta section — 12/12 classes detected
+- [x] 3.4 Bump versions: helm-migration 2.2.0, backlog 1.1.1, execute-backlog 1.3.1,
+      claude-statusline 1.1.1
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on all four skills
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers preserved — moved to the description where they act, never dropped
+- [x] Q.4 No duplicated doctrine: the rule lives in `skills-authoring`, enforced by C8, not restated
+      in any skill
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 No description promises a policy its body contradicts
+- [x] Q.7 No README change — no skill added, removed or repurposed
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate prune-meta-sections --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` 12/12
+- [ ] V.6 `openspec archive prune-meta-sections --yes` after review

--- a/plugins/devops/skills/helm-migration/SKILL.md
+++ b/plugins/devops/skills/helm-migration/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: helm-migration
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 2.2.0
   category: devops
 license: MIT
 compatibility: Requires a Helm charts template repository accessible on the local filesystem. Works best in Claude Code.
@@ -258,30 +258,6 @@ Rules:
 
 ---
 
-## How to Use
-
-Use this prompt to trigger the skill:
-```
-Migrate this YAML-file to Helm following the helm-migration skill.
-Charts template path: [PATH_TO_CHARTS_TEMPLATE]
-Source YAML-file: [PATH_TO_YAML_FILE]
-Save files to: [DESTINATION_PATH]
-```
-
-Claude will generate:
-- `values.yaml` — workload definition
-- `env.yaml` — secrets, configmaps and PVCs (only if present in source YAML)
-
-### Example
-```
-Migrate this YAML-file to Helm following the helm-migration skill.
-Charts template path: /path/to/charts-template
-Source YAML-file: /path/to/source/deployment.yaml
-Save files to: /path/to/output/helm/
-```
-
----
-
 ## Troubleshooting
 
 **Problem**: Field exists in YAML but not in charts template.
@@ -323,19 +299,3 @@ See `references/examples.md` for complete before/after examples of:
 - Deployment with secretKeyRef and commented resource limits
 - Deployment with PVC
 
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Migrate this YAML to Helm"
-- "Convert this manifest to values.yaml"
-- "Generate values.yaml for this deployment"
-- "I need to helm-migrate this file"
-- "Create env.yaml from this YAML"
-
-Should NOT trigger on:
-- "Update the README"
-- "Fix this Python bug"
-- "Create a docker-compose file"
-- "Write documentation for this project"

--- a/plugins/tooling/skills/claude-statusline/SKILL.md
+++ b/plugins/tooling/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
@@ -165,20 +165,3 @@ for a secret (unlisted-but-linkable) gist. Manage with `gh gist edit|view|delete
   run. Cache slow git calls (keyed by `session_id`).
 - **Windows** — write the `command` path with forward slashes; Git Bash eats backslashes.
 
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Configure my Claude Code status line"
-- "Add context / cost / git to my statusline"
-- "My statusline.sh isn't showing up"
-- "Make the status bar show cache usage"
-- "My friend sent me this statusline gist, install it"
-- "Share my status line with someone"
-
-Should NOT trigger on:
-- "Customize my shell prompt / PS1 / starship / powerlevel10k"
-- "Set up a tmux status bar"
-- "Change the VS Code status bar"
-- "Write documentation for this project"

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: process
 license: MIT
 compatibility: >-
@@ -99,19 +99,3 @@ codebase.
 | Select option not found for a proposed value | Show available options; ask instead of guessing. |
 | Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
 
-## Trigger Test Cases
-
-Should trigger on:
-- "/backlog add social login authentication"
-- "Create a backlog item for rate limiting"
-- "Turn this idea into an issue on our board"
-- "Add this to the backlog of the project"
-
-Should NOT trigger on:
-- "Implement issue #123" (execute-backlog)
-- "Open a PR for this change"
-- "Create a ticket in Jira"
-- "List my GitHub issues"
-
-> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
-> against that client. `gh project` moves fast — re-probe before trusting a recipe on an older CLI.

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: process
 license: MIT
 compatibility: >-
@@ -91,19 +91,3 @@ to the `backlog` skill; consumes the same config.
     to the PR(s); present summary: what changed, validation evidence, the criteria table with
     every verdict, deviations (if any, pre-approved), next human step (review/merge).
 
-## Trigger Test Cases
-
-Should trigger on:
-- "/execute-backlog 123"
-- "Implement issue #42"
-- "Pick up the backlog item about push notifications"
-- "Execute https://github.com/org/repo/issues/7"
-
-Should NOT trigger on:
-- "Create a backlog item for X" (backlog)
-- "Merge PR #12"
-- "Deploy the fix"
-- "Close issue #9"
-
-> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
-> against that client.

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -28,6 +28,8 @@ MUTATIONS = {
  "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
      lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
  "C7 orphan wrapper": (None, None),
+ "C8 meta section": ("skills/openspec/SKILL.md",
+     lambda s: s + "\n## Trigger Test Cases\n\nShould trigger on:\n- \"do the thing\"\n"),
 }
 
 fails = []

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -9,6 +9,7 @@ Implements the mechanically checkable half of openspec/specs/skills-authoring:
   C5 versioned external APIs are pinned     (code-heavy skill without a version statement)
   C6 fence tags match content               (a block tagged X that is obviously not X)
   C7 no orphan wrapper skills               (every generated skill has a canonical source)
+  C8 no meta sections in SKILL.md           (triggers belong in the description, not the body)
 
 Exit 1 on any finding. Run from the repo root.
 """
@@ -221,6 +222,19 @@ def check_tags(skill: str, text: str) -> None:
             add(skill, "C6 wrong tag", f"block#{i} tagged {lang} but looks like JSON")
 
 
+# ── C8: meta sections ─────────────────────────────────────────────────────
+META_HEADING = re.compile(r"^## (How to Use|Trigger Test Cases|Prompt|Usage)\s*$", re.M | re.I)
+
+
+def check_meta(skill: str, text: str) -> None:
+    """A "Trigger Test Cases" or "How to Use" block is read only AFTER the skill has already
+    triggered, so it cannot influence routing — it is pure context cost at the moment it loads.
+    Triggers and anti-triggers belong in the frontmatter description, which is what the model
+    reads when choosing a skill."""
+    for m in META_HEADING.finditer(text):
+        add(skill, "C8 meta section", f"`{m.group(0).strip()}` — move its content to the description")
+
+
 # ── C7: no orphan wrapper skills ──────────────────────────────────────────
 def check_orphans() -> None:
     """A skill living only in a generated tree is outside generate.sh, outside the
@@ -245,6 +259,7 @@ def main() -> int:
         check_description(skill, text)
         check_pin(skill, text)
         check_tags(skill, text)
+        check_meta(skill, text)
         for ref in (p.parent / "references").glob("*.md"):
             rtext = ref.read_text(encoding="utf-8")
             check_refs(f"{skill}/{ref.name}", ref, rtext)

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: process
 license: MIT
 compatibility: >-
@@ -99,19 +99,3 @@ codebase.
 | Select option not found for a proposed value | Show available options; ask instead of guessing. |
 | Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
 
-## Trigger Test Cases
-
-Should trigger on:
-- "/backlog add social login authentication"
-- "Create a backlog item for rate limiting"
-- "Turn this idea into an issue on our board"
-- "Add this to the backlog of the project"
-
-Should NOT trigger on:
-- "Implement issue #123" (execute-backlog)
-- "Open a PR for this change"
-- "Create a ticket in Jira"
-- "List my GitHub issues"
-
-> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
-> against that client. `gh project` moves fast — re-probe before trusting a recipe on an older CLI.

--- a/skills/claude-statusline/SKILL.md
+++ b/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
@@ -165,20 +165,3 @@ for a secret (unlisted-but-linkable) gist. Manage with `gh gist edit|view|delete
   run. Cache slow git calls (keyed by `session_id`).
 - **Windows** — write the `command` path with forward slashes; Git Bash eats backslashes.
 
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Configure my Claude Code status line"
-- "Add context / cost / git to my statusline"
-- "My statusline.sh isn't showing up"
-- "Make the status bar show cache usage"
-- "My friend sent me this statusline gist, install it"
-- "Share my status line with someone"
-
-Should NOT trigger on:
-- "Customize my shell prompt / PS1 / starship / powerlevel10k"
-- "Set up a tmux status bar"
-- "Change the VS Code status bar"
-- "Write documentation for this project"

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: process
 license: MIT
 compatibility: >-
@@ -91,19 +91,3 @@ to the `backlog` skill; consumes the same config.
     to the PR(s); present summary: what changed, validation evidence, the criteria table with
     every verdict, deviations (if any, pre-approved), next human step (review/merge).
 
-## Trigger Test Cases
-
-Should trigger on:
-- "/execute-backlog 123"
-- "Implement issue #42"
-- "Pick up the backlog item about push notifications"
-- "Execute https://github.com/org/repo/issues/7"
-
-Should NOT trigger on:
-- "Create a backlog item for X" (backlog)
-- "Merge PR #12"
-- "Deploy the fix"
-- "Close issue #9"
-
-> **Verified against**: `gh 2.92.0`. Every subcommand and flag used below was probed
-> against that client.

--- a/skills/helm-migration/SKILL.md
+++ b/skills/helm-migration/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: helm-migration
 description: >-
-  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs.
+  Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 metadata:
   author: solvelab
-  version: 2.1.0
+  version: 2.2.0
   category: devops
 license: MIT
 compatibility: Requires a Helm charts template repository accessible on the local filesystem. Works best in Claude Code.
@@ -258,30 +258,6 @@ Rules:
 
 ---
 
-## How to Use
-
-Use this prompt to trigger the skill:
-```
-Migrate this YAML-file to Helm following the helm-migration skill.
-Charts template path: [PATH_TO_CHARTS_TEMPLATE]
-Source YAML-file: [PATH_TO_YAML_FILE]
-Save files to: [DESTINATION_PATH]
-```
-
-Claude will generate:
-- `values.yaml` — workload definition
-- `env.yaml` — secrets, configmaps and PVCs (only if present in source YAML)
-
-### Example
-```
-Migrate this YAML-file to Helm following the helm-migration skill.
-Charts template path: /path/to/charts-template
-Source YAML-file: /path/to/source/deployment.yaml
-Save files to: /path/to/output/helm/
-```
-
----
-
 ## Troubleshooting
 
 **Problem**: Field exists in YAML but not in charts template.
@@ -323,19 +299,3 @@ See `references/examples.md` for complete before/after examples of:
 - Deployment with secretKeyRef and commented resource limits
 - Deployment with PVC
 
----
-
-## Trigger Test Cases
-
-Should trigger on:
-- "Migrate this YAML to Helm"
-- "Convert this manifest to values.yaml"
-- "Generate values.yaml for this deployment"
-- "I need to helm-migrate this file"
-- "Create env.yaml from this YAML"
-
-Should NOT trigger on:
-- "Update the README"
-- "Fix this Python bug"
-- "Create a docker-compose file"
-- "Write documentation for this project"


### PR DESCRIPTION
## Why

#24 removed `How to Use` and `Trigger Test Cases` from `documentation`, arguing they are read only **after** the skill has already been selected — so they cannot influence routing, and they cost context on every invocation. The argument was accepted.

**It was applied to exactly one skill.** Four others kept theirs:

| skill | meta lines | % of file | sections |
|---|---|---|---|
| `helm-migration` | 38 | 11% | How to Use, Trigger Test Cases |
| `backlog` | 16 | 14% | Trigger Test Cases |
| `execute-backlog` | 16 | 15% | Trigger Test Cases |
| `claude-statusline` | 15 | 8% | Trigger Test Cases |

**85 lines loaded on every invocation that instruct nothing about the task.** A rule accepted for one skill and never applied to the rest is not a rule — it's an exception that happens to be documented.

## Checked before deleting, not assumed redundant

- `backlog`, `execute-backlog`, `claude-statusline` — every case already covered by the description. `claude-statusline`'s *"tmux status bar"* is its *"non-Claude-Code status bars"*; `execute-backlog`'s *"Merge PR #12"* is its *"Do NOT use … for merging PRs"*.
- **`helm-migration` was not.** Four of its cases were uncovered — README, a Python bug, a docker-compose file, project documentation — **all anti-triggers**, because its description carried **no routing guidance of any kind**: no `Do NOT use` clause, no redirect to a sibling skill. Those four were the only routing rule that skill had anywhere, sitting in a section that loads too late to use them.

Assuming redundancy would have thrown them away. They are now in the description, where they can affect selection.

`helm-migration`'s `How to Use` was separately redundant: 24 lines telling the user which prompt to type — read after they typed — listing three inputs its own workflow step 1 already asks for.

## A sweep I did not act on

A first pass flagged **17 skills** for lacking a `Do NOT use` clause. Most route via a **redirect** instead (`for animation … use r3f-animation`, `see fivem-lua`), which serves the same purpose. The new requirement accepts either form, so the check does not manufacture 17 edits for a phrasing preference.

## Enforcement

New validator check **C8 — no meta sections in `SKILL.md`**, with the reasoning inside the check so a contributor who hits it gets the argument rather than a rule number. Self-test extended: **12/12 defect classes detected**.

## Spec delta

`skills-authoring` → **ADDED** *Triggers live in the description, not the body*: a case the description does not cover is folded in rather than filed away, and every skill states where it does not apply — as an explicit `Do NOT use` clause **or** as a redirect.

`helm-migration` 2.2.0 · `backlog` 1.1.1 · `execute-backlog` 1.3.1 · `claude-statusline` 1.1.1

`V.6` intentionally left open.
