### PR TITLE
🐛 fix(ci): lê a dispensa do payload do evento, não de env ecoado no log

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,11 @@ jobs:
         run: python3 scripts/validate-repo-hygiene.py --selftest
 
       - name: OpenSpec rite gate (skills-rite schema)
-        # PR_BODY carries the waiver line the spec-rite gate reads. It is authored by whoever
-        # opened the pull request, including from a fork: the gate matches it as text and never
-        # executes or interpolates it.
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
+        # The spec-rite gate reads the waiver line from the event payload the runner already wrote
+        # (GITHUB_EVENT_PATH). Handing the pull request body over through this step's `env:` block
+        # printed the whole body into the build log, because Actions echoes that block — measured
+        # on run 32648727841. The body is still untrusted input: the gate matches it as text and
+        # never executes or interpolates it.
         run: bash scripts/validate-rite.sh
 
       - name: Rite evidence self-test (the gate is itself gated)

--- a/openspec/changes/fix-waiver-transport/.openspec.yaml
+++ b/openspec/changes/fix-waiver-transport/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-08-23

--- a/openspec/changes/fix-waiver-transport/README.md
+++ b/openspec/changes/fix-waiver-transport/README.md
@@ -1,0 +1,3 @@
+# fix-waiver-transport
+
+Read the spec-rite waiver from the event payload file instead of an env block the CI echoes

--- a/openspec/changes/fix-waiver-transport/design.md
+++ b/openspec/changes/fix-waiver-transport/design.md
@@ -1,0 +1,83 @@
+## Context
+
+`scripts/validate-spec-rite.py:227` lê o corpo do PR de `os.environ.get("PR_BODY", "")`, alimentado
+por `.github/workflows/ci.yml:103-107`:
+
+```yaml
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+```
+
+O Actions imprime o bloco `env:` no cabeçalho do passo, então o corpo sai no log. Medido no run
+`32648727841` (job `97216916829`), com o corpo do PR #90 inteiro — tabelas, seções e tudo.
+
+O que **não** está errado, e não muda: o corpo entra como valor de `env`, nunca interpolado no texto
+do `run:`, então não há superfície de injeção; e a regex `WAIVER` é ancorada e o script não executa
+nada do que lê.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- O gate lê a dispensa sem que o corpo do PR passe por um canal que o CI ecoa.
+- A troca não afrouxa nenhuma regra de decisão nem a forma da linha de dispensa.
+- O leitor novo é coberto por teste, porque é a superfície nova.
+
+**Non-Goals:**
+
+- Mudar a forma da dispensa, as regras `S0`/`S1`/`S2`, a allowlist de release ou a isenção de diff
+  confinado a `openspec/`.
+- Mascarar com `::add-mask::`.
+- Auditar outros passos do `ci.yml`. Nenhum outro recebe entrada de terceiro hoje.
+- Declarar `spec_rite` no `.github/backlog.yml` deste repositório.
+
+## Decisions
+
+**`GITHUB_EVENT_PATH` em vez de `env`.** É o arquivo que o próprio runner escreve com o payload do
+webhook — documentado como *"The path to the file on the runner that contains the full event webhook
+payload"*. `github.event` é exatamente esse payload, então `pull_request.body` está lá por
+construção: é a mesma origem que hoje alimenta o `env`, lida um passo antes. Nada precisa ser
+passado pelo workflow, e o que não é passado não é impresso.
+
+**`PR_BODY` fica, rebaixado a override.** Ele é o que torna o gate testável fora do CI — os cenários
+end-to-end do change anterior dependem dele. Precedência: `PR_BODY` definido vence; senão o payload;
+senão vazio. O override primeiro, e não por último, porque a única razão de alguém defini-lo
+explicitamente é querer aquele valor.
+
+**`::add-mask::` foi descartado.** Mascarar trata sintoma: o dado continua atravessando o canal e o
+log vira `***` no meio de um bloco que existe para ser lido. A correção é o dado não passar por ali.
+
+**Falha de leitura vira corpo vazio, não traceback.** `json.load` em `try/except` estreito, com
+aviso. Se o gate morrer porque o canal de leitura tropeçou, ele deixa de ser gate e vira flake — e o
+efeito prático seria bloquear PRs por um motivo que nada tem a ver com o rito. Corpo vazio mantém a
+decisão nas regras que já existem: sem dispensa, `S1` dispara se houver caminho fora de `openspec/`.
+
+**O delta modifica o requisito existente, não acrescenta um vizinho.** *The rite gates evidence
+before it gates quality* já tem o parágrafo que trata a dispensa como entrada não confiável. "Não
+publique o que lê" é a outra metade da mesma preocupação com o mesmo dado. Um requisito novo ao lado
+dele partiria a doutrina em dois lugares que precisam ser lidos juntos — exatamente o que
+`skills-authoring` proíbe.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Ciclo OpenSpec e formato dos artefatos | `openspec` | já canônica — este change não a toca |
+| Gate de spec no rito backlog-first (detecção, veredito, transporte da dispensa) | `skills/execute-backlog/references/spec-rite.md` | já canônica — e verificado que ela **não** nomeia o transporte, então não muda |
+| Entrada não confiável: casar como texto, nunca executar | a spec `skills-catalog` (*The rite gates evidence...*) + `scripts/validate-spec-rite.py` | já canônica — este change acrescenta a metade "não publique", no mesmo requisito |
+| Não afirmar sem probar (o `env:` ecoado foi medido, não suposto) | `verify-before-claiming` | já canônica — nenhuma doutrina reescrita aqui |
+
+## Risks / Trade-offs
+
+- **O payload não trazer `pull_request.body`** → o override e o corpo vazio cobrem, e o critério de
+  aceite do log prova qual caminho rodou no CI real.
+- **Afrouxar a checagem sem perceber ao trocar o transporte** → os cenários `S1`/`S2` do `--selftest`
+  ficam intactos e são a rede; o leitor novo ganha casos próprios.
+- **Perder contexto ao depurar uma dispensa recusada, agora que o log não mostra o corpo** → a
+  mensagem de erro do gate já cita a forma esperada da linha; o corpo do PR continua a um clique.
+- **O arquivo do payload ser grande** → é lido uma vez, e só a chave do corpo é usada.
+
+## Open Questions
+
+_Nenhuma._ A única incerteza — se a chave existe no arquivo — é resolvida pela execução de CI deste
+próprio PR, e o fallback cobre o caso contrário sem quebrar nada.

