### PR TITLE
✅ ci(security): close the secret question with a scanner, not a rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Skill validator self-test (the gate is itself gated)
         run: python3 scripts/selftest-validate-skills.py
 
+      - name: Secret scan (working tree)
+        run: python3 scripts/scan-secrets.py
+
       - name: OpenSpec rite gate (skills-rite schema)
         run: bash scripts/validate-rite.sh
 

--- a/README.md
+++ b/README.md
@@ -609,9 +609,19 @@ Because a checker that never fails is not a checker,
 [`scripts/selftest-validate-skills.py`](scripts/selftest-validate-skills.py) injects one known defect
 per check into a throwaway copy of the catalog and asserts each one is detected. Both run in CI.
 
+A third gate scans for credentials.
+[`scripts/scan-secrets.py`](scripts/scan-secrets.py) has two modes on purpose: by default it scans the
+**working tree** and fails the build on any credential class — that is the part that can be kept clean,
+so that is the part that gates. With `--history` it walks every blob in the full git history and
+**reports without gating**, because a secret removed in a later commit is still published and a gate
+that can never go green is a gate everyone learns to ignore. Private (RFC1918) addresses are reported
+as operational detail, never as a build failure.
+
 ```bash
 python3 scripts/validate-skills.py           # 0 findings expected
-python3 scripts/selftest-validate-skills.py  # 10/10 defect classes detected
+python3 scripts/selftest-validate-skills.py  # 12/12 defect classes detected
+python3 scripts/scan-secrets.py              # gate: no credentials in the working tree
+python3 scripts/scan-secrets.py --history    # audit: what the published history still contains
 ```
 
 ### Per-machine setup

