### PR TITLE
🐛 fix(skills): audit the five skills whose runtime this environment lacks

### DIFF
--- a/claude/skills/assettoserver-plugin/SKILL.md
+++ b/claude/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/fivem-lua/SKILL.md
+++ b/claude/skills/fivem-lua/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Conventions for writing FiveM (CitizenFX) server/client Lua resources. Use when working on FiveM/FXServer Lua — RegisterNetEvent/RegisterNUICallback handlers, fxmanifest, exports, NUI (SendNUIMessage/SetNuiFocus), threads/CreateThread, StateBags, or natives. Enforces the client-is-never-trusted boundary (validate payload + derive actor from `source`), explicit fxmanifest order, no busy `while true` loops, module-per-global pattern, and NUI focus/disconnect cleanup. Do NOT use for react-three-fiber or non-FiveM Lua.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/cursor/rules/assettoserver-plugin.mdc
+++ b/cursor/rules/assettoserver-plugin.mdc
@@ -20,9 +20,12 @@ MUST be compiled against the upstream **source checkout at the exact tag matchin
 
 Encode this in the build, don't rely on discipline:
 
-- Do NOT hardcode the TFM — inherit it from upstream:
-  `<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` in the csproj,
-  and in the publish script detect the real one:
+- Do NOT hardcode the TFM — inherit it from upstream. **A fallback default here is a trap**: it is
+  used exactly when detection failed, which is when you can least afford a guess. Pin it to the
+  runtime you actually target and treat a mismatch as an error, not a default:
+  `<TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>` — upstream
+  **v0.0.54 targets `net8.0`** (verified against its `AssettoServer.csproj` at that tag). In the
+  publish script detect the real one:
   `awk -F'[><]' '/<TargetFramework>/{print $3; exit}' "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj"`,
   then pass `-p:TargetFramework="$target_framework"` to `dotnet publish`.
 - Add an MSBuild guard target that hard-errors before Restore/Build/Publish when the upstream
@@ -108,13 +111,18 @@ public class MyPluginCommandModule : ACModuleBase
 ## Forbidden constructs (the runtime WILL crash or misbehave)
 
 Qmmands instantiates command modules by reflection, without DI. These three constructs compile
-fine and fail only inside the real runtime — enforce them with the bug-hunter gate below:
+fine and fail only inside the real runtime — enforce them with the bug-hunter gate below.
+
+**The third row is version-scoped.** It holds while the pinned runtime targets `net8.0`. When the pin
+moves to a runtime on .NET 9 or later the type exists and the ban must be lifted rather than carried
+forward — re-read the detected TFM at that point, and scope the Cecil assert to it instead of
+asserting it unconditionally.
 
 | Forbidden | Why | Do instead |
 |---|---|---|
 | `CommandContext.Services` (`get_Services()`) | crashes at command execution | static accessor bridge (below) |
 | Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | parameterless ctor + accessor |
-| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | type missing in the host runtime | `private readonly object _lock = new();` |
+| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; the pinned runtime is **net8.0**, so it is absent at load time | `private readonly object _lock = new();` |
 
 **Static accessor bridge** — the sanctioned way to get services into command modules: the
 `IHostedService` publishes DI-built singletons into static accessors at `StartAsync`