--- a/openspec/changes/fix-waiver-transport/proposal.md
+++ b/openspec/changes/fix-waiver-transport/proposal.md
@@ -1,0 +1,63 @@
+# Change: Ler a dispensa do payload do evento, não de env que o CI ecoa
+
+## Why
+
+O gate entregue pelo `2026-08-23-add-spec-rite-gate` recebe o corpo do PR por variável de ambiente, e
+o GitHub Actions imprime o bloco `env:` de todo passo `run:` no cabeçalho do passo. Medido no run
+`32648727841`, job `97216916829`, passo *OpenSpec rite gate*:
+
+```
+##[group]Run bash scripts/validate-rite.sh
+shell: /usr/bin/bash -e {0}
+env:
+  PR_BODY: Closes #89
+
+Spec-rite: add-spec-rite-gate
+...
+```
+
+O corpo inteiro do PR sai no log. Um gate virou canal de divulgação do que ele lê.
+
+Neste repositório o dano é nulo — é público, e o corpo do PR já é visível a qualquer um. O que
+importa é a forma, porque ela viaja: as duas skills de backlog são portáteis, `spec-rite.md`
+documenta o mecanismo, e o mesmo desenho vai ser copiado para repositórios privados, onde o log do
+Actions tem plateia diferente do PR.
+
+## What Changes
+
+- `scripts/validate-spec-rite.py` passa a ler o corpo do PR do arquivo apontado por
+  `GITHUB_EVENT_PATH` — o payload completo do webhook, que para `pull_request` carrega
+  `pull_request.body`. `PR_BODY` é rebaixado a **override explícito** para teste local e para o caso
+  de o payload não trazer a chave.
+- `.github/workflows/ci.yml` perde o bloco `env:` do passo do gate.
+- O `--selftest` cobre o leitor novo: payload sintético lido, arquivo ausente tratado, precedência do
+  override respeitada.
+- **Nada da decisão muda.** As regras `S0`/`S1`/`S2`, a regex ancorada, a allowlist de release e a
+  isenção de diff confinado a `openspec/` ficam idênticas. Só o transporte.
+
+**Não é BREAKING.** A forma da linha de dispensa (`Spec-rite: none — <motivo>`) é a mesma, e quem
+abre PR não muda nada no que escreve.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ O gate já existe; o que muda é por onde ele lê.
+
+### Modified Capabilities
+
+- `skills-catalog`: *The rite gates evidence before it gates quality* — o parágrafo que já trata a
+  dispensa como entrada não confiável ganha a segunda metade da mesma preocupação. Hoje ele governa
+  o que o gate **faz com** o que lê (casar como texto, nunca executar); passa a governar também o que
+  o gate **faz aparecer**: um gate não publica o conteúdo que lê num canal com plateia diferente da
+  do próprio conteúdo. É a mesma regra vista do outro lado, não um requisito novo ao lado dela.
+
+## Impact
+
+- `scripts/validate-spec-rite.py`, `.github/workflows/ci.yml`.
+- `openspec/specs/skills-catalog/spec.md`, após o archive.
+- Nenhum skill e nenhum doc: verificado que nem `README.md` nem
+  `skills/execute-backlog/references/spec-rite.md` nomeiam o transporte —
+  `grep -n "PR_BODY" README.md skills/execute-backlog/references/spec-rite.md` não retorna nada.
+  Essa neutralidade é propriedade a preservar, e vira critério de aceite.
+- Consumidores do catálogo: nenhuma diferença. Quem abre PR: nenhuma diferença.