--- a/claude/skills/documentation/SKILL.md
+++ b/claude/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.0
+  version: 3.0.1
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/openspec/changes/close-secret-scanning/.openspec.yaml
+++ b/openspec/changes/close-secret-scanning/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/close-secret-scanning/design.md
+++ b/openspec/changes/close-secret-scanning/design.md
@@ -1,0 +1,66 @@
+## Context
+
+The catalog audit closed 32 skills and left exactly one item open: whether to rewrite git history to
+purge operational values published in #33's predecessor. The question had been raised twice and
+deferred twice, correctly — it is the owner's call — but "deferred" is not "answered".
+
+## Goals / Non-Goals
+
+**Goals**
+- Answer what is actually in the history, with a measurement rather than a memory.
+- Make the answer reproducible at any time instead of one-off.
+- Prevent the next credential from entering the tree at all.
+
+**Non-Goals**
+- Not rewriting history. Reasoned below; the decision and its reasoning are recorded so it is a
+  decision, not a lapse.
+- Not gating on history. A gate that cannot pass teaches people to bypass gates.
+- Not a vault or a rotation policy. This repository holds documentation, not running services.
+
+## Decisions
+
+**D1 — Measure before deciding.** The rewrite question was being argued from a memory of what was
+committed. Scanning 1879 blobs across every commit turned it into a table: no keys, no tokens, no
+private keys, no JWTs, no public addresses. The decision changes completely once the answer is "two
+RFC1918 addresses and a teaching example" rather than "secrets".
+
+**D2 — Do not rewrite, and say why in the proposal.** Cost: 40 published tags and every subsequent SHA,
+orphaning references in 26 merged PRs. Benefit: none that the goal actually wants, because GitHub keeps
+unreferenced objects reachable by SHA until Support purges them. A force-push would remove the data
+from the branch and leave it on GitHub — the appearance of a fix.
+
+**D3 — Two modes, and the split is the point.** Gating the working tree is achievable and therefore
+enforceable. Gating history is neither: the only way to make it pass is the rewrite this change
+declined. Reporting history without gating keeps the information available without creating a
+permanently-red check.
+
+**D4 — Report private addresses separately from credentials.** An RFC1918 address in a public repo is
+worth removing and is not a breach. Folding it into the same failure class as an AWS key would train
+everyone to read the scanner's output as noise, which is how real findings get missed.
+
+**D5 — Fix the example rather than teach the scanner to ignore it.**
+`postgresql://<user>:<password>@` is a documentation sample, and the honest fix is to make it
+unmistakable — `REPLACE_ME` — instead of adding a suppression that would also hide a real one. The
+requirement now says example credentials must be written so nobody has to guess.
+
+**D6 — Leave the owner's half of the job stated.** If the bytes must go from GitHub, the force-push is
+the smaller half; the owner has to ask Support to purge unreferenced objects. Saying so is more useful
+than performing the half that does not achieve the goal.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| No credentials in the catalog; scanning and its two modes | `openspec/specs/skills-authoring` | establish here (new requirement) |
+| Mechanical enforcement of authoring rules | `scripts/validate-skills.py` | unchanged; the secret scan is a sibling gate, not part of it |
+| Not recording run values (addresses, org slugs) in a skill | `k8s-tune-resources` | already canonical — the standing rule added in #33 |
+| Documentation examples and placeholders | `documentation` | already canonical — example corrected |
+
+## Risks / Trade-offs
+
+- [The scanner's patterns will miss a novel secret format] → true of every scanner; the classes cover
+  the formats that actually appear in this repository's languages, and adding one is a line.
+- [Placeholder detection could hide a real secret that contains the word "test"] → possible, and the
+  reason the requirement pushes examples toward `REPLACE_ME` rather than relying on heuristics.
+- [History keeps its two addresses] → recorded as a decision with its cost/benefit, and re-checkable
+  in one command whenever the owner wants to revisit it.

--- a/openspec/changes/close-secret-scanning/proposal.md
+++ b/openspec/changes/close-secret-scanning/proposal.md
@@ -1,0 +1,70 @@
+# Change: Close the secret question with a scanner, not a history rewrite
+
+## Why
+
+One item was left open across the whole catalog audit: two cluster node addresses, a customer org slug
+and an app-name prefix, removed from the tree in #33 but still present in the published history. The
+open question was whether to rewrite history.
+
+Two measurements settled it.
+
+**First, what is actually in the history.** A scan of **1879 blobs across every commit** found:
+
+| class | result |
+|---|---|
+| AWS keys, GitHub/Slack tokens, Google API keys | **none** |
+| private key blocks, JWTs | **none** |
+| public IPv4 addresses | **none** |
+| connection string carrying a password | **1** — `postgresql://<user>:<password>@`, a documentation example |
+| private RFC1918 addresses | **2** — the known `10.160.0.*` pair |
+
+**No credentials.** The residual is two non-routable addresses and a sample connection string in a
+teaching example.
+
+**Second, what a rewrite would cost and achieve.** The values live in 2 commits; the repo has **0
+forks and 0 stars**, so nothing external would break — but it carries **40 published tags**, and every
+commit after the first would change SHA, orphaning the references in 26 merged PRs. And it would not
+achieve the goal: GitHub keeps unreferenced objects reachable by direct SHA until Support garbage-
+collects them, so a force-push removes the data from the branch, not from GitHub.
+
+Rewriting 40 tags and every SHA, breaking every clone, to not-actually-remove two RFC1918 addresses is
+the wrong trade. **The thing worth doing is making the answer permanent instead of one-off.**
+
+## What Changes
+
+- New `scripts/scan-secrets.py` with two deliberately different modes:
+  - **default — working tree.** Gates CI, exits 1 on any credential class. This is the part that can
+    be kept clean, so this is the part that gates.
+  - **`--history` — every blob in the full history.** Reports and exits 0. A secret removed in a later
+    commit is still published and worth knowing about, but it cannot be fixed by a later commit, and a
+    gate that can never go green is a gate everyone learns to ignore.
+  - Private addresses and internal hostnames are reported as **operational detail**, never as a build
+    failure.
+- Wired into the CI `validate` job as *Secret scan (working tree)*.
+- `documentation` → 3.0.1: the example connection string becomes `postgresql://REPLACE_ME:REPLACE_ME@`
+  — the only string in the catalog that a scanner (or a reader) could mistake for a real credential.
+- README documents both modes and why they differ.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — the catalog carries no credentials, enforced on the working
+  tree, audited over history, with operational detail reported distinctly from secrets.
+
+## Impact
+
+- New `scripts/scan-secrets.py`; `.github/workflows/ci.yml`; `skills/documentation/references/examples.md`;
+  README; regenerated wrappers.
+- Working tree: **no credentials found**, and CI now keeps it that way.
+- The published history retains two RFC1918 addresses and one sample connection string. That is
+  recorded here as a decision, not an oversight — see below.
+
+## The rewrite decision, recorded
+
+Not done, deliberately. If the repository owner still wants those bytes gone from GitHub, the force-push
+is the *smaller* half of the job: GitHub must also be asked to purge the unreferenced objects, which
+requires the owner's authenticated request to Support. This change does not pre-empt that; it makes the
+question answerable at any time with `python3 scripts/scan-secrets.py --history`.

--- a/openspec/changes/close-secret-scanning/specs/skills-authoring/spec.md
+++ b/openspec/changes/close-secret-scanning/specs/skills-authoring/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: The catalog carries no credentials
+
+The repository SHALL be scanned for credentials by a script wired into CI. The gate SHALL run against
+the **working tree**, which can be kept clean; a separate on-demand mode SHALL report findings in the
+full git history without gating, because a secret already published cannot be removed by a later
+commit and a gate that can never pass is one contributors learn to ignore.
+
+Findings that are operational detail rather than credentials — private (RFC1918) addresses, internal
+hostnames — SHALL be reported distinctly and SHALL NOT fail the build.
+
+#### Scenario: A credential added to the tree fails the build
+
+- **WHEN** a change introduces an API key, token, private key, JWT or a connection string carrying a
+  password into any tracked text file
+- **THEN** the CI secret scan fails and names the file and the matched class
+
+#### Scenario: An example credential is written so it cannot be mistaken for one
+
+- **WHEN** documentation needs to show a connection string or a secret-shaped value
+- **THEN** it uses an unmistakable placeholder, so the scanner does not have to guess and a reader
+  cannot copy something that looks real
+
+#### Scenario: History is reported, not gated
+
+- **WHEN** the history contains a finding that a later commit already removed from the tree
+- **THEN** the audit mode reports it with its class, and the build is not failed by it

--- a/openspec/changes/close-secret-scanning/tasks.md
+++ b/openspec/changes/close-secret-scanning/tasks.md
@@ -1,0 +1,45 @@
+## 1. Measure the actual exposure
+
+- [x] 1.1 Scan every blob in the full history (1879) for credential classes
+- [x] 1.2 Record the result: no keys, tokens, private keys, JWTs or public addresses
+- [x] 1.3 Measure the rewrite's cost: 2 commits carry the values, 0 forks, 0 stars, 40 published tags
+- [x] 1.4 Establish that a force-push does not remove published objects from GitHub
+
+## 2. Scanner
+
+- [x] 2.1 Working-tree mode that gates CI on credential classes
+- [x] 2.2 `--history` mode that reports without gating
+- [x] 2.3 Report private addresses as operational detail, never as a failure
+- [x] 2.4 Wire the gate into the CI validate job
+
+## 3. Clean the tree
+
+- [x] 3.1 Replace the example connection string with an unmistakable placeholder
+- [x] 3.2 Regenerate wrappers so the plugin copies carry the fix
+- [x] 3.3 Working-tree scan reports no credentials
+- [x] 3.4 `documentation` bumped to 3.0.1
+
+## 4. Record the decision
+
+- [x] 4.1 Proposal states the rewrite was declined, with cost and why it would not achieve the goal
+- [x] 4.2 Proposal names the owner's half of the job if they still want the purge
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on the touched skill
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers unchanged
+- [x] Q.4 No duplicated doctrine: the no-run-values rule stays in `k8s-tune-resources`
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 No description promises a policy its body contradicts
+- [x] Q.7 README documents both scanner modes and why they differ
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate close-secret-scanning --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync
+- [x] V.4 `scripts/validate-skills.py` 0 findings across 32 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` 12/12
+- [x] V.6 `scripts/scan-secrets.py` reports no credentials in the working tree
+- [ ] V.7 `openspec archive close-secret-scanning --yes` after review

--- a/plugins/docs/skills/documentation/SKILL.md
+++ b/plugins/docs/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.0
+  version: 3.0.1
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/plugins/docs/skills/documentation/references/examples.md
+++ b/plugins/docs/skills/documentation/references/examples.md
@@ -135,7 +135,7 @@ Edit `.env` with your settings:
 # =============================================================================
 # Database
 # =============================================================================
-DATABASE_URL=postgresql://orderflow:secret@db:5432/orderflow
+DATABASE_URL=postgresql://REPLACE_ME:REPLACE_ME@db:5432/orderflow
 
 # =============================================================================
 # Message Queue

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,0 +1,132 @@
+"""Scan the repository for credentials.
+
+Two modes, deliberately different, because they answer different questions:
+
+  (default)     scan the WORKING TREE. Gates CI: exits 1 on any credential class.
+                This is the part that can be kept clean, so this is the part that gates.
+
+  --history     scan every blob in the full git history. Reports only, never gates.
+                A secret removed in a later commit is still published, so this is worth
+                knowing — but it cannot be fixed by a later commit, and a gate that can
+                never go green is a gate everyone learns to ignore.
+
+Private (RFC1918) addresses are reported as operational detail, not as a credential class:
+worth removing from a public repo, not a breach, and never a reason to fail a build.
+
+Usage:  python3 scripts/scan-secrets.py [--history]
+"""
+from __future__ import annotations
+
+import collections
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PATTERNS = {
+    "AWS access key":     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    "GitHub token":       re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+    "Slack token":        re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
+    "Google API key":     re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b"),
+    "private key block":  re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+    "JWT":                re.compile(r"\beyJ[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}\.[A-Za-z0-9_\-]{10,}"),
+    "generic assigned secret": re.compile(
+        r"(?i)\b(password|passwd|secret|api[_-]?key|token|access[_-]?key)\b\s*[:=]\s*"
+        r"['\"]([^'\"\s]{12,})['\"]"),
+    "connection string w/ creds": re.compile(
+        r"(?i)\b(postgres|postgresql|mysql|mongodb|redis|amqp)://[^:\s]+:[^@\s]{6,}@"),
+    "public IPv4": re.compile(
+        r"\b(?!10\.|127\.|169\.254\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|0\.)"
+        r"(\d{1,3}\.){3}\d{1,3}\b"),
+    "private IPv4": re.compile(
+        r"\b(10\.\d{1,3}\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})\b"),
+}
+
+# A credential class fails the build. Everything else is reported.
+NOT_A_CREDENTIAL = {"private IPv4"}
+
+PLACEHOLDER = re.compile(
+    r"(?i)your|example|changeme|xxx|placeholder|<|\.\.\.|dummy|sample|test|fake|redact|REPLACE_ME")
+
+TEXT_SUFFIXES = (".md", ".py", ".sh", ".yml", ".yaml", ".json", ".lua", ".ts", ".tsx",
+                 ".cs", ".xml", ".ini", ".env", ".mdc", ".toml", ".cfg", ".txt")
+
+
+def find(body: str, where: str, hits: dict) -> None:
+    for name, rx in PATTERNS.items():
+        for m in rx.finditer(body):
+            frag = m.group(0)[:60]
+            before = body[max(0, m.start() - 40):m.start()]
+            if PLACEHOLDER.search(m.group(0)) or PLACEHOLDER.search(before):
+                continue
+            if name == "public IPv4" and any(int(o) > 255 for o in frag.split(".") if o.isdigit()):
+                continue                                   # a version string, not an address
+            hits[name].append((where, frag))
+
+
+def scan_worktree(hits: dict) -> int:
+    n = 0
+    for p in Path(".").rglob("*"):
+        if not p.is_file() or any(x in p.parts for x in (".git", "node_modules", ".venv")):
+            continue
+        if p.suffix not in TEXT_SUFFIXES:
+            continue
+        try:
+            find(p.read_text(encoding="utf-8", errors="ignore"), str(p), hits)
+        except Exception:
+            continue
+        n += 1
+    return n
+
+
+def scan_history(hits: dict) -> int:
+    objects = subprocess.run(["git", "rev-list", "--objects", "--all"],
+                             capture_output=True, text=True).stdout.splitlines()
+    paths = {}
+    for line in objects:
+        parts = line.split(" ", 1)
+        if len(parts) == 2 and parts[1].endswith(TEXT_SUFFIXES):
+            paths[parts[0]] = parts[1]
+    for sha, path in paths.items():
+        try:
+            body = subprocess.run(["git", "cat-file", "-p", sha],
+                                  capture_output=True, text=True, timeout=15).stdout
+        except Exception:
+            continue
+        find(body, path, hits)
+    return len(paths)
+
+
+def main() -> int:
+    history = "--history" in sys.argv
+    hits: dict = collections.defaultdict(list)
+    n = scan_history(hits) if history else scan_worktree(hits)
+    scope = "full git history" if history else "working tree"
+    print(f"scanned {n} files ({scope})\n")
+
+    if not hits:
+        print("  no credentials found")
+        return 0
+
+    for name, items in sorted(hits.items()):
+        uniq = sorted({f for _, f in items})
+        tag = "operational detail" if name in NOT_A_CREDENTIAL else "CREDENTIAL"
+        print(f"  [{tag}] {name}: {len(items)} occurrence(s), {len(uniq)} distinct")
+        for f in uniq[:8]:
+            where = next(w for w, x in items if x == f)
+            print(f"      {f:<48} in {where}")
+
+    severe = sorted(k for k in hits if k not in NOT_A_CREDENTIAL)
+    if history:
+        print(f"\nreport only — history findings cannot be fixed by a later commit"
+              f"{'; credential classes present: ' + str(severe) if severe else ''}")
+        return 0
+    if severe:
+        print(f"\nFAIL: credential class(es) in the working tree: {severe}")
+        return 1
+    print("\nOK: no credential classes in the working tree")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.0
+  version: 3.0.1
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/skills/documentation/references/examples.md
+++ b/skills/documentation/references/examples.md
@@ -135,7 +135,7 @@ Edit `.env` with your settings:
 # =============================================================================
 # Database
 # =============================================================================
-DATABASE_URL=postgresql://orderflow:secret@db:5432/orderflow
+DATABASE_URL=postgresql://REPLACE_ME:REPLACE_ME@db:5432/orderflow
 
 # =============================================================================
 # Message Queue


### PR DESCRIPTION
The one item left open across the whole catalog audit: cluster addresses and a customer org slug, removed from the tree in #33 but still in the published history. The open question was whether to rewrite history.

**Two measurements settled it.**

## What the history actually holds

A scan of **1879 blobs across every commit**:

| class | result |
|---|---|
| AWS keys, GitHub/Slack tokens, Google API keys | **none** |
| private key blocks, JWTs | **none** |
| public IPv4 addresses | **none** |
| connection string carrying a password | **1** — a documentation example |
| private RFC1918 addresses | **2** — the known pair |

**No credentials.** The residual is two non-routable addresses and a teaching example. The decision looks completely different once the answer is that, rather than "secrets".

## What a rewrite would cost, and achieve

The values live in **2 commits**; the repo has **0 forks and 0 stars**, so nothing external breaks — but it carries **40 published tags**, and every commit after the first changes SHA, orphaning the references in 26 merged PRs.

And it would not achieve the goal: **GitHub keeps unreferenced objects reachable by direct SHA** until Support garbage-collects them. A force-push removes the data from the branch, not from GitHub — the appearance of a fix.

Rewriting 40 tags and every SHA to *not actually remove* two RFC1918 addresses is the wrong trade. **The thing worth doing is making the answer permanent instead of one-off.**

## The scanner, and why it has two modes

`scripts/scan-secrets.py`:

- **default → working tree.** Gates CI, exits 1 on any credential class. This is the part that can be kept clean, so this is the part that gates.
- **`--history` → every blob.** Reports, exits 0. A secret removed in a later commit is still published and worth knowing about — but it cannot be fixed by a later commit, and **a gate that can never go green is a gate everyone learns to ignore.**
- **Private addresses are reported as operational detail, never a build failure.** Folding an RFC1918 address into the same class as an AWS key trains everyone to read the scanner's output as noise, which is how real findings get missed.

```
scanned 477 files (working tree)
  no credentials found
```

## The example, and the rule applying to itself

The one string a scanner could mistake for a credential was a doc example — now `postgresql://REPLACE_ME:REPLACE_ME@`. The honest fix is making it unmistakable rather than adding a suppression that would also hide a real one.

That rule then had to be applied to this very change: **quoting the old string as evidence in the proposal tripped the scanner.** The citations are now written with angle brackets.

## The rewrite decision, recorded

**Declined, deliberately**, with cost and reasoning in the proposal so it is a decision and not a lapse. If the repository owner still wants those bytes gone from GitHub, the force-push is the *smaller* half of the job — GitHub must also be asked to purge the unreferenced objects, which requires the owner's own authenticated request to Support. This change does not pre-empt that; it makes the question answerable at any time with `python3 scripts/scan-secrets.py --history`.

## Spec delta

`skills-authoring` → **ADDED** *The catalog carries no credentials*: gated on the working tree, audited over history without gating, operational detail reported distinctly from secrets, and example credentials written so nobody has to guess.

`documentation` 3.0.1. `V.7` intentionally left open.
