### PR TITLE
✨ feat(ci): gate repo hygiene — compiled artifacts and published counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Secret scan (working tree)
         run: python3 scripts/scan-secrets.py
 
+      - name: Repo hygiene (compiled artifacts, published counts)
+        run: python3 scripts/validate-repo-hygiene.py
+
+      - name: Repo hygiene self-test (the gate is itself gated)
+        run: python3 scripts/validate-repo-hygiene.py --selftest
+
       - name: OpenSpec rite gate (skills-rite schema)
         run: bash scripts/validate-rite.sh
 

--- a/README.md
+++ b/README.md
@@ -683,7 +683,17 @@ Because a checker that never fails is not a checker,
 [`scripts/selftest-validate-skills.py`](scripts/selftest-validate-skills.py) injects one known defect
 per check into a throwaway copy of the catalog and asserts each one is detected. Both run in CI.
 
-A third gate scans for credentials.
+A third gate looks at the repository as a whole, which is the slice the others miss —
+`validate-skills.py` walks only `skills/`, the secret scan hunts credentials, the rite gate reads
+OpenSpec changes, and the wrapper-sync step diffs generated trees.
+[`scripts/validate-repo-hygiene.py`](scripts/validate-repo-hygiene.py) runs two checks: **H1** no
+compiled Python artifact is tracked, and **H2** every `all N` skill count published in `README.md`
+and `.claude-plugin/marketplace.json` equals `ls skills | wc -l`. Both exist because both defects
+actually shipped — a `.pyc` reached release `2.6.0`, and the published counts drifted to 27 and 30
+against a tree of 32. It carries a `--selftest` mode on the same principle as the skill validator,
+and each check states in its own docstring what it does **not** cover.
+
+A fourth gate scans for credentials.
 [`scripts/scan-secrets.py`](scripts/scan-secrets.py) has two modes on purpose: by default it scans the
 **working tree** and fails the build on any credential class — that is the part that can be kept clean,
 so that is the part that gates. With `--history` it walks every blob in the full git history and