--- a/openspec/changes/fix-waiver-transport/specs/skills-catalog/spec.md
+++ b/openspec/changes/fix-waiver-transport/specs/skills-catalog/spec.md
@@ -1,0 +1,113 @@
+## MODIFIED Requirements
+
+### Requirement: The rite gates evidence before it gates quality
+
+The repository's spec-driven rite SHALL require every active change to open its task list with a
+group recording what was probed: local paths opened rather than recalled, external tools, flags,
+config keys, API names and versions checked against the installed version, and anything that could
+not be probed written down as an open question rather than stated as fact. The group SHALL be the
+first task group, and its presence and position SHALL be enforced by the same script that enforces
+the other mandatory groups, because the OpenSpec CLI validates delta-spec format only.
+
+Recorded evidence SHALL be a command together with a fragment of its raw output, never a conclusion,
+so that a reviewer can re-run it. That rule SHALL be enforced in **shape**: a ticked box in the
+evidence group SHALL be checked against the form its kind owes — a path opened together with the
+commit or date it was read at; a probe together with a fragment of its output; a gap named or
+explicitly declared absent — with a file-specific error naming the box and what is missing. The
+rules SHALL be per box kind rather than uniform, because the kinds do not share a shape and a
+uniform rule rejects boxes that are correct as written.
+
+The gate SHALL cover the **absence** of a change and not only the shape of one that is present. A
+gate whose checks are written as a loop over active changes passes vacuously when there are none,
+which reads as approval of a pull request that recorded nothing. Therefore a pull request whose diff
+touches paths outside the workflow's own directory SHALL be required to carry one of: an active
+change, a change archived within the same diff, or a waiver line in the pull request body naming a
+reason. Paths written by the release automation alone SHALL be exempt, and the check SHALL run only
+where a base revision to compare against exists. Where it runs in continuous integration and no base
+revision can be resolved, it SHALL fail rather than skip, because a gate that cannot measure must not
+approve — an unresolvable base there is a misconfigured checkout, not an exemption.
+
+The waiver SHALL be treated as untrusted input: it is authored by whoever opened the pull request,
+including from a fork, and SHALL be matched as text and never executed or interpolated into a
+command.
+
+The same care SHALL apply to what the gate makes appear. A gate SHALL NOT publish the content it
+reads into a channel whose audience differs from that content's own: it reads the pull request body
+from the payload the runner already writes, rather than having it handed over through a mechanism the
+continuous-integration system echoes into the build log. Where the gate is nonetheless given the
+content explicitly — for local runs, or as a fallback — that path SHALL be the deliberate override
+and not the default. Failure to read the payload SHALL degrade to an empty body rather than an
+error, so that the decision stays with the rules that already exist instead of the build failing for
+a reason unrelated to the rite.
+
+Every enforcing script SHALL state that it verifies presence, position and shape, and **not the
+truth of the contents**: a box padded to satisfy the shape passes, and no script can tell an
+invented output from a real one. A script that also verifies that a change exists SHALL state that
+existence is not honesty — a change scaffolded to satisfy the gate passes it.
+
+The mandatory groups that are **not** gated on shape SHALL have their evidence density reported
+without affecting the exit code, so that a group whose boxes carry no probe is visible to a reviewer
+without reading the diff.
+
+#### Scenario: A change without recorded evidence fails the build
+
+- **WHEN** an active change's task list lacks the evidence group, or carries it somewhere other than
+  the first task group
+- **THEN** the rite gate script fails with a file-specific error naming the missing or misplaced
+  group, and the build does not pass
+
+#### Scenario: A pull request that records nothing fails the build
+
+- **WHEN** a pull request's diff touches a path outside the workflow's own directory and carries
+  neither an active change, nor a change archived in the same diff, nor a waiver line
+- **THEN** the rite gate fails, naming the offending path, rather than passing because the loop over
+  active changes found nothing to check
+
+#### Scenario: A gate that cannot measure does not approve
+
+- **WHEN** the check runs in continuous integration and no base revision can be resolved
+- **THEN** it fails naming the missing fetch depth, rather than passing because it had nothing to
+  compare against
+
+#### Scenario: The waiver is a written line, not a judgment
+
+- **WHEN** the same diff is accompanied by a waiver line in the pull request body naming a reason
+- **THEN** the gate passes and the reason is visible to the reviewer in the pull request itself
+- **AND** the line is matched as text, never executed, because its author is whoever opened the pull
+  request
+
+#### Scenario: The gate does not publish what it reads
+
+- **WHEN** the gate needs the pull request body to look for a waiver
+- **THEN** it reads it from the event payload the runner already wrote, so no step hands the body
+  over through a mechanism that prints it into the build log
+- **AND** an explicit hand-over remains available as an override for running the gate outside
+  continuous integration, taking precedence when it is set
+- **AND** a payload that is missing, unreadable or without the key yields an empty body, leaving the
+  existing rules to decide, rather than failing the build
+
+#### Scenario: A ticked box that states a conclusion fails the build
+
+- **WHEN** a ticked box in the evidence group records a conclusion instead of the form its kind owes
+- **THEN** the gate fails, naming the box and the missing element
+- **AND** the same box rewritten with a command and a fragment of its output passes
+
+#### Scenario: The gate declares what it cannot check
+
+- **WHEN** the gate passes
+- **THEN** the enforcing scripts state that shape is not truth — a box padded to satisfy the rule is
+  indistinguishable from an earned one — so that a green run is not read as verified evidence
+- **AND** they state that the existence of a change is not the honesty of one
+
+#### Scenario: A group that is reported rather than gated is not implied to be gated
+
+- **WHEN** a mandatory group carries items that are judgments rather than executions
+- **THEN** its evidence density is printed as a labelled report that never changes the exit code,
+  and the check states that the group is reported and not gated, rather than demanding a command
+  where none belongs
+
+#### Scenario: A gate introduced mid-flight does not exempt existing work
+
+- **WHEN** a new mandatory group is added while a change is already open
+- **THEN** the open change is backfilled with the group in the same change that introduces the gate,
+  rather than being added to an exemption list

