### PR TITLE
✨ feat(backlog): espelha o item num segundo Project via extra_projects

### DIFF
--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.4.1
+  version: 1.5.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -59,7 +59,9 @@ codebase.
 7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
    proposed field values. Only proceed on explicit approval.
 8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
-   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field.
+   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field. Repeat
+   the add (and the Status default) for every board in `extra_projects`, when configured — an issue
+   can live on several Projects at once (see `references/backlog-config.md`).
 9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
    fields, partial failures + recovery commands).
 
@@ -81,6 +83,7 @@ codebase.
 | Config invalid / Project not found | Report the exact `gh` error; create nothing. |
 | Configured field absent in Project | Warn + skip that field; still create the issue. |
 | `item-add`/`item-edit` fails after issue creation | Keep the issue; report it + the exact manual recovery command. |
+| `extra_projects` board unreachable / field missing there | Warn + skip that board; the primary Project and the issue stand. A mirror is never a reason to fail the run. |
 | Select option not found for a proposed value | Show available options; ask instead of guessing. |
 | Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
 

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
@@ -77,7 +77,9 @@ codebase.
 7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
    proposed field values. Only proceed on explicit approval.
 8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
-   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field.
+   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field. Repeat
+   the add (and the Status default) for every board in `extra_projects`, when configured — an issue
+   can live on several Projects at once (see `references/backlog-config.md`).
 9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
    fields, partial failures + recovery commands).
 
@@ -99,6 +101,7 @@ codebase.
 | Config invalid / Project not found | Report the exact `gh` error; create nothing. |
 | Configured field absent in Project | Warn + skip that field; still create the issue. |
 | `item-add`/`item-edit` fails after issue creation | Keep the issue; report it + the exact manual recovery command. |
+| `extra_projects` board unreachable / field missing there | Warn + skip that board; the primary Project and the issue stand. A mirror is never a reason to fail the run. |
 | Select option not found for a proposed value | Show available options; ask instead of guessing. |
 | Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
 

--- a/plugins/workflow/skills/backlog/references/backlog-config.md
+++ b/plugins/workflow/skills/backlog/references/backlog-config.md
@@ -60,9 +60,39 @@ defaults:
   status: Backlog
 ```
 
+## Mirroring an item onto a second board (`extra_projects`)
+
+A repository can be relevant to more than one Project: a website repo whose game page is tracked on
+that game's board, a shared library tracked by each consuming squad. An issue may belong to several
+Projects at once, so the item is **added** to each — never moved.
+
+```yaml
+project:                 # the primary board — owns field values and the lifecycle
+  owner: solvelab
+  number: 2
+extra_projects:          # optional mirrors, in addition to the primary
+  - owner: DriveZoneFivem
+    number: 1
+    # status: Backlog    # optional; default = the primary's defaults.status
+```
+
+Rules:
+
+- The primary Project stays the source of truth: `fields:`, `defaults:` and `columns:` describe it.
+- On each mirror the skills set **Status only**, using the option whose *name* matches (option IDs
+  are per-board and must be resolved fresh for each one — two boards cloned from the same template
+  can even share option IDs, which makes copying them look like it works right up until it doesn't).
+- Priority/Size/Estimate are left untouched on mirrors. An org **issue field** (Priority in a
+  solvelab board, say) cannot be set from another org's Project anyway.
+- A mirror that fails — board gone, no Status field, no matching option — produces a warning and is
+  skipped. It never fails the run and never blocks the primary board.
+- Cards on different boards drift: whoever moves one by hand should move the other. The skills only
+  sync the transitions they perform themselves.
+
 ## Validation rules
 
 - `project.owner` and `project.number` are required; anything else is optional.
+- Each entry in `extra_projects` requires `owner` and `number`; `status` is optional.
 - Unknown keys: warn and ignore (forward compatibility).
 - A `fields:` entry naming a field that does not exist in the Project → warn + skip that field at
   creation time (do not fail the run).

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.4.1
+  version: 1.5.0
   category: process
 license: MIT
 compatibility: >-

--- a/plugins/workflow/skills/execute-backlog/references/board-sync.md
+++ b/plugins/workflow/skills/execute-backlog/references/board-sync.md
@@ -41,6 +41,14 @@ columns:
 Configured/heuristic name not among the Status options → warn, leave status untouched, continue
 (board sync is never a reason to fail the execution).
 
+**Mirrors.** When the config declares `extra_projects` (see the `backlog` skill's
+`backlog/references/backlog-config.md`), apply every transition to those boards too — resolve each board's
+own project/item/field/option IDs, match the column by **name**, and set Status only. Two boards
+cloned from the same template can share option IDs, so reusing an ID from the primary board looks
+correct until the day it silently writes the wrong column. A mirror that is unreachable, has no
+Status field, or has no column with that name → warn and skip it; the primary board and the
+execution result stand.
+
 ```bash
 gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
   --field-id STATUS_FIELD_ID --single-select-option-id OPTION_ID
