### PR TITLE
✨ feat(rito): exige change OpenSpec e fecha o passe vazio do gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
+        # fetch-depth: 0 — the spec-rite gate diffs this branch against its base. The default
+        # depth of 1 leaves no base revision, and a gate that cannot measure must not approve.
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Wrappers in sync with skills/
         run: |
@@ -96,10 +100,18 @@ jobs:
         run: python3 scripts/validate-repo-hygiene.py --selftest
 
       - name: OpenSpec rite gate (skills-rite schema)
+        # PR_BODY carries the waiver line the spec-rite gate reads. It is authored by whoever
+        # opened the pull request, including from a fork: the gate matches it as text and never
+        # executes or interpolates it.
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: bash scripts/validate-rite.sh
 
       - name: Rite evidence self-test (the gate is itself gated)
         run: python3 scripts/validate-rite-evidence.py --selftest
+
+      - name: Spec-rite self-test (the gate is itself gated)
+        run: python3 scripts/validate-spec-rite.py --selftest
 
       - name: Claude plugin validation (best-effort)
         continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -226,6 +226,11 @@ fix, and no new prompt ever arrives to trigger the rite.
 runs it on every prompt, and its output becomes context for that turn. It **informs, never blocks** —
 no tool call is denied, and the user can waive the rite explicitly.
 
+Where the working directory carries `openspec/`, the reminder gains one extra sentence naming the
+spec gate: the item also becomes an OpenSpec change, validated strict before the first edit outside
+`openspec/`. The sentence is conditional on purpose — it never fires in a repo that has no such
+workflow, so the reminder does not teach a step that does not exist there.
+
 ```jsonc
 // ~/.claude/settings.json
 {
@@ -409,8 +414,17 @@ Daily flow:
 | Command | What happens |
 |---|---|
 | `/backlog <idea>` | analyzes the repo for real context → drafts a structured issue → **preview for approval** → creates the issue + adds it to the Project with fields set (card in **Backlog**) |
-| `/execute-backlog <n>` | reads the issue → completeness gate (card → **Ready**) → implementation plan for approval (card → **In progress**) → implements on `backlog/<n>-<slug>` following the repo's own rites → tests + validations → PR with `Closes #n` (card → **In review**) — never merges, never closes issues |
+| `/execute-backlog <n>` | reads the issue → completeness gate (card → **Ready**) → spec gate where the repo runs one → implementation plan for approval (card → **In progress**) → implements on `backlog/<n>-<slug>` following the repo's own rites → tests + validations → PR with `Closes #n` (card → **In review**) — never merges, never closes issues |
 | you merge the PR | issue auto-closes; the board's built-in *Item closed → Done* workflow moves the card to **Done** |
+
+**In a repo that runs a spec-driven workflow** (an `openspec/` directory), the two commands carry a
+third gate between them. `/backlog` records the verdict in the item — the change that will register
+the work, or a waiver written as a line with a reason — and `/execute-backlog` re-checks that verdict
+against the real change surface, creates the change, and validates it strict **before** editing
+anything outside `openspec/`. Raising a verdict needs no permission; lowering one stops for the user.
+The policy is the repo's, in the `spec_rite` key of the backlog config; a repo that carries the
+workflow and states no policy is treated as requiring the change. Protocol:
+[`spec-rite.md`](skills/execute-backlog/references/spec-rite.md).
 
 Requirements: `gh` ≥ 2.40 with the scopes above, write access to the target repos, and a GitHub
 Project v2 in the org/user. Full details live in the skills themselves:
@@ -667,6 +681,16 @@ last) and runs
 `openspec validate --all --strict`, wired as the **"OpenSpec rite gate"** step in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Run it locally before pushing — CI is the
 backstop, not the first line.
+
+Every check above iterates over *active changes*, which means a pull request that opened none used to
+pass them all vacuously: the loop found nothing, `fail` stayed 0, and the gate printed `rite gate OK`.
+That is how PR #80 and PR #84 shipped blocking CI gates with no proposal and had to be registered
+retroactively by PR #88. [`scripts/validate-spec-rite.py`](scripts/validate-spec-rite.py) reads the
+**diff** instead: a pull request touching anything outside `openspec/` (beyond the paths the release
+automation writes) must carry an active change, a change archived in the same diff, or a waiver line
+`Spec-rite: none — <reason>` in its body. The waiver is authored by whoever opened the PR, including
+from a fork, so it is matched as text and never executed. The checkout runs at `fetch-depth: 0`
+because a gate with no base revision cannot measure, and a gate that cannot measure must not approve.
 
 A second gate checks the **content** of the skills themselves.
 [`scripts/validate-skills.py`](scripts/validate-skills.py) runs eight checks over every

--- a/claude/global/hooks/backlog-rite.py
+++ b/claude/global/hooks/backlog-rite.py
@@ -5,6 +5,12 @@ Reads the hook payload on stdin and, when the prompt looks like a request to cha
 code, prints a short reminder that becomes additional context for the turn. Silent
 otherwise: diagnosing, reading and answering are free.
 
+Where the working directory runs a spec-driven workflow, the reminder gains one extra
+sentence naming that workflow's gate. It is conditional on purpose: a reminder that
+fires everywhere stops being read, which would also cost the backlog sentence next to
+it. The payload's `cwd` is a documented field common to every hook event; os.getcwd()
+is the fallback for the case where it is missing.
+
 Why a hook and not only a rule in personal-rules.md: the harness runs this on every
 prompt, so enforcement does not depend on the assistant noticing a rule already in
 context. It informs — it never blocks a tool call, and the user can always waive.
