### PR TITLE
✨ feat(python-rest-api): state the async/sync lane rule for DB access

### DIFF
--- a/claude/skills/python-rest-api/SKILL.md
+++ b/claude/skills/python-rest-api/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production
   services. Use when creating or reviewing a Python API service — project layout, response envelope
   with centralized response codes, exception-handler registry (input errors are never raw 500),
-  Field-constraint validation, tenant-isolation lookups, session-per-request DB access,
+  Field-constraint validation, tenant-isolation lookups, the async/sync lane rule for
+  session-per-request DB access,
   pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures,
   testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis
   fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency
@@ -12,7 +13,7 @@ description: >-
   ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.4.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/python-rest-api.mdc
+++ b/cursor/rules/python-rest-api.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production services. Use when creating or reviewing a Python API service — project layout, response envelope with centralized response codes, exception-handler registry (input errors are never raw 500), Field-constraint validation, tenant-isolation lookups, session-per-request DB access, pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures, testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency with partial unique indexes, JSONB dialect variants, request size/depth limits, and out-of-process ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
+  Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production services. Use when creating or reviewing a Python API service — project layout, response envelope with centralized response codes, exception-handler registry (input errors are never raw 500), Field-constraint validation, tenant-isolation lookups, the async/sync lane rule for session-per-request DB access, pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures, testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency with partial unique indexes, JSONB dialect variants, request size/depth limits, and out-of-process ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 alwaysApply: false
 ---
 
@@ -121,9 +121,58 @@ Repository lookups for user-owned resources always take the pair — `find_by_id
 and services raise `NotFoundException` (not `ForbiddenException`) when the resource belongs to someone
 else, so existence is not leaked. Regression-tested in `tests/test_bola_guards.py`-style suites.
 
+## Async or sync — pick one lane per endpoint
+
+**Never `async def` + a synchronous `Session`.** A blocking call inside an `async def` handler holds
+the event loop for its whole duration, so the worker stops serving every other request until it
+returns. Measured with 10 concurrent 50 ms "queries" (`asyncio.gather`, Python 3.14): a blocking call
+inside `async def` took **501 ms** — perfectly serialized, ~10x the cost of one — against **50 ms**
+awaited. **10x**, and it grows with concurrency.
+
+Two coherent lanes; a service may use both, but never mix them inside one endpoint's call path:
+
+| Lane | Endpoint | Session | Why it works |
+|---|---|---|---|
+| **Sync** (default) | `def` | `Session(engine)` | FastAPI runs a `def` endpoint in a threadpool — the loop is never blocked |
+| **Async** | `async def` | `AsyncSession` | nothing blocks; every I/O is awaited |
+
+The sync lane is the right default: it is the cheaper migration, it is what the DB section below
+prescribes, and a threadpool handler is not a compromise. Reach for the async lane when the endpoint
+is I/O-bound on more than the database (fan-out to several services, streaming), and then commit to it
+end to end.
+
+**The trap is the mixed lane, and it is easy to fall into**: the middleware and exception handlers this
+skill prescribes are `async def`, because Starlette requires it. That does not make your endpoints
+async. Read the endpoint's own signature before choosing a session type.
+
+Async lane, the parts that change:
+
+```python
+engine = create_async_engine(settings.database_url, pool_pre_ping=True, pool_size=..., pool_recycle=...)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with AsyncSessionLocal() as session:
+        yield session
+```
+
+Repositories become `async def` and `await session.execute(...)`; `session.commit()` becomes
+`await session.commit()`. In `tests/conftest.py` the fixture becomes async and `pytest-asyncio` needs
+`asyncio_mode = "auto"` in the pytest config, or every async test is silently skipped as "not
+collected".
+
+**The failure mode that survives a green suite**: a test fixture that overrides `get_session` with a
+*sync* session against SQLite keeps passing, because a single test never has concurrency. The block
+only appears under load, in production. If you are on the async lane, the override must be async too.
+
+Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`.
+
+Outbound calls follow the same rule — `backend-resilience` ships `safe_call` and `safe_call_async` for
+exactly this reason. The DB half and the HTTP half of one request must be in the same lane.
+
 ## DB & transactions
 