--- a/cursor/rules/fivem-lua.mdc
+++ b/cursor/rules/fivem-lua.mdc
@@ -43,6 +43,24 @@ RegisterNetEvent("res:doThing", function(targetId, amount)
 end)
 ```
 
+- **A rejection nobody can see is not a defence.** Every `return` above drops a forged event
+  silently, so a server under attack looks exactly like a quiet one. Count and log rejections with
+  the source, and rate-limit on the counter — the spike *is* the signal:
+
+```lua
+local rejects = {}                                   -- [src] = count in the current window
+
+local function reject(src, event, reason)
+  rejects[src] = (rejects[src] or 0) + 1
+  print(("[sec] reject src=%s event=%s reason=%s count=%d"):format(src, event, reason, rejects[src]))
+  return false                                       -- callers: `if not ok then return end`
+end
+```
+
+  Reset the window on a timer, and treat a player whose count crosses a threshold as hostile
+  (drop, then kick) rather than validating them one message at a time forever. Without the counter
+  the rate-limit above has nothing to rate-limit on.
+
 ## fxmanifest
 
 - Use **explicit file order** in `client_scripts`/`server_scripts`/`shared_scripts`. Avoid glob

--- a/openspec/changes/audit-runtime-bound-skills/.openspec.yaml
+++ b/openspec/changes/audit-runtime-bound-skills/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/audit-runtime-bound-skills/design.md
+++ b/openspec/changes/audit-runtime-bound-skills/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Every audit in this catalog stopped at the same five skills with the same reason: no Assetto Corsa
+server, no FXServer, no DriveZone repos. Coverage was honestly reported as 26 of 31 — but "cannot run
+it" had quietly become "cannot audit it", and those are different claims.
+
+## Goals / Non-Goals
+
+**Goals**
+- Audit the five without their runtimes, using the lenses that do not need one.
+- Fix what those lenses find, with probed evidence.
+- Say plainly which of the five needed no change, rather than editing to make a number move.
+
+**Non-Goals**
+- Not simulating a runtime. Nothing here pretends to have executed a plugin or a FiveM resource.
+- Not restructuring any of the five. Their layout, references and doctrine stand.
+- Not manufacturing findings for the three that came out clean.
+
+## Decisions
+
+**D1 — Probe the public half of a runtime claim.** "The type is missing in the host runtime" reads
+unverifiable, but it decomposes into two checkable facts: which .NET version introduced the type, and
+which framework the pinned upstream tag targets. Both are public. Together they settled the question
+without an Assetto Corsa install.
+
+**D2 — A fallback default that contradicts a constraint is worse than no default.** The `net9.0`
+fallback applies exactly when TFM detection failed — the moment a wrong guess is most likely to be
+believed. It is corrected to the probed value, and the reasoning is written next to it so the next
+person bumping the pin does not reintroduce a convenient default.
+
+**D3 — Version-scope the ban instead of deleting or freezing it.** `System.Threading.Lock` is genuinely
+absent on net8.0 and genuinely present on net9.0. A rule that is true only under a condition has to
+state the condition, or it becomes false the day the pin moves — silently, since the Cecil assert
+enforcing it would keep passing.
+
+**D4 — Apply the newest adversarial lens to the skills that never got it.** The five defect classes
+added to `bug-hunter` in #37 came from defects found elsewhere in the catalog. `fivem-lua`'s
+trust-boundary section fails *Observable degradation* squarely: it validates and returns, and the word
+"log" does not appear anywhere in the skill.
+
+**D5 — Silence at a trust boundary is the defect, not the rejection.** Dropping a forged event is
+correct. Dropping it with no counter means the section's own instruction to "rate-limit it" has
+nothing to rate-limit on, and an attack is indistinguishable from quiet. The fix is a counter and a
+log line, not stricter validation.
+
+**D6 — Report the three that needed nothing.** `assettoserver-ops` and `assettoserver-csp-lua` were
+read in full and scanned with every lens; both already carry dense enforcement statements and none of
+the defect classes applies cleanly. `openspec-drivezone` was corrected by an earlier change. Editing
+them to make the audit look thorough would be the failure this catalog's rules were written to remove.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| AssettoServer plugin build contract and forbidden constructs | `assettoserver-plugin` | already canonical — TFM corrected, Lock row version-scoped |
+| FiveM trust boundary (`source`, validation) | `fivem-lua` | already canonical — rejection observability added |
+| Adversarial defect classes applied as a lens | `bug-hunter` | link (already canonical) |
+| Fallback observability in a service | `backend-resilience` | link (already canonical) — same principle, different runtime |
+| Cecil-based forbidden-construct gate | `bug-hunter/references/track-dotnet-plugin.md` | unchanged; the scoping note points at it |
+
+## Risks / Trade-offs
+
+- [The TFM pin ages when upstream moves to .NET 9] → that is precisely why the Lock row is now
+  version-scoped and says what to do at the bump, instead of carrying a silently-false ban.
+- [A rejection counter is state a resource must reset] → the rule says to window it; unbounded
+  counters were the failure mode `log-event-collector` already documented.
+- [Three of five needed no edit] → stated as a result rather than hidden, so the coverage number
+  means what it says.

--- a/openspec/changes/audit-runtime-bound-skills/proposal.md
+++ b/openspec/changes/audit-runtime-bound-skills/proposal.md
@@ -1,0 +1,68 @@
+# Change: Audit the skills whose runtime this environment does not have
+
+## Why
+
+Five skills had only ever received mechanical validation, every audit stopping at the same excuse:
+`assettoserver-ops`, `assettoserver-plugin` and `assettoserver-csp-lua` need an Assetto Corsa server,
+`fivem-lua` needs FXServer, `openspec-drivezone` needs the DriveZone repos. None of that is available
+here.
+
+The excuse was partly wrong. Three lenses do not need the runtime: reading the doctrine, applying the
+five defect classes `bug-hunter` gained in #37, and probing the parts of the claim that are public.
+Two real defects came out.
+
+**1. `assettoserver-plugin` prescribes the exact TFM its own rule forbids.** Its version-pinning
+section says to inherit the target framework from upstream and gives
+`<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` as the fallback.
+Ninety lines later its forbidden-constructs table bans `System.Threading.Lock` because the "type
+[is] missing in the host runtime".
+
+Both cannot be true. `System.Threading.Lock` ships in **.NET 9**, so on a `net9.0` host it exists.
+Probed against upstream: `AssettoServer/AssettoServer.csproj` at tag **v0.0.54** targets **`net8.0`**.
+
+So the ban is correct and **the fallback is the bug** — and it is the worst possible kind, because a
+fallback applies precisely when detection failed. Compiling a plugin for `net9.0` against a `net8.0`
+host is the "undefined behavior at load time" that same section exists to prevent, and it silently
+makes `System.Threading.Lock` compile so the runtime can fail on it later.
+
+**2. `fivem-lua` rejects forged input silently.** Its trust-boundary section — "the most important
+rule" — validates type, presence and range and then `return`s. The word *log* appears nowhere in the
+skill. A server under attack therefore looks exactly like a quiet one, and the same section's
+instruction to "rate-limit it" has no counter to rate-limit on. This is the **Observable degradation**
+class added to `bug-hunter` in #37, applied to a skill that had never been given that lens.
+
+## What Changes
+
+- `assettoserver-plugin` → 1.3.0:
+  - TFM fallback corrected to `net8.0`, with the probed evidence (upstream v0.0.54) recorded inline,
+    and a note that a fallback default is a trap because it applies exactly when detection failed.
+  - The `System.Threading.Lock` row states *why* it is absent (a .NET 9 type on a net8.0 host) and is
+    explicitly **version-scoped**: when the pin moves to a .NET 9+ runtime the ban must be lifted, and
+    the Cecil assert scoped to the detected TFM rather than asserted unconditionally.
+- `fivem-lua` → 1.3.0: a rejection-counter rule at the trust boundary — count and log every rejected
+  event with its `source`, rate-limit on the counter, escalate a player past the threshold instead of
+  validating them one message at a time forever. The Lua added was syntax-checked with `luac -p`.
+
+## Deliberately unchanged
+
+`assettoserver-ops` and `assettoserver-csp-lua` were read in full and scanned with the same lenses.
+Both already state their enforcement layer densely (24 and 38 references to a script, gate or CI
+check), and none of the five defect classes applies cleanly to what they cover. **No edit was
+manufactured for them.** `openspec-drivezone` states its two-layered enforcement and the CLI's real
+limitation correctly, which an earlier change already corrected.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — a skill that cannot be exercised in the working environment
+  SHALL still be audited by reading, by the adversarial defect classes, and by probing the public part
+  of its claims; "no runtime" is not a reason to leave it unaudited.
+
+## Impact
+
+- `skills/assettoserver-plugin/SKILL.md`, `skills/fivem-lua/SKILL.md`, regenerated wrappers.
+- A plugin built by following the corrected skill targets the framework its host actually runs.
+- A FiveM resource built by following the corrected skill can tell that it is being attacked.

--- a/openspec/changes/audit-runtime-bound-skills/specs/skills-authoring/spec.md
+++ b/openspec/changes/audit-runtime-bound-skills/specs/skills-authoring/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: No runtime is not an excuse
+
+A skill whose subject cannot be exercised in the working environment SHALL still be audited by
+reading its doctrine in full, by applying the adversarial defect classes from `bug-hunter`, and by
+probing whatever part of its claims is publicly verifiable. Leaving such a skill at mechanical
+validation only SHALL be recorded as a gap, never treated as complete.
+
+#### Scenario: A public claim is probed even when the runtime is absent
+
+- **WHEN** a skill pins a version, names an upstream target framework, or asserts that a type or API
+  is present or absent in a runtime
+- **THEN** the claim is checked against the public source (release tag, manifest, upstream file)
+  before the skill is considered audited
+
+#### Scenario: An internal contradiction is found without running anything
+
+- **WHEN** two statements in the same skill cannot both hold — a prescribed default that violates a
+  constraint stated elsewhere in the file
+- **THEN** the contradiction is resolved against the probed evidence, and the losing statement is
+  corrected rather than left for the runtime to expose
+
+#### Scenario: An unaudited skill is reported, not silently counted as done
+
+- **WHEN** an audit cannot reach a skill's subject at all
+- **THEN** the coverage report names the skill and what is missing, instead of reporting a total that
+  implies it was covered

--- a/openspec/changes/audit-runtime-bound-skills/tasks.md
+++ b/openspec/changes/audit-runtime-bound-skills/tasks.md
@@ -1,0 +1,45 @@
+## 1. Audit without the runtime
+
+- [x] 1.1 Read all five skills in full
+- [x] 1.2 Apply the five `bug-hunter` defect classes (#37) as a lens to each
+- [x] 1.3 Probe every publicly verifiable claim
+
+## 2. assettoserver-plugin (1.3.0)
+
+- [x] 2.1 Confirm `System.Threading.Lock` ships in .NET 9
+- [x] 2.2 Probe upstream `AssettoServer.csproj` at tag v0.0.54 — targets `net8.0`
+- [x] 2.3 Correct the TFM fallback to `net8.0` and record the probed evidence inline
+- [x] 2.4 State why a fallback default is a trap here
+- [x] 2.5 Version-scope the `System.Threading.Lock` ban and say what to do when the pin moves
+
+## 3. fivem-lua (1.3.0)
+
+- [x] 3.1 Confirm the skill never mentions logging a rejection
+- [x] 3.2 Add the rejection counter + log rule at the trust boundary
+- [x] 3.3 Syntax-check the added Lua with `luac -p`
+
+## 4. Report what needed nothing
+
+- [x] 4.1 `assettoserver-ops`, `assettoserver-csp-lua`: read in full, lenses applied, no defect found
+- [x] 4.2 `openspec-drivezone`: enforcement already corrected by an earlier change
+- [x] 4.3 Record all three in the proposal rather than editing to move a number
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on both touched skills
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers and "Do NOT use for" boundaries unchanged
+- [x] Q.4 No duplicated doctrine: observability principle links `backend-resilience`; the Cecil gate
+      stays in `bug-hunter/references/track-dotnet-plugin.md`
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 No description promises a policy its body contradicts
+- [x] Q.7 No README change — no skill added, removed or repurposed
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate audit-runtime-bound-skills --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync: `./generate.sh` then clean `git diff` on generated trees
+- [x] V.4 `scripts/validate-skills.py` 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` 12/12
+- [ ] V.6 `openspec archive audit-runtime-bound-skills --yes` after review

