### PR TITLE
🐛 fix(claude-statusline): make the token segment a session total, not a per-turn snapshot

### DIFF
--- a/claude/skills/claude-statusline/SKILL.md
+++ b/claude/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.2.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/openspec/changes/cumulative-statusline-tokens/.openspec.yaml
+++ b/openspec/changes/cumulative-statusline-tokens/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-06

--- a/openspec/changes/cumulative-statusline-tokens/design.md
+++ b/openspec/changes/cumulative-statusline-tokens/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The shipped status line reports six things; five of them are already session-scoped
+(`cost.total_cost_usd`, duration, lines changed, context %, rate limits). The token segment was the
+odd one out — it read the current turn and therefore reset every prompt, which made it look like the
+session was cheap no matter how long it ran.
+
+## Goals / Non-Goals
+
+**Goals**
+- The token and cost figures answer "this session", matching the rest of the line.
+- Accumulation survives the way the status line is actually invoked.
+- Every failure mode degrades to the old behaviour rather than to a broken line.
+
+**Non-Goals**
+- Not replacing `💰 total_cost_usd`. That stays the authoritative session cost; the In/Out split is a
+  breakdown, and the two are computed differently on purpose.
+- Not persisting anything beyond token counts and their prices. No prompts, no paths, no content.
+- Not reconstructing history for sessions already in progress — accumulation starts when the new
+  script does.
+
+## Decisions
+
+**D1 — Accumulate in the script, because the payload has nothing to accumulate from.** Documented in
+`fields.md` and re-confirmed here: `total_input_tokens` / `total_output_tokens` are the current
+context, not a running total, and `cost.total_cost_usd` is a single figure with no input/output or
+cache breakdown. There is nothing to read; there is only something to keep.
+
+**D2 — `prompt_id` is the commit key, and this is the whole trick.** The status line re-renders many
+times per turn. Keying on anything else — a timestamp, the usage values themselves — either multiplies
+a turn or misses one. `prompt_id` moves exactly once per turn, which is the definition of what a turn
+boundary is here. Verified by rendering the same turn three times and watching the total not move.
+
+**D3 — Display banked + in-flight.** Committing only on turn change would leave the current response
+invisible until the next prompt. Adding the live snapshot on top keeps the number honest while it is
+being earned, and the commit then replaces the estimate with the same figure.
+
+**D4 — Bank the cost, not just the tokens.** Re-deriving cost from cumulative tokens would apply the
+current model's rate to every historical token, so switching from Opus to Haiku mid-session would
+silently rewrite what the earlier turns cost. Pricing each turn as it closes keeps history intact —
+checked: an Opus session at `$0.36` grew by `$0.04` when a Haiku turn was added, not to a repriced
+total.
+
+**D5 — Key the state on `session_id`, which the reference already recommends for exactly this.** It is
+stable per session, unlike `$$`, which changes on every render.
+
+**D6 — Degrade to the old behaviour, never to a broken line.** A status line that errors is worse than
+one that shows less. Missing `prompt_id` (older CLI, or before the first input) means nothing is
+banked and the display is the current turn — precisely what it did before. Missing `session_id` means
+no file is written. A corrupt state file is ignored and overwritten on the next render.
+
+**D7 — Prune on session creation.** Once per session is rare enough that a `find` costs nothing, and
+it is the only moment the script knows a new file is appearing. The alternative — pruning on every
+render — would put a filesystem walk in a hot path that runs several times a second.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Status line script, its segments and installation | `claude-statusline` | already canonical — token segment reworked |
+| The JSON fields the harness passes, and their semantics | `claude-statusline/references/fields.md` | already canonical — records that no cumulative token field exists |
+| Bounded state for a long-lived process | `log-event-collector` | link in spirit — same class of defect, different subject; the pruning rule here follows its bounded-ring reasoning |
+| Shipped-script state disclosure | `openspec/specs/skills-catalog` | spec delta |
+
+## Risks / Trade-offs
+
+- [State can drift if a session is resumed after the prune window] → 30 days is far beyond a working
+  session; a pruned session simply starts counting again, which is the same as a new session.
+- [Two Claude Code windows on the same session id would share the file] → they share the session, so
+  sharing the total is correct.
+- [The In/Out cost split can diverge slightly from `total_cost_usd`] → it always could; they are
+  computed from different inputs. The 💰 figure remains authoritative and is unchanged.