-- `Session(engine)` per request via the `get_session` dependency; engine with `pool_pre_ping=True`,
+- **Sync lane** (see above): `Session(engine)` per request via the `get_session` dependency; engine with `pool_pre_ping=True`,
   bounded pool (`pool_size`/`max_overflow`), `pool_recycle`.
 - Atomicity by transaction scoping: validate → mutate → **one** `session.commit()` per request. No
   partial commits mid-operation.

--- a/openspec/changes/add-async-lane-rule/.openspec.yaml
+++ b/openspec/changes/add-async-lane-rule/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/add-async-lane-rule/design.md
+++ b/openspec/changes/add-async-lane-rule/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`python-rest-api` is the baseline `api-resilience-testing` and `bug-hunter` assume, so a silent
+performance trap in it propagates. The trap was not introduced by the skill's author — it appeared when
+#22 added async middleware and an async exception handler beside a sync data-access section, and
+nothing in the file connected the two.
+
+## Goals / Non-Goals
+
+**Goals**
+- State the rule that prevents the mixed lane, with a measurement behind it.
+- Give the async lane enough detail to follow, including the test setup.
+- Keep the sync lane as the default it deserves to be.
+
+**Non-Goals**
+- Not migrating anything. This is doctrine.
+- Not advocating async. The mixed lane is the defect; the sync lane is fine and cheaper.
+- Not quoting throughput benchmarks. The defensible claim is about blocking, which is mechanical and
+  measurable in seconds; a "3-5x more requests/sec" figure from a blog post is not reproducible here
+  and was deliberately left out.
+
+## Decisions
+
+**D1 — Measure the blocking, do not assert it.** "A sync call blocks the event loop" is true and easy
+to state, and easy to ignore. 501 ms against 50 ms for the same ten calls is not. The measurement is
+ten lines of `asyncio` and the skill records its conditions so a reader can rerun it.
+
+**D2 — Name the sync lane the default.** Most services here are DB-bound and already sync; FastAPI's
+threadpool for `def` endpoints is a real solution, not a fallback. Presenting async as the goal would
+push readers into the harder migration for no gain.
+
+**D3 — Call out the middleware trap by name.** The most likely path into the mixed lane is imitation:
+the reader sees `async def dispatch` and `async def too_deep` in this very skill and concludes the
+codebase is async. Starlette requires those to be async; endpoints are unaffected. Saying so where the
+rule is stated costs two sentences and removes the trap.
+
+**D4 — Document the test failure, not just the runtime one.** A sync session override in an async
+fixture keeps a suite green because a single test has no concurrency. That is the reason this defect
+reaches production: the suite agrees with the mistake.
+
+**D5 — Place the section above the DB section, not inside it.** The rule governs which lane the DB
+prescription belongs to, so it has to be read first. The DB section's first bullet now names its lane
+rather than presenting itself as the only option.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| API layering, session-per-request, transactions | `python-rest-api` | already canonical — lane rule added above the DB section |
+| Sync vs async helpers for outbound calls | `backend-resilience` | link (already canonical) — same rule, HTTP half |
+| Adversarial testing of concurrency | `bug-hunter` | link (already canonical) — its burst class is how you would catch this |
+| Measurement discipline for performance claims | `openspec/specs/skills-authoring` | spec delta |
+
+## Risks / Trade-offs
+
+- [The measurement uses `time.sleep`, not a real driver] → deliberately: it isolates the property
+  under test (a blocking call in a coroutine) from driver and network noise. The conditions are stated
+  so the reader can substitute a real query.
+- [Readers may take the async lane as an endorsement] → the table names the sync lane the default and
+  says when async earns its cost.
+- [The async lane section could rot as SQLAlchemy moves] → pinned to the probed versions.

