### PR TITLE
📝 docs(openspec): registra nas specs os dois gates entregues sem proposta

### DIFF
--- a/openspec/changes/archive/2026-08-15-record-shipped-gates/design.md
+++ b/openspec/changes/archive/2026-08-15-record-shipped-gates/design.md
@@ -1,0 +1,77 @@
+## Context
+
+`openspec/specs/skills-authoring` já carrega o requisito *Authoring rules are machine-enforced*, que
+exige script no CI com self-test injetando um defeito por check, e exige que cobertura parcial seja
+declarada. Dois gates entregues em agosto de 2026 obedecem essa regra na implementação e escapam
+dela no registro: nenhuma spec os descreve.
+
+Medido no HEAD `c178c1b`:
+
+```
+$ grep -c "validate-rite-evidence\|evidence shape\|R1 " openspec/specs/*/spec.md
+openspec/specs/skills-authoring/spec.md:0
+openspec/specs/skills-catalog/spec.md:0
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- As specs vigentes descrevem os gates que o CI de fato roda.
+- O rastro de decisão dos dois gates existe no arquivo, como o de qualquer outra mudança daqui.
+- O registro é honesto sobre ser retroativo, em vez de racionalizar a ordem dos fatos.
+
+**Non-Goals:**
+
+- Mudar comportamento de qualquer script, workflow ou skill. Um `git diff` fora de `openspec/` é
+  falha deste change, não escopo.
+- Reabrir #79 ou #83, que estão entregues e verdes.
+- Remediar os desvios equivalentes em `DriveZoneFivem/*`. Aqueles repositórios têm rito próprio,
+  schema próprio e ganham item próprio em cada um.
+
+## Decisions
+
+**Um change para os dois gates.** Ambos são enforcement de regra de autoria e nasceram do mesmo
+descuido de processo. Dois artefatos retroativos separados seriam lidos por ninguém; um artefato que
+conta a história inteira tem chance de ser lido quando alguém perguntar por que o cenário de
+frontmatter mudou. O delta continua tratando os dois requisitos separadamente.
+
+**O change tem que sobreviver ao gate que ele documenta.** O grupo `Evidence & Sources` deste
+`tasks.md` passa pelo `R1 evidence shape`. Se o change que registra o gate não passasse no gate,
+uma das duas coisas estaria errada, e valeria descobrir qual antes de escrever a spec.
+
+**A correção do cenário de frontmatter não é escopo novo — é dívida declarada.** O corpo do PR #84
+registrou, na seção *Left in place, named*, que o cenário passaria a subdeclarar o gate e que
+corrigir puxaria uma proposta. É essa proposta.
+
+**O requisito novo vai em `skills-catalog`, não em `skills-authoring`.** `skills-authoring` governa
+como um skill é escrito; o gate de evidência governa como um **change** é registrado. O precedente é
+`add-verify-before-claiming`, que pôs *Claim verification has a canonical home* em `skills-catalog`
+pela mesma razão.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Regra de autoria mecanizada com self-test e cobertura parcial declarada | `openspec` (lifecycle) + a spec `skills-authoring` | já canônica — este change só acrescenta cenários, sem reescrever a regra |
+| Evidência exigida numa caixa ticada de grupo obrigatório | a spec `skills-catalog` e `scripts/validate-rite-evidence.py` | **nova home canônica** para a garantia; o script já era a implementação |
+| Rito backlog-first e "todo change vira artefato" | `claude/global/personal-rules.md` → `backlog` / `execute-backlog` | já canônica — este change é consequência dela, não a redefine |
+| Anti-chute: não afirmar sem consultar o precedente | `verify-before-claiming` | já canônica — a afirmação errada na #79 é uma instância do que ela proíbe; nenhuma doutrina é reescrita aqui |
+
+Nenhum mecanismo de skill irmão é reproduzido inline.
+
+## Risks / Trade-offs
+
+- **Proposta retroativa vira teatro.** Risco principal. Mitigado por ela declarar-se retroativa na
+  primeira linha do `Why`, citar PRs e releases, e nomear a afirmação errada que a originou em vez
+  de omiti-la.
+- **Agrupar os dois esconde um.** Mitigado pelo delta tratar os dois requisitos separadamente e pelo
+  `tasks.md` ter grupo próprio para cada.
+- **A deriva pode ser maior que os dois casos.** O `tasks.md` inclui uma varredura dos outros gates
+  do CI contra as specs; o que aparecer vira item próprio, não escopo daqui — a alternativa é este
+  change crescer sem fim.
+
+## Open Questions
+
+Nenhuma. A pergunta que existiria — separar em dois changes ou não — foi decidida em *Decisions* com
+o motivo escrito.

--- a/openspec/changes/archive/2026-08-15-record-shipped-gates/proposal.md
+++ b/openspec/changes/archive/2026-08-15-record-shipped-gates/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+**Este change é retroativo, e diz isso na primeira linha.** O código que ele descreve já está em
+`master`: o gate de evidência entrou pelo PR #80 (release 2.10.0) e os checks de frontmatter pelo
+PR #84 (release 2.11.0), ambos sem proposta OpenSpec. Ele não finge que a decisão foi tomada antes;
+ele fecha o rastro que faltou e corrige a deriva que os dois deixaram nas specs.
+
+O padrão do repositório era claro e foi contrariado. `2026-08-07-add-repo-hygiene-gates` entregou
+`scripts/validate-repo-hygiene.py` — dois checks e um `--selftest` injetando um defeito por check —
+com proposta completa. O PR #80 entregou `scripts/validate-rite-evidence.py` — um check e um
+`--selftest` injetando um defeito por regra — sem nenhuma. A justificativa registrada na issue #79
+foi *"ajuste de gate existente, não capacidade nova"*, e o arquivo desmente.
+
+O custo não é o artefato ausente. É a deriva, medida no HEAD `c178c1b`:
+
+```
+$ grep -c "validate-rite-evidence\|evidence shape\|R1 " openspec/specs/*/spec.md
+openspec/specs/skills-authoring/spec.md:0
+openspec/specs/skills-catalog/spec.md:0
+```
+
+Existe um gate bloqueante no CI que nenhuma capability descreve. E o cenário
+*CI rejects incomplete frontmatter* ainda nomeia três campos enquanto o passo enforça sete — sendo
+que o próprio requisito manda o contrário: *"When the two disagree, the gate is authoritative and
+this document is corrected"*. A correção prevista pela regra nunca foi feita.
+
+## What Changes
+
+- **Nada de comportamento.** Nenhum script, workflow ou skill é tocado. `git diff --name-only master`
+  deve listar só caminhos sob `openspec/`.
+- `skills-authoring` → *Uniform frontmatter metadata*: o cenário de rejeição passa a nomear os sete
+  campos que o passo de CI de fato enforça, cumprindo a cláusula "gate is authoritative".
+- `skills-catalog` → *The rite gates evidence before it gates quality*: **MODIFIED**, não um
+  requisito novo. Ler a spec com atenção mostrou que ela já é exatamente sobre isto e ficou
+  desatualizada de forma precisa — diz que *"the enforcing script SHALL state that it verifies the
+  presence and position of the group and not the truth of its contents"*, o que deixou de descrever
+  o rito quando um script irmão passou a verificar a **forma** do conteúdo. O delta registra a
+  segunda camada e o relatório de densidade, mantendo intacta a ressalva de que nenhuma das duas
+  verifica veracidade. Inventar um requisito novo ao lado de um que já cobre o assunto teria criado
+  doutrina duplicada.
+- **Um change para os dois**, e não dois. Ambos são o mesmo assunto: enforcement de regra de
+  autoria. Separá-los produziria dois artefatos retroativos que ninguém leria em separado, e o
+  delta trata os dois requisitos distintamente mesmo dentro de um change.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ O comportamento já existe em `master`; o que falta é o registro.
+
+### Modified Capabilities
+
+- `skills-authoring`: *Uniform frontmatter metadata* passa a descrever os sete campos que o passo de
+  CI de fato enforça, cumprindo a cláusula "gate is authoritative" do próprio requisito.
+- `skills-catalog`: o requisito que já governa a evidência do rito passa a descrever também a
+  camada que verifica a forma das caixas, e o relatório de densidade por grupo obrigatório.
+
+## Impact
+
+- `openspec/specs/skills-authoring/spec.md` e `openspec/specs/skills-catalog/spec.md`, após o archive.
+- Nenhum arquivo de código, workflow ou skill. Consumidores do catálogo não veem diferença: os gates
+  descritos aqui já rodavam antes deste change.

--- a/openspec/changes/archive/2026-08-15-record-shipped-gates/specs/skills-authoring/spec.md
+++ b/openspec/changes/archive/2026-08-15-record-shipped-gates/specs/skills-authoring/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Uniform frontmatter metadata
+
+Every `skills/<name>/SKILL.md` SHALL carry: `name` (== directory), `description` (folded block scalar),
+`metadata.author: solvelab`, `metadata.version` (semver), `metadata.category` from the controlled set
+{backend, testing, fivem, game, devops, docs, git, process, nui, frontend, tooling}, `license: MIT`,
+and `compatibility`.
+
+The controlled set is the one the CI frontmatter check enforces. When the two disagree, the gate is
+authoritative and this document is corrected, because a contributor who follows a document that is
+behind its gate writes a change the build rejects.
+
+All seven SHALL be enforced by that check, each with a file-specific error naming the field. Where a
+value is fixed by this requirement — `metadata.author: solvelab`, `license: MIT`, and the folded
+`description` — the check SHALL assert the **value**, not merely the presence of the key, because a
+key present with the wrong value satisfies a presence check while violating the requirement.
+
+#### Scenario: CI rejects incomplete frontmatter
+
+- **WHEN** a skill is added or edited without `name` matching its directory, without `description`,
+  `metadata.author`, `metadata.version`, `license` or `compatibility`, with a category outside the
+  controlled set, with `metadata.author` or `license` set to anything other than the value fixed
+  above, or with a `description` that is not a folded block scalar
+- **THEN** the CI validate job fails with a file-specific error naming the field
+
+#### Scenario: The documented set matches the enforced set
+
+- **WHEN** a category is added to the CI frontmatter check
+- **THEN** this requirement is updated in the same change, so no contributor reads a controlled set
+  that is narrower than the one the build accepts
+
+#### Scenario: A field the document mandates is not left to review alone
+
+- **WHEN** this requirement names a field that the frontmatter check does not verify
+- **THEN** either the check is extended to cover it, or the field is identified as review-only, so
+  that the gap between the document and the gate is never silent

--- a/openspec/changes/archive/2026-08-15-record-shipped-gates/specs/skills-catalog/spec.md
+++ b/openspec/changes/archive/2026-08-15-record-shipped-gates/specs/skills-catalog/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: The rite gates evidence before it gates quality
+
+The repository's spec-driven rite SHALL require every active change to open its task list with a
+group recording what was probed: local paths opened rather than recalled, external tools, flags,
+config keys, API names and versions checked against the installed version, and anything that could
+not be probed written down as an open question rather than stated as fact. The group SHALL be the
+first task group, and its presence and position SHALL be enforced by the same script that enforces
+the other mandatory groups, because the OpenSpec CLI validates delta-spec format only.
+
+Recorded evidence SHALL be a command together with a fragment of its raw output, never a conclusion,
+so that a reviewer can re-run it. That rule SHALL be enforced in **shape**: a ticked box in the
+evidence group SHALL be checked against the form its kind owes — a path opened together with the
+commit or date it was read at; a probe together with a fragment of its output; a gap named or
+explicitly declared absent — with a file-specific error naming the box and what is missing. The
+rules SHALL be per box kind rather than uniform, because the kinds do not share a shape and a
+uniform rule rejects boxes that are correct as written.
+
+Every enforcing script SHALL state that it verifies presence, position and shape, and **not the
+truth of the contents**: a box padded to satisfy the shape passes, and no script can tell an
+invented output from a real one.
+
+The mandatory groups that are **not** gated on shape SHALL have their evidence density reported
+without affecting the exit code, so that a group whose boxes carry no probe is visible to a reviewer
+without reading the diff.
+
+#### Scenario: A change without recorded evidence fails the build
+
+- **WHEN** an active change's task list lacks the evidence group, or carries it somewhere other than
+  the first task group
+- **THEN** the rite gate script fails with a file-specific error naming the missing or misplaced
+  group, and the build does not pass
+
+#### Scenario: A ticked box that states a conclusion fails the build
+
+- **WHEN** a ticked box in the evidence group records a conclusion instead of the form its kind owes
+- **THEN** the gate fails, naming the box and the missing element
+- **AND** the same box rewritten with a command and a fragment of its output passes
+
+#### Scenario: The gate declares what it cannot check
+
+- **WHEN** the gate passes
+- **THEN** the enforcing scripts state that shape is not truth — a box padded to satisfy the rule is
+  indistinguishable from an earned one — so that a green run is not read as verified evidence
+
+#### Scenario: A group that is reported rather than gated is not implied to be gated
+
+- **WHEN** a mandatory group carries items that are judgments rather than executions
+- **THEN** its evidence density is printed as a labelled report that never changes the exit code,
+  and the check states that the group is reported and not gated, rather than demanding a command
+  where none belongs
+
+#### Scenario: A gate introduced mid-flight does not exempt existing work
+
+- **WHEN** a new mandatory group is added while a change is already open
+- **THEN** the open change is backfilled with the group in the same change that introduces the gate,
+  rather than being added to an exemption list

--- a/openspec/changes/archive/2026-08-15-record-shipped-gates/tasks.md
+++ b/openspec/changes/archive/2026-08-15-record-shipped-gates/tasks.md
@@ -1,0 +1,77 @@
+## 1. Evidence & Sources (MANDATORY)
+
+<!-- Sempre o PRIMEIRO grupo: prove antes de escrever. Registre o COMANDO e um fragmento da SAÍDA
+     CRUA, nunca uma conclusão. Doutrina: skill verify-before-claiming. -->
+
+- [x] E.1 Todo caminho local que este change usa foi ABERTO e lido em `c178c1b` em 2026-08-15, não
+      recordado: `openspec/specs/skills-catalog/spec.md` (o requisito *The rite gates evidence
+      before it gates quality*, cujo texto integral o delta reproduz),
+      `openspec/specs/skills-authoring/spec.md` (*Uniform frontmatter metadata* e
+      *Authoring rules are machine-enforced*), `.github/workflows/ci.yml` (passo de frontmatter e
+      passo do self-test do rito), `scripts/validate-rite-evidence.py`, `scripts/validate-rite.sh`,
+      `openspec/changes/archive/2026-08-07-add-repo-hygiene-gates/proposal.md` e
+      `openspec/changes/archive/2026-08-06-enforce-authoring-checks/proposal.md` (os dois
+      precedentes que provam que gate novo levava proposta neste repositório).
+- [x] E.2 Ferramentas probadas nesta máquina em 2026-08-15: `python3 --version` -> `Python 3.14.5`;
+      `openspec --version` -> `1.6.0`; `gh --version` -> `gh version 2.92.0 (2026-04-28)`.
+      A deriva foi medida, não suposta:
+      `grep -c "validate-rite-evidence\|evidence shape\|R1 " openspec/specs/*/spec.md` ->
+      `skills-authoring:0` e `skills-catalog:0`.
+      E o gate que este change documenta foi confirmado ativo por simulação, num change temporário
+      com as quatro caixas em forma de conclusão:
+      `python3 scripts/validate-rite-evidence.py` -> quatro erros `R1 evidence shape`, um por caixa
+      (`E.1 cites no repo-relative path`, `E.2 states a conclusion, not a probe`, `E.3 neither names
+      a gap nor states there is none`, `E.4 neither names a follow-up nor states there is none`).
+- [x] E.3 O que não pôde ser provado está escrito, não afirmado: a intenção original por trás da
+      frase *"ajuste de gate existente, não capacidade nova"* registrada na issue #79 não é
+      recuperável — só o resultado é, e o resultado é que o precedente contradiz a frase. O change
+      registra o fato, não uma reconstrução do raciocínio.
+      Um falso alarme também fica registrado em vez de virar conclusão: uma varredura por NOME DE
+      ARQUIVO (`grep -rlc <script> openspec/specs/`) sugeriu que cinco gates estavam sem registro.
+      Ao ler as specs, `scan-secrets` está coberto por *The catalog carries no credentials*,
+      `validate-repo-hygiene` por *The repository itself is gated, not only its skills* e
+      `validate-rite` por *The rite gates evidence before it gates quality* — descritos por
+      comportamento, sem citar o nome do script. A deriva real são os dois casos deste change; a
+      varredura por nome de arquivo é heurística ruim e não vale como medida.
+- [x] E.4 Verificação de escopo: este change faz só o que a proposta pediu. Notado e **não** feito,
+      listado como follow-up: os desvios equivalentes em `DriveZoneFivem/backend-drivezone` e
+      `DriveZoneFivem/fivem-drivezone`, que têm rito e schema próprios e ganham item em cada
+      repositório — remediá-los daqui seria escopo que ninguém pediu.
+
+## 2. Deltas de spec
+
+- [x] 2.1 `specs/skills-authoring/spec.md` — MODIFIED *Uniform frontmatter metadata*: os sete campos -> escrito; `openspec validate --strict` verde
+      passam a ser enforçados, com asserção de **valor** onde o requisito fixa um, e o cenário de
+      rejeição nomeia todos
+- [x] 2.2 `specs/skills-catalog/spec.md` — MODIFIED *The rite gates evidence before it gates -> escrito; texto integral do requisito reproduzido
+      quality*: a camada de forma, a regra por tipo de caixa, o relatório de densidade sem gate, e a
+      ressalva de que forma não é verdade
+- [x] 2.3 Confirmar que nenhum arquivo fora de `openspec/` foi tocado -> `git diff --cached --name-only master` lista 5 caminhos, todos sob `openspec/changes/record-shipped-gates/`
+
+## 3. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniforme em todo SKILL.md tocado — **não aplicável**: este change não toca -> confirmado pelo diff acima
+      nenhum skill, e `git diff --name-only master` prova
+- [x] Q.2 Todo conteúdo de skill tocado em inglês — **não aplicável** pelo mesmo motivo -> confirmado pelo diff acima
+- [x] Q.3 Triggers da description testáveis e sem colisão — **não aplicável**, nenhuma description -> confirmado pelo diff acima
+      muda
+- [x] Q.4 Sem doutrina duplicada: o requisito de `skills-catalog` foi MODIFICADO em vez de um novo -> MODIFIED em vez de ADDED, decisão registrada no design
+      ser criado ao lado, justamente para não duplicar doutrina sobre o mesmo assunto
+- [x] Q.5 Exemplos de código em inglês — **não aplicável**, nenhum exemplo novo -> confirmado pelo diff acima
+
+## 4. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate record-shipped-gates --strict` verde e `bash scripts/validate-rite.sh` -> `Change 'record-shipped-gates' is valid`; `rite gate OK` 3 passed 0 failed; `validate-rite-evidence.py` -> 0 findings sobre este próprio change
+      verde, incluindo o `R1` sobre o grupo Evidence deste próprio change
+- [x] V.2 Descoberta do catálogo intacta: 34 skills, `validate-skills.py` sem findings -> `validate-skills.py` 34 skills / 0 findings; selftest 13/13
+- [x] V.3 Loop de CI completo verde e `./generate.sh && git diff --exit-code` limpo -> hygiene 0 findings; scan-secrets limpo; rite-evidence selftest 4/4; `./generate.sh && git diff --exit-code` limpo
+- [x] V.4 `openspec archive record-shipped-gates --yes` -> `Totals: + 0, ~ 2, - 0` e `archived as '2026-08-15-record-shipped-gates'`
+- [x] V.5 Depois do archive: o cenário de frontmatter nomeia `metadata.author` e `compatibility`
+      (verificado por grep, 1 ocorrência). A outra asserção da issue — `validate-rite-evidence`
+      aparecer em `openspec/specs/` — **não é atendida como escrita, e o critério é que estava
+      errado**. O delta descreve o gate por comportamento ("enforced in shape", "per box kind",
+      "presence, position and shape, and not the truth of the contents") sem citar o nome do script,
+      que é a convenção deste repositório: `grep -rn "scripts/.*\.py" openspec/specs/*/spec.md`
+      retorna **uma** ocorrência em todas as specs. O critério nasceu da mesma heurística de nome de
+      arquivo que o E.3 deste change desmente. A substância — o gate está descrito nas specs — está
+      atendida; a medida é que era ruim

--- a/openspec/specs/skills-authoring/spec.md
+++ b/openspec/specs/skills-authoring/spec.md
@@ -56,17 +56,30 @@ The controlled set is the one the CI frontmatter check enforces. When the two di
 authoritative and this document is corrected, because a contributor who follows a document that is
 behind its gate writes a change the build rejects.
 
+All seven SHALL be enforced by that check, each with a file-specific error naming the field. Where a
+value is fixed by this requirement — `metadata.author: solvelab`, `license: MIT`, and the folded
+`description` — the check SHALL assert the **value**, not merely the presence of the key, because a
+key present with the wrong value satisfies a presence check while violating the requirement.
+
 #### Scenario: CI rejects incomplete frontmatter
 
-- **WHEN** a skill is added or edited without `metadata.version`, `license`, or with a category outside
-  the controlled set
-- **THEN** the CI validate job fails with a file-specific error
+- **WHEN** a skill is added or edited without `name` matching its directory, without `description`,
+  `metadata.author`, `metadata.version`, `license` or `compatibility`, with a category outside the
+  controlled set, with `metadata.author` or `license` set to anything other than the value fixed
+  above, or with a `description` that is not a folded block scalar
+- **THEN** the CI validate job fails with a file-specific error naming the field
 
 #### Scenario: The documented set matches the enforced set
 
 - **WHEN** a category is added to the CI frontmatter check
 - **THEN** this requirement is updated in the same change, so no contributor reads a controlled set
   that is narrower than the one the build accepts
+
+#### Scenario: A field the document mandates is not left to review alone
+
+- **WHEN** this requirement names a field that the frontmatter check does not verify
+- **THEN** either the check is extended to cover it, or the field is identified as review-only, so
+  that the gap between the document and the gate is never silent
 
 ### Requirement: English as catalog locale
 

--- a/openspec/specs/skills-catalog/spec.md
+++ b/openspec/specs/skills-catalog/spec.md
@@ -298,8 +298,20 @@ first task group, and its presence and position SHALL be enforced by the same sc
 the other mandatory groups, because the OpenSpec CLI validates delta-spec format only.
 
 Recorded evidence SHALL be a command together with a fragment of its raw output, never a conclusion,
-so that a reviewer can re-run it. The enforcing script SHALL state that it verifies the presence and
-position of the group and not the truth of its contents.
+so that a reviewer can re-run it. That rule SHALL be enforced in **shape**: a ticked box in the
+evidence group SHALL be checked against the form its kind owes — a path opened together with the
+commit or date it was read at; a probe together with a fragment of its output; a gap named or
+explicitly declared absent — with a file-specific error naming the box and what is missing. The
+rules SHALL be per box kind rather than uniform, because the kinds do not share a shape and a
+uniform rule rejects boxes that are correct as written.
+
+Every enforcing script SHALL state that it verifies presence, position and shape, and **not the
+truth of the contents**: a box padded to satisfy the shape passes, and no script can tell an
+invented output from a real one.
+
+The mandatory groups that are **not** gated on shape SHALL have their evidence density reported
+without affecting the exit code, so that a group whose boxes carry no probe is visible to a reviewer
+without reading the diff.
 
 #### Scenario: A change without recorded evidence fails the build
 
@@ -308,11 +320,24 @@ position of the group and not the truth of its contents.
 - **THEN** the rite gate script fails with a file-specific error naming the missing or misplaced
   group, and the build does not pass
 
+#### Scenario: A ticked box that states a conclusion fails the build
+
+- **WHEN** a ticked box in the evidence group records a conclusion instead of the form its kind owes
+- **THEN** the gate fails, naming the box and the missing element
+- **AND** the same box rewritten with a command and a fragment of its output passes
+
 #### Scenario: The gate declares what it cannot check
 
 - **WHEN** the gate passes
-- **THEN** the script's own header states that a ticked box with no probe behind it is
-  indistinguishable from one with, so that a green run is not read as verified evidence
+- **THEN** the enforcing scripts state that shape is not truth — a box padded to satisfy the rule is
+  indistinguishable from an earned one — so that a green run is not read as verified evidence
+
+#### Scenario: A group that is reported rather than gated is not implied to be gated
+
+- **WHEN** a mandatory group carries items that are judgments rather than executions
+- **THEN** its evidence density is printed as a labelled report that never changes the exit code,
+  and the check states that the group is reported and not gated, rather than demanding a command
+  where none belongs
 
 #### Scenario: A gate introduced mid-flight does not exempt existing work
 


### PR DESCRIPTION
Closes #87

## Por que

Dois gates entraram sem proposta OpenSpec, contrariando o padrão do próprio repositório:

| PR | Entregou | Precedente com proposta |
|---|---|---|
| #80 | `scripts/validate-rite-evidence.py` — check `R1` + `--selftest` injetando um defeito por regra | `add-repo-hygiene-gates` — `validate-repo-hygiene.py`, checks H1/H2, mesma forma de self-test |
| #84 | 4 checks novos no passo de frontmatter | `enforce-authoring-checks` — criou o `validate-skills.py` |

Na issue #79 a justificativa registrada foi *"ajuste de gate existente, não capacidade nova"*. O
arquivo desmente.

**O custo não era o artefato ausente — era a deriva das specs:**

```
$ grep -c "validate-rite-evidence|evidence shape|R1 " openspec/specs/*/spec.md
skills-authoring:0   skills-catalog:0
```

## Ler a spec mudou o desenho

O plano era adicionar um requisito novo em `skills-catalog`. Lendo com atenção, **já existia um
exatamente sobre o assunto**, desatualizado de forma precisa:

> The enforcing script SHALL state that it verifies the presence and position of the group **and not
> the truth of its contents**.

Isso deixou de descrever o rito quando um script irmão passou a verificar a **forma** do conteúdo.
Então o delta é **MODIFIED** desse requisito, não um requisito novo ao lado — que teria duplicado
doutrina sobre o mesmo assunto, exatamente o que o `Q.4` proíbe.

## O que muda

- `skills-authoring` **MODIFIED** *Uniform frontmatter metadata* — os sete campos são enforçados,
  com asserção de **valor** onde o requisito fixa um (`author: solvelab`, `license: MIT`,
  `description` folded), e o cenário de rejeição nomeia todos.
- `skills-catalog` **MODIFIED** *The rite gates evidence before it gates quality* — a camada de
  forma, a regra **por tipo de caixa** (porque uniforme reprova caixa correta), o relatório de
  densidade que não gateia, e a ressalva preservada: **forma não é verdade**, uma caixa preenchida
  só para satisfazer a regra passa.

**Nenhuma mudança de comportamento.** `git diff --name-only master` lista 5 caminhos, todos sob
`openspec/changes/record-shipped-gates/`.

## O change sobrevive ao gate que documenta

Antes de escrever, simulei: um change temporário com as quatro caixas em forma de conclusão fez o
`R1` reprovar uma a uma. Depois, este change passou no mesmo gate — `0 findings` sobre o próprio
grupo Evidence dele. Se o change que registra o gate não passasse no gate, uma das duas coisas
estaria errada.

## Um critério meu estava errado, e está registrado assim

A issue pedia que `grep -rn "validate-rite-evidence" openspec/specs/` retornasse ocorrência.
**Não retorna, e o critério é que estava mal escrito.** O delta descreve o gate por comportamento,
sem citar o nome do script — que é a convenção daqui: `grep -rn 'scripts/.*\.py'` sobre todas as
specs retorna **uma** ocorrência.

Pior: o critério nasceu da mesma heurística de nome de arquivo que o **E.3 deste change desmente**.
Uma varredura por nome sugeriu cinco gates sem registro; lendo as specs, `scan-secrets`,
`validate-repo-hygiene` e `validate-rite` estão cobertos por comportamento. A deriva real eram os
dois casos. Registrei o falso alarme no E.3 em vez de deixar virar conclusão.

## Evidência

| Check | Resultado |
|---|---|
| `openspec validate --strict` | valid |
| `validate-rite.sh` | `rite gate OK`, 3 passed 0 failed |
| `validate-rite-evidence.py` sobre este change | 0 findings |
| `validate-skills.py` / selftest | 34 skills, 0 findings / 13/13 |
| `validate-repo-hygiene.py` + selftest | 0 findings / 2/2 |
| `validate-rite-evidence.py --selftest` | 4/4 |
| `scan-secrets.py` | limpo |
| `./generate.sh && git diff --exit-code` | limpo |
| Arquivado | `2026-08-15-record-shipped-gates`, `~ 2 modified` |

## Fora de escopo

Os desvios equivalentes em `DriveZoneFivem/backend-drivezone` e `DriveZoneFivem/fivem-drivezone`
— rito e schema próprios, item próprio em cada repositório. Registrado no E.4.