--- a/plugins/fivem/skills/fivem-lua/SKILL.md
+++ b/plugins/fivem/skills/fivem-lua/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Conventions for writing FiveM (CitizenFX) server/client Lua resources. Use when working on FiveM/FXServer Lua — RegisterNetEvent/RegisterNUICallback handlers, fxmanifest, exports, NUI (SendNUIMessage/SetNuiFocus), threads/CreateThread, StateBags, or natives. Enforces the client-is-never-trusted boundary (validate payload + derive actor from `source`), explicit fxmanifest order, no busy `while true` loops, module-per-global pattern, and NUI focus/disconnect cleanup. Do NOT use for react-three-fiber or non-FiveM Lua.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -47,6 +47,24 @@ RegisterNetEvent("res:doThing", function(targetId, amount)
   -- + permission/relationship check before acting on targetId
 end)
 ```
+
+- **A rejection nobody can see is not a defence.** Every `return` above drops a forged event
+  silently, so a server under attack looks exactly like a quiet one. Count and log rejections with
+  the source, and rate-limit on the counter — the spike *is* the signal:
+
+```lua
+local rejects = {}                                   -- [src] = count in the current window
+
+local function reject(src, event, reason)
+  rejects[src] = (rejects[src] or 0) + 1
+  print(("[sec] reject src=%s event=%s reason=%s count=%d"):format(src, event, reason, rejects[src]))
+  return false                                       -- callers: `if not ok then return end`
+end
+```
+
+  Reset the window on a timer, and treat a player whose count crosses a threshold as hostile
+  (drop, then kick) rather than validating them one message at a time forever. Without the counter
+  the rate-limit above has nothing to rate-limit on.
 
 ## fxmanifest
 

--- a/plugins/game/skills/assettoserver-plugin/SKILL.md
+++ b/plugins/game/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -33,9 +33,12 @@ MUST be compiled against the upstream **source checkout at the exact tag matchin
 
 Encode this in the build, don't rely on discipline:
 
-- Do NOT hardcode the TFM — inherit it from upstream:
-  `<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` in the csproj,
-  and in the publish script detect the real one:
+- Do NOT hardcode the TFM — inherit it from upstream. **A fallback default here is a trap**: it is
+  used exactly when detection failed, which is when you can least afford a guess. Pin it to the
+  runtime you actually target and treat a mismatch as an error, not a default:
+  `<TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>` — upstream
+  **v0.0.54 targets `net8.0`** (verified against its `AssettoServer.csproj` at that tag). In the
+  publish script detect the real one:
   `awk -F'[><]' '/<TargetFramework>/{print $3; exit}' "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj"`,
   then pass `-p:TargetFramework="$target_framework"` to `dotnet publish`.
 - Add an MSBuild guard target that hard-errors before Restore/Build/Publish when the upstream
@@ -121,13 +124,18 @@ public class MyPluginCommandModule : ACModuleBase
 ## Forbidden constructs (the runtime WILL crash or misbehave)
 
 Qmmands instantiates command modules by reflection, without DI. These three constructs compile
-fine and fail only inside the real runtime — enforce them with the bug-hunter gate below:
+fine and fail only inside the real runtime — enforce them with the bug-hunter gate below.
+
+**The third row is version-scoped.** It holds while the pinned runtime targets `net8.0`. When the pin
+moves to a runtime on .NET 9 or later the type exists and the ban must be lifted rather than carried
+forward — re-read the detected TFM at that point, and scope the Cecil assert to it instead of
+asserting it unconditionally.
 
 | Forbidden | Why | Do instead |
 |---|---|---|
 | `CommandContext.Services` (`get_Services()`) | crashes at command execution | static accessor bridge (below) |
 | Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | parameterless ctor + accessor |
-| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | type missing in the host runtime | `private readonly object _lock = new();` |
+| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; the pinned runtime is **net8.0**, so it is absent at load time | `private readonly object _lock = new();` |
 
 **Static accessor bridge** — the sanctioned way to get services into command modules: the
 `IHostedService` publishes DI-built singletons into static accessors at `StartAsync`

--- a/skills/assettoserver-plugin/SKILL.md
+++ b/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -33,9 +33,12 @@ MUST be compiled against the upstream **source checkout at the exact tag matchin
 
 Encode this in the build, don't rely on discipline:
 
-- Do NOT hardcode the TFM — inherit it from upstream:
-  `<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` in the csproj,
-  and in the publish script detect the real one:
+- Do NOT hardcode the TFM — inherit it from upstream. **A fallback default here is a trap**: it is
+  used exactly when detection failed, which is when you can least afford a guess. Pin it to the
+  runtime you actually target and treat a mismatch as an error, not a default:
+  `<TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>` — upstream
+  **v0.0.54 targets `net8.0`** (verified against its `AssettoServer.csproj` at that tag). In the
+  publish script detect the real one:
   `awk -F'[><]' '/<TargetFramework>/{print $3; exit}' "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj"`,
   then pass `-p:TargetFramework="$target_framework"` to `dotnet publish`.
 - Add an MSBuild guard target that hard-errors before Restore/Build/Publish when the upstream
@@ -121,13 +124,18 @@ public class MyPluginCommandModule : ACModuleBase
 ## Forbidden constructs (the runtime WILL crash or misbehave)
 
 Qmmands instantiates command modules by reflection, without DI. These three constructs compile
-fine and fail only inside the real runtime — enforce them with the bug-hunter gate below:
+fine and fail only inside the real runtime — enforce them with the bug-hunter gate below.
+
+**The third row is version-scoped.** It holds while the pinned runtime targets `net8.0`. When the pin
+moves to a runtime on .NET 9 or later the type exists and the ban must be lifted rather than carried
+forward — re-read the detected TFM at that point, and scope the Cecil assert to it instead of
+asserting it unconditionally.
 
 | Forbidden | Why | Do instead |
 |---|---|---|
 | `CommandContext.Services` (`get_Services()`) | crashes at command execution | static accessor bridge (below) |
 | Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | parameterless ctor + accessor |
-| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | type missing in the host runtime | `private readonly object _lock = new();` |
+| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; the pinned runtime is **net8.0**, so it is absent at load time | `private readonly object _lock = new();` |
 
 **Static accessor bridge** — the sanctioned way to get services into command modules: the
 `IHostedService` publishes DI-built singletons into static accessors at `StartAsync`

--- a/skills/fivem-lua/SKILL.md
+++ b/skills/fivem-lua/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Conventions for writing FiveM (CitizenFX) server/client Lua resources. Use when working on FiveM/FXServer Lua — RegisterNetEvent/RegisterNUICallback handlers, fxmanifest, exports, NUI (SendNUIMessage/SetNuiFocus), threads/CreateThread, StateBags, or natives. Enforces the client-is-never-trusted boundary (validate payload + derive actor from `source`), explicit fxmanifest order, no busy `while true` loops, module-per-global pattern, and NUI focus/disconnect cleanup. Do NOT use for react-three-fiber or non-FiveM Lua.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
@@ -47,6 +47,24 @@ RegisterNetEvent("res:doThing", function(targetId, amount)
   -- + permission/relationship check before acting on targetId
 end)
 ```