@@ -24,6 +30,7 @@ reminder to match your own process instead of adopting it blindly.
 """
 
 import json
+import os
 import re
 import sys
 
@@ -61,6 +68,23 @@ REMINDER = (
     "The user may waive this explicitly; without a waiver, ask before coding."
 )
 
+# Appended only where the workflow exists. Naming a gate that is not there would teach a step the
+# repo does not have, and would spend the reminder's credibility on noise.
+SPEC_RITE = (
+    " This repo runs a spec-driven rite (openspec/): the item also becomes an OpenSpec change, "
+    "validated with `openspec validate <id> --strict`, BEFORE the first edit outside openspec/. "
+    "Skipping it needs a written waiver, not a silent judgement."
+)
+
+# Directory that marks the workflow. One name, checked literally — guessing at variants would be
+# the same achismo the rite exists to stop.
+SPEC_RITE_DIR = "openspec"
+
+
+def has_spec_rite(payload: dict) -> bool:
+    cwd = payload.get("cwd") or os.getcwd()
+    return os.path.isdir(os.path.join(cwd, SPEC_RITE_DIR))
+
 
 def main() -> int:
     try:
@@ -73,7 +97,10 @@ def main() -> int:
         return 0
 
     if CHANGE_SIGNALS.search(prompt):
-        print(REMINDER)
+        reminder = REMINDER
+        if has_spec_rite(payload):
+            reminder += SPEC_RITE
+        print(reminder)
 
     return 0
 

--- a/claude/global/personal-rules.md
+++ b/claude/global/personal-rules.md
@@ -19,7 +19,7 @@ Every code change starts as a backlog item. No exception for "small fixes" — s
 - **Plan mode is not a bypass.** An approved plan still becomes an issue before the first edit — `ExitPlanMode` approves the *plan*, it does not waive the rite.
 - If I ask for code without an issue, say so and offer to run `/backlog` first. I can waive it explicitly; without an explicit waiver, do not start editing.
 - Out of scope for the rite: personal config (`~/.claude`), scratchpad files, one-off ops commands.
-- OpenSpec is a complement, not a parallel path: bug/adjustment → backlog only; new capability, breaking change or architecture shift → backlog issue **plus** an OpenSpec proposal referenced from it.
+- OpenSpec is a complement, not a parallel path — and in a repo that carries `openspec/`, the default is **fail-closed**: the backlog item also becomes an OpenSpec change, validated with `openspec validate <id> --strict` before the first edit outside `openspec/`. The exit is a written waiver, never a silent judgement: a line `Spec-rite: none — <reason>` in the PR body, which CI reads. A repo that carries the workflow and states no policy is treated as requiring the change; the policy itself lives in the repo's `spec_rite` config, not in my head. Classifying a change as "just an adjustment" is exactly how two blocking CI gates shipped unregistered and had to be backfilled — the classification now has to be written down to count.
 
 ## Grounding (no achismo)
 Never guess. A claim is anything you assert **or act on** as if it were true — a sentence, a flag

--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -8,14 +8,17 @@ description: >-
   (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
   "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
   idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite:
-  the item created here is what execute-backlog turns into a branch and a pull request.
+  the item created here is what execute-backlog turns into a branch and a pull request. In a
+  repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also
+  declares its spec verdict — the change that will register the work, or a written waiver —
+  so execute-backlog inherits a decision instead of making a new one.
   First run per repo/workspace launches a
   config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
   use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.4.0
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -10,12 +10,15 @@ description: >-
   the review column. Use when the user invokes /execute-backlog <n>, says
   "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
   issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced
-  by the backlog skill, and this skill carries it to a reviewable PR. Uses the backlog skill's
+  by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a
+  spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code:
+  the item's spec verdict is re-checked, the change is created and validated strict, and only then
+  does the plan go to approval. Uses the backlog skill's
   config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.5.0
+  version: 1.6.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Turn a natural-language idea into a structured GitHub backlog item: analyze the current repository (or multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create the GitHub issue and add it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite: the item created here is what execute-backlog turns into a branch and a pull request. First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT use for implementing an existing issue (that is execute-backlog), for creating pull requests, or for non-GitHub trackers (Jira, Linear, Trello).
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the current repository (or multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create the GitHub issue and add it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite: the item created here is what execute-backlog turns into a branch and a pull request. In a repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also declares its spec verdict — the change that will register the work, or a written waiver — so execute-backlog inherits a decision instead of making a new one. First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT use for implementing an existing issue (that is execute-backlog), for creating pull requests, or for non-GitHub trackers (Jira, Linear, Trello).
 alwaysApply: false
 ---
 
@@ -12,7 +12,7 @@ configured GitHub Project v2 — never a copy of the user's sentence, always gro
 codebase.
 
 - **Issue section template + writing guidance**: `references/issue-template.md`
-- **Config schema (both modes, precedence, wizard)**: `references/backlog-config.md`
+- **Config schema (both modes, precedence, wizard, `spec_rite`)**: `references/backlog-config.md`
 - **gh recipes for Projects v2 (IDs, item-edit, verification, recovery)**: `references/gh-projects.md`
 
 ## CRITICAL: Ground rules
@@ -34,6 +34,13 @@ codebase.
    fresh each run (they drift and differ per Project).
 6. Ask questions **only** when essential information is missing or ambiguous (max ~3, objective).
    Everything derivable from the repo must be derived, not asked.
+7. **Spec-rite gate** — in a repo that runs a spec-driven workflow, the item is not complete until
+   it declares its verdict: the change that will register the work, or a waiver written as a line
+   with a reason. The default is that the change is required; a repo carrying the workflow with no
+   stated policy is treated as requiring it, because an unstated policy is the absence of a
+   decision, not permission to skip. Never decide this silently — the verdict is a section of the
+   item and appears in the preview. The workflow's own lifecycle is not restated here: it is
+   `openspec`, or the project's fork (`openspec-drivezone` is one).
 
 ## Workflow
 
@@ -55,21 +62,33 @@ codebase.
    candidate → show it and ask whether to continue, enrich the existing issue instead, or cancel.
 5. **Gap questions** — only for essentials the repo cannot answer (e.g. which provider, which of
    two plausible scopes). Batch them in one round.
-6. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
+6. **Spec-rite triage** — repo with a spec-driven workflow only; skip when there is none:
+
+   ```bash
+   [ -d openspec ] && grep -m1 '^schema:' openspec/config.yaml   # which schema this repo runs
+   openspec list                                                 # a related change may be open
+   ```
+
+   Read `spec_rite.policy` from config (`references/backlog-config.md`); absent with the workflow
+   present ⇒ `required`. Then propose the verdict: a verb-led change id (`add-`, `update-`,
+   `remove-`, `refactor-`) plus the capabilities its delta will touch, or the waiver line and the
+   reason it is legitimate. An existing open change that already covers the idea is named instead
+   of a new one.
+7. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
    apply. When the item produces code, fill the **Glossary** from the vocabulary harvested in step 3
    before deciding any new name; a term neither the codebase nor the user resolves becomes a gap
    question in step 5, never a translation invented here (`code-locale`). Workspace mode adds
    *Affected repositories* (role per repo) and elects the **primary affected repo** (issue home,
    unless `issues_repo` is configured). Propose field values (Status default from config;
    Priority/Size/Estimate heuristics) each with a 1-line rationale.
-7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
-   proposed field values. Only proceed on explicit approval.
-8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
+8. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees,
+   proposed field values and the spec verdict. Only proceed on explicit approval.
+9. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
    `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field. Repeat
    the add (and the Status default) for every board in `extra_projects`, when configured — an issue
    can live on several Projects at once (see `references/backlog-config.md`).
-9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
-   fields, partial failures + recovery commands).
+10. **Report** — issue URL, project item confirmation, fields set, the spec verdict recorded, plus
+   any warnings (skipped fields, partial failures + recovery commands).
 
 ## Setup wizard (first run, per repo/workspace)
 

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search), validate it is complete enough to execute, re-analyze the current repo/workspace state, present an implementation plan for approval BEFORE touching code, implement on a dedicated branch following the repo's conventions, add/update tests, run the repo's discoverable validations (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced by the backlog skill, and this skill carries it to a reviewable PR. Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+  Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search), validate it is complete enough to execute, re-analyze the current repo/workspace state, present an implementation plan for approval BEFORE touching code, implement on a dedicated branch following the repo's conventions, add/update tests, run the repo's discoverable validations (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code: the item's spec verdict is re-checked, the change is created and validated strict, and only then does the plan go to approval. Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 alwaysApply: false
 ---
 
@@ -11,6 +11,7 @@ Drive an existing issue to a reviewable pull request while keeping the board in 
 to the `backlog` skill; consumes the same config.
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
+- **Spec-driven gate: detection, verdict, upgrade/downgrade, archive timing**: `references/spec-rite.md`
 - **Discovering and running each repo's validations**: `references/validation-matrix.md`
 - **Ticking the item's checkboxes + evidence table + completeness gate**: `references/acceptance-tracking.md`
 - **Board transitions + PR↔issue linking + recovery**: `references/board-sync.md`
@@ -43,6 +44,13 @@ to the `backlog` skill; consumes the same config.
    repo's own established process for that stage (spec/proposal rites, implementation and test
    rites, review templates). The generic workflow here is the fallback, never an override
    (`references/execution-flow.md`, *Per-stage rite discovery*).
+10. **Spec-before-code is a hard gate too** — in a repo that runs a spec-driven workflow, no file
+   **outside that workflow's own directory** is edited before the change exists and its strict
+   validation is green. The policy belongs to the repo (`spec_rite.policy` in the backlog config);
+   a repo that carries the workflow and states no policy is treated as requiring the change. The
+   verdict the item carries is re-checked, never re-decided: raise it without asking, lower it only
+   with the user. The workflow's own lifecycle is not restated here — it is `openspec` (or the
+   project's fork, e.g. `openspec-drivezone`). Protocol: `references/spec-rite.md`.
 
 ## Workflow
 
@@ -64,24 +72,35 @@ to the `backlog` skill; consumes the same config.
    repositories section in workspace mode; verify local clones, offer `gh repo clone` for missing
    ones). Collect: current state of cited files, conventions, test setup, related recent changes,
    and the identifier vocabulary the repo already uses for the item's concepts (`code-locale`).
-5. **Implementation plan** — present: interpretation of the item, files to change per repo, the
-   Glossary, test strategy, validations to run, risks, estimated blast radius. **Wait for approval.**
-6. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
-   project skills (e.g. `conventional-commit`, project-specific rites like OpenSpec when the repo
-   uses them). Names for anything new come from the approved Glossary (rail 8). Move the board item
+5. **Spec rite** — repo with a spec-driven workflow only; skip when there is none. Detect it and
+   the schema it runs, re-check the item's verdict against the surface the re-analysis just
+   measured, and — when the verdict requires it — create the change and validate it strict before
+   step 6. Raising a verdict needs no permission; lowering one does. Full protocol, detection
+   commands and archive timing: `references/spec-rite.md`.
+6. **Implementation plan** — present: interpretation of the item, files to change per repo, the
+   Glossary, test strategy, validations to run, risks, estimated blast radius. In a repo with a
+   spec rite, also the change id, the capabilities its delta touches and the strict-validation
+   output line. **Wait for approval.**
+7. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
+   project skills (e.g. `conventional-commit`, and the repo's spec rite when it has one). Names for
+   anything new come from the approved Glossary (rail 8). A spec rite's task list is ticked task by
+   task as each one lands and is validated, never in a batch at the end. Move the board item
    to the configured in-progress column when work starts.
-7. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
-8. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
+8. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
+9. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers. A repo that wires an identifier-locale
    check is running one of its own discovered commands — never invent one where none exists.
-9. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
+10. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
     the validation evidence, tick the proven ones in the issue body (surgical read-modify-write),
     and gate on the rest: unmet or manual-only criteria stop the run for a decision before any PR
-    is opened (`references/acceptance-tracking.md`).
-10. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
+    is opened (`references/acceptance-tracking.md`). A spec rite's mandatory closure group is part
+    of the sweep, not a separate afterthought.
+11. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
     `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
-    left anything unticked. No auto-merge. Follow `conventional-commit` PR rules when present.
-11. **Sync & report** — move the board item to the review column; comment on the issue with links
+    left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
+    gate reads — the change id, or the written waiver and its reason (`references/spec-rite.md`).
+    No auto-merge. Follow `conventional-commit` PR rules when present.
+12. **Sync & report** — move the board item to the review column; comment on the issue with links
     to the PR(s); present summary: what changed, validation evidence, the criteria table with
-    every verdict, deviations (if any, pre-approved), next human step (review/merge).
-
+    every verdict, deviations (if any, pre-approved), next human step (review/merge). A change left
+    active on purpose is reported as pending, naming what closes it.

--- a/openspec/changes/add-spec-rite-gate/.openspec.yaml
+++ b/openspec/changes/add-spec-rite-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-23

--- a/openspec/changes/add-spec-rite-gate/README.md
+++ b/openspec/changes/add-spec-rite-gate/README.md
@@ -1,0 +1,3 @@
+# add-spec-rite-gate
+
+Require an OpenSpec change in the backlog rite and close the rite gate's vacuous pass

--- a/openspec/changes/add-spec-rite-gate/design.md
+++ b/openspec/changes/add-spec-rite-gate/design.md
@@ -1,0 +1,121 @@
+## Context
+
+O rito backlog-first deste repositório é enforçado em quatro camadas, e o OpenSpec só aparece de
+verdade em nenhuma delas. Medido no HEAD `c275a38`, em 2026-08-23:
+
+```
+$ grep -rn -i "openspec" skills/backlog | wc -l
+0
+$ grep -rn -i "openspec" skills/execute-backlog | wc -l
+5
+$ grep -c -i "openspec" claude/global/hooks/backlog-rite.py
+0
+```
+
+As cinco ocorrências em `execute-backlog` são todas exemplo dentro de um mecanismo genérico de
+descoberta (`references/execution-flow.md:54`, `SKILL.md:89`,
+`references/acceptance-tracking.md:13`), nunca um passo da espinha numerada.
+
+A camada 4 é a única que sobreviveria a um contribuidor sem os hooks locais, e ela aprova por
+vacuidade:
+
+```
+$ ls openspec/changes/
+archive
+$ sed -n '20,26p' scripts/validate-rite.sh
+for dir in "$CHANGES_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  name="$(basename "$dir")"
+  [ "$name" = "archive" ] && continue
+```
+
+Sem change ativa, o corpo do loop nunca roda. `scripts/validate-rite-evidence.py:121` faz o mesmo
+por outro caminho — `if not base.exists(): return []`, e a lista de `tasks.md` ativos sai vazia.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Um PR que toque `skills/**` sem change OpenSpec e sem dispensa escrita não fica verde.
+- A decisão de dispensar vira uma linha escrita, revisável, em vez de um julgamento interno do
+  modelo.
+- As três camadas acima do CI nomeiam o rito de spec explicitamente, e a de baixo o exige.
+- O rito continua portátil: as duas skills rodam também nos repositórios DriveZone, com rito e
+  schema próprios.
+
+**Non-Goals:**
+
+- Reescrever a doutrina vanilla de `skills/openspec/SKILL.md` §*When a proposal is required*. Ela
+  descreve o OpenSpec; a política de rigor é do repositório.
+- Mexer em `skills/openspec-drivezone/`.
+- Remediar os desvios equivalentes nos repositórios DriveZone — rito próprio, item próprio lá.
+- Arquivar este change no mesmo PR. O precedente é PR separado (`#78`, `#74`).
+- Provar que a change é honesta. O gate prova que ela existe; a revisão julga o conteúdo.
+
+## Decisions
+
+**Fail-closed com dispensa escrita, e não "proposta sempre, sem exceção".** A escolha do mantenedor
+foi gate duro. Gate duro literal não é implementável: o CLI 1.6.0 exige ≥1 delta de spec por change
+e `skills/openspec/SKILL.md:36-38` registra que `skip_specs` foi probado e não tem efeito. Um typo
+forçaria inventar requisito — que a doutrina do próprio repositório proíbe (*"A near-duplicate
+ADDED requirement is the wrong answer: it splits the doctrine"*). A forma que preserva a intenção é
+inverter o default: o artefato é exigido, e a única saída é uma linha escrita que o CI lê e o
+revisor vê. Nada escapa por julgamento silencioso, que era o alvo.
+
+**A política mora no repositório, não na skill.** `backlog` e `execute-backlog` são portáteis e
+rodam em repositórios com ritos diferentes. Hardcodar "proposta obrigatória" nelas exportaria a
+política deste repositório para todos. A chave `spec_rite.policy` em `backlog.yml` resolve isso, e o
+default sem chave, com `openspec/` presente, é `required` — a ausência de decisão não vira permissão.
+
+**Upgrade automático, downgrade com o usuário.** O modo de falha medido nas issues #79 e #84 foi o
+downgrade silencioso: o item nasce sem exigir artefato, e a implementação cresce sem que ninguém
+revisite. Subir o veredito (dispensa → artefato) não tira nada de ninguém e é automático. Descer
+(artefato → dispensa) é exatamente o movimento que produziu a deriva, e para.
+
+**A dispensa vive no corpo do PR, não em label nem em arquivo.** Label não carrega motivo. Arquivo
+no repositório vira lixo permanente por uma decisão de um PR só. O corpo do PR é onde o revisor já
+está olhando, e o `github.event.pull_request.body` chega ao script sem API extra.
+
+**A dispensa é entrada não confiável.** Ela é escrita por quem abre o PR, inclusive de um fork. O
+script casa por regex ancorada e nunca interpola em comando — a alternativa (avaliar a linha, ou
+passá-la a um shell) daria execução arbitrária a um contribuidor externo.
+
+**`fetch-depth: 0` é pré-requisito, não detalhe.** `.github/workflows/ci.yml:28` usa
+`actions/checkout@v5` sem `with:`, ou seja profundidade 1: não existe base para `git diff`. Sem essa
+mudança a checagem nova não tem o que ler, e a forma de falha seria a pior possível — um gate que
+não consegue medir e por isso passa.
+
+**A checagem só roda em `pull_request`.** Em `push` para `master` o merge já aconteceu; reprovar ali
+não protege nada e quebraria os commits de release do semantic-release.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Ciclo OpenSpec (explore → propose → validate --strict → apply → archive), formato de proposal/delta/tasks, quando uma proposta é exigida na doutrina vanilla | `openspec` | já canônica — `backlog` e `execute-backlog` carregam o **gate** e linkam; nenhuma delas restata o ciclo |
+| Variante de schema forkado com gates obrigatórios | `openspec-drivezone` | já canônica — citada como precedente de fork, não reescrita |
+| Rito backlog-first (todo change vira item antes da primeira edição) | `claude/global/personal-rules.md` → `backlog` / `execute-backlog` | já canônica — este change acrescenta a perna de spec, não redefine o rito |
+| Anti-chute: não afirmar nem agir sobre fato não verificado; o downgrade silencioso da #79 é uma instância | `verify-before-claiming` | já canônica — `execute-backlog` linka no novo rail, sem restatar a escada de pesquisa |
+| Camada de máquina em inglês (chaves de config, marcador do PR, nomes de arquivo) | `code-locale` | já canônica — o Glossary da issue #89 é a fonte dos nomes novos |
+| Rito adversarial de teste do que foi implementado | `bug-hunter` | já canônica — o `--selftest` do gate segue o padrão dos gates irmãos, sem restatar a metodologia |
+
+## Risks / Trade-offs
+
+- **PR de fork escreve a dispensa** → a dispensa é dado, não instrução: regex ancorada, sem
+  execução, sem interpolação. O revisor continua sendo quem julga o motivo.
+- **Falso positivo nos commits do semantic-release** (`chore(release): … [skip ci]`) → allowlist de
+  `VERSION`, `CHANGELOG.md` e `.claude-plugin/*.json`, mais a restrição a evento `pull_request`.
+- **O gate reprovar o PR que o introduz** → este PR carrega change ativa, logo passa. Verificado
+  antes de abrir.
+- **Atrito virar burla** → a dispensa existe justamente para o caso legítimo. Se ela começar a
+  aparecer em todo PR, o sintoma fica visível no histórico dos PRs, que era o objetivo.
+- **`fetch-depth: 0` deixa o checkout mais lento** → o repositório é pequeno (histórico de meses,
+  sem binários grandes); o custo é de segundos e é o preço de conseguir diffar.
+- **O gate provar existência e ser lido como prova de qualidade** → o cabeçalho `KNOWN LIMIT` do
+  script declara explicitamente que existência não é honestidade, no mesmo lugar onde já declara que
+  forma não é verdade.
+
+## Open Questions
+
+- O payload de `UserPromptSubmit` carrega a chave `cwd`? A implementação probou o payload real antes
+  de escrever; o fallback `os.getcwd()` cobre o caso de não carregar. Registrado em `E.2`.

--- a/openspec/changes/add-spec-rite-gate/design.md
+++ b/openspec/changes/add-spec-rite-gate/design.md
@@ -80,6 +80,21 @@ está olhando, e o `github.event.pull_request.body` chega ao script sem API extr
 script casa por regex ancorada e nunca interpola em comando — a alternativa (avaliar a linha, ou
 passá-la a um shell) daria execução arbitrária a um contribuidor externo.
 
+**A checagem nova é um irmão em Python, não mais um bloco no bash.** `validate-rite.sh` já
+orquestra um irmão (`validate-rite-evidence.py`) com a justificativa de ser "um KIND de check
+diferente". Este é um terceiro: os dois primeiros iteram sobre changes ativas, este lê o diff. Além
+disso o `--selftest` do padrão da casa injeta defeito e afirma detecção — em bash isso exigiria
+fixtures de git a cada caso, enquanto a decisão modelada como função pura (`evaluate`) é exercitada
+com entradas sintéticas, incluindo os casos de falso positivo que precisam ficar em silêncio.
+`scripts/validate-rite.sh --selftest` encaminha para ele, então o comando da issue continua válido.
+O que o selftest não cobre — o encanamento de git que alimenta a função — é declarado no
+`KNOWN LIMIT` do script e coberto pela falha de base irresolvível no CI.
+
+**Base irresolvível falha no CI e é pulada localmente.** Se o gate não consegue diffar, ele não pode
+aprovar: no CI isso significa checkout mal configurado, e passar seria repetir o passe vazio numa
+forma nova. Fora do CI (clone raso, branch sem `origin/master`) a checagem se declara pulada, porque
+ali ela não é a defesa — o CI é.
+
 **`fetch-depth: 0` é pré-requisito, não detalhe.** `.github/workflows/ci.yml:28` usa
 `actions/checkout@v5` sem `with:`, ou seja profundidade 1: não existe base para `git diff`. Sem essa
 mudança a checagem nova não tem o que ler, e a forma de falha seria a pior possível — um gate que

--- a/openspec/changes/add-spec-rite-gate/proposal.md
+++ b/openspec/changes/add-spec-rite-gate/proposal.md
@@ -1,0 +1,75 @@
+# Change: Exigir change OpenSpec no rito e fechar o passe vazio do gate
+
+## Why
+
+O rito deste repositório tem quatro camadas de enforcement e o OpenSpec está ausente ou opcional em
+todas as quatro. A camada que deveria reprovar aprova por vacuidade: `scripts/validate-rite.sh`
+itera `for dir in "$CHANGES_DIR"/*/`, pula `archive` com `continue`, e quando não existe change
+ativa nenhuma o corpo do loop nunca executa — `fail` continua `0` e o script imprime `rite gate OK`.
+`scripts/validate-rite-evidence.py:121` tem o mesmo comportamento: retorna `[]` sem change ativa,
+logo `findings` vazio, logo `exit 0`.
+
+O gate valida a **forma** de uma change que existe. Nada exige que ela exista.
+
+A consequência já ocorreu duas vezes, e está no arquivo deste repositório: o PR #80 entregou
+`scripts/validate-rite-evidence.py` e o PR #84 entregou quatro checks de frontmatter — ambos gates
+bloqueantes novos no CI, ambos **sem proposta OpenSpec**, ambos verdes. O
+`2026-08-15-record-shipped-gates` existe só para registrar retroativamente o que os dois deixaram
+de registrar, e abre com *"ambos sem proposta OpenSpec"*.
+
+A justificativa gravada na issue #79 — *"ajuste de gate existente, não capacidade nova"* — é um
+julgamento discricionário, invisível, e desmentido pelo precedente
+`2026-08-07-add-repo-hygiene-gates`, que tem exatamente a mesma forma e teve proposta completa. Um
+rito cuja única defesa é o modelo lembrar de uma regra não é um rito; é uma intenção.
+
+## What Changes
+
+- **Camada 4 (gate)** — `scripts/validate-rite.sh` ganha a checagem que fecha o passe vazio: um
+  diff que toca caminho fora de `openspec/` exige change ativa, archive novo no próprio diff, ou
+  uma dispensa escrita `Spec-rite: none — <motivo>` no corpo do PR. A checagem ganha `--selftest`
+  injetando um defeito por regra, como todo gate deste repositório.
+  `.github/workflows/ci.yml` ganha `fetch-depth: 0` (hoje 1, sem base para diffar), `PR_BODY` no
+  ambiente e o passo de self-test.
+- **Camada 3 (`execute-backlog`)** — o gate de spec sai do reference e entra na espinha numerada:
+  novo safety rail *Spec-before-code* e novo passo entre a re-análise e o plano. O plano
+  apresentado para aprovação passa a carregar change-id, capabilities e a saída do `--strict`.
+- **Camada 2 (`backlog`)** — a triagem de rito passa a existir e a ficar escrita na issue: novo
+  ground rule, novo passo de workflow, nova seção obrigatória no `issue-template.md` e a chave
+  `spec_rite` documentada em `backlog-config.md`.
+- **Camada 1 (hook)** — `claude/global/hooks/backlog-rite.py` nomeia o rito de spec, e **só** onde
+  ele existe: a frase extra é emitida apenas quando há `openspec/` no `cwd` do payload.
+- **Doutrina** — `claude/global/personal-rules.md` passa a descrever a mesma política que o gate
+  enforça, em vez de uma classificação discricionária que o gate não conhece.
+
+**Não é BREAKING para consumidores do catálogo**: nenhum skill é adicionado, removido ou renomeado;
+a composição e a descoberta por `npx` ficam idênticas. É breaking para o **fluxo de contribuição**
+deste repositório, que passa a exigir artefato ou dispensa escrita em todo PR.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Todo o comportamento novo cai em requisitos que já existem sobre o rito e sobre as
+skills de backlog.
+
+### Modified Capabilities
+
+- `skills-catalog`: *The development rite is enforced outside the model's discretion* ganha a perna
+  spec-driven — o rito não termina no item de backlog, e o artefato de spec é exigido por um gate
+  fora da discrição do modelo, com dispensa possível apenas por escrito.
+- `skills-catalog`: *The backlog skills declare their place in one rite* passa a exigir que as duas
+  metades declarem também o gate de spec entre elas, sem restatar o ciclo OpenSpec.
+- `skills-catalog`: *The rite gates evidence before it gates quality* passa a exigir que o gate
+  cubra a **ausência** de change, não só a forma de uma change presente — o passe vazio é o furo
+  que este change fecha.
+
+## Impact
+
+- `scripts/validate-rite.sh`, `.github/workflows/ci.yml`.
+- `skills/backlog/SKILL.md` + `references/issue-template.md` + `references/backlog-config.md`.
+- `skills/execute-backlog/SKILL.md` + `references/execution-flow.md` + novo `references/spec-rite.md`.
+- `claude/global/hooks/backlog-rite.py`, `claude/global/personal-rules.md`, `README.md`.
+- Árvores geradas por `./generate.sh` (`claude/`, `codex/`, `cursor/`, `copilot/`,
+  `plugins/workflow/`), porque as descrições dos dois skills mudam e o CI diffa a árvore gerada.
+- Consumidores do catálogo: nenhuma diferença. Contribuidores deste repositório: todo PR passa a
+  precisar de change ativa ou de dispensa escrita.

--- a/openspec/changes/add-spec-rite-gate/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-spec-rite-gate/specs/skills-catalog/spec.md
@@ -1,0 +1,189 @@
+## MODIFIED Requirements
+
+### Requirement: The development rite is enforced outside the model's discretion
+
+The catalog SHALL state, in its portable global rules, that every code change starts as a backlog
+item, and SHALL ship an enforcement artifact that fires without depending on the assistant noticing
+the rule. The artifact SHALL inform rather than block: it never denies a tool call, and the user can
+always waive the rite explicitly. Diagnosing, reading and answering SHALL remain unrestricted — the
+rite applies only when code is going to change.
+
+In a repository that runs a spec-driven workflow, the rite SHALL NOT end at the backlog item. The
+spec artifact SHALL be named by the same enforcement artifact that names the backlog step, and the
+naming SHALL be conditional on that workflow being present, so that the reminder stays silent where
+it does not apply. A repository whose spec policy is unstated SHALL be treated as requiring the
+artifact, so that the absence of a decision is not read as permission to skip it.
+
+The decision to ship without a spec artifact SHALL be a written one. A judgment made silently by the
+assistant, or by a contributor in conversation, SHALL NOT satisfy the rite: the waiver SHALL exist as
+a reviewable line in the pull request, and the gate SHALL be what reads it.
+
+#### Scenario: A code-change request carries the rite into context
+
+- **WHEN** a prompt asks for an implementation, fix, refactor or removal
+- **THEN** the shipped `UserPromptSubmit` hook injects the rite reminder naming `/backlog` as the
+  entry point and `/execute-backlog` as the second step
+- **AND** the reminder states that diagnosis is free and that an approved plan is not a waiver
+
+#### Scenario: The reminder names the spec rite only where it exists
+
+- **WHEN** the prompt matches a code-change signal and the working directory carries the
+  spec-driven workflow's directory
+- **THEN** the reminder also names the spec artifact as a step that precedes the first edit outside
+  that directory
+- **AND** the same prompt in a working directory without that workflow produces the reminder without
+  the spec sentence, so the added line never fires where it has no meaning
+
+#### Scenario: The reminder is silent inside its own rite
+
+- **WHEN** the prompt is already a rite command (`/backlog`, `/execute-backlog`), another slash
+  command, or contains an explicit waiver
+- **THEN** the hook produces no output, so the reminder never fires against the flow it enforces
+
+#### Scenario: Plan approval is not a bypass
+
+- **WHEN** an assistant finishes planning and the plan is approved
+- **THEN** the rule as stated in the global rules requires the work to become a backlog item before
+  the first edit, because approving a plan approves the plan and not the skipping of the rite
+
+#### Scenario: The enforcement artifact persists nothing
+
+- **WHEN** the shipped hook runs
+- **THEN** it reads the prompt payload, matches, prints and exits, writing no state outside the
+  repository and requiring no credentials
+
+### Requirement: The backlog skills declare their place in one rite
+
+The `backlog` and `execute-backlog` descriptions SHALL identify each other as the two halves of a
+single flow — creation then execution — so that a reader arriving at either one learns where the
+work came from and where it goes next. Neither description SHALL restate the other's workflow.
+
+Where the target repository runs a spec-driven workflow, both skills SHALL carry the gate that
+workflow imposes between them, and neither SHALL restate its lifecycle: the lifecycle has a canonical
+home in the catalog's own spec-driven skill, and the backlog skills SHALL link to it. The creating
+skill SHALL record the verdict — the artifact that will exist, or the written waiver — in the item
+itself, so the executing skill inherits a decision instead of making a new one. The executing skill
+SHALL re-check that verdict against the change it is about to make, SHALL raise it without asking
+when the work outgrew the item, and SHALL NOT lower it without the user, because a silent downgrade
+is the failure this gate exists to prevent.
+
+The policy SHALL be the repository's to set rather than the skills', because both skills run against
+repositories with different rites; a repository that states no policy while carrying the workflow
+SHALL be treated as requiring the artifact.
+
+#### Scenario: Entry point is discoverable from the execution skill
+
+- **WHEN** a user reads the `execute-backlog` description
+- **THEN** it names `backlog` as the step that produces the item it consumes
+
+#### Scenario: Exit is discoverable from the creation skill
+
+- **WHEN** a user reads the `backlog` description
+- **THEN** it names `execute-backlog` as the step that turns the created item into a pull request
+
+#### Scenario: The item carries its spec verdict
+
+- **WHEN** the creating skill drafts an item for a repository that runs the spec-driven workflow
+- **THEN** the drafted item declares either the change identifier and the capabilities its delta will
+  touch, or the written waiver and its reason
+- **AND** the verdict appears in the approval preview alongside the proposed field values
+
+#### Scenario: The executing skill refuses to edit before the artifact exists
+
+- **WHEN** the executing skill is about to change a file outside the spec-driven workflow's own
+  directory, in a repository whose policy requires the artifact
+- **THEN** it stops until the change exists and its strict validation is green, and the plan it
+  presents for approval carries the change identifier, the affected capabilities and the validation
+  output
+
+#### Scenario: A verdict is raised silently and lowered only by the user
+
+- **WHEN** re-analysis shows the work touches more than the item's waiver assumed
+- **THEN** the executing skill raises the verdict to requiring an artifact without asking
+- **AND** the reverse move — dropping a required artifact to a waiver — stops for an explicit user
+  decision rather than being taken by the assistant
+
+### Requirement: The rite gates evidence before it gates quality
+
+The repository's spec-driven rite SHALL require every active change to open its task list with a
+group recording what was probed: local paths opened rather than recalled, external tools, flags,
+config keys, API names and versions checked against the installed version, and anything that could
+not be probed written down as an open question rather than stated as fact. The group SHALL be the
+first task group, and its presence and position SHALL be enforced by the same script that enforces
+the other mandatory groups, because the OpenSpec CLI validates delta-spec format only.
+
+Recorded evidence SHALL be a command together with a fragment of its raw output, never a conclusion,
+so that a reviewer can re-run it. That rule SHALL be enforced in **shape**: a ticked box in the
+evidence group SHALL be checked against the form its kind owes — a path opened together with the
+commit or date it was read at; a probe together with a fragment of its output; a gap named or
+explicitly declared absent — with a file-specific error naming the box and what is missing. The
+rules SHALL be per box kind rather than uniform, because the kinds do not share a shape and a
+uniform rule rejects boxes that are correct as written.
+
+The gate SHALL cover the **absence** of a change and not only the shape of one that is present. A
+gate whose checks are written as a loop over active changes passes vacuously when there are none,
+which reads as approval of a pull request that recorded nothing. Therefore a pull request whose diff
+touches paths outside the workflow's own directory SHALL be required to carry one of: an active
+change, a change archived within the same diff, or a waiver line in the pull request body naming a
+reason. Paths written by the release automation alone SHALL be exempt, and the check SHALL run only
+where a base revision to compare against exists.
+
+The waiver SHALL be treated as untrusted input: it is authored by whoever opened the pull request,
+including from a fork, and SHALL be matched as text and never executed or interpolated into a
+command.
+
+Every enforcing script SHALL state that it verifies presence, position and shape, and **not the
+truth of the contents**: a box padded to satisfy the shape passes, and no script can tell an
+invented output from a real one. A script that also verifies that a change exists SHALL state that
+existence is not honesty — a change scaffolded to satisfy the gate passes it.
+
+The mandatory groups that are **not** gated on shape SHALL have their evidence density reported
+without affecting the exit code, so that a group whose boxes carry no probe is visible to a reviewer
+without reading the diff.
+
+#### Scenario: A change without recorded evidence fails the build
+
+- **WHEN** an active change's task list lacks the evidence group, or carries it somewhere other than
+  the first task group
+- **THEN** the rite gate script fails with a file-specific error naming the missing or misplaced
+  group, and the build does not pass
+
+#### Scenario: A pull request that records nothing fails the build
+
+- **WHEN** a pull request's diff touches a path outside the workflow's own directory and carries
+  neither an active change, nor a change archived in the same diff, nor a waiver line
+- **THEN** the rite gate fails, naming the offending path, rather than passing because the loop over
+  active changes found nothing to check
+
+#### Scenario: The waiver is a written line, not a judgment
+
+- **WHEN** the same diff is accompanied by a waiver line in the pull request body naming a reason
+- **THEN** the gate passes and the reason is visible to the reviewer in the pull request itself
+- **AND** the line is matched as text, never executed, because its author is whoever opened the pull
+  request
+
+#### Scenario: A ticked box that states a conclusion fails the build
+
+- **WHEN** a ticked box in the evidence group records a conclusion instead of the form its kind owes
+- **THEN** the gate fails, naming the box and the missing element
+- **AND** the same box rewritten with a command and a fragment of its output passes
+
+#### Scenario: The gate declares what it cannot check
+
+- **WHEN** the gate passes
+- **THEN** the enforcing scripts state that shape is not truth — a box padded to satisfy the rule is
+  indistinguishable from an earned one — so that a green run is not read as verified evidence
+- **AND** they state that the existence of a change is not the honesty of one
+
+#### Scenario: A group that is reported rather than gated is not implied to be gated
+
+- **WHEN** a mandatory group carries items that are judgments rather than executions
+- **THEN** its evidence density is printed as a labelled report that never changes the exit code,
+  and the check states that the group is reported and not gated, rather than demanding a command
+  where none belongs
+
+#### Scenario: A gate introduced mid-flight does not exempt existing work
+
+- **WHEN** a new mandatory group is added while a change is already open
+- **THEN** the open change is backfilled with the group in the same change that introduces the gate,
+  rather than being added to an exemption list

--- a/openspec/changes/add-spec-rite-gate/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-spec-rite-gate/specs/skills-catalog/spec.md
@@ -126,7 +126,9 @@ which reads as approval of a pull request that recorded nothing. Therefore a pul
 touches paths outside the workflow's own directory SHALL be required to carry one of: an active
 change, a change archived within the same diff, or a waiver line in the pull request body naming a
 reason. Paths written by the release automation alone SHALL be exempt, and the check SHALL run only
-where a base revision to compare against exists.
+where a base revision to compare against exists. Where it runs in continuous integration and no base
+revision can be resolved, it SHALL fail rather than skip, because a gate that cannot measure must not
+approve — an unresolvable base there is a misconfigured checkout, not an exemption.
 
 The waiver SHALL be treated as untrusted input: it is authored by whoever opened the pull request,
 including from a fork, and SHALL be matched as text and never executed or interpolated into a
@@ -154,6 +156,12 @@ without reading the diff.
   neither an active change, nor a change archived in the same diff, nor a waiver line
 - **THEN** the rite gate fails, naming the offending path, rather than passing because the loop over
   active changes found nothing to check
+
+#### Scenario: A gate that cannot measure does not approve
+
+- **WHEN** the check runs in continuous integration and no base revision can be resolved
+- **THEN** it fails naming the missing fetch depth, rather than passing because it had nothing to
+  compare against
 
 #### Scenario: The waiver is a written line, not a judgment
 

--- a/openspec/changes/add-spec-rite-gate/tasks.md
+++ b/openspec/changes/add-spec-rite-gate/tasks.md
@@ -52,14 +52,14 @@
 
 ## 3. Camada 3 — `execute-backlog` põe o gate de spec na espinha numerada
 
-- [ ] 3.1 Novo safety rail *Spec-before-code* em `skills/execute-backlog/SKILL.md`
-- [ ] 3.2 Novo passo numerado de spec-rite entre *Context re-analysis* e *Implementation plan*, e o
+- [x] 3.1 Novo safety rail *Spec-before-code* em `skills/execute-backlog/SKILL.md`
+- [x] 3.2 Novo passo numerado de spec-rite entre *Context re-analysis* e *Implementation plan*, e o
       plano passando a carregar change-id, capabilities e a saída do `--strict`
-- [ ] 3.3 Novo `skills/execute-backlog/references/spec-rite.md`: detecção, descoberta do schema,
+- [x] 3.3 Novo `skills/execute-backlog/references/spec-rite.md`: detecção, descoberta do schema,
       tabela de veredito, protocolo de upgrade/downgrade, timing do archive
-- [ ] 3.4 `references/execution-flow.md` deixa de tratar OpenSpec como exemplo e aponta para o novo
+- [x] 3.4 `references/execution-flow.md` deixa de tratar OpenSpec como exemplo e aponta para o novo
       reference; passo de PR passa a carregar a linha `Spec-rite:`
-- [ ] 3.5 `metadata.version` de `execute-backlog` bumpada e a descrição refletindo o gate novo
+- [x] 3.5 `metadata.version` de `execute-backlog` bumpada e a descrição refletindo o gate novo
 
 ## 4. Camada 2 — `backlog` passa a produzir o veredito por escrito
 

--- a/openspec/changes/add-spec-rite-gate/tasks.md
+++ b/openspec/changes/add-spec-rite-gate/tasks.md
@@ -26,11 +26,21 @@
       resolve o fork — por isso o change foi criado com `openspec new change ... --schema skills-rite`);
       `ls openspec/changes/` -> `archive` (única entrada, o que torna o loop do gate vazio);
       `grep -rn -i "openspec" skills/backlog | wc -l` -> `0`;
-      `gh auth status` -> `Token scopes: 'admin:org', ..., 'project', 'repo', 'workflow', ...`
-- [ ] E.3 Aberto e registrado, não afirmado: o payload de `UserPromptSubmit` carrega a chave `cwd`?
-      A implementação probará o payload real antes de escrever a frase condicional; o fallback
-      `os.getcwd()` cobre o caso de não carregar. Nenhuma outra lacuna.
-- [ ] E.4 Follow-ups listados, não executados aqui: (a) `openspec templates` sem `--schema` ignorar o
+      `gh auth status` -> `Token scopes: 'admin:org', ..., 'project', 'repo', 'workflow', ...`;
+      docs oficiais de hooks (code.claude.com/docs/en/hooks, lidas em 2026-08-23) -> `cwd` é campo
+      comum de entrada de **todo** hook event, ao lado de `session_id`, `transcript_path`,
+      `permission_mode` e `hook_event_name`;
+      `echo '{"prompt":"corrige o bug X","cwd":"/tmp"}' | python3 claude/global/hooks/backlog-rite.py`
+      -> saída termina em `...ask before coding.` (sem a frase de spec), e o mesmo prompt com
+      `"cwd":"$PWD"` -> `... This repo runs a spec-driven rite (openspec/): ...`;
+      `python3 scripts/validate-spec-rite.py --selftest` ->
+      `3/3 defect classes detected, 6/6 false-positive cases stayed silent`
+- [x] E.3 A única lacuna aberta na proposta — se o payload de `UserPromptSubmit` carrega `cwd` —
+      foi fechada pelas docs oficiais em 2026-08-23: `cwd` é campo comum de todo hook event. O
+      fallback `os.getcwd()` ficou no código como defesa, não como suposição. Nenhuma outra lacuna
+      em aberto: o que o `--selftest` do gate novo não cobre (o encanamento de git que alimenta a
+      função de decisão) está declarado no `KNOWN LIMIT` do próprio script, não escondido.
+- [x] E.4 Follow-ups listados, não executados aqui: (a) `openspec templates` sem `--schema` ignorar o
       `openspec/config.yaml` é um comportamento do CLI 1.6.0 que merece item próprio (documentar ou
       reportar upstream); (b) os desvios equivalentes nos repositórios DriveZone ganham item em cada
       um, com rito próprio; (c) o archive deste change é PR separado, conforme o precedente `#78`/`#74`
@@ -73,9 +83,9 @@
 
 ## 5. Camada 1 — o hook nomeia o rito de spec onde ele existe
 
-- [ ] 5.1 Probar o payload real de `UserPromptSubmit` e registrar o resultado em `E.3`
-- [ ] 5.2 Frase condicional na `REMINDER`, emitida só quando há `openspec/` no diretório do payload
-- [ ] 5.3 Docstring do hook atualizada para descrever a condicional
+- [x] 5.1 Probar o payload real de `UserPromptSubmit` e registrar o resultado em `E.3`
+- [x] 5.2 Frase condicional na `REMINDER`, emitida só quando há `openspec/` no diretório do payload
+- [x] 5.3 Docstring do hook atualizada para descrever a condicional
 
 ## 6. Doutrina, docs e árvore gerada
 

--- a/openspec/changes/add-spec-rite-gate/tasks.md
+++ b/openspec/changes/add-spec-rite-gate/tasks.md
@@ -89,37 +89,37 @@
 
 ## 6. Doutrina, docs e árvore gerada
 
-- [ ] 6.1 `claude/global/personal-rules.md` descrevendo a mesma política que o gate enforça
-- [ ] 6.2 `README.md`: seção do hook e quickstart de backlog refletindo o gate de spec
-- [ ] 6.3 `./generate.sh` re-rodado e o resultado commitado (`claude/`, `codex/`, `cursor/`,
+- [x] 6.1 `claude/global/personal-rules.md` descrevendo a mesma política que o gate enforça
+- [x] 6.2 `README.md`: seção do hook e quickstart de backlog refletindo o gate de spec
+- [x] 6.3 `./generate.sh` re-rodado e o resultado commitado (`claude/`, `codex/`, `cursor/`,
       `copilot/`, `plugins/workflow/`)
 
 ## 7. Quality Gates (MANDATORY)
 
 <!-- Revisão adversarial dos skills tocados — não happy-path. -->
 
-- [ ] Q.1 Frontmatter uniforme em cada `SKILL.md` tocado: `name` == diretório, description folded,
+- [x] Q.1 Frontmatter uniforme em cada `SKILL.md` tocado: `name` == diretório, description folded,
       `metadata.author solvelab`, `metadata.version` semver, category no conjunto controlado,
       `license MIT`, `compatibility` presente
-- [ ] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
-- [ ] Q.3 Triggers de description testáveis: as frases que roteiam para `backlog` e
+- [x] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
+- [x] Q.3 Triggers de description testáveis: as frases que roteiam para `backlog` e
       `execute-backlog` não colidem entre si nem com `openspec` / `openspec-drivezone`; fronteira
       "Do NOT use for" presente
-- [ ] Q.4 Zero doutrina duplicada: o ciclo OpenSpec continua morando em `skills/openspec/` e as duas
+- [x] Q.4 Zero doutrina duplicada: o ciclo OpenSpec continua morando em `skills/openspec/` e as duas
       skills de backlog linkam, conforme a tabela Canonical Home do `design.md`
-- [ ] Q.5 Todo exemplo de código nos skills tocados usa identificadores, rotas, chaves e nomes de
+- [x] Q.5 Todo exemplo de código nos skills tocados usa identificadores, rotas, chaves e nomes de
       evento em inglês; termo mantido em outra língua carrega o motivo inline (`code-locale`)
 
 ## 8. Validation & Closure (MANDATORY)
 
 <!-- Sempre o último grupo. "Pronto" é verificável, não é opinião. -->
 
-- [ ] V.1 `openspec validate add-spec-rite-gate --strict` verde
-- [ ] V.2 `bash scripts/validate-rite.sh` verde neste branch (que carrega change ativa) e
+- [x] V.1 `openspec validate add-spec-rite-gate --strict` verde
+- [x] V.2 `bash scripts/validate-rite.sh` verde neste branch (que carrega change ativa) e
       `bash scripts/validate-rite.sh --selftest` verde
-- [ ] V.3 `bash generate.sh && git diff --exit-code` limpo; `python3 scripts/validate-skills.py`,
+- [x] V.3 `bash generate.sh && git diff --exit-code` limpo; `python3 scripts/validate-skills.py`,
       `python3 scripts/selftest-validate-skills.py` e `python3 scripts/validate-repo-hygiene.py`
       verdes
-- [ ] V.4 README / docs atualizados onde o change altera o fluxo de contribuição
+- [x] V.4 README / docs atualizados onde o change altera o fluxo de contribuição
 - [ ] V.5 `openspec archive add-spec-rite-gate --yes` — **após o merge**, em PR separado, conforme o
       precedente `#78`/`#74`

--- a/openspec/changes/add-spec-rite-gate/tasks.md
+++ b/openspec/changes/add-spec-rite-gate/tasks.md
@@ -63,13 +63,13 @@
 
 ## 4. Camada 2 — `backlog` passa a produzir o veredito por escrito
 
-- [ ] 4.1 Novo ground rule de spec-rite em `skills/backlog/SKILL.md`, linkando `openspec` sem
+- [x] 4.1 Novo ground rule de spec-rite em `skills/backlog/SKILL.md`, linkando `openspec` sem
       restatar o ciclo
-- [ ] 4.2 Novo passo de triagem no workflow, antes do Draft, e o veredito entrando no preview
-- [ ] 4.3 Seção de spec-rite em `references/issue-template.md`, obrigatória quando há `openspec/`
-- [ ] 4.4 Chave `spec_rite` (`tool`, `policy`) documentada em `references/backlog-config.md`, com o
+- [x] 4.2 Novo passo de triagem no workflow, antes do Draft, e o veredito entrando no preview
+- [x] 4.3 Seção de spec-rite em `references/issue-template.md`, obrigatória quando há `openspec/`
+- [x] 4.4 Chave `spec_rite` (`tool`, `policy`) documentada em `references/backlog-config.md`, com o
       default fail-closed
-- [ ] 4.5 `metadata.version` de `backlog` bumpada e a descrição refletindo a triagem nova
+- [x] 4.5 `metadata.version` de `backlog` bumpada e a descrição refletindo a triagem nova
 
 ## 5. Camada 1 — o hook nomeia o rito de spec onde ele existe
 

--- a/openspec/changes/add-spec-rite-gate/tasks.md
+++ b/openspec/changes/add-spec-rite-gate/tasks.md
@@ -37,17 +37,17 @@
 
 ## 2. Camada 4 — o gate de CI deixa de aprovar por vacuidade
 
-- [ ] 2.1 `scripts/validate-rite.sh`: nova checagem antes do loop atual — diff que toca caminho fora
+- [x] 2.1 `scripts/validate-rite.sh`: nova checagem antes do loop atual — diff que toca caminho fora
       de `openspec/` exige change ativa, diretório novo sob `openspec/changes/archive/` no próprio
       diff, ou a linha `Spec-rite: none — <motivo>` em `PR_BODY`
-- [ ] 2.2 Allowlist dos caminhos escritos só pela automação de release (`VERSION`, `CHANGELOG.md`,
+- [x] 2.2 Allowlist dos caminhos escritos só pela automação de release (`VERSION`, `CHANGELOG.md`,
       `.claude-plugin/*.json`) e restrição a evento `pull_request`
-- [ ] 2.3 `PR_BODY` tratado como entrada não confiável: regex ancorada, sem execução, sem
+- [x] 2.3 `PR_BODY` tratado como entrada não confiável: regex ancorada, sem execução, sem
       interpolação em comando
-- [ ] 2.4 `scripts/validate-rite.sh --selftest` injetando um defeito por regra nova, no padrão dos
+- [x] 2.4 `scripts/validate-rite.sh --selftest` injetando um defeito por regra nova, no padrão dos
       gates irmãos deste repositório
-- [ ] 2.5 Cabeçalho `KNOWN LIMIT` estendido: existência de change não é honestidade de change
-- [ ] 2.6 `.github/workflows/ci.yml`: `fetch-depth: 0` no checkout, `PR_BODY` no ambiente do passo do
+- [x] 2.5 Cabeçalho `KNOWN LIMIT` estendido: existência de change não é honestidade de change
+- [x] 2.6 `.github/workflows/ci.yml`: `fetch-depth: 0` no checkout, `PR_BODY` no ambiente do passo do
       gate, e passo de self-test do gate
 
 ## 3. Camada 3 — `execute-backlog` põe o gate de spec na espinha numerada

--- a/openspec/changes/add-spec-rite-gate/tasks.md
+++ b/openspec/changes/add-spec-rite-gate/tasks.md
@@ -1,0 +1,115 @@
+## 1. Evidence & Sources (MANDATORY)
+
+<!-- Sempre o PRIMEIRO grupo: prove antes de escrever. Registre o COMANDO e um fragmento da SAÍDA
+     CRUA, nunca uma conclusão. Doutrina: skill verify-before-claiming. -->
+
+- [x] E.1 Todo caminho local que este change usa foi ABERTO e lido em `c275a38` em 2026-08-23, não
+      recordado: `scripts/validate-rite.sh` (o loop `for dir in "$CHANGES_DIR"/*/` e o
+      `[ "$name" = "archive" ] && continue` das linhas 20-23), `scripts/validate-rite-evidence.py`
+      (`active_task_files` e as regras de shape `_shape_ok`), `.github/workflows/ci.yml` (o passo
+      *Checkout* sem `with:` e o passo *OpenSpec rite gate*), `skills/backlog/SKILL.md`,
+      `skills/backlog/references/issue-template.md`, `skills/backlog/references/backlog-config.md`,
+      `skills/execute-backlog/SKILL.md`, `skills/execute-backlog/references/execution-flow.md`,
+      `skills/execute-backlog/references/acceptance-tracking.md`,
+      `skills/execute-backlog/references/board-sync.md`,
+      `skills/execute-backlog/references/validation-matrix.md`,
+      `claude/global/hooks/backlog-rite.py`, `claude/global/personal-rules.md`,
+      `skills/openspec/SKILL.md`, `openspec/config.yaml`,
+      `openspec/schemas/skills-rite/schema.yaml`, `openspec/schemas/skills-rite/templates/tasks.md`,
+      `openspec/specs/skills-catalog/spec.md`, `generate.sh` e
+      `openspec/changes/archive/2026-08-15-record-shipped-gates/proposal.md`
+- [x] E.2 Ferramentas e comportamentos probados nesta máquina em 2026-08-23:
+      `openspec --version` -> `1.6.0`;
+      `openspec schema which skills-rite` -> `Source: project` / `Path: /home/diegops/ai-skills/openspec/schemas/skills-rite`;
+      `openspec templates` -> `Schema: spec-driven` (o default do CLI **não** herda o
+      `schema: skills-rite` do `openspec/config.yaml`; só `openspec templates --schema skills-rite`
+      resolve o fork — por isso o change foi criado com `openspec new change ... --schema skills-rite`);
+      `ls openspec/changes/` -> `archive` (única entrada, o que torna o loop do gate vazio);
+      `grep -rn -i "openspec" skills/backlog | wc -l` -> `0`;
+      `gh auth status` -> `Token scopes: 'admin:org', ..., 'project', 'repo', 'workflow', ...`
+- [ ] E.3 Aberto e registrado, não afirmado: o payload de `UserPromptSubmit` carrega a chave `cwd`?
+      A implementação probará o payload real antes de escrever a frase condicional; o fallback
+      `os.getcwd()` cobre o caso de não carregar. Nenhuma outra lacuna.
+- [ ] E.4 Follow-ups listados, não executados aqui: (a) `openspec templates` sem `--schema` ignorar o
+      `openspec/config.yaml` é um comportamento do CLI 1.6.0 que merece item próprio (documentar ou
+      reportar upstream); (b) os desvios equivalentes nos repositórios DriveZone ganham item em cada
+      um, com rito próprio; (c) o archive deste change é PR separado, conforme o precedente `#78`/`#74`
+
+## 2. Camada 4 — o gate de CI deixa de aprovar por vacuidade
+
+- [ ] 2.1 `scripts/validate-rite.sh`: nova checagem antes do loop atual — diff que toca caminho fora
+      de `openspec/` exige change ativa, diretório novo sob `openspec/changes/archive/` no próprio
+      diff, ou a linha `Spec-rite: none — <motivo>` em `PR_BODY`
+- [ ] 2.2 Allowlist dos caminhos escritos só pela automação de release (`VERSION`, `CHANGELOG.md`,
+      `.claude-plugin/*.json`) e restrição a evento `pull_request`
+- [ ] 2.3 `PR_BODY` tratado como entrada não confiável: regex ancorada, sem execução, sem
+      interpolação em comando
+- [ ] 2.4 `scripts/validate-rite.sh --selftest` injetando um defeito por regra nova, no padrão dos
+      gates irmãos deste repositório
+- [ ] 2.5 Cabeçalho `KNOWN LIMIT` estendido: existência de change não é honestidade de change
+- [ ] 2.6 `.github/workflows/ci.yml`: `fetch-depth: 0` no checkout, `PR_BODY` no ambiente do passo do
+      gate, e passo de self-test do gate
+
+## 3. Camada 3 — `execute-backlog` põe o gate de spec na espinha numerada
+
+- [ ] 3.1 Novo safety rail *Spec-before-code* em `skills/execute-backlog/SKILL.md`
+- [ ] 3.2 Novo passo numerado de spec-rite entre *Context re-analysis* e *Implementation plan*, e o
+      plano passando a carregar change-id, capabilities e a saída do `--strict`
+- [ ] 3.3 Novo `skills/execute-backlog/references/spec-rite.md`: detecção, descoberta do schema,
+      tabela de veredito, protocolo de upgrade/downgrade, timing do archive
+- [ ] 3.4 `references/execution-flow.md` deixa de tratar OpenSpec como exemplo e aponta para o novo
+      reference; passo de PR passa a carregar a linha `Spec-rite:`
+- [ ] 3.5 `metadata.version` de `execute-backlog` bumpada e a descrição refletindo o gate novo
+
+## 4. Camada 2 — `backlog` passa a produzir o veredito por escrito
+
+- [ ] 4.1 Novo ground rule de spec-rite em `skills/backlog/SKILL.md`, linkando `openspec` sem
+      restatar o ciclo
+- [ ] 4.2 Novo passo de triagem no workflow, antes do Draft, e o veredito entrando no preview
+- [ ] 4.3 Seção de spec-rite em `references/issue-template.md`, obrigatória quando há `openspec/`
+- [ ] 4.4 Chave `spec_rite` (`tool`, `policy`) documentada em `references/backlog-config.md`, com o
+      default fail-closed
+- [ ] 4.5 `metadata.version` de `backlog` bumpada e a descrição refletindo a triagem nova
+
+## 5. Camada 1 — o hook nomeia o rito de spec onde ele existe
+
+- [ ] 5.1 Probar o payload real de `UserPromptSubmit` e registrar o resultado em `E.3`
+- [ ] 5.2 Frase condicional na `REMINDER`, emitida só quando há `openspec/` no diretório do payload
+- [ ] 5.3 Docstring do hook atualizada para descrever a condicional
+
+## 6. Doutrina, docs e árvore gerada
+
+- [ ] 6.1 `claude/global/personal-rules.md` descrevendo a mesma política que o gate enforça
+- [ ] 6.2 `README.md`: seção do hook e quickstart de backlog refletindo o gate de spec
+- [ ] 6.3 `./generate.sh` re-rodado e o resultado commitado (`claude/`, `codex/`, `cursor/`,
+      `copilot/`, `plugins/workflow/`)
+
+## 7. Quality Gates (MANDATORY)
+
+<!-- Revisão adversarial dos skills tocados — não happy-path. -->
+
+- [ ] Q.1 Frontmatter uniforme em cada `SKILL.md` tocado: `name` == diretório, description folded,
+      `metadata.author solvelab`, `metadata.version` semver, category no conjunto controlado,
+      `license MIT`, `compatibility` presente
+- [ ] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
+- [ ] Q.3 Triggers de description testáveis: as frases que roteiam para `backlog` e
+      `execute-backlog` não colidem entre si nem com `openspec` / `openspec-drivezone`; fronteira
+      "Do NOT use for" presente
+- [ ] Q.4 Zero doutrina duplicada: o ciclo OpenSpec continua morando em `skills/openspec/` e as duas
+      skills de backlog linkam, conforme a tabela Canonical Home do `design.md`
+- [ ] Q.5 Todo exemplo de código nos skills tocados usa identificadores, rotas, chaves e nomes de
+      evento em inglês; termo mantido em outra língua carrega o motivo inline (`code-locale`)
+
+## 8. Validation & Closure (MANDATORY)
+
+<!-- Sempre o último grupo. "Pronto" é verificável, não é opinião. -->
+
+- [ ] V.1 `openspec validate add-spec-rite-gate --strict` verde
+- [ ] V.2 `bash scripts/validate-rite.sh` verde neste branch (que carrega change ativa) e
+      `bash scripts/validate-rite.sh --selftest` verde
+- [ ] V.3 `bash generate.sh && git diff --exit-code` limpo; `python3 scripts/validate-skills.py`,
+      `python3 scripts/selftest-validate-skills.py` e `python3 scripts/validate-repo-hygiene.py`
+      verdes
+- [ ] V.4 README / docs atualizados onde o change altera o fluxo de contribuição
+- [ ] V.5 `openspec archive add-spec-rite-gate --yes` — **após o merge**, em PR separado, conforme o
+      precedente `#78`/`#74`

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -8,14 +8,17 @@ description: >-
   (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
   "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
   idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite:
-  the item created here is what execute-backlog turns into a branch and a pull request.
+  the item created here is what execute-backlog turns into a branch and a pull request. In a
+  repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also
+  declares its spec verdict — the change that will register the work, or a written waiver —
+  so execute-backlog inherits a decision instead of making a new one.
   First run per repo/workspace launches a
   config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
   use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.4.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,7 +33,7 @@ configured GitHub Project v2 — never a copy of the user's sentence, always gro
 codebase.
 
 - **Issue section template + writing guidance**: `references/issue-template.md`
-- **Config schema (both modes, precedence, wizard)**: `references/backlog-config.md`
+- **Config schema (both modes, precedence, wizard, `spec_rite`)**: `references/backlog-config.md`
 - **gh recipes for Projects v2 (IDs, item-edit, verification, recovery)**: `references/gh-projects.md`
 
 ## CRITICAL: Ground rules
@@ -52,6 +55,13 @@ codebase.
    fresh each run (they drift and differ per Project).
 6. Ask questions **only** when essential information is missing or ambiguous (max ~3, objective).
    Everything derivable from the repo must be derived, not asked.
+7. **Spec-rite gate** — in a repo that runs a spec-driven workflow, the item is not complete until
+   it declares its verdict: the change that will register the work, or a waiver written as a line
+   with a reason. The default is that the change is required; a repo carrying the workflow with no
+   stated policy is treated as requiring it, because an unstated policy is the absence of a
+   decision, not permission to skip. Never decide this silently — the verdict is a section of the
+   item and appears in the preview. The workflow's own lifecycle is not restated here: it is
+   `openspec`, or the project's fork (`openspec-drivezone` is one).
 
 ## Workflow
 
@@ -73,21 +83,33 @@ codebase.
    candidate → show it and ask whether to continue, enrich the existing issue instead, or cancel.
 5. **Gap questions** — only for essentials the repo cannot answer (e.g. which provider, which of
    two plausible scopes). Batch them in one round.
-6. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
+6. **Spec-rite triage** — repo with a spec-driven workflow only; skip when there is none:
+
+   ```bash
+   [ -d openspec ] && grep -m1 '^schema:' openspec/config.yaml   # which schema this repo runs
+   openspec list                                                 # a related change may be open
+   ```
+
+   Read `spec_rite.policy` from config (`references/backlog-config.md`); absent with the workflow
+   present ⇒ `required`. Then propose the verdict: a verb-led change id (`add-`, `update-`,
+   `remove-`, `refactor-`) plus the capabilities its delta will touch, or the waiver line and the
+   reason it is legitimate. An existing open change that already covers the idea is named instead
+   of a new one.
+7. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
    apply. When the item produces code, fill the **Glossary** from the vocabulary harvested in step 3
    before deciding any new name; a term neither the codebase nor the user resolves becomes a gap
    question in step 5, never a translation invented here (`code-locale`). Workspace mode adds
    *Affected repositories* (role per repo) and elects the **primary affected repo** (issue home,
    unless `issues_repo` is configured). Propose field values (Status default from config;
    Priority/Size/Estimate heuristics) each with a 1-line rationale.
-7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
-   proposed field values. Only proceed on explicit approval.
-8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
+8. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees,
+   proposed field values and the spec verdict. Only proceed on explicit approval.
+9. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
    `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field. Repeat
    the add (and the Status default) for every board in `extra_projects`, when configured — an issue
    can live on several Projects at once (see `references/backlog-config.md`).
-9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
-   fields, partial failures + recovery commands).
+10. **Report** — issue URL, project item confirmation, fields set, the spec verdict recorded, plus
+   any warnings (skipped fields, partial failures + recovery commands).
 
 ## Setup wizard (first run, per repo/workspace)
 

--- a/plugins/workflow/skills/backlog/references/backlog-config.md
+++ b/plugins/workflow/skills/backlog/references/backlog-config.md
@@ -38,6 +38,11 @@ labels:                # optional: intent → existing repo label
   feature: enhancement
   bug: bug
 assignees: []          # optional default assignees (GitHub logins)
+
+# Optional — the repo's spec-driven policy. See "Spec rite" below.
+spec_rite:
+  tool: openspec
+  policy: required
 ```
 
 ## Workspace mode example
@@ -59,6 +64,31 @@ fields:
 defaults:
   status: Backlog
 ```
+
+## Spec rite (`spec_rite`)
+
+The policy belongs to the repository, not to this skill: both backlog skills run against
+repositories with different rites, so hardcoding one here would export a single project's process to
+every project.
+
+```yaml
+spec_rite:
+  tool: openspec        # which spec-driven workflow; read from openspec/config.yaml when present
+  policy: required      # required | triage | none
+```
+
+| `policy` | Meaning |
+|---|---|
+| `required` | Every code-producing item declares a change; the only exit is a written waiver with a reason |
+| `triage` | The workflow's own doctrine decides — `openspec`, *When a proposal is required* |
+| `none` | The repository carries the workflow but does not gate on it |
+
+**Key absent while the workflow is present ⇒ `required`.** An unstated policy is the absence of a
+decision, not permission to skip. No workflow present ⇒ the whole gate is a no-op and the drafted
+item carries no spec section.
+
+The verdict this key produces is consumed by `execute-backlog`
+(`execute-backlog/references/spec-rite.md`), which re-checks it and may raise it.
 
 ## Mirroring an item onto a second board (`extra_projects`)
 

--- a/plugins/workflow/skills/backlog/references/issue-template.md
+++ b/plugins/workflow/skills/backlog/references/issue-template.md
@@ -48,6 +48,22 @@ Harvest before deciding: every row is either taken from what the codebase alread
 or marked `new — decided here`. A term neither the codebase nor the user resolves is a gap question,
 never a translation invented in the draft. Protocol: `code-locale`.
 
+## Spec rite   <!-- required when the target repo runs a spec-driven workflow -->
+
+- Workflow / schema: `openspec`, schema `<name>` (from `openspec/config.yaml`; absent → vanilla)
+- Policy: `required` (from `spec_rite.policy`, or the fail-closed default)
+- Verdict: **change required** — id `<verb-led-change-id>`
+- Capabilities the delta touches: `<capability>` (ADDED / MODIFIED / REMOVED)
+
+<!-- or, when the work genuinely registers no requirement change: -->
+
+- Verdict: `Spec-rite: none — <the reason, one line>`
+
+The verdict is a decision recorded here, not one made at implementation time. `execute-backlog`
+re-checks it against the real change surface, raises it on its own when the work outgrew the item,
+and stops for the user before ever lowering it. Protocol:
+`execute-backlog/references/spec-rite.md`.
+
 ## Technical requirements
 
 - TR1 … (constraints: stack, patterns to follow — cite existing conventions/files)
@@ -80,6 +96,9 @@ conventions (cite the test dir/framework found).
 - `org/repo-a` — role in the implementation (primary).
 - `org/repo-b` — role.
 ```
+
+Omit the *Spec rite* section entirely in a repository with no such workflow — an empty heading is
+worse than no heading, and the gate is a no-op there.
 
 Field proposal guidance (shown in the preview with a 1-line rationale each):
 

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -10,12 +10,15 @@ description: >-
   the review column. Use when the user invokes /execute-backlog <n>, says
   "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
   issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced
-  by the backlog skill, and this skill carries it to a reviewable PR. Uses the backlog skill's
+  by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a
+  spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code:
+  the item's spec verdict is re-checked, the change is created and validated strict, and only then
+  does the plan go to approval. Uses the backlog skill's
   config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.5.0
+  version: 1.6.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,6 +33,7 @@ Drive an existing issue to a reviewable pull request while keeping the board in 
 to the `backlog` skill; consumes the same config.
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
+- **Spec-driven gate: detection, verdict, upgrade/downgrade, archive timing**: `references/spec-rite.md`
 - **Discovering and running each repo's validations**: `references/validation-matrix.md`
 - **Ticking the item's checkboxes + evidence table + completeness gate**: `references/acceptance-tracking.md`
 - **Board transitions + PR↔issue linking + recovery**: `references/board-sync.md`
@@ -62,6 +66,13 @@ to the `backlog` skill; consumes the same config.
    repo's own established process for that stage (spec/proposal rites, implementation and test
    rites, review templates). The generic workflow here is the fallback, never an override
    (`references/execution-flow.md`, *Per-stage rite discovery*).
+10. **Spec-before-code is a hard gate too** — in a repo that runs a spec-driven workflow, no file
+   **outside that workflow's own directory** is edited before the change exists and its strict
+   validation is green. The policy belongs to the repo (`spec_rite.policy` in the backlog config);
+   a repo that carries the workflow and states no policy is treated as requiring the change. The
+   verdict the item carries is re-checked, never re-decided: raise it without asking, lower it only
+   with the user. The workflow's own lifecycle is not restated here — it is `openspec` (or the
+   project's fork, e.g. `openspec-drivezone`). Protocol: `references/spec-rite.md`.
 
 ## Workflow
 
@@ -83,24 +94,35 @@ to the `backlog` skill; consumes the same config.
    repositories section in workspace mode; verify local clones, offer `gh repo clone` for missing
    ones). Collect: current state of cited files, conventions, test setup, related recent changes,
    and the identifier vocabulary the repo already uses for the item's concepts (`code-locale`).
-5. **Implementation plan** — present: interpretation of the item, files to change per repo, the
-   Glossary, test strategy, validations to run, risks, estimated blast radius. **Wait for approval.**
-6. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
-   project skills (e.g. `conventional-commit`, project-specific rites like OpenSpec when the repo
-   uses them). Names for anything new come from the approved Glossary (rail 8). Move the board item
+5. **Spec rite** — repo with a spec-driven workflow only; skip when there is none. Detect it and
+   the schema it runs, re-check the item's verdict against the surface the re-analysis just
+   measured, and — when the verdict requires it — create the change and validate it strict before
+   step 6. Raising a verdict needs no permission; lowering one does. Full protocol, detection
+   commands and archive timing: `references/spec-rite.md`.
+6. **Implementation plan** — present: interpretation of the item, files to change per repo, the
+   Glossary, test strategy, validations to run, risks, estimated blast radius. In a repo with a
+   spec rite, also the change id, the capabilities its delta touches and the strict-validation
+   output line. **Wait for approval.**
+7. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
+   project skills (e.g. `conventional-commit`, and the repo's spec rite when it has one). Names for
+   anything new come from the approved Glossary (rail 8). A spec rite's task list is ticked task by
+   task as each one lands and is validated, never in a batch at the end. Move the board item
    to the configured in-progress column when work starts.
-7. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
-8. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
+8. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
+9. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers. A repo that wires an identifier-locale
    check is running one of its own discovered commands — never invent one where none exists.
-9. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
+10. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
     the validation evidence, tick the proven ones in the issue body (surgical read-modify-write),
     and gate on the rest: unmet or manual-only criteria stop the run for a decision before any PR
-    is opened (`references/acceptance-tracking.md`).
-10. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
+    is opened (`references/acceptance-tracking.md`). A spec rite's mandatory closure group is part
+    of the sweep, not a separate afterthought.
+11. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
     `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
-    left anything unticked. No auto-merge. Follow `conventional-commit` PR rules when present.
-11. **Sync & report** — move the board item to the review column; comment on the issue with links
+    left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
+    gate reads — the change id, or the written waiver and its reason (`references/spec-rite.md`).
+    No auto-merge. Follow `conventional-commit` PR rules when present.
+12. **Sync & report** — move the board item to the review column; comment on the issue with links
     to the PR(s); present summary: what changed, validation evidence, the criteria table with
-    every verdict, deviations (if any, pre-approved), next human step (review/merge).
-
+    every verdict, deviations (if any, pre-approved), next human step (review/merge). A change left
+    active on purpose is reported as pending, naming what closes it.

--- a/plugins/workflow/skills/execute-backlog/references/execution-flow.md
+++ b/plugins/workflow/skills/execute-backlog/references/execution-flow.md
@@ -20,6 +20,8 @@ recommendation: proceed / refine via `/backlog` / abort.
 ## Plan — #<n> <title>
 
 **Interpretation**: 1-2 sentences — what will exist when done.
+**Spec rite**: change id + capabilities the delta touches + the strict-validation output line, or
+the written waiver and its reason (omit the whole line in a repo with no spec rite)
 **Repos/branches**: org/repo → backlog/<n>-<slug> (one line per repo, primary marked)
 **Changes**: per repo, file-level bullets (path → what and why)
 **Glossary**: term → identifier (from the item; rows derived here are marked NEW)
@@ -51,8 +53,8 @@ part of the deliverable and must appear in the plan.
 
 | Stage | What to look for | Examples |
 |---|---|---|
-| Ready (grooming gate) | Does the project require a formal proposal/spec before code? | `openspec/` directory → run its propose → `validate --strict` flow before planning; RFC/ADR templates in `docs/` |
-| In progress (implementation) | Implementation and test rites, commit conventions | OpenSpec `apply` with tasks checked one by one; adversarial-test rites (e.g. bug-hunter); `conventional-commit` |
+| Ready (grooming gate) | Does the project require a formal proposal/spec before code? | A spec-driven workflow is not an example here — it is a hard gate with its own protocol: `references/spec-rite.md`. Other shapes: RFC/ADR templates in `docs/` |
+| In progress (implementation) | Implementation and test rites, commit conventions | The spec rite's task list ticked task by task; adversarial-test rites (e.g. bug-hunter); `conventional-commit` |
 | In review (PR) | Review rites: PR templates, required checklists, CI gates | `.github/PULL_REQUEST_TEMPLATE*`, CONTRIBUTING review rules, project code-review skills |
 
 Discovery sources, in order:
@@ -63,6 +65,10 @@ Discovery sources, in order:
 
 Conflict between the generic flow and a project rite → the project rite wins; state in the plan
 which rite is being followed per stage so the user sees it before approving.
+
+Discovery is a judgment, and a judgment is exactly what fails silently. Where the rite is
+spec-driven, do not rely on this table: rail 10 and `references/spec-rite.md` make it a gate with a
+default that fails closed.
 
 ## Multi-repo orchestration (workspace mode)
 
@@ -79,4 +85,6 @@ which rite is being followed per stage so the user sees it before approving.
 - Branch: `backlog/<issue-number>-<kebab-slug>` from the repo's default branch, freshly pulled.
 - Commits: repo's own convention (check its history and skills; `conventional-commit` applies when
   present — no AI attribution).
+- A spec rite's artifacts are committed **before** the first commit that changes anything else, so
+  the history shows the registration preceding the work rather than trailing it.
 - Small, reviewable commits; no squashing of unrelated concerns.

--- a/plugins/workflow/skills/execute-backlog/references/spec-rite.md
+++ b/plugins/workflow/skills/execute-backlog/references/spec-rite.md
@@ -1,0 +1,95 @@
+# Spec rite — the gate between the item and the first edit
+
+Applies only to a repo that runs a spec-driven workflow. No such workflow → this file does not
+apply, and step 5 is a no-op.
+
+The workflow's own lifecycle — proposal format, delta format, when a proposal is required in the
+vanilla doctrine — is **not** restated here. It lives in `openspec`, or in the project's fork
+(`openspec-drivezone` is one). This file covers only the gate: what has to exist before a file is
+edited, who decides, and what is written down.
+
+## Detect the rite before deciding anything
+
+```bash
+[ -d openspec ] || echo "no spec-driven workflow — step 5 is a no-op"
+grep -m1 '^schema:' openspec/config.yaml     # which schema this repo runs; absent → vanilla
+openspec list                                # changes already active, one may be yours
+```
+
+A forked schema changes the artifacts, not the gate. Read the fork's own skill when one exists, and
+scaffold with it so the mandatory sections come from the repo's template:
+
+```bash
+openspec new change <change-id> --schema <schema-name>
+```
+
+`openspec templates` resolves the **default** schema, not the one in `openspec/config.yaml` — pass
+`--schema` explicitly or you get vanilla templates in a forked repo. Probed on CLI 1.6.0.
+
+## The verdict is inherited, re-checked, and never re-decided quietly
+
+The item created by `backlog` already carries a verdict: the change that will exist, or a written
+waiver and its reason. Re-check it against the surface the context re-analysis just measured.
+
+| Situation | Move |
+|---|---|
+| Item says a change is required | Create it, validate strict, carry the id into the plan |
+| Item waived it, and re-analysis agrees | Proceed; the waiver line goes in the PR body verbatim |
+| Item waived it, and the work turned out bigger | **Raise it without asking.** Create the change, say so in the plan |
+| Item requires it, and it now looks unnecessary | **Stop and ask.** Only the user lowers a verdict |
+| Item carries no verdict (groomed before the rite, or another tool) | Treat the repo policy as the verdict; `required` when the repo states none |
+
+The asymmetry is deliberate. A silent downgrade is the failure this gate exists to prevent: it is
+what shipped two blocking CI gates with no proposal and forced a retroactive change to register
+them afterwards. Raising a verdict costs an artifact nobody objects to; lowering one costs the trail.
+
+## Policy comes from the repo, not from this skill
+
+`spec_rite` in the backlog config (`.github/backlog.yml`, or the workspace `backlog.yml`):
+
+```yaml
+spec_rite:
+  tool: openspec        # which workflow; read from openspec/config.yaml when present
+  policy: required      # required | triage | none
+```
+
+- `required` — every code-producing item carries a change; the only exit is the written waiver.
+- `triage` — the workflow's own doctrine decides (`openspec`, *When a proposal is required*).
+- `none` — the repo has the workflow but does not gate on it.
+
+Key absent while the workflow is present → treat as `required`. An unstated policy is the absence of
+a decision, not permission to skip.
+
+## Before the first edit outside the workflow's directory
+
+```bash
+openspec validate <change-id> --strict     # the gate, not a formality — fix until green
+```
+
+Green is the precondition for step 6. The plan presented for approval carries the change id, the
+capabilities its delta touches, and this command's output line, so the approver sees what was
+registered before approving what will be built.
+
+## During implementation
+
+Tick the change's task list task by task, as each one lands and is validated — not in a batch at the
+end. A batch tick at the end records intent, and intent is what the rite is trying to stop.
+
+## In the PR body
+
+The line the repo's gate reads, one of:
+
+```text
+Spec-rite: <change-id>
+Spec-rite: none — <the reason the work registers nothing>
+```
+
+A waiver with no reason is worse than no waiver: it looks decided and says nothing.
+
+## Archive is not part of this run
+
+`openspec archive` syncs the delta into the main specs. Doing it in the implementation PR would move
+the specs before a human approved the code they describe. Leave the change **active**, and report it
+as pending in the final summary, naming the follow-up that closes it. Repos that separate the two
+carry the precedent in their history — look for an archive-only commit or PR before assuming
+otherwise.

--- a/scripts/validate-rite.sh
+++ b/scripts/validate-rite.sh
@@ -7,15 +7,23 @@
 # before it can merge or archive.
 #
 # KNOWN LIMIT: this checks that the gate SECTIONS are present and correctly
-# positioned. It cannot check that their boxes were earned — a ticked box with
-# no probe behind it looks identical to one with. The gate makes the evidence a
-# required, reviewable artifact; the review is what judges it.
+# positioned, and — through validate-spec-rite.py — that a change EXISTS at all.
+# It cannot check that either was earned: a ticked box with no probe behind it
+# looks identical to one with, and a change scaffolded to satisfy the gate passes
+# it. Existence is not honesty. The gate makes both a required, reviewable
+# artifact; the review is what judges them.
 #
-# Usage: scripts/validate-rite.sh   (from repo root; CI runs it on every PR)
+# Usage: scripts/validate-rite.sh              (from repo root; CI runs it on every PR)
+#        scripts/validate-rite.sh --selftest   (inject one defect per rule the
+#                                               new spec-rite check owns)
 set -uo pipefail
 
 CHANGES_DIR="openspec/changes"
 fail=0
+
+if [ "${1:-}" = "--selftest" ]; then
+  exec python3 scripts/validate-spec-rite.py --selftest
+fi
 
 for dir in "$CHANGES_DIR"/*/; do
   [ -d "$dir" ] || continue
@@ -56,6 +64,11 @@ done
 # different KIND of check: this script asks whether the gate sections exist, that one asks whether
 # a ticked box says what it ran. Its own header declares what it cannot do.
 python3 scripts/validate-rite-evidence.py || fail=1
+
+# Whether a change exists at all. Separate again, and for the reason the loop above makes obvious:
+# every check up to here iterates over active changes, so a pull request that opened none passes
+# them all vacuously. This one reads the diff instead of the changes directory.
+python3 scripts/validate-spec-rite.py || fail=1
 
 if command -v openspec >/dev/null 2>&1; then
   openspec validate --all --strict || fail=1

--- a/scripts/validate-spec-rite.py
+++ b/scripts/validate-spec-rite.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Spec-rite gate — a pull request that changes the repository must register the change.
+
+The sibling gates each answer a different question about an OpenSpec change:
+
+  validate-rite.sh            do the mandatory task groups exist, in the right positions?
+  validate-rite-evidence.py   does a ticked evidence box say what it ran?
+  validate-spec-rite.py       does a change exist at all?
+
+The third question had no gate, and its absence was not neutral: validate-rite.sh loops over
+`openspec/changes/*/`, skips `archive`, and with no active change the loop body never runs, so
+`fail` stays 0 and the script prints `rite gate OK`. A pull request that recorded nothing read as
+approved. PR #80 and PR #84 both shipped new blocking CI gates that way and had to be registered
+retroactively by PR #88.
+
+  S1 a diff outside openspec/ carries a change, an archive, or a written waiver
+  S2 the waiver names a reason
+
+KNOWN LIMIT: this proves that a change EXISTS, never that it is honest — a change scaffolded to
+satisfy the gate passes it, exactly as a padded evidence box passes the shape gate. Existence is a
+required, reviewable artifact; the review is what judges it. The selftest exercises the decision
+rules against synthetic inputs, not the git plumbing that feeds them: a misconfigured checkout is
+caught by the CI-only base-resolution failure below, not by the selftest.
+
+Exit 1 on any finding. Run from the repo root.
+Modes: (default) check this diff   |   --selftest inject one defect per rule and assert detection.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGES = "openspec/changes"
+
+# Everything the spec-driven workflow owns. A diff confined to it needs no separate registration:
+# it IS the registration.
+EXEMPT_PREFIX = "openspec/"
+
+# Paths the release automation writes on its own (semantic-release). A version bump is not a change
+# to the catalog and must not demand a proposal.
+EXEMPT_PATHS = {
+    "VERSION",
+    "CHANGELOG.md",
+    ".claude-plugin/plugin.json",
+    ".claude-plugin/marketplace.json",
+}
+
+# The waiver is authored by whoever opened the pull request, including from a fork. It is matched as
+# text and never executed, never interpolated into a command. Anchored to the start of a line so a
+# mention of the syntax inside a sentence does not silently waive the gate.
+WAIVER = re.compile(
+    r"^[ \t>*-]*Spec-rite:[ \t]*none[ \t]*(?:—|--|–|-)[ \t]*(?P<reason>.*\S)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# A bare `Spec-rite: none` with no reason at all — caught separately so the failure names the real
+# problem instead of reporting the whole line as missing.
+WAIVER_NO_REASON = re.compile(
+    r"^[ \t>*-]*Spec-rite:[ \t]*none[ \t]*(?:(?:—|--|–|-)[ \t]*)?$",
+    re.IGNORECASE | re.MULTILINE,
+)
+MIN_REASON = 8
+
+findings: list[str] = []
+
+# GitHub turns `::error` into a red annotation on the pull request. During --selftest the findings
+# are injected on purpose, so annotating them would put bogus failures on a PR whose job passed —
+# the same defect the sibling evidence gate hit on run 31790712710.
+annotate = True
+
+
+def add(check: str, detail: str) -> None:
+    findings.append(f"{check}: {detail}")
+    if annotate:
+        print(f"::error::{check} — {detail}")
+    else:
+        print(f"    injected: {check} — {detail}")
+
+
+# ── inputs ────────────────────────────────────────────────────────────────
+def active_changes(root: Path) -> list[str]:
+    base = root / CHANGES
+    if not base.is_dir():
+        return []
+    return sorted(
+        d.name for d in base.iterdir()
+        if d.is_dir() and d.name != "archive" and (d / "tasks.md").is_file()
+    )
+
+
+def resolve_base(root: Path) -> str | None:
+    """The revision this branch is measured against, or None when there is nothing to compare to."""
+    candidates = []
+    for env in ("SPEC_RITE_BASE", "GITHUB_BASE_REF"):
+        ref = os.environ.get(env, "").strip()
+        if ref:
+            candidates += [f"origin/{ref}", ref]
+    candidates += ["origin/master", "origin/main"]
+    for ref in candidates:
+        probe = subprocess.run(["git", "-C", str(root), "rev-parse", "--verify", "-q", f"{ref}^{{commit}}"],
+                               capture_output=True, text=True)
+        if probe.returncode == 0:
+            return ref
+    return None
+
+
+def changed_paths(root: Path, base: str) -> list[str]:
+    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", f"{base}...HEAD"],
+                         capture_output=True, text=True, check=True).stdout
+    return [line for line in out.splitlines() if line]
+
+
+# ── rules ─────────────────────────────────────────────────────────────────
+def requires_registration(paths: list[str]) -> list[str]:
+    return [p for p in paths if not p.startswith(EXEMPT_PREFIX) and p not in EXEMPT_PATHS]
+
+
+def archived_in_diff(paths: list[str]) -> bool:
+    return any(p.startswith(f"{CHANGES}/archive/") for p in paths)
+
+
+def waiver_reason(pr_body: str) -> str | None:
+    m = WAIVER.search(pr_body or "")
+    return m.group("reason").strip() if m else None
+
+
+def evaluate(paths: list[str], changes: list[str], pr_body: str) -> None:
+    """The whole decision, as a pure function of its inputs — this is what --selftest exercises."""
+    offenders = requires_registration(paths)
+    if not offenders:
+        return
+    if changes or archived_in_diff(paths):
+        return
+
+    reason = waiver_reason(pr_body)
+    if reason is not None:
+        if len(reason) < MIN_REASON:
+            add("S2 waiver reason", f"the waiver names no usable reason ({reason!r}) — "
+                                    "write `Spec-rite: none — <why this change registers nothing>`")
+        return
+
+    if WAIVER_NO_REASON.search(pr_body or ""):
+        add("S2 waiver reason", "the pull request body carries `Spec-rite: none` with no reason — "
+                                "write `Spec-rite: none — <why this change registers nothing>`")
+        return
+
+    sample = ", ".join(offenders[:5]) + (f" (+{len(offenders) - 5} more)" if len(offenders) > 5 else "")
+    add("S1 unregistered change",
+        f"this diff touches {len(offenders)} path(s) outside {EXEMPT_PREFIX} — {sample} — with no "
+        f"active change under {CHANGES}/, no change archived in the same diff, and no waiver. "
+        "Open a change (`openspec new change <id> --schema skills-rite`) or add a line "
+        "`Spec-rite: none — <reason>` to the pull request body")
+
+
+# ── selftest ──────────────────────────────────────────────────────────────
+# One injected defect per rule, plus the false-positive cases the rules must stay silent on.
+DEFECTS = [
+    ("S1 unregistered change", (["skills/backlog/SKILL.md"], [], "")),
+    ("S2 waiver reason", (["skills/backlog/SKILL.md"], [], "Spec-rite: none — x")),
+    ("S2 waiver reason", (["skills/backlog/SKILL.md"], [], "Spec-rite: none")),
+]
+
+SILENT = [
+    ("diff confined to openspec/", (["openspec/changes/x/tasks.md"], [], "")),
+    ("release automation only", (["VERSION", "CHANGELOG.md", ".claude-plugin/plugin.json"], [], "")),
+    ("active change present", (["skills/backlog/SKILL.md"], ["add-spec-rite-gate"], "")),
+    ("archived in the same diff", ([f"{CHANGES}/archive/2026-01-01-x/tasks.md", "README.md"], [], "")),
+    ("waiver with a reason", (["skills/backlog/SKILL.md"], [], "Spec-rite: none — typo no README")),
+    ("waiver quoted in a list item", (["README.md"], [], "- Spec-rite: none — correcao de link quebrado")),
+]
+
+
+def selftest() -> int:
+    global findings, annotate
+    annotate = False
+    caught = 0
+    for label, (paths, changes, body) in DEFECTS:
+        findings = []
+        evaluate(paths, changes, body)
+        if any(f.startswith(label) for f in findings):
+            print(f"  CAUGHT  {label}: {body!r}")
+            caught += 1
+        else:
+            print(f"  MISSED  {label}: {body!r}   <-- the rule cannot fire")
+
+    quiet = 0
+    for label, (paths, changes, body) in SILENT:
+        findings = []
+        evaluate(paths, changes, body)
+        if findings:
+            print(f"  FALSE POSITIVE  {label}   <-- {findings[0]}")
+        else:
+            print(f"  SILENT  {label}")
+            quiet += 1
+
+    print(f"\n{caught}/{len(DEFECTS)} defect classes detected, "
+          f"{quiet}/{len(SILENT)} false-positive cases stayed silent")
+    return 0 if caught == len(DEFECTS) and quiet == len(SILENT) else 1
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+
+    event = os.environ.get("GITHUB_EVENT_NAME", "")
+    in_ci = os.environ.get("GITHUB_ACTIONS", "") == "true"
+    if in_ci and event and event != "pull_request":
+        print(f"  spec-rite gate: skipped (event {event}, not pull_request)")
+        return 0
+
+    base = resolve_base(ROOT)
+    if base is None:
+        # A gate that cannot measure must not approve. In CI an unresolvable base means the checkout
+        # was not given enough history (fetch-depth), which is a misconfiguration, not an exemption.
+        if in_ci:
+            add("S0 base revision", "no base revision to diff against — the checkout needs "
+                                    "`fetch-depth: 0` for this gate to measure anything")
+            return 1
+        print("  spec-rite gate: skipped (no base revision to diff against)")
+        return 0
+
+    paths = changed_paths(ROOT, base)
+    evaluate(paths, active_changes(ROOT), os.environ.get("PR_BODY", ""))
+    print(f"  spec-rite gate: {len(findings)} findings "
+          f"(base {base}, {len(paths)} changed path(s), "
+          f"{len(active_changes(ROOT))} active change(s))")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -8,14 +8,17 @@ description: >-
   (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
   "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
   idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite:
-  the item created here is what execute-backlog turns into a branch and a pull request.
+  the item created here is what execute-backlog turns into a branch and a pull request. In a
+  repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also
+  declares its spec verdict — the change that will register the work, or a written waiver —
+  so execute-backlog inherits a decision instead of making a new one.
   First run per repo/workspace launches a
   config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
   use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
   for non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.4.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,7 +33,7 @@ configured GitHub Project v2 — never a copy of the user's sentence, always gro
 codebase.
 
 - **Issue section template + writing guidance**: `references/issue-template.md`
-- **Config schema (both modes, precedence, wizard)**: `references/backlog-config.md`
+- **Config schema (both modes, precedence, wizard, `spec_rite`)**: `references/backlog-config.md`
 - **gh recipes for Projects v2 (IDs, item-edit, verification, recovery)**: `references/gh-projects.md`
 
 ## CRITICAL: Ground rules
@@ -52,6 +55,13 @@ codebase.
    fresh each run (they drift and differ per Project).
 6. Ask questions **only** when essential information is missing or ambiguous (max ~3, objective).
    Everything derivable from the repo must be derived, not asked.
+7. **Spec-rite gate** — in a repo that runs a spec-driven workflow, the item is not complete until
+   it declares its verdict: the change that will register the work, or a waiver written as a line
+   with a reason. The default is that the change is required; a repo carrying the workflow with no
+   stated policy is treated as requiring it, because an unstated policy is the absence of a
+   decision, not permission to skip. Never decide this silently — the verdict is a section of the
+   item and appears in the preview. The workflow's own lifecycle is not restated here: it is
+   `openspec`, or the project's fork (`openspec-drivezone` is one).
 
 ## Workflow
 
@@ -73,21 +83,33 @@ codebase.
    candidate → show it and ask whether to continue, enrich the existing issue instead, or cancel.
 5. **Gap questions** — only for essentials the repo cannot answer (e.g. which provider, which of
    two plausible scopes). Batch them in one round.
-6. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
+6. **Spec-rite triage** — repo with a spec-driven workflow only; skip when there is none:
+
+   ```bash
+   [ -d openspec ] && grep -m1 '^schema:' openspec/config.yaml   # which schema this repo runs
+   openspec list                                                 # a related change may be open
+   ```
+
+   Read `spec_rite.policy` from config (`references/backlog-config.md`); absent with the workflow
+   present ⇒ `required`. Then propose the verdict: a verb-led change id (`add-`, `update-`,
+   `remove-`, `refactor-`) plus the capabilities its delta will touch, or the waiver line and the
+   reason it is legitimate. An existing open change that already covers the idea is named instead
+   of a new one.
+7. **Draft** — fill the template from `references/issue-template.md`; omit sections that do not
    apply. When the item produces code, fill the **Glossary** from the vocabulary harvested in step 3
    before deciding any new name; a term neither the codebase nor the user resolves becomes a gap
    question in step 5, never a translation invented here (`code-locale`). Workspace mode adds
    *Affected repositories* (role per repo) and elects the **primary affected repo** (issue home,
    unless `issues_repo` is configured). Propose field values (Status default from config;
    Priority/Size/Estimate heuristics) each with a 1-line rationale.
-7. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees and
-   proposed field values. Only proceed on explicit approval.
-8. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
+8. **Preview + approval** — show the complete issue markdown, target repo, labels, assignees,
+   proposed field values and the spec verdict. Only proceed on explicit approval.
+9. **Create** — in order, capturing outputs (exact commands in `references/gh-projects.md`):
    `gh issue create` → `gh project item-add` → `gh project item-edit` per configured field. Repeat
    the add (and the Status default) for every board in `extra_projects`, when configured — an issue
    can live on several Projects at once (see `references/backlog-config.md`).
-9. **Report** — issue URL, project item confirmation, fields set, plus any warnings (skipped
-   fields, partial failures + recovery commands).
+10. **Report** — issue URL, project item confirmation, fields set, the spec verdict recorded, plus
+   any warnings (skipped fields, partial failures + recovery commands).
 
 ## Setup wizard (first run, per repo/workspace)
 

--- a/skills/backlog/references/backlog-config.md
+++ b/skills/backlog/references/backlog-config.md
@@ -38,6 +38,11 @@ labels:                # optional: intent → existing repo label
   feature: enhancement
   bug: bug
 assignees: []          # optional default assignees (GitHub logins)
+
+# Optional — the repo's spec-driven policy. See "Spec rite" below.
+spec_rite:
+  tool: openspec
+  policy: required
 ```
 
 ## Workspace mode example
@@ -59,6 +64,31 @@ fields:
 defaults:
   status: Backlog
 ```
+
+## Spec rite (`spec_rite`)
+
+The policy belongs to the repository, not to this skill: both backlog skills run against
+repositories with different rites, so hardcoding one here would export a single project's process to
+every project.
+
+```yaml
+spec_rite:
+  tool: openspec        # which spec-driven workflow; read from openspec/config.yaml when present
+  policy: required      # required | triage | none
+```
+
+| `policy` | Meaning |
+|---|---|
+| `required` | Every code-producing item declares a change; the only exit is a written waiver with a reason |
+| `triage` | The workflow's own doctrine decides — `openspec`, *When a proposal is required* |
+| `none` | The repository carries the workflow but does not gate on it |
+
+**Key absent while the workflow is present ⇒ `required`.** An unstated policy is the absence of a
+decision, not permission to skip. No workflow present ⇒ the whole gate is a no-op and the drafted
+item carries no spec section.
+
+The verdict this key produces is consumed by `execute-backlog`
+(`execute-backlog/references/spec-rite.md`), which re-checks it and may raise it.
 
 ## Mirroring an item onto a second board (`extra_projects`)
 

--- a/skills/backlog/references/issue-template.md
+++ b/skills/backlog/references/issue-template.md
@@ -48,6 +48,22 @@ Harvest before deciding: every row is either taken from what the codebase alread
 or marked `new — decided here`. A term neither the codebase nor the user resolves is a gap question,
 never a translation invented in the draft. Protocol: `code-locale`.
 
+## Spec rite   <!-- required when the target repo runs a spec-driven workflow -->
+
+- Workflow / schema: `openspec`, schema `<name>` (from `openspec/config.yaml`; absent → vanilla)
+- Policy: `required` (from `spec_rite.policy`, or the fail-closed default)
+- Verdict: **change required** — id `<verb-led-change-id>`
+- Capabilities the delta touches: `<capability>` (ADDED / MODIFIED / REMOVED)
+
+<!-- or, when the work genuinely registers no requirement change: -->
+
+- Verdict: `Spec-rite: none — <the reason, one line>`
+
+The verdict is a decision recorded here, not one made at implementation time. `execute-backlog`
+re-checks it against the real change surface, raises it on its own when the work outgrew the item,
+and stops for the user before ever lowering it. Protocol:
+`execute-backlog/references/spec-rite.md`.
+
 ## Technical requirements
 
 - TR1 … (constraints: stack, patterns to follow — cite existing conventions/files)
@@ -80,6 +96,9 @@ conventions (cite the test dir/framework found).
 - `org/repo-a` — role in the implementation (primary).
 - `org/repo-b` — role.
 ```
+
+Omit the *Spec rite* section entirely in a repository with no such workflow — an empty heading is
+worse than no heading, and the gate is a no-op there.
 
 Field proposal guidance (shown in the preview with a 1-line rationale each):
 

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -10,12 +10,15 @@ description: >-
   the review column. Use when the user invokes /execute-backlog <n>, says
   "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
   issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced
-  by the backlog skill, and this skill carries it to a reviewable PR. Uses the backlog skill's
+  by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a
+  spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code:
+  the item's spec verdict is re-checked, the change is created and validated strict, and only then
+  does the plan go to approval. Uses the backlog skill's
   config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.5.0
+  version: 1.6.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,6 +33,7 @@ Drive an existing issue to a reviewable pull request while keeping the board in 
 to the `backlog` skill; consumes the same config.
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
+- **Spec-driven gate: detection, verdict, upgrade/downgrade, archive timing**: `references/spec-rite.md`
 - **Discovering and running each repo's validations**: `references/validation-matrix.md`
 - **Ticking the item's checkboxes + evidence table + completeness gate**: `references/acceptance-tracking.md`
 - **Board transitions + PR↔issue linking + recovery**: `references/board-sync.md`
@@ -62,6 +66,13 @@ to the `backlog` skill; consumes the same config.
    repo's own established process for that stage (spec/proposal rites, implementation and test
    rites, review templates). The generic workflow here is the fallback, never an override
    (`references/execution-flow.md`, *Per-stage rite discovery*).
+10. **Spec-before-code is a hard gate too** — in a repo that runs a spec-driven workflow, no file
+   **outside that workflow's own directory** is edited before the change exists and its strict
+   validation is green. The policy belongs to the repo (`spec_rite.policy` in the backlog config);
+   a repo that carries the workflow and states no policy is treated as requiring the change. The
+   verdict the item carries is re-checked, never re-decided: raise it without asking, lower it only
+   with the user. The workflow's own lifecycle is not restated here — it is `openspec` (or the
+   project's fork, e.g. `openspec-drivezone`). Protocol: `references/spec-rite.md`.
 
 ## Workflow
 
@@ -83,24 +94,35 @@ to the `backlog` skill; consumes the same config.
    repositories section in workspace mode; verify local clones, offer `gh repo clone` for missing
    ones). Collect: current state of cited files, conventions, test setup, related recent changes,
    and the identifier vocabulary the repo already uses for the item's concepts (`code-locale`).
-5. **Implementation plan** — present: interpretation of the item, files to change per repo, the
-   Glossary, test strategy, validations to run, risks, estimated blast radius. **Wait for approval.**
-6. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
-   project skills (e.g. `conventional-commit`, project-specific rites like OpenSpec when the repo
-   uses them). Names for anything new come from the approved Glossary (rail 8). Move the board item
+5. **Spec rite** — repo with a spec-driven workflow only; skip when there is none. Detect it and
+   the schema it runs, re-check the item's verdict against the surface the re-analysis just
+   measured, and — when the verdict requires it — create the change and validate it strict before
+   step 6. Raising a verdict needs no permission; lowering one does. Full protocol, detection
+   commands and archive timing: `references/spec-rite.md`.
+6. **Implementation plan** — present: interpretation of the item, files to change per repo, the
+   Glossary, test strategy, validations to run, risks, estimated blast radius. In a repo with a
+   spec rite, also the change id, the capabilities its delta touches and the strict-validation
+   output line. **Wait for approval.**
+7. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
+   project skills (e.g. `conventional-commit`, and the repo's spec rite when it has one). Names for
+   anything new come from the approved Glossary (rail 8). A spec rite's task list is ticked task by
+   task as each one lands and is validated, never in a batch at the end. Move the board item
    to the configured in-progress column when work starts.
-7. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
-8. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
+8. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
+9. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers. A repo that wires an identifier-locale
    check is running one of its own discovered commands — never invent one where none exists.
-9. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
+10. **Acceptance sweep** — walk the item's checkboxes one by one, assign each a verdict backed by
     the validation evidence, tick the proven ones in the issue body (surgical read-modify-write),
     and gate on the rest: unmet or manual-only criteria stop the run for a decision before any PR
-    is opened (`references/acceptance-tracking.md`).
-10. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
+    is opened (`references/acceptance-tracking.md`). A spec rite's mandatory closure group is part
+    of the sweep, not a separate afterthought.
+11. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
     `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
-    left anything unticked. No auto-merge. Follow `conventional-commit` PR rules when present.
-11. **Sync & report** — move the board item to the review column; comment on the issue with links
+    left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
+    gate reads — the change id, or the written waiver and its reason (`references/spec-rite.md`).
+    No auto-merge. Follow `conventional-commit` PR rules when present.
+12. **Sync & report** — move the board item to the review column; comment on the issue with links
     to the PR(s); present summary: what changed, validation evidence, the criteria table with
-    every verdict, deviations (if any, pre-approved), next human step (review/merge).
-
+    every verdict, deviations (if any, pre-approved), next human step (review/merge). A change left
+    active on purpose is reported as pending, naming what closes it.

--- a/skills/execute-backlog/references/execution-flow.md
+++ b/skills/execute-backlog/references/execution-flow.md
@@ -20,6 +20,8 @@ recommendation: proceed / refine via `/backlog` / abort.
 ## Plan — #<n> <title>
 
 **Interpretation**: 1-2 sentences — what will exist when done.
+**Spec rite**: change id + capabilities the delta touches + the strict-validation output line, or
+the written waiver and its reason (omit the whole line in a repo with no spec rite)
 **Repos/branches**: org/repo → backlog/<n>-<slug> (one line per repo, primary marked)
 **Changes**: per repo, file-level bullets (path → what and why)
 **Glossary**: term → identifier (from the item; rows derived here are marked NEW)
@@ -51,8 +53,8 @@ part of the deliverable and must appear in the plan.
 
 | Stage | What to look for | Examples |
 |---|---|---|
-| Ready (grooming gate) | Does the project require a formal proposal/spec before code? | `openspec/` directory → run its propose → `validate --strict` flow before planning; RFC/ADR templates in `docs/` |
-| In progress (implementation) | Implementation and test rites, commit conventions | OpenSpec `apply` with tasks checked one by one; adversarial-test rites (e.g. bug-hunter); `conventional-commit` |
+| Ready (grooming gate) | Does the project require a formal proposal/spec before code? | A spec-driven workflow is not an example here — it is a hard gate with its own protocol: `references/spec-rite.md`. Other shapes: RFC/ADR templates in `docs/` |
+| In progress (implementation) | Implementation and test rites, commit conventions | The spec rite's task list ticked task by task; adversarial-test rites (e.g. bug-hunter); `conventional-commit` |
 | In review (PR) | Review rites: PR templates, required checklists, CI gates | `.github/PULL_REQUEST_TEMPLATE*`, CONTRIBUTING review rules, project code-review skills |
 
 Discovery sources, in order:
@@ -63,6 +65,10 @@ Discovery sources, in order:
 
 Conflict between the generic flow and a project rite → the project rite wins; state in the plan
 which rite is being followed per stage so the user sees it before approving.
+
+Discovery is a judgment, and a judgment is exactly what fails silently. Where the rite is
+spec-driven, do not rely on this table: rail 10 and `references/spec-rite.md` make it a gate with a
+default that fails closed.
 
 ## Multi-repo orchestration (workspace mode)
 
@@ -79,4 +85,6 @@ which rite is being followed per stage so the user sees it before approving.
 - Branch: `backlog/<issue-number>-<kebab-slug>` from the repo's default branch, freshly pulled.
 - Commits: repo's own convention (check its history and skills; `conventional-commit` applies when
   present — no AI attribution).
+- A spec rite's artifacts are committed **before** the first commit that changes anything else, so
+  the history shows the registration preceding the work rather than trailing it.
 - Small, reviewable commits; no squashing of unrelated concerns.

--- a/skills/execute-backlog/references/spec-rite.md
+++ b/skills/execute-backlog/references/spec-rite.md
@@ -1,0 +1,95 @@
+# Spec rite — the gate between the item and the first edit
+
+Applies only to a repo that runs a spec-driven workflow. No such workflow → this file does not
+apply, and step 5 is a no-op.
+
+The workflow's own lifecycle — proposal format, delta format, when a proposal is required in the
+vanilla doctrine — is **not** restated here. It lives in `openspec`, or in the project's fork
+(`openspec-drivezone` is one). This file covers only the gate: what has to exist before a file is
+edited, who decides, and what is written down.
+
+## Detect the rite before deciding anything
+
+```bash
+[ -d openspec ] || echo "no spec-driven workflow — step 5 is a no-op"
+grep -m1 '^schema:' openspec/config.yaml     # which schema this repo runs; absent → vanilla
+openspec list                                # changes already active, one may be yours
+```
+
+A forked schema changes the artifacts, not the gate. Read the fork's own skill when one exists, and
+scaffold with it so the mandatory sections come from the repo's template:
+
+```bash
+openspec new change <change-id> --schema <schema-name>
+```
+
+`openspec templates` resolves the **default** schema, not the one in `openspec/config.yaml` — pass
+`--schema` explicitly or you get vanilla templates in a forked repo. Probed on CLI 1.6.0.
+
+## The verdict is inherited, re-checked, and never re-decided quietly
+
+The item created by `backlog` already carries a verdict: the change that will exist, or a written
+waiver and its reason. Re-check it against the surface the context re-analysis just measured.
+
+| Situation | Move |
+|---|---|
+| Item says a change is required | Create it, validate strict, carry the id into the plan |
+| Item waived it, and re-analysis agrees | Proceed; the waiver line goes in the PR body verbatim |
+| Item waived it, and the work turned out bigger | **Raise it without asking.** Create the change, say so in the plan |
+| Item requires it, and it now looks unnecessary | **Stop and ask.** Only the user lowers a verdict |
+| Item carries no verdict (groomed before the rite, or another tool) | Treat the repo policy as the verdict; `required` when the repo states none |
+
+The asymmetry is deliberate. A silent downgrade is the failure this gate exists to prevent: it is
+what shipped two blocking CI gates with no proposal and forced a retroactive change to register
+them afterwards. Raising a verdict costs an artifact nobody objects to; lowering one costs the trail.
+
+## Policy comes from the repo, not from this skill
+
+`spec_rite` in the backlog config (`.github/backlog.yml`, or the workspace `backlog.yml`):
+
+```yaml
+spec_rite:
+  tool: openspec        # which workflow; read from openspec/config.yaml when present
+  policy: required      # required | triage | none
+```
+
+- `required` — every code-producing item carries a change; the only exit is the written waiver.
+- `triage` — the workflow's own doctrine decides (`openspec`, *When a proposal is required*).
+- `none` — the repo has the workflow but does not gate on it.
+
+Key absent while the workflow is present → treat as `required`. An unstated policy is the absence of
+a decision, not permission to skip.
+
+## Before the first edit outside the workflow's directory
+
+```bash
+openspec validate <change-id> --strict     # the gate, not a formality — fix until green
+```
+
+Green is the precondition for step 6. The plan presented for approval carries the change id, the
+capabilities its delta touches, and this command's output line, so the approver sees what was
+registered before approving what will be built.
+
+## During implementation
+
+Tick the change's task list task by task, as each one lands and is validated — not in a batch at the
+end. A batch tick at the end records intent, and intent is what the rite is trying to stop.
+
+## In the PR body
+
+The line the repo's gate reads, one of:
+
+```text
+Spec-rite: <change-id>
+Spec-rite: none — <the reason the work registers nothing>
+```
+
+A waiver with no reason is worse than no waiver: it looks decided and says nothing.
+
+## Archive is not part of this run
+
+`openspec archive` syncs the delta into the main specs. Doing it in the implementation PR would move
+the specs before a human approved the code they describe. Leave the change **active**, and report it
+as pending in the final summary, naming the follow-up that closes it. Repos that separate the two
+carry the precedent in their history — look for an archive-only commit or PR before assuming
+otherwise.


### PR DESCRIPTION
Closes #89

Spec-rite: add-spec-rite-gate

## O que muda

O rito backlog-first tinha quatro camadas de enforcement e o OpenSpec não era exigido em nenhuma. A camada que deveria reprovar aprovava por vacuidade: todas as checagens de `scripts/validate-rite.sh` iteram sobre `openspec/changes/*/`, então um PR que não abriu change nenhuma passava por todas — `fail` ficava 0 e o script imprimia `rite gate OK`.

Foi assim que os PRs #80 e #84 entregaram gates bloqueantes novos de CI sem proposta, verdes, e precisaram do registro retroativo do #88.

| Camada | Antes | Depois |
|---|---|---|
| Hook `backlog-rite.py` | 0 menções a OpenSpec | frase condicional, só onde há `openspec/` no `cwd` |
| Skill `backlog` | 0 menções a OpenSpec | ground rule, passo de triagem, seção obrigatória na issue, chave `spec_rite` |
| Skill `execute-backlog` | 5 menções, todas exemplo em reference | rail *Spec-before-code* + passo numerado antes do plano |
| Gate `validate-rite.sh` | passa verde sem change ativa | `validate-spec-rite.py` lê o diff, não o diretório de changes |

A dispensa é a única saída, e é escrita: `Spec-rite: none — <motivo>` no corpo do PR. Vem de quem abriu o PR, inclusive de um fork, então é casada por regex ancorada e nunca executada nem interpolada.

## Ressalva registrada

Gate duro literal ("toda issue que produz código exige proposta") não é implementável: o CLI 1.6.0 exige ≥1 delta de spec por change e `skip_specs` foi probado e não tem efeito, então um typo forçaria inventar requisito — o que a doutrina do próprio repo proíbe. A forma entregue preserva a intenção invertendo o default: artefato exigido, dispensa só por escrito. Registrado em `design.md`.

## Evidência

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | gate falha sem change e sem dispensa | met | clone de probe, `PR_BODY="" bash scripts/validate-rite.sh` → `S1 unregistered change — ... skills/backlog/SKILL.md ...` / `rite gate FAILED` / exit 1 |
| 2 | mesma diff passa com dispensa escrita | met | `PR_BODY="Spec-rite: none — ..." bash scripts/validate-rite.sh` → `rite gate OK` / exit 0 |
| 3 | self-test do gate | met | `bash scripts/validate-rite.sh --selftest` → `3/3 defect classes detected, 6/6 false-positive cases stayed silent` |
| 4 | CI com `fetch-depth: 0` e passo de self-test | met | `.github/workflows/ci.yml:32-34` e passo *Spec-rite self-test* |
| 5 | `backlog` menciona OpenSpec e tem triagem | met | `grep -c -i openspec skills/backlog/SKILL.md` → `4`; passo 6 *Spec-rite triage* |
| 6-9 | seções e reference novos | met | `issue-template.md` (*Spec rite*), `backlog-config.md` (*Spec rite*), `execute-backlog/SKILL.md:69` (rail 10) e `:97` (passo 5), `references/spec-rite.md` (7 seções) |
| 10 | hook condicional | met | payload com `cwd` do repo → frase presente; `cwd=/tmp` → ausente; prompt de diagnóstico → silêncio |
| 11 | rito da própria change | met | `openspec validate add-spec-rite-gate --strict` → `is valid`; `validate-rite-evidence.py` → `0 findings` |
| 12 | wrappers em sincronia | met | `bash generate.sh && git diff --exit-code` limpo |
| 13 | suíte do repo | met | `validate-skills.py` 34/0 findings; `selftest-validate-skills.py` 13/13; `validate-repo-hygiene.py` 0 findings + 2/2; `scan-secrets.py` 0; `check-identifier-locale.py --selftest` 7 tiers + 16 clean |
| 14 | doutrina alinhada | met | `personal-rules.md:22` e README (*Spec-Driven Rite* + quickstart) descrevem o mesmo default fail-closed |
| 15 | nomes seguem o Glossary | met | `spec_rite`, `tool`, `policy`, `PR_BODY`, `Spec-rite:`, `validate-spec-rite.py` — todos do Glossary da issue; C9 verde |

Cenários adicionais probados além dos critérios: base irresolvível no CI **falha** (`S0 base revision`) em vez de pular, porque um gate que não mede não pode aprovar; fora do CI a checagem se declara pulada; evento `push` é pulado.

## Known gaps

- `openspec archive add-spec-rite-gate` fica **pendente de propósito** (V.5 aberta em `tasks.md`). Arquivar aqui moveria as specs antes de um humano aprovar o código que elas descrevem. Segue o precedente #78 / #74: PR separado depois do merge.
- O `--selftest` exercita as regras de decisão contra entradas sintéticas, não o encanamento de git que as alimenta. Declarado no `KNOWN LIMIT` do script; o caso real é coberto pela falha de base irresolvível no CI.
- O gate prova que a change **existe**, nunca que ela é honesta — uma change montada só pra passar passa. Declarado no cabeçalho, ao lado da ressalva equivalente sobre forma de evidência.
