### PR TITLE
📝 docs(readme): drop the inert shared/conventions/ and say where a cross-tool rule goes

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,6 @@ ai-skills/
 │   └── skills/                               # Generated: @-include wrappers
 ├── cursor/rules/                             # Generated: .mdc rules with content inlined
 ├── copilot/instructions/                     # Generated: .instructions.md link wrappers
-├── shared/conventions/                       # Cross-tool coding standards
 ├── VERSION                                   # Single source of truth for the collection version
 ├── CHANGELOG.md                              # Keep a Changelog format
 ├── generate.sh                               # Regenerates all tool wrappers from skills/
@@ -332,7 +331,6 @@ ai-skills/
 | `codex/skills/` | Generated OpenAI Codex wrappers using `@./path` file includes |
 | `cursor/rules/` | Generated Cursor .mdc rules with content inlined |
 | `copilot/instructions/` | Generated GitHub Copilot wrappers with markdown link references |
-| `shared/conventions/` | Coding standards shared across all tools |
 
 ---
 
@@ -790,18 +788,26 @@ Process-wide conventions are enforced by the [Spec-Driven Rite](#-spec-driven-ri
 authoring rules live in `openspec/specs/skills-authoring/spec.md`, catalog composition in
 `openspec/specs/skills-catalog/spec.md`.
 
-The `shared/conventions/` folder is for coding standards and patterns that apply across all AI tools. Place files here when the same convention should be followed regardless of which tool is being used.
+A coding standard that applies across tools and stacks — naming, commit format, error handling,
+API design — is **a skill**, not a separate file tree. Skills are what every tool actually loads:
+`install.sh` symlinks them into `~/.claude/skills/`, `generate.sh` mirrors them into the Codex,
+Cursor and Copilot trees, and `scripts/validate-skills.py` validates their links and code blocks.
 
-Examples of what belongs here:
-- Code style guides (naming, formatting, error handling)
-- Git conventions (commit messages, branch naming)
-- Architecture patterns (folder structure, layering rules)
-- API design standards (naming, versioning, error responses)
+`openspec/specs/skills-authoring/spec.md` (*Single canonical home per rule*) governs how such a rule
+is placed: it is defined in exactly one skill and referenced by a one-line link everywhere else.
+Worked examples in this catalog:
 
-Reference shared conventions from tool-specific skills when needed:
+| Cross-cutting rule | Canonical skill |
+|---|---|
+| Which language identifiers, routes and keys are written in | `skills/code-locale/` |
+| Research before asserting; report what could not be found | `skills/verify-before-claiming/` |
+| Commit and PR format | `skills/conventional-commit/` |
+
+Reference one from a sibling skill with a single line under its `## See also`, never by restating
+it:
 
 ```markdown
-Follow the conventions defined in shared/conventions/api-design.md.
+- `code-locale` — event names and StateBag keys are English even when the repo's prose is not.
 ```
 
 ---


### PR DESCRIPTION
Closes #81

## Outcome chosen: **A — remove**

The item deliberately did not prejudge between removing the directory and making it real. Here is
why A won.

`shared/` held one tracked file:

```
$ git ls-files shared/
shared/conventions/.gitkeep
```

Nothing loaded it. Verified on `master` at `3236168`: `shared/` appears in no script, no
generator, no installer, no manifest, and neither OpenSpec spec. A convention placed there had zero
probability of reaching an agent's context. `README.md:804` compounded that by teaching readers to
cite `shared/conventions/api-design.md` — a file never written — and `validate-skills.py` C1
walks only `skills/`, so the dangling path escaped every gate in the repo.

**The premise was tested this session and did not hold.** `code-locale` is exactly what the README
described: a naming standard applying across tools. It went to `skills/`, and
`add-code-locale-doctrine/design.md` records the reason as measured rather than preferred. Keeping
a folder whose stated purpose was just filled by a different mechanism is keeping a decoy.

Outcome B would have cost a generator hook, an install path, content to write and README text
explaining consumption — to duplicate what `skills/` already does, loads automatically, and has
validated by C1/C2/C7.

## What changed

- `README.md:315` and `:335` — the `shared/conventions/` rows leave the directory tree and the
  layout table.
- `README.md` *Shared Conventions* — **the first paragraph is untouched**, because it was already
  correct: process conventions really are enforced by the rite, and both specs it cites exist. Only
  the folder pitch and the dangling example are replaced, by where a cross-tool rule actually goes,
  three worked examples from this catalog, and the `## See also` form that references one.
- `shared/conventions/.gitkeep` removed — `shared/` disappears, since #77 already took
  `shared/skills/`.

## Prose was verified, not written from memory

Rewriting documentation risks replacing a false claim with a fresh one. Every path and behavioural
statement in the new text was grepped before commit:

| Claim | Verified against |
|---|---|
| `install.sh` symlinks skills into `~/.claude/skills/` | `install.sh:9,28,43` |
| `generate.sh` mirrors into the Codex/Cursor/Copilot trees | `generate.sh:20-22` |
| `validate-skills.py` validates links and code blocks | `scripts/validate-skills.py:5,7` (C1, C3) |
| *Single canonical home per rule* exists | `openspec/specs/skills-authoring/spec.md` |
| The three cited skills exist | `skills/{code-locale,verify-before-claiming,conventional-commit}/` |
| The `See also` example line | copied verbatim from `skills/fivem-lua/SKILL.md`, not invented |

## Evidence

| Check | Result |
|---|---|
| `grep -c "shared/" README.md` | **0** |
| `grep -c "api-design.md" README.md` | **0** |
| `git ls-files shared/` | **0** — directory gone |
| `validate-skills.py` | 34 skills, 0 findings |
| `validate-repo-hygiene.py` + `--selftest` | 0 findings / 2/2 |
| `scan-secrets.py` | no credentials |
| `validate-rite.sh` (incl. the new evidence gate) | `rite gate OK` |
| `validate-rite-evidence.py --selftest` | 4/4 |
| `./generate.sh && git diff --exit-code` | clean |

All 6 acceptance criteria ticked individually, each carrying its measured result in the issue body.

## Residual risk, named

A consumer outside this repository could reference `shared/conventions/` and would break silently.
The search covered this repository only. Mitigation is cheap: one revertible commit, and
`README.md:804` is itself proof that the documented consumer (`api-design.md`) never existed.

## Scope respected

No extension of C1 to README paths — named in the item as a separate concern with its own
false-positive surface, since the README is full of deliberately illustrative paths. No change to
`skills/`, the rite, or the generated trees.