--- a/openspec/changes/add-async-lane-rule/proposal.md
+++ b/openspec/changes/add-async-lane-rule/proposal.md
@@ -1,0 +1,66 @@
+# Change: State the async/sync lane rule for DB access in python-rest-api
+
+## Why
+
+Executes solvelab/ai-skills#50. `python-rest-api` prescribed a **synchronous** SQLAlchemy session while
+its own prescribed code ran on the async path, and never mentioned the interaction.
+
+Measured in the file before this change:
+
+| line | content | kind |
+|---|---|---|
+| 29 | stack lists `pytest-asyncio`, `httpx` | async-capable |
+| 110 | `async def dispatch(self, request, call_next)` — the body-limit middleware | **async** |
+| 117 | `async def too_deep(request, exc)` — the RecursionError handler | **async** |
+| 139 | `Session(engine)` per request via `get_session` | **sync** |
+
+Occurrences of `AsyncSession`: **0**. Occurrences of `event loop`: **0**.
+
+The gap got wider when #22 added an `async def` middleware and an `async def` exception handler to the
+same file — the skill now shipped async code sitting next to sync data-access doctrine with nothing
+connecting them. A reader can pick `async def` for an endpoint because the examples are async, open a
+sync `Session` because the DB section says to, and serve one request at a time with no error and no
+log line saying why.
+
+The claim was measured rather than asserted. 10 concurrent 50 ms "queries" via `asyncio.gather` on
+Python 3.14:
+
+| shape | wall clock | |
+|---|---|---|
+| blocking call inside `async def` | **501 ms** | perfectly serialized, ~10x the cost of one |
+| the same work awaited | **50 ms** | concurrent |
+
+**10x**, and it grows with concurrency.
+
+## What Changes
+
+- `python-rest-api` → 1.4.0. New section **Async or sync — pick one lane per endpoint**, placed above
+  the DB section it qualifies:
+  - the rule: never `async def` + a synchronous `Session`, with the measured numbers
+  - the two coherent lanes in a table (`def` + `Session` in a threadpool; `async def` + `AsyncSession`)
+    and why the sync lane is the right default
+  - the trap named explicitly: the middleware and exception handlers this skill prescribes are
+    `async def` because Starlette requires it — that does not make the endpoints async
+  - what the async lane changes: `create_async_engine`, `async_sessionmaker`, an async `get_session`,
+    awaited repositories, and `asyncio_mode = "auto"` for `pytest-asyncio`
+  - the failure that survives a green suite: a sync session override in a fixture keeps passing,
+    because one test never has concurrency — the block only appears under load
+  - the outbound half links `backend-resilience` (`safe_call` / `safe_call_async`), same rule
+- The DB section's first bullet now names its lane instead of reading as the only option.
+- Description names the lane rule.
+- Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`, both probed.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Simulated failure behaviour** — a claim about a performance or
+  concurrency property must be measured and its conditions stated, not asserted from the mechanism.
+
+## Impact
+
+- `skills/python-rest-api/SKILL.md`, regenerated wrappers.
+- A service built from the skill can no longer land in the mixed lane by following the examples.
+- Closes #50.

--- a/openspec/changes/add-async-lane-rule/specs/skills-authoring/spec.md
+++ b/openspec/changes/add-async-lane-rule/specs/skills-authoring/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: Simulated failure behaviour
+
+Any claim a skill makes about how prescribed code behaves under failure (timeout, dependency down,
+partial payload, concurrency, replay, hostile input) SHALL be backed by a reproducible run of that
+code against that failure before publication, and the skill SHALL state the measured outcome where it
+motivates a rule.
+
+A claim about a **performance or concurrency property** — blocking, serialization, throughput — SHALL
+likewise be measured rather than asserted, and the measurement's conditions stated, so a reader can
+reproduce or refute it.
+
+#### Scenario: Prescribed snippet is exercised against the failure it claims to handle
+
+- **WHEN** a skill ships a code snippet as the recommended handling for a failure mode
+- **THEN** the snippet is run against that failure mode and the observed result is recorded
+- **AND** if the result contradicts the surrounding doctrine, the snippet is corrected before the
+  skill is published
+
+#### Scenario: A quantified claim carries its measurement
+
+- **WHEN** a rule is justified by a cost, a count, or a latency (e.g. "N callers each pay the full
+  timeout", "worst case is X seconds")
+- **THEN** the skill states the measured number and the conditions it was measured under, rather than
+  an unquantified assertion
+
+#### Scenario: A concurrency claim is demonstrated, not asserted
+
+- **WHEN** a rule rests on a property like "this blocks the event loop" or "these serialize"
+- **THEN** the property is demonstrated with a runnable measurement and the skill records the numbers
+  and the conditions, instead of relying on the reader trusting the mechanism

--- a/openspec/changes/add-async-lane-rule/tasks.md
+++ b/openspec/changes/add-async-lane-rule/tasks.md
@@ -1,0 +1,36 @@
+## 1. Measure before writing
+
+- [x] 1.1 Probe the installed versions (`SQLAlchemy 2.0.51`, `pytest-asyncio 1.4.0`) and confirm
+      `AsyncSession` / `create_async_engine` import
+- [x] 1.2 Measure event-loop blocking: 10 concurrent 50 ms calls, blocking vs awaited
+- [x] 1.3 Record the numbers and the conditions (501 ms vs 50 ms, 10x)
+
+## 2. python-rest-api (1.4.0)
+
+- [x] 2.1 Add **Async or sync — pick one lane per endpoint** above the DB section
+- [x] 2.2 State the rule and the two coherent lanes; name the sync lane the default
+- [x] 2.3 Name the middleware/handler trap explicitly
+- [x] 2.4 Give the async lane's engine, sessionmaker, dependency and `asyncio_mode`
+- [x] 2.5 Document the green-suite failure (sync override in an async fixture)
+- [x] 2.6 Link `backend-resilience` for the outbound half
+- [x] 2.7 Name the lane in the DB section's first bullet
+- [x] 2.8 Pin the probed versions; update the description; bump to 1.4.0
+
+## 3. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers unchanged; description gains the lane rule
+- [x] Q.4 No duplicated doctrine: outbound half stays in `backend-resilience`, linked not restated
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 Description states no policy the body contradicts
+- [x] Q.7 No README change — skill purpose unchanged
+
+## 4. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate add-async-lane-rule --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync
+- [x] V.4 `scripts/validate-skills.py` 0 findings across 31 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` 12/12
+- [ ] V.6 `openspec archive add-async-lane-rule --yes` after review