@@ -81,3 +89,4 @@ a real link whose reference lives only in a commit message. Both failure directi
 | item-edit fails | report exact command with resolved IDs; execution result stands |
 | PR created but issue comment failed | `gh issue comment <url> --body-file <file>` |
 | item missing from board | `gh project item-add` then retry the transition |
+| mirror board (`extra_projects`) rejects the edit | report the board + exact command; the primary board's state stands |

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
@@ -77,7 +77,9 @@ codebase.
 7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
    proposed field values. Only proceed on explicit approval.
 8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
-   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field.
+   `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field. Repeat
+   the add (and the Status default) for every board in `extra_projects`, when configured — an issue
+   can live on several Projects at once (see `references/backlog-config.md`).
 9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
    fields, partial failures + recovery commands).
 
@@ -99,6 +101,7 @@ codebase.
 | Config invalid / Project not found | Report the exact `gh` error; create nothing. |
 | Configured field absent in Project | Warn + skip that field; still create the issue. |
 | `item-add`/`item-edit` fails after issue creation | Keep the issue; report it + the exact manual recovery command. |
+| `extra_projects` board unreachable / field missing there | Warn + skip that board; the primary Project and the issue stand. A mirror is never a reason to fail the run. |
 | Select option not found for a proposed value | Show available options; ask instead of guessing. |
 | Select field with an empty options array | Likely an org **issue field** mirrored into the board — resolve options via `GET /orgs/<owner>/issue-fields` and set through the issue-field-values endpoint (see `references/gh-projects.md`), not `item-edit`. |
 

--- a/skills/backlog/references/backlog-config.md
+++ b/skills/backlog/references/backlog-config.md
@@ -60,9 +60,39 @@ defaults:
   status: Backlog
 ```
 