+
+- **A rejection nobody can see is not a defence.** Every `return` above drops a forged event
+  silently, so a server under attack looks exactly like a quiet one. Count and log rejections with
+  the source, and rate-limit on the counter — the spike *is* the signal:
+
+```lua
+local rejects = {}                                   -- [src] = count in the current window
+
+local function reject(src, event, reason)
+  rejects[src] = (rejects[src] or 0) + 1
+  print(("[sec] reject src=%s event=%s reason=%s count=%d"):format(src, event, reason, rejects[src]))
+  return false                                       -- callers: `if not ok then return end`
+end
+```
+
+  Reset the window on a timer, and treat a player whose count crosses a threshold as hostile
+  (drop, then kick) rather than validating them one message at a time forever. Without the counter
+  the rate-limit above has nothing to rate-limit on.
 
 ## fxmanifest
 


### PR DESCRIPTION
## Why

Every audit in this catalog stopped at the same five skills with the same excuse: `assettoserver-ops`, `assettoserver-plugin` and `assettoserver-csp-lua` need an Assetto Corsa server, `fivem-lua` needs FXServer, `openspec-drivezone` needs the DriveZone repos.

**The excuse was partly wrong.** "Cannot run it" had quietly become "cannot audit it", and those are different claims. Three lenses need no runtime: reading the doctrine, applying the five defect classes `bug-hunter` gained in #37, and probing the public part of the claims.