--- a/plugins/backend/skills/python-rest-api/SKILL.md
+++ b/plugins/backend/skills/python-rest-api/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production
   services. Use when creating or reviewing a Python API service — project layout, response envelope
   with centralized response codes, exception-handler registry (input errors are never raw 500),
-  Field-constraint validation, tenant-isolation lookups, session-per-request DB access,
+  Field-constraint validation, tenant-isolation lookups, the async/sync lane rule for
+  session-per-request DB access,
   pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures,
   testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis
   fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency
@@ -12,7 +13,7 @@ description: >-
   ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.4.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -134,9 +135,58 @@ Repository lookups for user-owned resources always take the pair — `find_by_id
 and services raise `NotFoundException` (not `ForbiddenException`) when the resource belongs to someone
 else, so existence is not leaked. Regression-tested in `tests/test_bola_guards.py`-style suites.
 
+## Async or sync — pick one lane per endpoint
+
+**Never `async def` + a synchronous `Session`.** A blocking call inside an `async def` handler holds
+the event loop for its whole duration, so the worker stops serving every other request until it
+returns. Measured with 10 concurrent 50 ms "queries" (`asyncio.gather`, Python 3.14): a blocking call
+inside `async def` took **501 ms** — perfectly serialized, ~10x the cost of one — against **50 ms**
+awaited. **10x**, and it grows with concurrency.
+
+Two coherent lanes; a service may use both, but never mix them inside one endpoint's call path:
+
+| Lane | Endpoint | Session | Why it works |
+|---|---|---|---|
+| **Sync** (default) | `def` | `Session(engine)` | FastAPI runs a `def` endpoint in a threadpool — the loop is never blocked |
+| **Async** | `async def` | `AsyncSession` | nothing blocks; every I/O is awaited |
+
+The sync lane is the right default: it is the cheaper migration, it is what the DB section below
+prescribes, and a threadpool handler is not a compromise. Reach for the async lane when the endpoint
+is I/O-bound on more than the database (fan-out to several services, streaming), and then commit to it
+end to end.
+
+**The trap is the mixed lane, and it is easy to fall into**: the middleware and exception handlers this
+skill prescribes are `async def`, because Starlette requires it. That does not make your endpoints
+async. Read the endpoint's own signature before choosing a session type.
+
+Async lane, the parts that change:
+
+```python
+engine = create_async_engine(settings.database_url, pool_pre_ping=True, pool_size=..., pool_recycle=...)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with AsyncSessionLocal() as session:
+        yield session
+```
+
+Repositories become `async def` and `await session.execute(...)`; `session.commit()` becomes
+`await session.commit()`. In `tests/conftest.py` the fixture becomes async and `pytest-asyncio` needs
+`asyncio_mode = "auto"` in the pytest config, or every async test is silently skipped as "not
+collected".
+
+**The failure mode that survives a green suite**: a test fixture that overrides `get_session` with a
+*sync* session against SQLite keeps passing, because a single test never has concurrency. The block
+only appears under load, in production. If you are on the async lane, the override must be async too.
+
+Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`.
+
+Outbound calls follow the same rule — `backend-resilience` ships `safe_call` and `safe_call_async` for
+exactly this reason. The DB half and the HTTP half of one request must be in the same lane.
+
 ## DB & transactions
 