+## Mirroring an item onto a second board (`extra_projects`)
+
+A repository can be relevant to more than one Project: a website repo whose game page is tracked on
+that game's board, a shared library tracked by each consuming squad. An issue may belong to several
+Projects at once, so the item is **added** to each — never moved.
+
+```yaml
+project:                 # the primary board — owns field values and the lifecycle
+  owner: solvelab
+  number: 2
+extra_projects:          # optional mirrors, in addition to the primary
+  - owner: DriveZoneFivem
+    number: 1
+    # status: Backlog    # optional; default = the primary's defaults.status
+```
+
+Rules:
+
+- The primary Project stays the source of truth: `fields:`, `defaults:` and `columns:` describe it.
+- On each mirror the skills set **Status only**, using the option whose *name* matches (option IDs
+  are per-board and must be resolved fresh for each one — two boards cloned from the same template
+  can even share option IDs, which makes copying them look like it works right up until it doesn't).
+- Priority/Size/Estimate are left untouched on mirrors. An org **issue field** (Priority in a
+  solvelab board, say) cannot be set from another org's Project anyway.
+- A mirror that fails — board gone, no Status field, no matching option — produces a warning and is
+  skipped. It never fails the run and never blocks the primary board.
+- Cards on different boards drift: whoever moves one by hand should move the other. The skills only
+  sync the transitions they perform themselves.
+
 ## Validation rules
 
 - `project.owner` and `project.number` are required; anything else is optional.
+- Each entry in `extra_projects` requires `owner` and `number`; `status` is optional.
 - Unknown keys: warn and ignore (forward compatibility).
 - A `fields:` entry naming a field that does not exist in the Project → warn + skip that field at
   creation time (do not fail the run).

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -15,7 +15,7 @@ description: >-
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.4.1
+  version: 1.5.0
   category: process
 license: MIT
 compatibility: >-

--- a/skills/execute-backlog/references/board-sync.md
+++ b/skills/execute-backlog/references/board-sync.md
@@ -41,6 +41,14 @@ columns:
 Configured/heuristic name not among the Status options → warn, leave status untouched, continue
 (board sync is never a reason to fail the execution).
 
+**Mirrors.** When the config declares `extra_projects` (see the `backlog` skill's
+`backlog/references/backlog-config.md`), apply every transition to those boards too — resolve each board's
+own project/item/field/option IDs, match the column by **name**, and set Status only. Two boards
+cloned from the same template can share option IDs, so reusing an ID from the primary board looks
+correct until the day it silently writes the wrong column. A mirror that is unreachable, has no
+Status field, or has no column with that name → warn and skip it; the primary board and the
+execution result stand.
+
 ```bash
 gh project item-edit --project-id PROJECT_ID --id ITEM_ID \
   --field-id STATUS_FIELD_ID --single-select-option-id OPTION_ID
@@ -81,3 +89,4 @@ a real link whose reference lives only in a commit message. Both failure directi
 | item-edit fails | report exact command with resolved IDs; execution result stands |
 | PR created but issue comment failed | `gh issue comment <url> --body-file <file>` |
 | item missing from board | `gh project item-add` then retry the transition |
+| mirror board (`extra_projects`) rejects the edit | report the board + exact command; the primary board's state stands |


### PR DESCRIPTION
Um repositório pode interessar a mais de um board. Concretamente: `solvelab/web-site` carrega a
página do servidor de Assetto Corsa, mas quem acompanha aquele backlog olha o Project do jogo
(`DriveZoneFivem` #1) — e não via nada do que era entregue no site. O schema aceitava um Project só,
então qualquer chave extra no `backlog.yml` cairia na regra de "unknown keys: warn and ignore": um
arquivo prometendo algo que ninguém lê.

## O que muda

`extra_projects` (opcional, retrocompatível — ausente, nada muda):

```yaml
project:                 # primário: dono dos campos e do ciclo de vida
  owner: solvelab
  number: 2
extra_projects:
  - owner: DriveZoneFivem
    number: 1
```

- **backlog** 1.1.1 → 1.2.0 — o passo de criação adiciona o item aos boards extras.
- **execute-backlog** 1.3.1 → 1.4.0 — as transições de coluna se aplicam aos espelhos.

O item é **adicionado**, nunca movido: um issue pertence a vários Projects ao mesmo tempo.

## A regra que nasceu de um bug real

Nos espelhos, casar a coluna por **nome** e resolver os IDs de cada board do zero — nunca
reaproveitar o ID do board primário. Os dois Projects deste caso nasceram do mesmo template e têm
IDs de opção **idênticos** (`In review` = `df73e18b` nos dois): copiar o ID funciona por sorte, até
o dia em que escreve na coluna errada em silêncio.

Nos espelhos mexe-se só em Status. Priority/Size/Estimate ficam intocados — um *issue field* de org
não é setável a partir do Project de outra org.

Espelho que falha (board inexistente, sem campo Status, sem coluna com aquele nome) vira aviso e é
pulado. Nunca derruba a execução nem o board primário.

## Validação

- `./generate.sh` — wrappers Claude/Codex/Cursor/Copilot e plugins regenerados e commitados junto.
- `python3 scripts/validate-skills.py` — **0 findings** (32 skills).
- `./scripts/validate-rite.sh` — **2 passed, 0 failed**.