--- a/openspec/changes/cumulative-statusline-tokens/proposal.md
+++ b/openspec/changes/cumulative-statusline-tokens/proposal.md
@@ -1,0 +1,69 @@
+# Change: Make the status line's token segment a session total, not a per-turn snapshot
+
+## Why
+
+The status line's `↑ In … · ♻️ … · ↓ Out …` segment reads
+`context_window.current_usage.*`, which is the **current turn's** usage. It therefore
+resets every turn instead of accumulating, so it answers "what did the last response
+cost" when the question worth asking is "what has this session cost so far".
+
+There is no cumulative token field to switch to. `references/fields.md` already records
+that `context_window.total_input_tokens` / `total_output_tokens` stopped being cumulative
+in v2.1.132, and `cost.total_cost_usd` is the only running total the payload carries — it
+is a single number with no input/output or cache breakdown.
+
+So the total has to be accumulated by the script, and the accumulation has one non-obvious
+trap: **the status line re-renders many times per turn**. A naive `+=` on every render
+multiplies the turn's usage by however many times the UI repainted.
+
+## What Changes
+
+- `references/statusline.sh`: the token segment now shows the **session total**.
+  - State lives in `~/.claude/statusline-usage/<session_id>` — `session_id` is documented as
+    stable per session, which is exactly what a state filename needs.
+  - A turn is banked only when **`prompt_id` changes**, which is the only field that moves
+    once per turn. Re-renders of the same turn leave the totals alone.
+  - The display is `banked turns + the turn in flight`, so it stays live rather than lagging
+    one turn behind.
+  - **Costs are banked per turn at that turn's rates**, so switching model mid-session does
+    not reprice history.
+  - Stale state files are pruned (>30 days) on the first render of a new session — a cheap
+    moment, and it stops the directory growing for the life of the machine.
+- `references/fields.md`: records that no cumulative token field exists, and how to
+  accumulate one correctly.
+- `claude-statusline` → 1.2.0.
+
+## Verification
+
+Driven with synthetic payloads, three identical turns of 121k in / 500 out:
+
+| event | displayed |
+|---|---|
+| turn 1 | `↑ In 121k $0.18 · ↓ Out 500 $0.01` |
+| same turn, re-rendered twice | **unchanged** — no multiplication |
+| turn 2 (new `prompt_id`) | `↑ In 242k $0.36 · ↓ Out 1k $0.03` |
+| turn 3 | `↑ In 363k $0.54 · ↓ Out 2k $0.04` |
+
+Degradation, each checked:
+
+| condition | behaviour |
+|---|---|
+| no `prompt_id` (older CLI, or before first input) | falls back to the previous per-turn display, no crash |
+| no `session_id` | no state written, no crash |
+| model switched mid-session | Opus turns held at `$0.36`; a Haiku turn added `$0.04`, not a repriced total |
+| corrupt state file | ignored, self-heals on the next write |
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: `claude-statusline` ships a status line whose token segment reports the
+  session total rather than the last turn.
+
+## Impact
+
+- `skills/claude-statusline/references/statusline.sh` and `references/fields.md`; regenerated
+  wrappers. Anyone already running the shipped script gets session totals after copying the
+  new version; no configuration change is required.

--- a/openspec/changes/cumulative-statusline-tokens/specs/skills-catalog/spec.md
+++ b/openspec/changes/cumulative-statusline-tokens/specs/skills-catalog/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Shipped scripts state what they persist
+
+A skill that ships an executable which writes state outside the repository SHALL state where that
+state lives, what keys it, and how it is bounded. State that grows once per session SHALL be pruned
+by the script itself rather than left to accumulate for the life of the machine.
+
+#### Scenario: A shipped script's state is discoverable
+
+- **WHEN** a skill ships a script that persists anything between runs
+- **THEN** the skill names the path, the key it is filed under, and the retention, so a user can find
+  it, inspect it or delete it without reading the source
+
+#### Scenario: Per-session state does not grow without bound
+
+- **WHEN** a script keeps one state file per session
+- **THEN** it prunes stale files on a cheap occasion (such as the first write of a new session),
+  instead of relying on the user to clean up