Two real defects came out.

## 1. `assettoserver-plugin` prescribes the exact TFM its own rule forbids

Its version-pinning section says to inherit the target framework from upstream and gives the fallback:

```xml
<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>
```

Ninety lines later, its forbidden-constructs table:

| Forbidden | Why |
|---|---|
| `System.Threading.Lock` | type missing in the host runtime |

**Both cannot be true.** `System.Threading.Lock` ships in **.NET 9** — on a `net9.0` host it exists.

Probed against the public source: `AssettoServer/AssettoServer.csproj` at tag **v0.0.54** targets **`net8.0`**.

So the ban is correct and **the fallback is the bug** — and it's the worst kind, because a fallback applies precisely when detection failed, the moment a wrong guess is most likely to be believed. Compiling a plugin for `net9.0` against a `net8.0` host is exactly the *"undefined behavior at load time"* that same section exists to prevent, and it silently lets `System.Threading.Lock` compile so the runtime can fail on it later.

**Fixed:** fallback corrected to `net8.0` with the probed evidence recorded inline, plus why a default is a trap here. The Lock row now states *why* the type is absent and is explicitly **version-scoped** — when the pin moves to .NET 9+ the ban must be lifted and the Cecil assert scoped to the detected TFM, rather than carried forward as a rule that went false while its assert keeps passing.

