### PR TITLE
✨ feat(ci): enforce all seven frontmatter fields the spec mandates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,13 @@ jobs:
             head -1 "$f" | grep -q '^---$' || { echo "::error file=$f::Missing frontmatter"; fail=1; }
             grep -q '^name:' "$f" || { echo "::error file=$f::Missing name"; fail=1; }
             grep -q '^description:' "$f" || { echo "::error file=$f::Missing description"; fail=1; }
+            grep -q '^description: >-' "$f" || { echo "::error file=$f::description must be a folded block scalar ('description: >-')"; fail=1; }
             name="$(grep -m1 '^name:' "$f" | sed 's/^name: *//')"
             [ "$name" = "$dir" ] || { echo "::error file=$f::name '$name' != directory '$dir'"; fail=1; }
             grep -qE '^  version: [0-9]+\.[0-9]+\.[0-9]+' "$f" || { echo "::error file=$f::Missing metadata.version (semver)"; fail=1; }
-            grep -q '^license:' "$f" || { echo "::error file=$f::Missing license"; fail=1; }
+            grep -qx '  author: solvelab' "$f" || { echo "::error file=$f::metadata.author must be exactly 'solvelab'"; fail=1; }
+            grep -qx 'license: MIT' "$f" || { echo "::error file=$f::license must be exactly 'MIT'"; fail=1; }
+            grep -q '^compatibility:' "$f" || { echo "::error file=$f::Missing compatibility"; fail=1; }
             cat="$(grep -m1 '^  category:' "$f" | sed 's/^  category: *//')"
             if [ -z "$cat" ]; then
               echo "::error file=$f::Missing metadata.category"; fail=1


### PR DESCRIPTION
Closes #83

## Why

`openspec/specs/skills-authoring` → *Uniform frontmatter metadata* lists **seven** fields every
`SKILL.md` SHALL carry, and then makes the gate the authority:

> When the two disagree, the gate is authoritative and this document is corrected, because a
> contributor who follows a document that is behind its gate writes a change the build rejects.

The gate covered three and a half of the seven:

| Field the spec mandates | What CI did |
|---|---|
| `name` == directory · `metadata.version` semver · `metadata.category` | enforced |
| `license: MIT` | presence only — `license: WTFPL` passed |
| `description` folded (`>-`) | presence only — a plain string passed |
| `metadata.author: solvelab` | **not checked at all** |
| `compatibility` | **not checked at all** |

A document that subordinates itself to its gate was enforced by a gate ignoring most of what it
mandates, which left `Q.1` in the rite template as the only thing between a skill with no
`compatibility` and a merge — the review-only surface this catalog has already been burned by.

## What changed

Four greps in the existing *Skill frontmatter checks* step, each failing with the same
`::error file=$f::` form already used there. One file, four lines added.

The `description` **presence** check is kept alongside the new folded check on purpose: folding
them into one would report `must be a folded block scalar` for a file with no description at all,
which sends the reader looking for the wrong problem.

## Verified adversarially, not by inspection

The step has no self-test, so a grep written wrong — `grep -q 'author'`, matching the word
anywhere — would look enforced and enforce nothing. Every new check was therefore run against a
deliberately broken copy of a real skill:

| Mutation | Result |
|---|---|
| `metadata.author` removed | exit 1 — `metadata.author must be exactly 'solvelab'` |
| `author: someone-else` | exit 1 — same error |
| `compatibility` removed | exit 1 — `Missing compatibility` |
| `license: WTFPL` | exit 1 — `license must be exactly 'MIT'` |
| `description:` as a plain string | exit 1 — `description must be a folded block scalar` |
| **control** — unmutated copy | exit **0** |

## Evidence

| Check | Result |
|---|---|
| Frontmatter loop, untouched tree | exit 0, all 34 skills |
| `validate-skills.py` / `selftest-validate-skills.py` | 34 skills, 0 findings / 13/13 |
| `validate-repo-hygiene.py` + `--selftest` | 0 findings / 2/2 |
| `scan-secrets.py` | no credentials |
| `validate-rite.sh` | `rite gate OK` |
| `validate-rite-evidence.py --selftest` | 4/4 |
| `ci.yml` parses as YAML | valid |
| `./generate.sh && git diff --exit-code` | clean |

All 8 acceptance criteria ticked individually, each carrying its measured result in the issue body.

## Honest about the yield

**This fixes nothing that is currently broken.** All 34 skills already carry all seven fields
correctly — `author: solvelab` ×34, `license: MIT` ×34, every description folded. It closes a
hole before something falls through it, exactly like `Q.5`, and the issue says so rather than
implying a live defect.

## Left in place, named

- **No self-test on this step.** Extracting ~20 lines of inline bash into a script with injected
  defects is a larger change and its own item; adding four greps does not make that weakness worse.
- **The spec's `CI rejects incomplete frontmatter` scenario now understates the gate** — it names
  only `metadata.version`, `license` and category. A scenario narrower than reality, not a
  contradiction, and the requirement's own "gate is authoritative" clause covers that direction.
  Folding it in would make this a spec change and pull an OpenSpec proposal with it.