--- a/openspec/changes/fix-waiver-transport/tasks.md
+++ b/openspec/changes/fix-waiver-transport/tasks.md
@@ -34,19 +34,19 @@
 
 ## 2. Transporte: do env para o payload do evento
 
-- [ ] 2.1 `read_pr_body` em `scripts/validate-spec-rite.py`: `PR_BODY` quando definido, senão
+- [x] 2.1 `read_pr_body` em `scripts/validate-spec-rite.py`: `PR_BODY` quando definido, senão
       `pull_request.body` do arquivo em `GITHUB_EVENT_PATH`, senão vazio — precedência declarada em
       comentário
-- [ ] 2.2 Leitura defensiva: `json.load` em `try/except` estreito; payload ausente, ilegível ou sem a
+- [x] 2.2 Leitura defensiva: `json.load` em `try/except` estreito; payload ausente, ilegível ou sem a
       chave vira corpo vazio com aviso, nunca traceback
-- [ ] 2.3 `.github/workflows/ci.yml`: remover o bloco `env:` do passo do gate
-- [ ] 2.4 Cabeçalho do script atualizado: de onde a dispensa é lida e por que não do ambiente
+- [x] 2.3 `.github/workflows/ci.yml`: remover o bloco `env:` do passo do gate
+- [x] 2.4 Cabeçalho do script atualizado: de onde a dispensa é lida e por que não do ambiente
 
 ## 3. Cobertura do leitor novo
 
-- [ ] 3.1 `--selftest` cobre: payload sintético em arquivo temporário lido, arquivo ausente tratado,
+- [x] 3.1 `--selftest` cobre: payload sintético em arquivo temporário lido, arquivo ausente tratado,
       override `PR_BODY` vencendo o payload
-- [ ] 3.2 Os cenários `S0`/`S1`/`S2` e os seis casos de falso positivo continuam intactos e verdes
+- [x] 3.2 Os cenários `S0`/`S1`/`S2` e os seis casos de falso positivo continuam intactos e verdes
 
 ## 4. Quality Gates (MANDATORY)
 

--- a/openspec/changes/fix-waiver-transport/tasks.md
+++ b/openspec/changes/fix-waiver-transport/tasks.md
@@ -52,24 +52,27 @@
 
 <!-- Revisão adversarial dos skills tocados — não happy-path. -->
 
-- [ ] Q.1 Frontmatter uniforme em cada `SKILL.md` tocado: nenhum skill é tocado por este change, e
+- [x] Q.1 Frontmatter uniforme em cada `SKILL.md` tocado: nenhum skill é tocado por este change, e
       isso é declarado aqui em vez de deixado em branco