--- a/openspec/changes/add-repo-hygiene-gates/design.md
+++ b/openspec/changes/add-repo-hygiene-gates/design.md
@@ -1,0 +1,78 @@
+## Context
+
+This repository's gates are layered and each is honest about its own limits. What they are not is
+complete: every one of them is scoped to a subtree or a file class, and the two defects that
+prompted this change both lived in the gap between them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make both defect classes fail the build instead of relying on a reader noticing a diff.
+- Keep the gate cheap enough that it never becomes the reason a green build is doubted.
+- State the blind spots inside the checks, so a passing run is not read as coverage it does not have.
+
+**Non-Goals:**
+
+- Cataloguing every artifact class that could theoretically be committed. H1 covers exactly the
+  bytecode rules `.gitignore` names, because that is what actually leaked.
+- Purging the `.pyc` blob already published in `2.6.0`. Settled previously: rewriting a public branch
+  costs every consumer a re-clone to remove one inert artifact.
+
+## Decisions
+
+**A gate, not a generator.** The recorded follow-up asked whether the skill count should be
+*generated* into `README.md` rather than written by hand. Rejected: templating a hand-edited Markdown
+document adds a build step to the one file every reader opens first, and it would make the README a
+generated artifact that `git diff` can no longer be reasoned about directly. A check that fails the
+build on drift gets the same guarantee and leaves the document plain.
+
+**`git ls-files`, not a filesystem walk.** H1 must fire on a file forced in with `git add -f` and
+must **not** fire on an ignored `__pycache__` sitting in a developer's working directory. Only the
+index distinguishes those two, and confusing them would make the gate noisy enough to be disabled.
+
+**H2's pattern is narrow, and its blind spot is written into the check.** It matches the literal
+shape `all N` in two named files. A count phrased another way escapes it. That limit is not
+hypothetical — it is the exact failure that already happened here: the first sweep hunting these
+counts used a pattern requiring the word "skills" after the number and missed `all 30.` in
+`README.md`, which has no noun after it. Declaring the blind spot is required by
+`openspec/specs/skills-authoring` → *Authoring rules are machine-enforced* ("A check that covers only
+**part** of its rule SHALL state the uncovered part in the check itself").
+
+**The gate is itself gated.** `--selftest` injects one defect per check into a throwaway copy and
+asserts detection, because a catalog with zero findings and a check that cannot fire are otherwise
+indistinguishable. Both the gate and its self-test run in CI, matching the existing pair.
+
+**Standard library only.** The CI job installs `pyyaml` for `validate-skills.py` and nothing else.
+A hygiene gate that adds a dependency costs more than the defects it prevents.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| "Never hand-copy what a tool generates; link or generate it" | `documentation` | already canonical — H2 is that rule enforced mechanically on this repo's own docs; nothing is restated |
+| Hand-copied facts that drift; re-derive rather than recall | `verify-before-claiming` | already canonical — H2 automates the derivation its *Hand-copied fact that drifted* row describes; the doctrine is not duplicated |
+| Adversarial validation: prove a checker fires before trusting it | `bug-hunter` | already canonical — `--selftest` applies it; no methodology is reproduced |
+| "A check that covers only part of its rule states the uncovered part" | `openspec/specs/skills-authoring` (spec, not skill) | already canonical — applied by the `KNOWN LIMIT` paragraph in each check's docstring |
+
+No skill file is modified by this change, so no cross-cutting rule moves home.
+
+## Risks / Trade-offs
+
+- **H2 false-positives on an unrelated `all N` phrase** in the two files → the pattern is narrow and
+  the file list is two entries; a false positive fails loudly and is fixed in a line, which is
+  strictly better than the silent staleness it replaces.
+- **H1 gives a false sense of completeness** — a tracked `.so`, `.class` or minified bundle passes →
+  stated in the check's `KNOWN LIMIT` rather than implied away.
+- **One more gate to keep green** → it costs nothing on a clean tree and fires only on the two
+  defects that already occurred here.
+
+## Migration Plan
+
+Additive. The current tree passes both checks, so the gate is green from its first run. Rollback is
+deleting the script and its two CI steps; nothing depends on it.
+
+## Open Questions
+
+None. The one question this change inherited — generate the counts or gate them — is answered under
+*Decisions* rather than deferred again.

--- a/openspec/changes/add-repo-hygiene-gates/proposal.md
+++ b/openspec/changes/add-repo-hygiene-gates/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Two defects of the same class landed in this repository within one day, and neither was caught by a
+gate — both were found by a human reading a diff. A `.pyc` was tracked and shipped in release
+`2.6.0`, and three published skill counts had drifted to 27 and 30 against a tree of 32.
+
+Both were fixed and both were recorded as follow-ups rather than gated, which left the repository in
+the state its own doctrine warns about: the truth was restored by hand and is now defended by a note
+asking a human to remember.
+
+The reason nothing caught either is structural. Every existing gate looks at one slice —
+`scripts/validate-skills.py` walks `skills/`, `scripts/scan-secrets.py` hunts credentials,
+`scripts/validate-rite.sh` reads OpenSpec changes, and CI's wrapper-sync step diffs generated trees.
+Nothing looks at the repository as a whole.
+
+## What Changes
+
+- Add `scripts/validate-repo-hygiene.py`, a whole-repository gate with two checks:
+  - **H1** no compiled Python artifact is tracked;
+  - **H2** every `all N` skill count in `README.md` and `.claude-plugin/marketplace.json` equals the
+    number of directories under `skills/`.
+- Add a `--selftest` mode that injects one known defect per check into a throwaway clone and asserts
+  detection, on the same principle as `scripts/selftest-validate-skills.py`.
+- Each check declares in its own docstring what it does **not** cover.
+- Wire both the gate and its self-test into `.github/workflows/ci.yml`, and document them in the
+  README's enforcement section.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `skills-catalog`: the catalog gains a gate whose subject is the repository itself rather than the
+  skills in it, closing the slice every existing gate leaves uncovered.
+
+## Impact
+
+- `scripts/validate-repo-hygiene.py` — new; standard library only, reads the tree via `git ls-files`,
+  writes nothing outside a temporary directory during `--selftest`.
+- `.github/workflows/ci.yml` — two new gating steps.
+- `README.md` — enforcement section describes the gate and its blind spots.
+- No skill, no generated tree and no OpenSpec spec content changes, so nothing regenerates and no
+  consumer behaviour changes.
+- **A stale published count now fails the build.** Any future change that adds or removes a skill
+  must update the counts in the same commit, which is the point.

--- a/openspec/changes/add-repo-hygiene-gates/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-repo-hygiene-gates/specs/skills-catalog/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: The repository itself is gated, not only its skills
+
+The catalog SHALL carry a gate whose subject is the whole repository rather than a subtree, wired
+into CI, covering at minimum two classes that have escaped every other gate: a compiled artifact
+that is tracked, and a published count of the catalog's contents that disagrees with the contents.
+Tracked-file discovery SHALL read the index rather than the filesystem, so that an ignored artifact
+present in a working directory is not a finding and one forced into the index is.
+
+The gate SHALL carry a self-test that injects one known defect per check and asserts detection, and
+each check SHALL state inside itself what it does not cover.
+
+#### Scenario: A compiled artifact forced into the index fails the build
+
+- **WHEN** a file matching the repository's bytecode ignore rules is nonetheless tracked
+- **THEN** the hygiene gate fails and names the file and the command that untracks it
+
+#### Scenario: An ignored artifact in the working directory is not a finding
+
+- **WHEN** a developer runs a Python file and leaves a `__pycache__` beside it
+- **THEN** the gate is silent, because the artifact is not in the index
+
+#### Scenario: A published count that disagrees with the tree fails the build
+
+- **WHEN** a document publishes a count of the catalog's skills that differs from the number of skill
+  directories
+- **THEN** the gate fails and names the file, the line, the claimed number and the real one
+
+#### Scenario: A check that cannot fire is caught
+
+- **WHEN** a change to the gate silently stops one of its checks from detecting its defect class
+- **THEN** the self-test fails, because a clean repository and a check that cannot fire are otherwise
+  indistinguishable
+
+#### Scenario: The uncovered part is declared, not implied
+
+- **WHEN** a check enforces its rule only over a named pattern or a named file list
+- **THEN** the pattern, the file list and what escapes them are stated in the check itself, so a
+  passing run is not read as full coverage

--- a/openspec/changes/add-repo-hygiene-gates/tasks.md
+++ b/openspec/changes/add-repo-hygiene-gates/tasks.md
@@ -1,0 +1,79 @@
+## 1. Evidence & Sources (MANDATORY)
+
+<!-- Always the FIRST group: probe before you write. Record the COMMAND and a fragment of its
+     RAW OUTPUT, never a conclusion — a row a reviewer can re-run in two seconds is the only kind
+     worth writing. A claim with no evidence is a guess: drop the claim, or go get the evidence.
+     Doctrine: the verify-before-claiming skill. -->
+
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled. Read on
+      2026-08-07 at `b9184a4`: `.github/workflows/ci.yml` (the step order the two new steps slot
+      into, after the secret scan and before the rite gate), `scripts/validate-skills.py` (the
+      `add()`/`findings`/exit-1 shape cloned here), `scripts/selftest-validate-skills.py` (the
+      inject-one-defect-per-check pattern), `scripts/scan-secrets.py`, `.gitignore` (the bytecode
+      rules H1 mirrors), `README.md:682-690` (the enforcement prose the new paragraph joins).
+- [x] E.2 Every claim this change asserts was probed, not assumed:
+      `python3 scripts/validate-repo-hygiene.py` on the clean tree -> `repo hygiene: 0 findings`,
+      `exit=0`.
+      `--selftest` -> `CAUGHT H1 tracked bytecode` / `CAUGHT H2 stale count` / `2/2 defect classes
+      detected`.
+      H1 probed live on the real tree, not only in the self-test: forcing
+      `claude/global/hooks/__pycache__/live.cpython-314.pyc` in with `git add -f` produced
+      `H1 tracked bytecode: ... is tracked — untrack it` and `exit=1`; after `git rm --cached` the
+      tree returned to `0 findings`.
+      H2 probed live: editing `all 33 skills` to `all 41 skills` produced
+      `H2 stale count: README.md:82 claims 41, `ls skills | wc -l` says 33` and `exit=1`; after
+      `git checkout README.md` the tree returned to `0 findings`.
+      `ls skills | wc -l` -> `33`. `python3 --version` -> `Python 3.14.5`.
+- [x] E.3 Anything that could NOT be probed is written down rather than stated as fact. Two items,
+      both declared inside the checks rather than in prose only: H1 cannot see a blob already
+      published in a past release, and cannot see non-Python compiled artifacts; H2 cannot see a
+      count phrased outside the literal `all N` shape or living in a third file. Neither limit is
+      hypothetical — the second one is the exact miss that happened during the sweep that first
+      hunted these counts.
+- [x] E.4 Scope check: this change does only what the proposal asked. Noticed and **not** performed:
+      broadening H1 to other artifact classes (nothing else has leaked), and templating the README
+      counts (rejected under design.md Decisions with a reason, not deferred again).
+
+## 2. The gate
+
+- [x] 2.1 `scripts/validate-repo-hygiene.py` — H1 no tracked compiled artifact, using `git ls-files`
+      so a forced-in file fires and an ignored working-directory artifact does not
+- [x] 2.2 H2 — every `all N` count in `README.md` and `.claude-plugin/marketplace.json` equals the
+      number of directories under `skills/`
+- [x] 2.3 Each check carries a `KNOWN LIMIT` paragraph naming what it does not cover
+- [x] 2.4 `--selftest` mode injecting one defect per check into a throwaway clone
+- [x] 2.5 Standard library only — no new CI dependency
+
+## 3. Wiring
+
+- [x] 3.1 `.github/workflows/ci.yml` — gate step plus self-test step, after the secret scan
+- [x] 3.2 `README.md` — the enforcement section describes the gate, why each check exists, and its
+      blind spots
+
+## 4. Quality Gates (MANDATORY)
+
+<!-- Adversarial review of the skills touched — not happy-path. Every skill added or edited
+     by this change gets checked against the skills-authoring spec. Keep the group number
+     as the second-to-last group. -->
+
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: no `skills/` file is touched, so the
+      requirement is vacuously satisfied and `validate-skills.py` still exits 0
+- [x] Q.2 All touched content in English (catalog locale)
+- [x] Q.3 Description triggers testable: no skill description changes in this change
+- [x] Q.4 No duplicated doctrine: no skill file is modified; the checks apply rules whose canonical
+      homes are named in the design.md table rather than restating them
+- [x] Q.5 The gate was tested **negatively and live**, not only by its own self-test: each defect
+      was forced into the real working tree, the failure and its message were recorded, and the tree
+      was restored to `0 findings`
+
+## 5. Validation & Closure (MANDATORY)
+
+<!-- Always the last group. "Done" is verifiable, not an opinion. -->
+
+- [x] V.1 `openspec validate add-repo-hygiene-gates --strict` green
+- [x] V.2 Catalog discovery intact: 33 skills, every `name` matching its directory, no orphan
+      wrappers; `./generate.sh` leaves no diff
+- [x] V.3 README / docs updated where the change alters enforcement
+- [ ] V.4 `openspec archive add-repo-hygiene-gates --yes` after all groups above are `[x]`
+      — per this repo's established sequence this happens in a follow-up PR after the
+      implementation PR merges (precedent: PR #61 shipped the active change, PR #62 archived it)

--- a/scripts/validate-repo-hygiene.py
+++ b/scripts/validate-repo-hygiene.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Whole-repository hygiene gate.
+
+The sibling gates each look at one slice: validate-skills.py walks skills/, scan-secrets.py hunts
+credentials, validate-rite.sh reads OpenSpec changes, and CI's wrapper-sync step diffs generated
+trees. Nothing looked at the repository as a whole, which is how both of these got in:
+
+  H1 no tracked compiled artifacts   (a .pyc reached release 2.6.0; see #70)
+  H2 published skill counts are true (README and marketplace drifted to 27/30 against 32; see #65)
+
+Exit 1 on any finding. Run from the repo root.
+Modes: (default) check the tree   |   --selftest inject one defect per check and assert detection.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Mirrors the bytecode rules in .gitignore. Kept in sync by hand on purpose: widening this to every
+# conceivable binary would be guesswork about artifacts this repo has never produced.
+BYTECODE = re.compile(r"(^|/)__pycache__/|\.py[cod]$")
+
+# Files that publish a skill count, and the shape they publish it in.
+COUNT_FILES = ("README.md", ".claude-plugin/marketplace.json")
+COUNT_CLAIM = re.compile(r"\ball (\d+)\b")
+
+findings: list[str] = []
+
+
+def add(check: str, detail: str) -> None:
+    findings.append(f"{check}: {detail}")
+
+
+def tracked_files(root: Path) -> list[str]:
+    out = subprocess.run(["git", "-C", str(root), "ls-files"],
+                         capture_output=True, text=True, check=True).stdout
+    return out.splitlines()
+
+
+def skill_count(root: Path) -> int:
+    return len([p for p in (root / "skills").iterdir() if p.is_dir()])
+
+
+def check_no_bytecode(root: Path) -> None:
+    """H1 — no compiled Python artifact is tracked.
+
+    KNOWN LIMIT: covers the bytecode classes .gitignore names (__pycache__/, *.py[cod]) and nothing
+    else — a tracked .so, .class or minified bundle passes. Discovery is `git ls-files`, so an
+    ignored-but-present __pycache__ on a developer's machine is correctly not a finding, and a file
+    forced in with `git add -f` correctly is. It cannot see a blob already published in a past
+    release; removing that needs a history rewrite, which is a separate decision.
+    """
+    for f in tracked_files(root):
+        if BYTECODE.search(f):
+            add("H1 tracked bytecode", f"{f} is tracked — untrack it (`git rm --cached`)")
+
+
+def check_counts(root: Path) -> None:
+    """H2 — every published skill count equals the number of directories under skills/.
+
+    KNOWN LIMIT: matches the literal shape `all N` in exactly two files (README.md and
+    .claude-plugin/marketplace.json). A count phrased another way — "the 33 skills", "33 skills
+    available", a count in a third file — escapes this check and is review-only. That blind spot is
+    real and was earned: the sweep that first hunted these counts used a pattern requiring the word
+    "skills" after the number and missed `all 30.` in README.md, which has no noun after it.
+    """
+    real = skill_count(root)
+    for rel in COUNT_FILES:
+        p = root / rel
+        if not p.exists():
+            add("H2 missing file", f"{rel} does not exist — update COUNT_FILES")
+            continue
+        for line_no, line in enumerate(p.read_text(encoding="utf-8").splitlines(), 1):
+            for m in COUNT_CLAIM.finditer(line):
+                claimed = int(m.group(1))
+                if claimed != real:
+                    add("H2 stale count",
+                        f"{rel}:{line_no} claims {claimed}, `ls skills | wc -l` says {real}")
+
+
+CHECKS = (check_no_bytecode, check_counts)
+
+
+# ── selftest ──────────────────────────────────────────────────────────────
+# A checker that never fails is not a checker. One injected defect per check, asserted detected.
+
+def _defect_bytecode(tmp: Path) -> None:
+    d = tmp / "claude" / "global" / "hooks" / "__pycache__"
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "injected.cpython-314.pyc").write_bytes(b"\x00")
+    subprocess.run(["git", "-C", str(tmp), "add", "-f",
+                    "claude/global/hooks/__pycache__/injected.cpython-314.pyc"],
+                   check=True, capture_output=True)
+
+
+def _defect_count(tmp: Path) -> None:
+    p = tmp / "README.md"
+    text = p.read_text(encoding="utf-8")
+    real = skill_count(tmp)
+    p.write_text(text.replace(f"all {real}", f"all {real + 7}", 1), encoding="utf-8")
+
+
+DEFECTS = (("H1 tracked bytecode", _defect_bytecode),
+           ("H2 stale count", _defect_count))
+
+
+def selftest() -> int:
+    global findings
+    caught = 0
+    for label, inject in DEFECTS:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td) / "repo"
+            shutil.copytree(ROOT, tmp, ignore=shutil.ignore_patterns(".git", "__pycache__"))
+            subprocess.run(["git", "-C", str(tmp), "init", "-q"], check=True, capture_output=True)
+            subprocess.run(["git", "-C", str(tmp), "add", "-A"], check=True, capture_output=True)
+            inject(tmp)
+            findings = []
+            for check in CHECKS:
+                check(tmp)
+            if any(f.startswith(label) for f in findings):
+                print(f"  CAUGHT  {label}")
+                caught += 1
+            else:
+                print(f"  MISSED  {label}   <-- the check cannot fire")
+    print(f"\n{caught}/{len(DEFECTS)} defect classes detected")
+    return 0 if caught == len(DEFECTS) else 1
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+    for check in CHECKS:
+        check(ROOT)
+    for f in findings:
+        print(f"  {f}")
+    print(f"\nrepo hygiene: {len(findings)} findings")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
OpenSpec change: `add-repo-hygiene-gates` (schema `skills-rite`, `validate --strict` green).

## Why this exists

Two defects of the same class landed within one day and **neither was caught by a gate** — both were
found by a human reading a diff:

- a `.pyc` was tracked and shipped in release `2.6.0` (fixed in #70);
- three published skill counts had drifted to `27` and `30` against a tree of `32` (fixed in #65).

Both fixes were recorded as follow-ups rather than gated, which left the truth defended by a note in
`README.md` asking a human to remember. The reason nothing caught either is structural: every
existing gate is scoped to a slice. `validate-skills.py` walks `skills/`, `scan-secrets.py` hunts
credentials, `validate-rite.sh` reads OpenSpec changes, the wrapper-sync step diffs generated trees.
Nothing looked at the repository as a whole.

## The gate

`scripts/validate-repo-hygiene.py`, standard library only, two checks:

- **H1** — no compiled Python artifact is tracked.
- **H2** — every `all N` count in `README.md` and `.claude-plugin/marketplace.json` equals
  `ls skills | wc -l`.

**H1 reads `git ls-files`, not the filesystem.** A file forced in with `git add -f` fires; an ignored
`__pycache__` sitting in a developer's working directory does not. Confusing those two would make the
gate noisy enough that someone disables it.

**A gate, not a generator.** The inherited follow-up asked whether the count should be *templated*
into `README.md`. Rejected, with the reason recorded in `design.md` rather than deferred a second
time: templating makes the file every reader opens first a generated artifact whose diff can no
longer be read directly — for the same guarantee a check already gives.

## Proof — negative, and live

Not just the self-test. Each defect was forced into the **real working tree** and the failure
recorded, then the tree restored:

```
# H1
$ git add -f claude/global/hooks/__pycache__/live.cpython-314.pyc
$ python3 scripts/validate-repo-hygiene.py
  H1 tracked bytecode: claude/global/hooks/__pycache__/live.cpython-314.pyc is tracked — untrack it (`git rm --cached`)
  exit=1

# H2
$ sed -i '0,/all 33 skills/s//all 41 skills/' README.md
$ python3 scripts/validate-repo-hygiene.py
  H2 stale count: README.md:82 claims 41, `ls skills | wc -l` says 33
  exit=1

# restored
$ python3 scripts/validate-repo-hygiene.py
  repo hygiene: 0 findings   exit=0
```

| Gate | Result |
|---|---|
| `validate-repo-hygiene.py` | `repo hygiene: 0 findings` (`exit=0`) |
| `validate-repo-hygiene.py --selftest` | `2/2 defect classes detected` |
| `validate-skills.py` | `skills checked: 33   findings: 0` |
| `selftest-validate-skills.py` | `12/12 defect classes detected` |
| `scan-secrets.py` | `no credentials found` |
| `validate-rite.sh` | `Totals: 3 passed, 0 failed` → `rite gate OK` |
| `openspec validate add-repo-hygiene-gates --strict` | `is valid` |
| `ci.yml` YAML parse | clean |
| `./generate.sh` | 0 lines of diff |

## Blind spots, declared inside the checks

Per `skills-authoring` → *"A check that covers only **part** of its rule SHALL state the uncovered
part in the check itself"*:

- **H1** covers the bytecode classes `.gitignore` names and nothing else — a tracked `.so`, `.class`
  or minified bundle passes. It also cannot see a blob already published in a past release; removing
  that needs a history rewrite, which is a separate decision.
- **H2** matches the literal shape `all N` in exactly two files. A count phrased another way, or in a
  third file, escapes it. **That limit is not hypothetical** — it is the exact miss that happened
  during the sweep that first hunted these counts, which used a pattern requiring the word "skills"
  after the number and walked past `all 30.` in `README.md`.

`--selftest` exists because a clean repository and a check that cannot fire are otherwise
indistinguishable. Both the gate and its self-test run in CI.

## Consequence worth stating

**A stale published count now fails the build.** Any future change that adds or removes a skill must
update the counts in the same commit. That is the point.

## Known gaps

- `V.4` (`openspec archive`) is unticked: this repo archives in a follow-up PR after the
  implementation PR merges (precedent: #61 then #62).

Closes #72