## 2. `fivem-lua` rejects forged input silently

Its trust-boundary section — labelled *"the most important rule"* — validates type, presence and range, then `return`s. **The word "log" appears nowhere in the skill.**

A server under attack therefore looks exactly like a quiet one, and the same section's own instruction to *"rate-limit it"* has no counter to rate-limit on.

That is the **Observable degradation** class added to `bug-hunter` in #37, applied to a skill that had never been given that lens. Added a rejection counter + log rule keyed on `source`, windowed, escalating past a threshold instead of validating a hostile player one message at a time forever. The Lua was syntax-checked with `luac -p`.

## Deliberately unchanged — three of five needed nothing

- `assettoserver-ops` and `assettoserver-csp-lua`: read in full, scanned with every lens. Both already state their enforcement layer densely (**24** and **38** references to a script, gate or CI check) and none of the five defect classes applies cleanly to what they cover.
- `openspec-drivezone`: its two-layered enforcement and the CLI's real limitation were already corrected by an earlier change.

**No edit was manufactured for them.** Editing to make an audit look thorough is the failure this catalog's rules were written to remove.

## Spec delta

`skills-authoring` → **ADDED** *No runtime is not an excuse*: a skill whose subject cannot be exercised must still be audited by reading, by the adversarial defect classes, and by probing the publicly verifiable part of its claims — and an unaudited skill must be **reported**, never folded into a total that implies it was covered.

`assettoserver-plugin` 1.3.0 · `fivem-lua` 1.3.0. `V.6` intentionally left open.