-- `Session(engine)` per request via the `get_session` dependency; engine with `pool_pre_ping=True`,
+- **Sync lane** (see above): `Session(engine)` per request via the `get_session` dependency; engine with `pool_pre_ping=True`,
   bounded pool (`pool_size`/`max_overflow`), `pool_recycle`.
 - Atomicity by transaction scoping: validate → mutate → **one** `session.commit()` per request. No
   partial commits mid-operation.

--- a/skills/python-rest-api/SKILL.md
+++ b/skills/python-rest-api/SKILL.md
@@ -4,7 +4,8 @@ description: >-
   Conventions for Python REST APIs (FastAPI + pydantic v2), distilled from real solvelab production
   services. Use when creating or reviewing a Python API service — project layout, response envelope
   with centralized response codes, exception-handler registry (input errors are never raw 500),
-  Field-constraint validation, tenant-isolation lookups, session-per-request DB access,
+  Field-constraint validation, tenant-isolation lookups, the async/sync lane rule for
+  session-per-request DB access,
   pydantic-settings config, two-tier health endpoints, and the testing stack (SQLite unit fixtures,
   testcontainers integration marker, adversarial test naming, OpenAPI golden snapshot, Schemathesis
   fuzz gate). Also machine-to-machine service auth (named token catalog), domain-state idempotency
@@ -12,7 +13,7 @@ description: >-
   ingestion workers (UDP). The baseline that api-resilience-testing and bug-hunter assume.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.4.0
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -134,9 +135,58 @@ Repository lookups for user-owned resources always take the pair — `find_by_id
 and services raise `NotFoundException` (not `ForbiddenException`) when the resource belongs to someone
 else, so existence is not leaked. Regression-tested in `tests/test_bola_guards.py`-style suites.
 
+## Async or sync — pick one lane per endpoint
+
+**Never `async def` + a synchronous `Session`.** A blocking call inside an `async def` handler holds
+the event loop for its whole duration, so the worker stops serving every other request until it
+returns. Measured with 10 concurrent 50 ms "queries" (`asyncio.gather`, Python 3.14): a blocking call
+inside `async def` took **501 ms** — perfectly serialized, ~10x the cost of one — against **50 ms**
+awaited. **10x**, and it grows with concurrency.
+
+Two coherent lanes; a service may use both, but never mix them inside one endpoint's call path:
+
+| Lane | Endpoint | Session | Why it works |
+|---|---|---|---|
+| **Sync** (default) | `def` | `Session(engine)` | FastAPI runs a `def` endpoint in a threadpool — the loop is never blocked |
+| **Async** | `async def` | `AsyncSession` | nothing blocks; every I/O is awaited |
+
+The sync lane is the right default: it is the cheaper migration, it is what the DB section below
+prescribes, and a threadpool handler is not a compromise. Reach for the async lane when the endpoint
+is I/O-bound on more than the database (fan-out to several services, streaming), and then commit to it
+end to end.
+
+**The trap is the mixed lane, and it is easy to fall into**: the middleware and exception handlers this
+skill prescribes are `async def`, because Starlette requires it. That does not make your endpoints
+async. Read the endpoint's own signature before choosing a session type.
+
+Async lane, the parts that change:
+
+```python
+engine = create_async_engine(settings.database_url, pool_pre_ping=True, pool_size=..., pool_recycle=...)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    async with AsyncSessionLocal() as session:
+        yield session
+```
+
+Repositories become `async def` and `await session.execute(...)`; `session.commit()` becomes
+`await session.commit()`. In `tests/conftest.py` the fixture becomes async and `pytest-asyncio` needs
+`asyncio_mode = "auto"` in the pytest config, or every async test is silently skipped as "not
+collected".
+
+**The failure mode that survives a green suite**: a test fixture that overrides `get_session` with a
+*sync* session against SQLite keeps passing, because a single test never has concurrency. The block
+only appears under load, in production. If you are on the async lane, the override must be async too.
+
+Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`.
+
+Outbound calls follow the same rule — `backend-resilience` ships `safe_call` and `safe_call_async` for
+exactly this reason. The DB half and the HTTP half of one request must be in the same lane.
+
 ## DB & transactions
 