-- [ ] Q.2 Todo conteúdo de skill tocado em inglês: nenhum skill tocado (ver Q.1)
-- [ ] Q.3 Triggers de description testáveis: nenhuma description muda
-- [ ] Q.4 Zero doutrina duplicada: a regra "um gate não publica o que lê" entra **dentro** do
+- [x] Q.2 Todo conteúdo de skill tocado em inglês: nenhum skill tocado (ver Q.1)
+- [x] Q.3 Triggers de description testáveis: nenhuma description muda
+- [x] Q.4 Zero doutrina duplicada: a regra "um gate não publica o que lê" entra **dentro** do
       requisito que já governa a dispensa, não num requisito vizinho, conforme a tabela Canonical
       Home do `design.md`
-- [ ] Q.5 Exemplos de código em inglês: o código tocado é script de CI, com identificadores em
+- [x] Q.5 Exemplos de código em inglês: o código tocado é script de CI, com identificadores em
       inglês vindos do Glossary da issue #92 (`read_pr_body`, `GITHUB_EVENT_PATH`, `PR_BODY`)
 
 ## 5. Validation & Closure (MANDATORY)
 
 <!-- Sempre o último grupo. "Pronto" é verificável, não é opinião. -->
 
-- [ ] V.1 `openspec validate fix-waiver-transport --strict` verde
-- [ ] V.2 `bash scripts/validate-rite.sh` verde neste branch e `--selftest` verde
-- [ ] V.3 `bash generate.sh && git diff --exit-code` limpo; `validate-skills.py`,
+- [x] V.1 `openspec validate fix-waiver-transport --strict` verde
+- [x] V.2 `bash scripts/validate-rite.sh` verde neste branch e `--selftest` verde
+- [x] V.3 `bash generate.sh && git diff --exit-code` limpo; `validate-skills.py`,
       `selftest-validate-skills.py` e `validate-repo-hygiene.py` verdes