--- a/openspec/changes/cumulative-statusline-tokens/tasks.md
+++ b/openspec/changes/cumulative-statusline-tokens/tasks.md
@@ -1,0 +1,50 @@
+## 1. Establish that accumulation is necessary
+
+- [x] 1.1 Confirm the segment reads `context_window.current_usage.*` (per turn)
+- [x] 1.2 Confirm no cumulative token field exists in the payload
+- [x] 1.3 Confirm `session_id` is stable and `prompt_id` moves once per turn
+
+## 2. Implement
+
+- [x] 2.1 Parse `session_id` and `prompt_id` out of the payload
+- [x] 2.2 State file keyed on `session_id`
+- [x] 2.3 Bank a turn only when `prompt_id` changes
+- [x] 2.4 Display banked + in-flight
+- [x] 2.5 Bank cost per turn at that turn's rates
+- [x] 2.6 Prune state older than 30 days on the first render of a new session
+
+## 3. Verify
+
+- [x] 3.1 Three turns accumulate: 121k -> 242k -> 363k
+- [x] 3.2 Re-rendering the same turn does not move the total
+- [x] 3.3 No `prompt_id`: falls back to the per-turn display, no crash
+- [x] 3.4 No `session_id`: no state written, no crash
+- [x] 3.5 Model switch mid-session does not reprice history ($0.36 + $0.04)
+- [x] 3.6 Corrupt state file is ignored and self-heals
+- [x] 3.7 `bash -n` clean
+
+## 4. Document and sync
+
+- [x] 4.1 `fields.md` records that no cumulative token field exists and how to accumulate one
+- [x] 4.2 Shipped `statusline.sh` matches the installed one
+- [x] 4.3 `claude-statusline` bumped to 1.2.0
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform
+- [x] Q.2 Content in English (catalog locale)
+- [x] Q.3 Triggers unchanged
+- [x] Q.4 No duplicated doctrine: bounded-state reasoning links `log-event-collector`, not restated
+- [x] Q.5 Every quantified claim carries its measured number and conditions
+- [x] Q.6 Description states no policy the body contradicts
+- [x] Q.7 No README change — the script's segments are unchanged in shape
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate cumulative-statusline-tokens --strict` green
+- [x] V.2 `scripts/validate-rite.sh` green
+- [x] V.3 Wrappers in sync
+- [x] V.4 `scripts/validate-skills.py` 0 findings across 32 skills
+- [x] V.5 `scripts/selftest-validate-skills.py` 12/12
+- [x] V.6 `scripts/scan-secrets.py` clean
+- [ ] V.7 `openspec archive cumulative-statusline-tokens --yes` after review

--- a/plugins/tooling/skills/claude-statusline/SKILL.md
+++ b/plugins/tooling/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.2.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/plugins/tooling/skills/claude-statusline/references/fields.md
+++ b/plugins/tooling/skills/claude-statusline/references/fields.md
@@ -23,6 +23,7 @@ absent entirely.
 | `cost.total_api_duration_ms` | Time waiting on the API. |
 | `cost.total_lines_added` / `cost.total_lines_removed` | Lines the assistant changed this session. |
 | `context_window.total_input_tokens` / `total_output_tokens` | Tokens currently in context (not cumulative, since v2.1.132). |
+| — | **There is no cumulative token field.** `cost.total_cost_usd` is the only running total the payload carries. A session token total has to be accumulated by the script itself: key the state file on `session_id`, and commit a turn only when `prompt_id` changes — the status line re-renders many times per turn, so a naive `+=` multiplies. See `statusline.sh`. |
 | `context_window.context_window_size` | Max context (200000, or 1000000 for extended). |
 | `context_window.used_percentage` / `remaining_percentage` | Pre-computed context %; may be `null` early. |
 | `context_window.current_usage` | `{input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}`. `null` before first API call and right after `/compact`. |

--- a/plugins/tooling/skills/claude-statusline/references/statusline.sh
+++ b/plugins/tooling/skills/claude-statusline/references/statusline.sh
@@ -5,7 +5,7 @@
 # Line 3: 📊 ctx | 🚦 5h | 7d                                                  (all progress meters)
 input=$(cat)
 
-IFS=$'\t' read -r MODEL DIR COST CTX EFFORT THINKING RL5 RL7 DUR ADDED REMOVED IN_TOK CACHE_W CACHE_R OUT_TOK <<< "$(jq -r '[
+IFS=$'\t' read -r MODEL DIR COST CTX EFFORT THINKING RL5 RL7 DUR ADDED REMOVED IN_TOK CACHE_W CACHE_R OUT_TOK SESSION_ID PROMPT_ID <<< "$(jq -r '[
   (.model.display_name // "Claude"),
   (.workspace.current_dir // .cwd // "."),
   (.cost.total_cost_usd // 0),
@@ -20,7 +20,9 @@ IFS=$'\t' read -r MODEL DIR COST CTX EFFORT THINKING RL5 RL7 DUR ADDED REMOVED I
   (.context_window.current_usage.input_tokens // 0),
   (.context_window.current_usage.cache_creation_input_tokens // 0),
   (.context_window.current_usage.cache_read_input_tokens // 0),
-  (.context_window.current_usage.output_tokens // 0)
+  (.context_window.current_usage.output_tokens // 0),
+  (.session_id // ""),
+  (.prompt_id // "")
 ] | map(tostring) | join("\t")' <<< "$input")"
 
 # ANSI colors
@@ -161,21 +163,73 @@ esac
 if [ "${ADDED:-0}" -gt 0 ] 2>/dev/null || [ "${REMOVED:-0}" -gt 0 ] 2>/dev/null; then
   line2+=("📝 ${C_GREEN}+${ADDED}${C_RESET} ${C_RED}-${REMOVED}${C_RESET}")
 fi
-# tokens — 📥 In (total) · ♻️ cache health % · 📤 Out
-TOTAL_IN=$(( ${IN_TOK:-0} + ${CACHE_W:-0} + ${CACHE_R:-0} ))
+# tokens — ↑ In (session total) · ♻️ cache health % · ↓ Out (session total)
+#
+# context_window.current_usage.* is the CURRENT turn, not a running total, and
+# context_window.total_input_tokens stopped being cumulative in v2.1.132 — so the
+# session total is accumulated here. The state file is keyed by session_id (stable
+# per session) and a turn is committed only when prompt_id changes, because the
+# status line re-renders many times per turn and a naive += would multiply.
+# Costs are committed per turn at that turn's rates, so switching model mid-session
+# does not reprice history.
+usage_state="${HOME}/.claude/statusline-usage/${SESSION_ID:-nosession}"
+CUM_IN=0; CUM_CW=0; CUM_CR=0; CUM_OUT=0; CUM_IN_COST=0; CUM_OUT_COST=0
+LAST_PROMPT=""; LAST_IN=0; LAST_CW=0; LAST_CR=0; LAST_OUT=0; LAST_IN_COST=0; LAST_OUT_COST=0
+if [ -n "${SESSION_ID:-}" ] && [ -r "$usage_state" ]; then
+  IFS=$'\t' read -r LAST_PROMPT CUM_IN CUM_CW CUM_CR CUM_OUT CUM_IN_COST CUM_OUT_COST \
+                    LAST_IN LAST_CW LAST_CR LAST_OUT LAST_IN_COST LAST_OUT_COST < "$usage_state" || true
+fi
+
+# price the CURRENT turn (fresh input full price, cache write 1.25x, cache read 0.1x)
+TURN_IN_COST=0; TURN_OUT_COST=0
+RATES=$(price_rates "$MODEL")
+if [ -n "$RATES" ]; then
+  read -r IN_RATE OUT_RATE <<< "$RATES"
+  TURN_IN_COST=$(awk "BEGIN{printf \"%.6f\", (${IN_TOK:-0}*$IN_RATE + ${CACHE_W:-0}*$IN_RATE*1.25 + ${CACHE_R:-0}*$IN_RATE*0.1)/1000000}")
+  TURN_OUT_COST=$(awk "BEGIN{printf \"%.6f\", ${OUT_TOK:-0}*$OUT_RATE/1000000}")
+fi
+
+# a new prompt_id means the turn we were tracking finished — bank it
+if [ -n "${PROMPT_ID:-}" ] && [ "$PROMPT_ID" != "$LAST_PROMPT" ]; then
+  CUM_IN=$(( ${CUM_IN:-0} + ${LAST_IN:-0} ))
+  CUM_CW=$(( ${CUM_CW:-0} + ${LAST_CW:-0} ))
+  CUM_CR=$(( ${CUM_CR:-0} + ${LAST_CR:-0} ))
+  CUM_OUT=$(( ${CUM_OUT:-0} + ${LAST_OUT:-0} ))
+  CUM_IN_COST=$(awk "BEGIN{printf \"%.6f\", ${CUM_IN_COST:-0} + ${LAST_IN_COST:-0}}")
+  CUM_OUT_COST=$(awk "BEGIN{printf \"%.6f\", ${CUM_OUT_COST:-0} + ${LAST_OUT_COST:-0}}")
+  LAST_PROMPT="$PROMPT_ID"
+fi
+
+if [ -n "${SESSION_ID:-}" ]; then
+  if [ ! -e "$usage_state" ]; then
+    # first render of a new session: cheap moment to drop stale sessions, so the
+    # state directory does not grow for the life of the machine
+    mkdir -p "${usage_state%/*}" 2>/dev/null
+    find "${usage_state%/*}" -maxdepth 1 -type f -mtime +30 -delete 2>/dev/null || true
+  fi
+  mkdir -p "${usage_state%/*}" 2>/dev/null
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$LAST_PROMPT" "$CUM_IN" "$CUM_CW" "$CUM_CR" "$CUM_OUT" "$CUM_IN_COST" "$CUM_OUT_COST" \
+    "${IN_TOK:-0}" "${CACHE_W:-0}" "${CACHE_R:-0}" "${OUT_TOK:-0}" "$TURN_IN_COST" "$TURN_OUT_COST" \
+    > "$usage_state" 2>/dev/null || true
+fi
+
+# displayed totals = banked turns + the turn in flight
+SESS_IN=$(( ${CUM_IN:-0} + ${IN_TOK:-0} ))
+SESS_CW=$(( ${CUM_CW:-0} + ${CACHE_W:-0} ))
+SESS_CR=$(( ${CUM_CR:-0} + ${CACHE_R:-0} ))
+SESS_OUT=$(( ${CUM_OUT:-0} + ${OUT_TOK:-0} ))
+TOTAL_IN=$(( SESS_IN + SESS_CW + SESS_CR ))
 if [ "$TOTAL_IN" -gt 0 ]; then
-  CACHE_PCT=$(( CACHE_R * 100 / TOTAL_IN ))
+  CACHE_PCT=$(( SESS_CR * 100 / TOTAL_IN ))
   if   [ "$CACHE_PCT" -ge 80 ]; then CACHE_COL="$C_GREEN"
   elif [ "$CACHE_PCT" -ge 40 ]; then CACHE_COL="$C_YELLOW"
   else CACHE_COL="$C_RED"; fi
-  # per-turn $ of the last response's tokens (fresh input full price, cache write 1.25x, cache read 0.1x)
   seg_in="${C_IN}↑ In${C_RESET} $(human "$TOTAL_IN")"
-  seg_out="${C_OUT}↓ Out${C_RESET} $(human "${OUT_TOK:-0}")"
-  RATES=$(price_rates "$MODEL")
+  seg_out="${C_OUT}↓ Out${C_RESET} $(human "$SESS_OUT")"
   if [ -n "$RATES" ]; then
-    read -r IN_RATE OUT_RATE <<< "$RATES"
-    IN_COST=$(awk "BEGIN{printf \"%.2f\", (${IN_TOK:-0}*$IN_RATE + ${CACHE_W:-0}*$IN_RATE*1.25 + ${CACHE_R:-0}*$IN_RATE*0.1)/1000000}")
-    OUT_COST=$(awk "BEGIN{printf \"%.2f\", ${OUT_TOK:-0}*$OUT_RATE/1000000}")
+    IN_COST=$(awk "BEGIN{printf \"%.2f\", ${CUM_IN_COST:-0} + $TURN_IN_COST}")
+    OUT_COST=$(awk "BEGIN{printf \"%.2f\", ${CUM_OUT_COST:-0} + $TURN_OUT_COST}")
     seg_in="$seg_in ${C_COST}\$${IN_COST}${C_RESET}"
     seg_out="$seg_out ${C_COST}\$${OUT_COST}${C_RESET}"
   fi

--- a/skills/claude-statusline/SKILL.md
+++ b/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.2.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/skills/claude-statusline/references/fields.md
+++ b/skills/claude-statusline/references/fields.md
@@ -23,6 +23,7 @@ absent entirely.
 | `cost.total_api_duration_ms` | Time waiting on the API. |
 | `cost.total_lines_added` / `cost.total_lines_removed` | Lines the assistant changed this session. |
 | `context_window.total_input_tokens` / `total_output_tokens` | Tokens currently in context (not cumulative, since v2.1.132). |
+| — | **There is no cumulative token field.** `cost.total_cost_usd` is the only running total the payload carries. A session token total has to be accumulated by the script itself: key the state file on `session_id`, and commit a turn only when `prompt_id` changes — the status line re-renders many times per turn, so a naive `+=` multiplies. See `statusline.sh`. |
 | `context_window.context_window_size` | Max context (200000, or 1000000 for extended). |
 | `context_window.used_percentage` / `remaining_percentage` | Pre-computed context %; may be `null` early. |
 | `context_window.current_usage` | `{input_tokens, output_tokens, cache_creation_input_tokens, cache_read_input_tokens}`. `null` before first API call and right after `/compact`. |

--- a/skills/claude-statusline/references/statusline.sh
+++ b/skills/claude-statusline/references/statusline.sh
@@ -5,7 +5,7 @@
 # Line 3: 📊 ctx | 🚦 5h | 7d                                                  (all progress meters)
 input=$(cat)
 
-IFS=$'\t' read -r MODEL DIR COST CTX EFFORT THINKING RL5 RL7 DUR ADDED REMOVED IN_TOK CACHE_W CACHE_R OUT_TOK <<< "$(jq -r '[
+IFS=$'\t' read -r MODEL DIR COST CTX EFFORT THINKING RL5 RL7 DUR ADDED REMOVED IN_TOK CACHE_W CACHE_R OUT_TOK SESSION_ID PROMPT_ID <<< "$(jq -r '[
   (.model.display_name // "Claude"),
   (.workspace.current_dir // .cwd // "."),
   (.cost.total_cost_usd // 0),
@@ -20,7 +20,9 @@ IFS=$'\t' read -r MODEL DIR COST CTX EFFORT THINKING RL5 RL7 DUR ADDED REMOVED I
   (.context_window.current_usage.input_tokens // 0),
   (.context_window.current_usage.cache_creation_input_tokens // 0),
   (.context_window.current_usage.cache_read_input_tokens // 0),
-  (.context_window.current_usage.output_tokens // 0)
+  (.context_window.current_usage.output_tokens // 0),
+  (.session_id // ""),
+  (.prompt_id // "")
 ] | map(tostring) | join("\t")' <<< "$input")"
 
 # ANSI colors
@@ -161,21 +163,73 @@ esac
 if [ "${ADDED:-0}" -gt 0 ] 2>/dev/null || [ "${REMOVED:-0}" -gt 0 ] 2>/dev/null; then
   line2+=("📝 ${C_GREEN}+${ADDED}${C_RESET} ${C_RED}-${REMOVED}${C_RESET}")
 fi
-# tokens — 📥 In (total) · ♻️ cache health % · 📤 Out
-TOTAL_IN=$(( ${IN_TOK:-0} + ${CACHE_W:-0} + ${CACHE_R:-0} ))
+# tokens — ↑ In (session total) · ♻️ cache health % · ↓ Out (session total)
+#
+# context_window.current_usage.* is the CURRENT turn, not a running total, and
+# context_window.total_input_tokens stopped being cumulative in v2.1.132 — so the
+# session total is accumulated here. The state file is keyed by session_id (stable
+# per session) and a turn is committed only when prompt_id changes, because the
+# status line re-renders many times per turn and a naive += would multiply.
+# Costs are committed per turn at that turn's rates, so switching model mid-session
+# does not reprice history.
+usage_state="${HOME}/.claude/statusline-usage/${SESSION_ID:-nosession}"
+CUM_IN=0; CUM_CW=0; CUM_CR=0; CUM_OUT=0; CUM_IN_COST=0; CUM_OUT_COST=0
+LAST_PROMPT=""; LAST_IN=0; LAST_CW=0; LAST_CR=0; LAST_OUT=0; LAST_IN_COST=0; LAST_OUT_COST=0
+if [ -n "${SESSION_ID:-}" ] && [ -r "$usage_state" ]; then
+  IFS=$'\t' read -r LAST_PROMPT CUM_IN CUM_CW CUM_CR CUM_OUT CUM_IN_COST CUM_OUT_COST \
+                    LAST_IN LAST_CW LAST_CR LAST_OUT LAST_IN_COST LAST_OUT_COST < "$usage_state" || true
+fi
+
+# price the CURRENT turn (fresh input full price, cache write 1.25x, cache read 0.1x)
+TURN_IN_COST=0; TURN_OUT_COST=0
+RATES=$(price_rates "$MODEL")
+if [ -n "$RATES" ]; then
+  read -r IN_RATE OUT_RATE <<< "$RATES"
+  TURN_IN_COST=$(awk "BEGIN{printf \"%.6f\", (${IN_TOK:-0}*$IN_RATE + ${CACHE_W:-0}*$IN_RATE*1.25 + ${CACHE_R:-0}*$IN_RATE*0.1)/1000000}")
+  TURN_OUT_COST=$(awk "BEGIN{printf \"%.6f\", ${OUT_TOK:-0}*$OUT_RATE/1000000}")
+fi
+
+# a new prompt_id means the turn we were tracking finished — bank it
+if [ -n "${PROMPT_ID:-}" ] && [ "$PROMPT_ID" != "$LAST_PROMPT" ]; then
+  CUM_IN=$(( ${CUM_IN:-0} + ${LAST_IN:-0} ))
+  CUM_CW=$(( ${CUM_CW:-0} + ${LAST_CW:-0} ))
+  CUM_CR=$(( ${CUM_CR:-0} + ${LAST_CR:-0} ))
+  CUM_OUT=$(( ${CUM_OUT:-0} + ${LAST_OUT:-0} ))
+  CUM_IN_COST=$(awk "BEGIN{printf \"%.6f\", ${CUM_IN_COST:-0} + ${LAST_IN_COST:-0}}")
+  CUM_OUT_COST=$(awk "BEGIN{printf \"%.6f\", ${CUM_OUT_COST:-0} + ${LAST_OUT_COST:-0}}")
+  LAST_PROMPT="$PROMPT_ID"
+fi
+
+if [ -n "${SESSION_ID:-}" ]; then
+  if [ ! -e "$usage_state" ]; then
+    # first render of a new session: cheap moment to drop stale sessions, so the
+    # state directory does not grow for the life of the machine
+    mkdir -p "${usage_state%/*}" 2>/dev/null
+    find "${usage_state%/*}" -maxdepth 1 -type f -mtime +30 -delete 2>/dev/null || true
+  fi
+  mkdir -p "${usage_state%/*}" 2>/dev/null
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$LAST_PROMPT" "$CUM_IN" "$CUM_CW" "$CUM_CR" "$CUM_OUT" "$CUM_IN_COST" "$CUM_OUT_COST" \
+    "${IN_TOK:-0}" "${CACHE_W:-0}" "${CACHE_R:-0}" "${OUT_TOK:-0}" "$TURN_IN_COST" "$TURN_OUT_COST" \
+    > "$usage_state" 2>/dev/null || true
+fi
+
+# displayed totals = banked turns + the turn in flight
+SESS_IN=$(( ${CUM_IN:-0} + ${IN_TOK:-0} ))
+SESS_CW=$(( ${CUM_CW:-0} + ${CACHE_W:-0} ))
+SESS_CR=$(( ${CUM_CR:-0} + ${CACHE_R:-0} ))
+SESS_OUT=$(( ${CUM_OUT:-0} + ${OUT_TOK:-0} ))
+TOTAL_IN=$(( SESS_IN + SESS_CW + SESS_CR ))
 if [ "$TOTAL_IN" -gt 0 ]; then
-  CACHE_PCT=$(( CACHE_R * 100 / TOTAL_IN ))
+  CACHE_PCT=$(( SESS_CR * 100 / TOTAL_IN ))
   if   [ "$CACHE_PCT" -ge 80 ]; then CACHE_COL="$C_GREEN"
   elif [ "$CACHE_PCT" -ge 40 ]; then CACHE_COL="$C_YELLOW"
   else CACHE_COL="$C_RED"; fi
-  # per-turn $ of the last response's tokens (fresh input full price, cache write 1.25x, cache read 0.1x)
   seg_in="${C_IN}↑ In${C_RESET} $(human "$TOTAL_IN")"
-  seg_out="${C_OUT}↓ Out${C_RESET} $(human "${OUT_TOK:-0}")"
-  RATES=$(price_rates "$MODEL")
+  seg_out="${C_OUT}↓ Out${C_RESET} $(human "$SESS_OUT")"
   if [ -n "$RATES" ]; then
-    read -r IN_RATE OUT_RATE <<< "$RATES"
-    IN_COST=$(awk "BEGIN{printf \"%.2f\", (${IN_TOK:-0}*$IN_RATE + ${CACHE_W:-0}*$IN_RATE*1.25 + ${CACHE_R:-0}*$IN_RATE*0.1)/1000000}")
-    OUT_COST=$(awk "BEGIN{printf \"%.2f\", ${OUT_TOK:-0}*$OUT_RATE/1000000}")
+    IN_COST=$(awk "BEGIN{printf \"%.2f\", ${CUM_IN_COST:-0} + $TURN_IN_COST}")
+    OUT_COST=$(awk "BEGIN{printf \"%.2f\", ${CUM_OUT_COST:-0} + $TURN_OUT_COST}")
     seg_in="$seg_in ${C_COST}\$${IN_COST}${C_RESET}"
     seg_out="$seg_out ${C_COST}\$${OUT_COST}${C_RESET}"
   fi


### PR DESCRIPTION
The `↑ In … · ♻️ … · ↓ Out …` segment read `context_window.current_usage.*` — the **current turn** — so it reset every prompt instead of accumulating. Five of the line's six figures were already session-scoped; this one was the odd one out, and it made a long session look cheap.

## There was nothing to switch to

`references/fields.md` already records that `total_input_tokens` / `total_output_tokens` **stopped being cumulative in v2.1.132**, and `cost.total_cost_usd` is a single number with no input/output or cache breakdown. There is nothing to read — only something to keep.

## The trap

**The status line re-renders many times per turn.** A naive `+=` multiplies the turn by however many times the UI repainted.

`prompt_id` is the only field that moves exactly once per turn, so a turn is banked only when it changes. The display is **banked + in-flight**, so the number stays live instead of lagging a turn behind. State is keyed on `session_id`, which `fields.md` already recommends for exactly this.

**Costs are banked per turn at that turn's rates.** Re-deriving from cumulative tokens would apply the current model's price to every historical token — switching Opus → Haiku mid-session would silently rewrite what the earlier turns cost.

## Verified

Three identical turns of 121k in / 500 out:

| event | displayed |
|---|---|
| turn 1 | `↑ In 121k $0.18 · ↓ Out 500 $0.01` |
| **same turn, re-rendered twice** | **unchanged** |
| turn 2 (new `prompt_id`) | `↑ In 242k $0.36 · ↓ Out 1k $0.03` |
| turn 3 | `↑ In 363k $0.54 · ↓ Out 2k $0.04` |

Degradation, each checked:

| condition | behaviour |
|---|---|
| no `prompt_id` (older CLI, or before first input) | falls back to the old per-turn display |
| no `session_id` | nothing written |
| model switched mid-session | Opus held at `$0.36`; a Haiku turn added `$0.04` |
| corrupt state file | ignored, self-heals |

`bash -n` clean.

## Bounded state

One file per session under `~/.claude/statusline-usage/`, pruned after 30 days on the **first render of a new session** — rare enough that a `find` costs nothing, and it keeps a filesystem walk out of a path that runs several times a second. Same class of defect `log-event-collector` documents for its seen-set.

## Spec delta

`skills-catalog` → **ADDED** *Shipped scripts state what they persist*: a skill shipping an executable that writes state outside the repo names the path, the key and the retention, and prunes per-session state itself rather than leaving it to grow for the life of the machine.

`claude-statusline` 1.1.1 → 1.2.0. `V.7` intentionally left open.