-- `Session(engine)` per request via the `get_session` dependency; engine with `pool_pre_ping=True`,
+- **Sync lane** (see above): `Session(engine)` per request via the `get_session` dependency; engine with `pool_pre_ping=True`,
   bounded pool (`pool_size`/`max_overflow`), `pool_recycle`.
 - Atomicity by transaction scoping: validate → mutate → **one** `session.commit()` per request. No
   partial commits mid-operation.


### PR DESCRIPTION
Closes #50.

## The defect

`python-rest-api` prescribed a **synchronous** SQLAlchemy session while its own prescribed code ran on the async path, and never mentioned the interaction:

| line | content | kind |
|---|---|---|
| 29 | stack lists `pytest-asyncio`, `httpx` | async-capable |
| 110 | `async def dispatch(...)` — the body-limit middleware | **async** |
| 117 | `async def too_deep(...)` — the RecursionError handler | **async** |
| 139 | `Session(engine)` per request via `get_session` | **sync** |

Occurrences of `AsyncSession`: **0**. Occurrences of `event loop`: **0**.

The gap widened when #22 added that async middleware and handler to the same file — the skill shipped async code beside sync data-access doctrine with nothing connecting them. A reader can pick `async def` for an endpoint because the examples are async, open a sync `Session` because the DB section says to, and **serve one request at a time with no error and no log line saying why**.

## Measured, not asserted

10 concurrent 50 ms "queries" via `asyncio.gather`:

| shape | wall clock | |
|---|---|---|
| blocking call inside `async def` | **501 ms** | perfectly serialized, ~10x the cost of one |
| the same work awaited | **50 ms** | concurrent |

**10x**, and it grows with concurrency. `time.sleep` was used deliberately: it isolates the property under test from driver and network noise. Conditions are stated in the skill so a reader can substitute a real query.

## What the section says

- **The rule**: never `async def` + a synchronous `Session`.
- **Two coherent lanes**, with the **sync lane named the default** — FastAPI runs a `def` endpoint in a threadpool, which is a real solution, not a compromise. Async earns its cost when the endpoint is I/O-bound on more than the database.
- **The trap, by name**: the middleware and exception handlers *this skill prescribes* are `async def` because Starlette requires it. That does not make your endpoints async. Imitation is the most likely path into the mixed lane.
- **The async lane end to end**: `create_async_engine`, `async_sessionmaker`, async `get_session`, awaited repositories, and `asyncio_mode = "auto"` or every async test is silently skipped.
- **The failure that survives a green suite**: a sync session override in an async fixture keeps passing, because a single test never has concurrency. The suite agrees with the mistake — which is why this reaches production.
- The outbound half links `backend-resilience` (`safe_call` / `safe_call_async`): same rule, other side of the request.

Verified against **SQLAlchemy 2.0.51** and **pytest-asyncio 1.4.0**, both probed.

## Deliberately not included

A "3–5x more requests/sec" style figure from the async-vs-sync literature. It is not reproducible here, and the defensible claim is about blocking — which is mechanical and took ten lines to measure.

## Spec delta

`skills-authoring` → **MODIFIED** *Simulated failure behaviour*: a claim about a **performance or concurrency property** must be measured and its conditions stated, not asserted from the mechanism.

`python-rest-api` 1.3.0 → 1.4.0. `V.6` intentionally left open.