-- [ ] V.4 No run de CI deste PR, o log do passo do gate não contém trecho do corpo do PR, e mostra
-      qual caminho de leitura rodou
+- [x] V.4 Run `32650044909` (job `97220085306`, PR #93): o bloco `env:` sumiu — o cabeçalho vai de
+      `shell: /usr/bin/bash -e {0}` direto para `##[endgroup]` — e o grep por seis trechos exclusivos
+      do corpo do PR (`canal de divulgação`, `add-mask`, `Known gaps`, `read_pr_body() lê`,
+      `O que foi descartado`, `Spec-rite: fix-waiver-transport`) retorna `0` em todos. O gate seguiu
+      medindo: `spec-rite gate: 0 findings (base origin/master, 8 changed path(s), 1 active change(s))`
 - [ ] V.5 `openspec archive fix-waiver-transport --yes` — **após o merge**, em PR separado

--- a/openspec/changes/fix-waiver-transport/tasks.md
+++ b/openspec/changes/fix-waiver-transport/tasks.md
@@ -1,0 +1,75 @@
+## 1. Evidence & Sources (MANDATORY)
+
+<!-- Sempre o PRIMEIRO grupo: prove antes de escrever. Registre o COMANDO e um fragmento da SAÍDA
+     CRUA, nunca uma conclusão. Doutrina: skill verify-before-claiming. -->
+
+- [x] E.1 Todo caminho local que este change usa foi ABERTO e lido em `f99695a` em 2026-08-23, não
+      recordado: `scripts/validate-spec-rite.py` (a linha 227, `os.environ.get("PR_BODY", "")`, e as
+      regex `WAIVER` / `WAIVER_NO_REASON`), `.github/workflows/ci.yml` (o passo *OpenSpec rite gate*
+      e seu bloco `env:`), `openspec/specs/skills-catalog/spec.md` (o requisito *The rite gates
+      evidence before it gates quality*, cujo texto integral o delta reproduz),
+      `skills/execute-backlog/references/spec-rite.md` e `README.md` (para confirmar que **não**
+      nomeiam o transporte), e `openspec/changes/archive/2026-08-23-add-spec-rite-gate/design.md`
+      (a decisão original de transporte, que este change corrige)
+- [x] E.2 Probado em 2026-08-23, não suposto:
+      `gh run view 32648727841 --log --job 97216916829 | awk '/OpenSpec rite gate.*group.Run bash/,/endgroup/'`
+      -> `env:` / `PR_BODY: Closes #89` seguido do corpo inteiro do PR #90 — é a medição que motiva
+      este change;
+      `grep -n "PR_BODY" README.md skills/execute-backlog/references/spec-rite.md` -> sem saída
+      (nenhum doc nomeia o transporte, logo nenhum doc muda);
+      docs do GitHub Actions (docs.github.com, variables reference, lidas em 2026-08-23) ->
+      `GITHUB_EVENT_PATH` = *"The path to the file on the runner that contains the full event webhook
+      payload"*;
+      `openspec --version` -> `1.6.0`
+- [x] E.3 Lacuna nomeada, não preenchida com substituto plausível: as docs descrevem o arquivo como
+      "full event webhook payload" mas não enumeram `pull_request.body` nele. A inferência é sólida
+      — `github.event` é esse mesmo payload e é o que hoje alimenta o `env` — porém só a execução de
+      CI deste PR confirma. Por isso o override e a degradação para corpo vazio existem, e por isso
+      um critério de aceite é o `grep` no log do run real. Nenhuma outra lacuna.
+- [x] E.4 Follow-ups listados, não executados aqui: (a) declarar `spec_rite` no
+      `.github/backlog.yml` deste repositório em vez de depender do default fail-closed; (b) auditar
+      outros passos do `ci.yml` caso algum passe a receber entrada de terceiro; (c) `openspec
+      templates` sem `--schema` ignorar o `openspec/config.yaml` (follow-up herdado do change
+      anterior, ainda aberto)
+
+## 2. Transporte: do env para o payload do evento
+
+- [ ] 2.1 `read_pr_body` em `scripts/validate-spec-rite.py`: `PR_BODY` quando definido, senão
+      `pull_request.body` do arquivo em `GITHUB_EVENT_PATH`, senão vazio — precedência declarada em
+      comentário
+- [ ] 2.2 Leitura defensiva: `json.load` em `try/except` estreito; payload ausente, ilegível ou sem a
+      chave vira corpo vazio com aviso, nunca traceback
+- [ ] 2.3 `.github/workflows/ci.yml`: remover o bloco `env:` do passo do gate
+- [ ] 2.4 Cabeçalho do script atualizado: de onde a dispensa é lida e por que não do ambiente
+
+## 3. Cobertura do leitor novo
+
+- [ ] 3.1 `--selftest` cobre: payload sintético em arquivo temporário lido, arquivo ausente tratado,
+      override `PR_BODY` vencendo o payload
+- [ ] 3.2 Os cenários `S0`/`S1`/`S2` e os seis casos de falso positivo continuam intactos e verdes
+
+## 4. Quality Gates (MANDATORY)
+
+<!-- Revisão adversarial dos skills tocados — não happy-path. -->
+
+- [ ] Q.1 Frontmatter uniforme em cada `SKILL.md` tocado: nenhum skill é tocado por este change, e
+      isso é declarado aqui em vez de deixado em branco
+- [ ] Q.2 Todo conteúdo de skill tocado em inglês: nenhum skill tocado (ver Q.1)
+- [ ] Q.3 Triggers de description testáveis: nenhuma description muda
+- [ ] Q.4 Zero doutrina duplicada: a regra "um gate não publica o que lê" entra **dentro** do
+      requisito que já governa a dispensa, não num requisito vizinho, conforme a tabela Canonical
+      Home do `design.md`
+- [ ] Q.5 Exemplos de código em inglês: o código tocado é script de CI, com identificadores em
+      inglês vindos do Glossary da issue #92 (`read_pr_body`, `GITHUB_EVENT_PATH`, `PR_BODY`)
+
+## 5. Validation & Closure (MANDATORY)
+
+<!-- Sempre o último grupo. "Pronto" é verificável, não é opinião. -->
+
+- [ ] V.1 `openspec validate fix-waiver-transport --strict` verde
+- [ ] V.2 `bash scripts/validate-rite.sh` verde neste branch e `--selftest` verde
+- [ ] V.3 `bash generate.sh && git diff --exit-code` limpo; `validate-skills.py`,
+      `selftest-validate-skills.py` e `validate-repo-hygiene.py` verdes
+- [ ] V.4 No run de CI deste PR, o log do passo do gate não contém trecho do corpo do PR, e mostra
+      qual caminho de leitura rodou
+- [ ] V.5 `openspec archive fix-waiver-transport --yes` — **após o merge**, em PR separado

--- a/scripts/validate-spec-rite.py
+++ b/scripts/validate-spec-rite.py
@@ -22,15 +22,24 @@ required, reviewable artifact; the review is what judges it. The selftest exerci
 rules against synthetic inputs, not the git plumbing that feeds them: a misconfigured checkout is
 caught by the CI-only base-resolution failure below, not by the selftest.
 
+The waiver is read from the event payload the runner already writes (GITHUB_EVENT_PATH), not from
+an environment variable handed to the step: GitHub Actions prints a step's `env:` block into the
+build log, so passing the pull request body that way published the whole body on every run —
+measured on run 32648727841. A gate must not become a disclosure channel for what it reads. PR_BODY
+survives as the deliberate override for running this outside CI.
+
 Exit 1 on any finding. Run from the repo root.
 Modes: (default) check this diff   |   --selftest inject one defect per rule and assert detection.
 """
 from __future__ import annotations
 
+import contextlib
+import json
 import os
 import re
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -107,6 +116,38 @@ def resolve_base(root: Path) -> str | None:
     return None
 
 
+def read_pr_body() -> str:
+    """The pull request body, without routing it through anything that echoes it.
+
+    Precedence, and the reason for it:
+      1. PR_BODY, when set — the only reason to set it explicitly is to want that exact value
+         (local runs, and the end-to-end probes of this gate).
+      2. pull_request.body from the file at GITHUB_EVENT_PATH — the payload the runner wrote for
+         itself. Nothing hands it over, so nothing prints it.
+      3. empty.
+
+    A payload that is missing, unreadable or without the key degrades to an empty body rather than
+    an error: the decision then falls to the rules that already exist, instead of the build failing
+    for a reason unrelated to the rite.
+    """
+    override = os.environ.get("PR_BODY")
+    if override is not None:
+        return override
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path:
+        return ""
+    try:
+        with open(event_path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(f"  spec-rite gate: event payload unreadable ({exc.__class__.__name__}) — "
+              "continuing with an empty body")
+        return ""
+    body = (payload.get("pull_request") or {}).get("body")
+    return body if isinstance(body, str) else ""
+
+
 def changed_paths(root: Path, base: str) -> list[str]:
     out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", f"{base}...HEAD"],
                          capture_output=True, text=True, check=True).stdout
@@ -173,6 +214,63 @@ SILENT = [
 ]
 
 
+@contextlib.contextmanager
+def _env(**pairs):
+    """Set/unset env vars for one case and put the process back the way it was."""
+    saved = {k: os.environ.get(k) for k in pairs}
+    try:
+        for k, v in pairs.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+def selftest_reader() -> int:
+    """The reader is the surface this change adds, so it gets cases of its own.
+
+    Exercised against files written here rather than a real event: what a real payload proves that
+    this cannot is whether the key is present at all, and that is what the CI run of the pull
+    request answers. The fallbacks below are what make that answer non-fatal either way.
+    """
+    ok = 0
+    with tempfile.TemporaryDirectory() as td:
+        good = Path(td) / "event.json"
+        good.write_text(json.dumps({"pull_request": {"body": "Spec-rite: none — from payload"}}))
+        broken = Path(td) / "broken.json"
+        broken.write_text("{not json")
+        keyless = Path(td) / "keyless.json"
+        keyless.write_text(json.dumps({"issue": {"body": "wrong event"}}))
+        missing = Path(td) / "does-not-exist.json"
+
+        cases = [
+            ("payload body is read", {"PR_BODY": None, "GITHUB_EVENT_PATH": str(good)},
+             "Spec-rite: none — from payload"),
+            ("PR_BODY overrides the payload", {"PR_BODY": "override wins", "GITHUB_EVENT_PATH": str(good)},
+             "override wins"),
+            ("missing payload file degrades to empty", {"PR_BODY": None, "GITHUB_EVENT_PATH": str(missing)}, ""),
+            ("malformed payload degrades to empty", {"PR_BODY": None, "GITHUB_EVENT_PATH": str(broken)}, ""),
+            ("payload without the key degrades to empty", {"PR_BODY": None, "GITHUB_EVENT_PATH": str(keyless)}, ""),
+            ("no payload path at all degrades to empty", {"PR_BODY": None, "GITHUB_EVENT_PATH": None}, ""),
+        ]
+        for label, env, expected in cases:
+            with _env(**env):
+                got = read_pr_body()
+            if got == expected:
+                print(f"  READER  {label}")
+                ok += 1
+            else:
+                print(f"  READER FAIL  {label}   <-- got {got!r}, expected {expected!r}")
+    return ok
+
+
 def selftest() -> int:
     global findings, annotate
     annotate = False
@@ -196,9 +294,14 @@ def selftest() -> int:
             print(f"  SILENT  {label}")
             quiet += 1
 
+    reader_ok = selftest_reader()
+    reader_total = 6
+
     print(f"\n{caught}/{len(DEFECTS)} defect classes detected, "
-          f"{quiet}/{len(SILENT)} false-positive cases stayed silent")
-    return 0 if caught == len(DEFECTS) and quiet == len(SILENT) else 1
+          f"{quiet}/{len(SILENT)} false-positive cases stayed silent, "
+          f"{reader_ok}/{reader_total} reader cases correct")
+    return 0 if (caught == len(DEFECTS) and quiet == len(SILENT)
+                 and reader_ok == reader_total) else 1
 
 
 # ── main ──────────────────────────────────────────────────────────────────
@@ -224,7 +327,7 @@ def main() -> int:
         return 0
 
     paths = changed_paths(ROOT, base)
-    evaluate(paths, active_changes(ROOT), os.environ.get("PR_BODY", ""))
+    evaluate(paths, active_changes(ROOT), read_pr_body())
     print(f"  spec-rite gate: {len(findings)} findings "
           f"(base {base}, {len(paths)} changed path(s), "
           f"{len(active_changes(ROOT))} active change(s))")


### PR DESCRIPTION
Closes #92

Spec-rite: fix-waiver-transport

## O problema

O gate entregue pelo #90 recebia o corpo do PR por `env:`, e o Actions imprime esse bloco no cabeçalho do passo. Medido no run `32648727841`, passo *OpenSpec rite gate*:

```
##[group]Run bash scripts/validate-rite.sh
shell: /usr/bin/bash -e {0}
env:
  PR_BODY: Closes #89

Spec-rite: add-spec-rite-gate

## O que muda
...
```

O corpo inteiro do PR no log. Um gate virou canal de divulgação do que ele lê.

Aqui o dano é nulo — repo público, corpo de PR já visível. O que importa é a forma, porque ela viaja: as skills são portáteis e o desenho vai ser copiado pra repo privado, onde o log do Actions tem plateia diferente do PR.

## O que muda

`read_pr_body()` lê `pull_request.body` do arquivo em `GITHUB_EVENT_PATH` — o payload que o runner já escreve pra si. Nada entrega o corpo, então nada o imprime. O bloco `env:` sai do `ci.yml`.

Precedência declarada no código: `PR_BODY` quando definido (override deliberado, é do que os probes locais dependem) → payload → vazio. Payload ausente, ilegível ou sem a chave degrada pra corpo vazio com aviso, nunca traceback: gate que morre pelo canal de leitura vira flake, e travaria PR por motivo que nada tem a ver com o rito.

**Nenhuma regra de decisão muda.** `S0`/`S1`/`S2`, regex ancorada, allowlist de release e a isenção de diff confinado a `openspec/` ficam idênticas.

## O que foi descartado

`::add-mask::` trata sintoma: o dado continua atravessando o canal e o log vira `***` no meio de um bloco que existe pra ser lido. A correção é o dado não passar por ali.

## Evidência

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | `ci.yml` sem `PR_BODY` no passo do gate | met | `grep -c "PR_BODY" .github/workflows/ci.yml` → `0` |
| 2 | leitor com precedência declarada | met | `scripts/validate-spec-rite.py`, `read_pr_body()` com a docstring de precedência |
| 3 | selftest cobre o leitor | met | `3/3 defect classes detected, 6/6 false-positive cases stayed silent, 6/6 reader cases correct` |
| 4 | payload com/sem dispensa | met | clone de probe, `env -u PR_BODY GITHUB_EVENT_PATH=<payload>`: com a linha → exit 0; sem a linha → `S1 unregistered change` / exit 1 |
| 5 | `validate-rite.sh` verde no branch + selftest | met | `rite gate OK`; selftest acima |
| 6 | log do CI sem trecho do corpo do PR | **pendente** | só o run deste PR prova — ver *Known gaps* |
| 7 | rito da própria change | met | `openspec validate fix-waiver-transport --strict` → `is valid`; `validate-rite-evidence.py` → `0 findings` |
| 8 | wrappers e suíte | met | `generate.sh && git diff --exit-code` limpo; `validate-skills.py` 34/0; `selftest-validate-skills.py` 13/13; `validate-repo-hygiene.py` 0 + 2/2; `scan-secrets.py` 0 |
| 9 | nenhum doc passa a nomear o transporte | met | `grep -n "PR_BODY\|GITHUB_EVENT_PATH" README.md skills/` → vazio; os dois seguem descrevendo "uma linha no corpo do PR" |
| 10 | delta registra "um gate não publica o que lê" | met | delta em `skills-catalog`, dentro do requisito que já governa a dispensa — não num vizinho |

## Known gaps

- **Critério 6 é bootstrap**: o log limpo só existe depois que este PR roda. Confiro no run deste PR e reporto na issue; se sobrar qualquer trecho do corpo no log, o PR volta pra bancada em vez de ser mergeado.
- `openspec archive fix-waiver-transport` fica pendente de propósito (V.5), em PR separado depois do merge, como #91.
- A lacuna nomeada em `E.3`: as docs descrevem `GITHUB_EVENT_PATH` como "full event webhook payload" mas não enumeram `pull_request.body`. A inferência é sólida — `github.event` é esse mesmo payload — e é justamente por não estar enumerada que o override e a degradação pra corpo vazio existem.
