### PR TITLE
✨ feat(ci): gate rite evidence shape and report per-group density

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
       - name: OpenSpec rite gate (skills-rite schema)
         run: bash scripts/validate-rite.sh
 
+      - name: Rite evidence self-test (the gate is itself gated)
+        run: python3 scripts/validate-rite-evidence.py --selftest
+
       - name: Claude plugin validation (best-effort)
         continue-on-error: true
         run: npx -y @anthropic-ai/claude-code@latest plugin validate . --strict || true

--- a/openspec/schemas/skills-rite/templates/tasks.md
+++ b/openspec/schemas/skills-rite/templates/tasks.md
@@ -3,7 +3,14 @@
 <!-- Always the FIRST group: probe before you write. Record the COMMAND and a fragment of its
      RAW OUTPUT, never a conclusion — a row a reviewer can re-run in two seconds is the only kind
      worth writing. A claim with no evidence is a guess: drop the claim, or go get the evidence.
-     Doctrine: the verify-before-claiming skill. -->
+     Doctrine: the verify-before-claiming skill.
+
+     Shape each box owes, gated by scripts/validate-rite-evidence.py once ticked:
+       E.1  a repo-relative path AND the commit sha or date it was read at
+       E.2  at least one `command` -> a fragment of its output
+       E.3  names the gap, or states explicitly that there is none
+       E.4  lists a follow-up, or states explicitly that there is none
+     The gate cannot tell a real output from an invented one — that is still the reviewer's job. -->
 
 - [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
       the commit or timestamp it was read at

--- a/scripts/validate-rite-evidence.py
+++ b/scripts/validate-rite-evidence.py
@@ -63,6 +63,11 @@ NEGATIVE = re.compile(r"\bnone\b|\bnothing\b|\bno gaps?\b|\bnenhum", re.I)
 
 findings: list[str] = []
 
+# GitHub turns `::error file=...` into a red annotation on the pull request. During --selftest the
+# findings are injected on purpose and their paths do not exist, so annotating them would put four
+# bogus failures on a PR whose job passed. Measured on run 31790712710 before this guard existed.
+annotate = True
+
 
 def add(check: str, path: Path, detail: str) -> None:
     # The selftest runs the checks against a temp copy, so the path is not always under ROOT.
@@ -72,7 +77,10 @@ def add(check: str, path: Path, detail: str) -> None:
         idx = path.parts.index(CHANGES.split("/")[0]) if CHANGES.split("/")[0] in path.parts else 0
         rel = str(Path(*path.parts[idx:]))
     findings.append(f"{check}: {rel}: {detail}")
-    print(f"::error file={rel}::{check} — {detail}")
+    if annotate:
+        print(f"::error file={rel}::{check} — {detail}")
+    else:
+        print(f"    injected: {check} — {detail}")
 
 
 # ── parsing ───────────────────────────────────────────────────────────────
@@ -231,7 +239,8 @@ DEFECTS = (("R1 evidence shape: E.1", _break_e1),
 
 
 def selftest() -> int:
-    global findings
+    global findings, annotate
+    annotate = False        # injected paths do not exist; see the note on `annotate`
     caught = 0
     for label, inject in DEFECTS:
         check, box = label.split(": ")

--- a/scripts/validate-rite-evidence.py
+++ b/scripts/validate-rite-evidence.py
@@ -1,0 +1,265 @@
+#!/usr/bin/env python3
+"""Evidence gate for the skills-rite mandatory groups.
+
+`scripts/validate-rite.sh` makes the mandatory groups structural — present, correctly positioned.
+Its own header states what it cannot do: "a ticked box with no probe behind it looks identical to
+one with. The gate makes the evidence a required, reviewable artifact; the review is what judges
+it." Measured across the archived corpus, that review half did not happen: of 305 ticked boxes in
+mandatory groups, 7 carried a command and its output (2%).
+
+This adds the half a script can honestly do.
+
+  R1 evidence shape   a ticked Evidence & Sources box states what was run, not a conclusion
+
+and prints, without gating, how dense every mandatory group's evidence is, so a `Quality Gates 0/5`
+is visible on the pull request without reading the diff.
+
+Per-kind rules, because the four E boxes do not share a shape — a uniform "command -> output" rule
+was measured first and rejected: it failed 14 of 20 historical boxes, including 3 of the 4 in the
+most recently written change, all correct as written.
+
+  E.1  paths opened          a repo-relative path AND the commit sha or date it was read at
+  E.2  tools probed          at least one `command` -> output pair
+  E.3  what could not be probed   names the gap, or states explicitly that there is none
+  E.4  scope check           lists a follow-up, or states explicitly that there is none
+
+KNOWN LIMIT — what this gate does NOT do. A passing run is not proof the evidence is real.
+  1. It cannot detect fabricated output. A box padded with `-> ok` passes every rule here. This
+     repo already designed and rejected a stronger version for that reason
+     (`openspec/changes/archive/2026-08-07-add-verify-before-claiming/design.md`): CI can only prove
+     a record is well-typed, which converts an obvious defect into a certified one. What is checked
+     here is only that a box STATES what the template already requires it to state.
+  2. `Quality Gates` and `Validation & Closure` are reported, never gated. Several of their items
+     are judgments rather than executions (`Q.3` is "triggers do not collide"), and demanding a
+     command there manufactures padding.
+  3. Only the four E kinds have rules. A fifth `E.5` a change invents is counted in the density
+     report and otherwise unchecked.
+  4. Unticked boxes are ignored. The rule is about what a tick claims, not about progress.
+  5. Only active changes are read; `openspec/changes/archive/` is history and is never re-litigated.
+  6. It fires on nothing in the current corpus — every historical E box passes. That is calibration
+     (no false positives on genuine boxes), not proof it works; `--selftest` is what proves that.
+
+Exit 1 on any finding. Run from the repo root.
+Modes: (default) check active changes   |   --selftest inject one defect per rule and assert detection.
+"""
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path.cwd()
+CHANGES = "openspec/changes"
+
+BOX = re.compile(r"^ *- \[(?P<tick>[ x])\] +(?P<id>[A-Z]\.\d+|\d+\.\d+)?(?P<rest>.*)$")
+GROUP = re.compile(r"^## +(?P<title>.+?)\s*$")
+BACKTICKED = re.compile(r"`([^`]+)`")
+ARROW = re.compile(r"->|→")
+SHA_OR_DATE = re.compile(r"`[0-9a-f]{7,40}`|\b20\d\d-\d\d-\d\d\b")
+PATH_IN_TICKS = re.compile(r"`[^`\s]+\.(?:md|py|sh|ya?ml|json|lua|tsx?|jsx?|cs|sql|toml|ini)[^`]*`")
+NEGATIVE = re.compile(r"\bnone\b|\bnothing\b|\bno gaps?\b|\bnenhum", re.I)
+
+findings: list[str] = []
+
+
+def add(check: str, path: Path, detail: str) -> None:
+    # The selftest runs the checks against a temp copy, so the path is not always under ROOT.
+    try:
+        rel: Path | str = path.relative_to(ROOT)
+    except ValueError:
+        idx = path.parts.index(CHANGES.split("/")[0]) if CHANGES.split("/")[0] in path.parts else 0
+        rel = str(Path(*path.parts[idx:]))
+    findings.append(f"{check}: {rel}: {detail}")
+    print(f"::error file={rel}::{check} — {detail}")
+
+
+# ── parsing ───────────────────────────────────────────────────────────────
+def parse_boxes(text: str) -> list[tuple[str, str, bool, str]]:
+    """Yield (group_title, box_id, ticked, full_text) with continuation lines folded in."""
+    out: list[tuple[str, str, bool, str]] = []
+    group = ""
+    pending: list[str] | None = None
+    meta: tuple[str, str, bool] | None = None
+
+    def flush() -> None:
+        if pending is not None and meta is not None:
+            out.append((meta[0], meta[1], meta[2], " ".join(pending)))
+
+    for line in text.splitlines():
+        g = GROUP.match(line)
+        if g:
+            flush()
+            pending, meta = None, None
+            group = g.group("title")
+            continue
+        b = BOX.match(line)
+        if b:
+            flush()
+            box_id = (b.group("id") or "").strip()
+            meta = (group, box_id, b.group("tick") == "x")
+            pending = [b.group("rest").strip()]
+            continue
+        if pending is not None and line.strip() and not line.lstrip().startswith("<!--"):
+            pending.append(line.strip())
+    flush()
+    return out
+
+
+def active_task_files(root: Path) -> list[Path]:
+    base = root / CHANGES
+    if not base.is_dir():
+        return []
+    return sorted(
+        d / "tasks.md" for d in base.iterdir()
+        if d.is_dir() and d.name != "archive" and (d / "tasks.md").is_file()
+    )
+
+
+# ── R1: evidence shape ────────────────────────────────────────────────────
+def _shape_ok(box_id: str, body: str) -> tuple[bool, str]:
+    if box_id == "E.1":
+        if not PATH_IN_TICKS.search(body):
+            return False, "cites no repo-relative path — name at least one file that was opened"
+        if not SHA_OR_DATE.search(body):
+            return False, "names no commit sha or date — state when the paths were read"
+        return True, ""
+    if box_id == "E.2":
+        if not (BACKTICKED.search(body) and ARROW.search(body)):
+            return False, "states a conclusion, not a probe — record `command` -> a fragment of its output"
+        return True, ""
+    if box_id in ("E.3", "E.4"):
+        subject = "gap" if box_id == "E.3" else "follow-up"
+        if NEGATIVE.search(body) or len(body) > 120:
+            return True, ""
+        return False, f"neither names a {subject} nor states there is none"
+    return True, ""
+
+
+def check_evidence_shape(root: Path) -> None:
+    for tasks in active_task_files(root):
+        for group, box_id, ticked, body in parse_boxes(tasks.read_text(encoding="utf-8")):
+            if not ticked or "Evidence & Sources" not in group:
+                continue
+            if box_id not in ("E.1", "E.2", "E.3", "E.4"):
+                continue
+            ok, why = _shape_ok(box_id, body)
+            if not ok:
+                add("R1 evidence shape", tasks, f"{box_id} {why}")
+
+
+CHECKS = (check_evidence_shape,)
+
+
+# ── density report (never gates) ──────────────────────────────────────────
+def report_density(root: Path) -> None:
+    files = active_task_files(root)
+    if not files:
+        print("  evidence density: no active change to report on")
+        return
+    print("  evidence density (report only — not a pass/fail result):")
+    for tasks in files:
+        change = tasks.parent.name
+        per: dict[str, list[bool]] = {}
+        for group, _box, ticked, body in parse_boxes(tasks.read_text(encoding="utf-8")):
+            if not ticked or "(MANDATORY)" not in group:
+                continue
+            per.setdefault(group.replace(" (MANDATORY)", ""), []).append(bool(ARROW.search(body)))
+        if not per:
+            continue
+        print(f"    {change}")
+        for group, marks in per.items():
+            print(f"      {group:<22} {sum(marks)}/{len(marks)} boxes carry a command -> output")
+
+
+# ── selftest ──────────────────────────────────────────────────────────────
+# A checker that never fails is not a checker. One injected defect per rule, asserted detected.
+_SCAFFOLD = """## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Read `scripts/validate-rite.sh` at `429d127` on 2026-08-14
+- [x] E.2 `python3 --version` -> `Python 3.14.5`
+- [x] E.3 Nothing could not be probed: none outstanding
+- [x] E.4 Scope check: none noticed, no follow-ups
+
+## 2. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate x --strict` -> valid
+"""
+
+
+def _seed(tmp: Path) -> Path:
+    d = tmp / CHANGES / "selftest-change"
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "tasks.md"
+    p.write_text(_SCAFFOLD, encoding="utf-8")
+    return p
+
+
+def _break_e1(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] E.1 Read `scripts/validate-rite.sh` at `429d127` on 2026-08-14",
+        "- [x] E.1 Read the relevant files"), encoding="utf-8")
+
+
+def _break_e2(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] E.2 `python3 --version` -> `Python 3.14.5`",
+        "- [x] E.2 Probed the tool versions"), encoding="utf-8")
+
+
+def _break_e3(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] E.3 Nothing could not be probed: none outstanding",
+        "- [x] E.3 Checked"), encoding="utf-8")
+
+
+def _break_e4(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] E.4 Scope check: none noticed, no follow-ups",
+        "- [x] E.4 Scope respected"), encoding="utf-8")
+
+
+DEFECTS = (("R1 evidence shape: E.1", _break_e1),
+           ("R1 evidence shape: E.2", _break_e2),
+           ("R1 evidence shape: E.3", _break_e3),
+           ("R1 evidence shape: E.4", _break_e4))
+
+
+def selftest() -> int:
+    global findings
+    caught = 0
+    for label, inject in DEFECTS:
+        check, box = label.split(": ")
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td) / "repo"
+            shutil.copytree(ROOT, tmp, ignore=shutil.ignore_patterns(".git", "__pycache__"))
+            inject(tmp)
+            findings = []
+            for run in CHECKS:
+                run(tmp)
+            if any(f.startswith(check) and box in f for f in findings):
+                print(f"  CAUGHT  {label}")
+                caught += 1
+            else:
+                print(f"  MISSED  {label}   <-- the rule cannot fire")
+    print(f"\n{caught}/{len(DEFECTS)} defect classes detected")
+    return 0 if caught == len(DEFECTS) else 1
+
+
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+    for run in CHECKS:
+        run(ROOT)
+    print(f"  rite evidence gate: {len(findings)} findings")
+    report_density(ROOT)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-rite.sh
+++ b/scripts/validate-rite.sh
@@ -52,6 +52,11 @@ for dir in "$CHANGES_DIR"/*/; do
   fi
 done
 
+# Evidence shape of the mandatory groups + the density report. Separate file because it is a
+# different KIND of check: this script asks whether the gate sections exist, that one asks whether
+# a ticked box says what it ran. Its own header declares what it cannot do.
+python3 scripts/validate-rite-evidence.py || fail=1
+
 if command -v openspec >/dev/null 2>&1; then
   openspec validate --all --strict || fail=1
 else


### PR DESCRIPTION
Closes #79

## Why

`scripts/validate-rite.sh` makes the skills-rite mandatory groups structural, and declares in its
own header that it cannot go further: *"a ticked box with no probe behind it looks identical to one
with. The gate makes the evidence a required, reviewable artifact; the review is what judges it."*

Measured across the archived corpus on `master`: of **305** ticked boxes in mandatory groups,
**7** carried a command and its output — **2%**. The review half never happened.

The defect that produced the item is recent and named: in `add-code-locale-doctrine`, 43 of 51
boxes were flipped in one `s.replace("- [ ] ", "- [x] ")`. One of them was `Q.3`
(*triggers testable and non-colliding*), never tested at tick time — verified afterwards, passed by
luck. Every gate stayed green throughout.

## What this adds

**`R1 evidence shape`** — a hard gate on ticked `Evidence & Sources` boxes of **active** changes,
one rule per box kind:

| Box | Owes |
|---|---|
| `E.1` | a repo-relative path **and** the commit sha or date it was read at |
| `E.2` | at least one ```command``` → a fragment of its output |
| `E.3` | names the gap, or states there is none |
| `E.4` | lists a follow-up, or states there is none |

**A density report** — per mandatory group, never touching the exit code:

```
  evidence density (report only — not a pass/fail result):
    add-code-locale-doctrine
      1. Evidence & Sources  1/4 boxes carry a command -> output
```

## Three things a reviewer should hold me to

**1. A uniform rule was tried first and is wrong.** Requiring `command` → output on every E box
fails **14 of the 20** historical boxes, including 3 of the 4 in the most recent change — all
correct as written. `E.1` records paths, `E.3` records a gap, `E.4` records follow-ups; none has
a command→output shape. The per-kind table is the result of that measurement, not a preference.

**2. The gate would not have caught the defect that motivated it.** The bulk-tick was in `Q.*` and
`V.*`; all four `E.*` boxes of that change pass every rule here. The gate is a regression guard.
The layer that addresses the motivating defect is the **density report**, which would have printed
`Quality Gates 0/5` on that PR. Both halves ship because neither alone is honest about the problem.

**3. This repo already rejected a stronger version of this idea.**
`2026-08-07-add-verify-before-claiming/design.md`: *"A provenance ledger checked by CI was designed
and rejected: CI can only prove such a ledger is well-typed, so a fabricated row passes every check
and leaves the reader trusting the skill more. That converts an obvious defect into a certified
one."* That argument still applies and is **not** solved here — a box padded with `-> ok` passes.
The mitigation is scope: this checks that a box *states* what the template already requires it to
state, and claims nothing about truth. The script says so in its own `KNOWN LIMIT`, which also
records that `Q.*`/`V.*` are reported and never gated.

## Evidence

| Check | Result |
|---|---|
| `validate-rite-evidence.py --selftest` | 4/4 defect classes detected |
| Removing the `E.2` rule | 3/4 — the self-test genuinely detects a disabled rule |
| Calibration: every `tasks.md` with an Evidence group | **20 boxes across 5 changes, 0 fail** |
| Fixture — `- [x] E.2 Probed the tool versions` | exit **1**, names `E.2` |
| Fixture — same box as ```python3 --version``` → ```Python 3.14.5``` | exit **0** |
| `bash scripts/validate-rite.sh` | `rite gate OK`, now printing the density block |
| `validate-skills.py` / `selftest-validate-skills.py` | 34 skills, 0 findings / 13/13 |
| `validate-repo-hygiene.py` + `--selftest` | 0 findings / 2/2 |
| `scan-secrets.py` | no credentials |
| `openspec validate --all --strict` | 3 passed, 0 failed |
| `./generate.sh && git diff --exit-code` | clean |

**Zero true positives on the current corpus.** Every historical E box passes. That is calibration —
no false positives on genuine boxes — not proof the check works, which is exactly why the self-test
is wired as its own CI step.

## Deviation, pre-approved

The item asked for the check and its self-test as **separate** CI steps. The self-test is its own
step (`ci.yml:99`); the check runs inside the existing rite step (`:96`) because
`validate-rite.sh` invokes it — required by the first acceptance criterion, and a separate step
would double-execute. Raised in the implementation plan and approved before coding.

## Scope respected

No verification that evidence is true · no hard gate on `Q.*`/`V.*` · no edits to archived
changes · no change to `execute-backlog`'s issue-checkbox rite · no skill content touched, so the
generated trees are unchanged.