### PR TITLE
✨ feat(code-locale): mede o locale na hora da escrita e cobre o caminho

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Identifier-locale detector self-test (the shipped script is itself gated)
         run: python3 skills/code-locale/references/check-identifier-locale.py --selftest
 
+      - name: Locale write-gate hook self-test (the shipped hook is itself gated)
+        run: python3 claude/global/hooks/locale-rite.py --selftest
+
       - name: Secret scan (working tree)
         run: python3 scripts/scan-secrets.py
 

--- a/README.md
+++ b/README.md
@@ -282,6 +282,43 @@ it — it cannot enforce anything on a pull request. The gate that survives an u
 with an `Evidence & Sources (MANDATORY)` group. The hook makes the guess less likely; CI makes the
 missing evidence visible.
 
+### The locale rite (English machine layer, measured at the write)
+
+`claude/global/hooks/locale-rite.py` is the third hook, and the only one that measures an artifact
+instead of matching a prompt. It runs on `PostToolUse` for `Write|Edit`, feeds the written **path**
+and the written **content** to [`check-identifier-locale.py`](skills/code-locale/references/check-identifier-locale.py),
+and returns the findings to the assistant. Silent when the write is clean.
+
+```jsonc
+// ~/.claude/settings.json — alongside the UserPromptSubmit block above
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-rite.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Why a different event.** The other two rites match a prompt, so a reminder is the best they can do.
+This one has the artifact in hand — the name that was just written — so it measures instead of
+reminding. The findings travel in `hookSpecificOutput.additionalContext`, not on plain stdout:
+`PostToolUse` is not one of the events that turn stdout into context (`UserPromptSubmit`,
+`UserPromptExpansion`, `SessionStart` are), so a hook that printed would be silently useless.
+
+Same contract as the other two: informs, never blocks, persists nothing, needs no credentials — and
+where the check itself is missing it exits silently instead of failing, because an absent gate must
+not present itself as an error.
+
 > Like `personal-rules.md`, this is the **maintainer's** process. Edit the signal lists and the
 > reminder text to match yours — both matchers cover Portuguese and English by default.
 

--- a/claude/global/hooks/locale-rite.py
+++ b/claude/global/hooks/locale-rite.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""PostToolUse hook — measures the code-locale rite at the moment a file is written.
+
+Reads the hook payload on stdin and, when a Write/Edit just landed, runs the shipped
+identifier-locale check against the written PATH and the written CONTENT. Findings go back to the
+assistant as context for the next turn. Silent when the write is clean.
+
+Why a hook and not only the skill and the global rule: both were already in place — the `code-locale`
+skill in the catalog and the Code Locale section of personal-rules.md — and Portuguese identifiers
+and file names kept reaching code in new sessions (issue #95). Doctrine in context is not
+measurement. This is the same argument `backlog-rite.py` states for its own rule, applied to the one
+rule whose violation is visible in the artifact itself.
+
+WHY `hookSpecificOutput.additionalContext` AND NOT PLAIN STDOUT
+    For PostToolUse, plain stdout goes to the debug log and the model never sees it. The events that
+    turn stdout into context are UserPromptSubmit, UserPromptExpansion and SessionStart — which is
+    why the repo's other two rite hooks can print and this one cannot. Probed against the installed
+    version rather than recalled: `claude --version` -> `2.1.246 (Claude Code)`, and the binary reads
+    `let {additionalContext:a,...l}=e.hookSpecificOutput` with the cap `additionalContext:8000`.
+    Docs: code.claude.com/docs/en/hooks (read 2026-08-26).
+
+WHAT THIS HOOK DELIBERATELY DOES NOT DO
+    - It never blocks. The tool already ran, and the rite informs; the user waives.
+    - It never writes state, reads credentials, or calls the network.
+    - It reports nothing when the shipped check is missing: a gate that is absent must not present
+      itself to the user as an error.
+    - It inherits every limit of the check it calls, including the open-vocabulary escape — a
+      Portuguese word outside the lexicon passes here exactly as it passes in CI.
+
+Wiring (~/.claude/settings.json):
+
+    "hooks": {
+      "PostToolUse": [
+        {"matcher": "Write|Edit",
+         "hooks": [{"type": "command",
+                    "command": "python3 ~/ai-skills/claude/global/hooks/locale-rite.py",
+                    "timeout": 10}]}
+      ]
+    }
+
+Like personal-rules.md, this is the maintainer's config — edit the matcher and the message to match
+your own process instead of adopting it blindly.
+
+Modes: (default) read one payload from stdin   |   --selftest assert the decisions against synthetic payloads.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# The check lives in the skill that owns the doctrine. Two directories up from claude/global/hooks/
+# is the repository root; the path is resolved, never guessed, and a miss exits silently.
+CHECK_PATH = Path(__file__).resolve().parents[3] / "skills/code-locale/references/check-identifier-locale.py"
+
+# The harness truncates a longer value; truncating here keeps the tail we choose rather than the
+# tail it chooses. Measured cap: `additionalContext:8000` in claude 2.1.246.
+CONTEXT_CAP = 8000
+
+WRITE_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit"}
+
+HEADER = (
+    "CODE-LOCALE: the write that just landed carries a non-English name in the machine layer. "
+    "Identifiers, file and directory names are English (code-locale skill); comments, docstrings "
+    "and user-facing strings keep the repository's language. Rename before continuing, or state the "
+    "reason the name is correct as written.\n\n"
+)
+
+
+def load_check():
+    """Import the shipped check by path. Its file name has hyphens, so it is not importable by name."""
+    if not CHECK_PATH.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("check_identifier_locale", CHECK_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:
+        return None
+
+
+def written_text(tool_name: str, tool_input: dict) -> str:
+    """The text this tool call added — never the file's existing content, which the rite does not judge."""
+    if tool_name == "Write":
+        return tool_input.get("content") or ""
+    if tool_name == "Edit":
+        return tool_input.get("new_string") or ""
+    if tool_name == "MultiEdit":
+        return "\n".join(e.get("new_string") or "" for e in tool_input.get("edits") or [])
+    if tool_name == "NotebookEdit":
+        return tool_input.get("new_source") or ""
+    return ""
+
+
+def findings_for(check, file_path: str, text: str, cwd: str) -> list:
+    path = Path(file_path)
+    if check.is_vendored(path):
+        return []
+    root = Path(cwd) if cwd else Path.cwd()
+    allow = check.load_allowlist(root)
+    findings = list(check.scan_path(path, allow, root))
+    lang = check.EXT_LANG.get(path.suffix.lower())
+    if lang and text:
+        rel = check.project_relative(path, root)
+        findings.extend(check.scan_text(text, lang, str(rel), allow))
+    return findings
+
+
+def report(findings: list) -> dict:
+    body = HEADER + "\n".join(f.render() for f in findings)
+    if len(body) > CONTEXT_CAP:
+        body = body[:CONTEXT_CAP - 80].rstrip() + "\n    … truncated; run the check on the file for the rest."
+    count = len(findings)
+    return {
+        "hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": body},
+        "systemMessage": f"code-locale: {count} non-English name{'s' if count != 1 else ''} in the last write",
+    }
+
+
+def evaluate(payload: dict, check) -> "dict | None":
+    """The whole decision, isolated from stdin and stdout so the selftest can drive it."""
+    if check is None:
+        return None
+    tool_name = payload.get("tool_name") or ""
+    if tool_name not in WRITE_TOOLS:
+        return None
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return None
+    file_path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
+    if not file_path:
+        return None
+    cwd = payload.get("cwd") or os.getcwd()
+    try:
+        findings = findings_for(check, file_path, written_text(tool_name, tool_input), cwd)
+    except Exception:
+        return None                      # a check that crashes must not crash the write
+    return report(findings) if findings else None
+
+
+def selftest() -> int:
+    check = load_check()
+    if check is None:
+        print(f"selftest FAILED: check not found at {CHECK_PATH}")
+        return 1
+    cwd = "/tmp/locale-rite-selftest"
+    cases = [
+        ("portuguese path reported", True, {
+            "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/servicos_pedido/shipping.py", "content": "x = 1\n"}}),
+        ("portuguese identifier reported", True, {
+            "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/orders/service.py",
+                           "content": "def buscar_order(x):\n    return x\n"}}),
+        ("edit reports its new_string", True, {
+            "tool_name": "Edit", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/orders/service.py", "old_string": "a",
+                           "new_string": "usuario_count = 1\n"}}),
+        ("no language profile still measures the path", True, {
+            "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/reports/cadastro.xlsx", "content": ""}}),
+        ("clean write is silent", False, {
+            "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/orders/shipping_cost.py",
+                           "content": "def compute_shipping(order_id):\n    return 0\n"}}),
+        ("portuguese comment is prose, not a finding", False, {
+            "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/orders/shipping.py",
+                           "content": "# calcula o frete do pedido\ntotal = 0\n"}}),
+        ("vendored path is silent", False, {
+            "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/node_modules/servicos/pedido.js", "content": "var a=1\n"}}),
+        ("another tool is ignored", False, {
+            "tool_name": "Bash", "cwd": cwd, "tool_input": {"command": "ls servicos_pedido"}}),
+        ("payload without file_path is ignored", False, {
+            "tool_name": "Write", "cwd": cwd, "tool_input": {}}),
+        ("payload without tool_input is ignored", False, {"tool_name": "Write", "cwd": cwd}),
+        ("empty payload is ignored", False, {}),
+    ]
+    failed = []
+    for name, should_report, payload in cases:
+        got = evaluate(payload, check)
+        ok = bool(got) == should_report
+        print(f"  {'OK     ' if ok else 'FAILED '} {name}")
+        if not ok:
+            failed.append(name)
+    reported = evaluate(cases[0][2], check)
+    shape_ok = (
+        isinstance(reported, dict)
+        and reported["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        and isinstance(reported["hookSpecificOutput"]["additionalContext"], str)
+        and len(reported["hookSpecificOutput"]["additionalContext"]) <= CONTEXT_CAP
+    )
+    print(f"  {'OK     ' if shape_ok else 'FAILED '} output shape is the field the harness reads")
+    if not shape_ok:
+        failed.append("output shape")
+    print()
+    if failed:
+        print("selftest FAILED: " + "; ".join(failed))
+        return 1
+    print(f"selftest OK: {len(cases)} decisions plus the output shape")
+    return 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv[1:]:
+        return selftest()
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    result = evaluate(payload, load_check())
+    if result:
+        print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/global/hooks/locale-rite.py
+++ b/claude/global/hooks/locale-rite.py
@@ -94,6 +94,23 @@ def written_text(tool_name: str, tool_input: dict) -> str:
     return ""
 
 
+def first_line_of(path: Path, text: str) -> int:
+    """Where the written fragment starts in the file, so a finding points at a real line.
+
+    An Edit hands over `new_string` alone, and scanning it in isolation numbers its lines from 1 —
+    which reads as "line 1 of the file" and sends the reader to the wrong place. Locating the
+    fragment in the file that the tool has already written is what makes the number true. A fragment
+    that cannot be located (a replace_all whose copies differ, a file already changed again) falls
+    back to 1, which is the previous behaviour and never worse than it.
+    """
+    try:
+        body = path.read_text(encoding="utf-8")
+    except OSError:
+        return 1
+    index = body.find(text)
+    return body.count("\n", 0, index) + 1 if index >= 0 else 1
+
+
 def findings_for(check, file_path: str, text: str, cwd: str) -> list:
     path = Path(file_path)
     if check.is_vendored(path):
@@ -104,7 +121,8 @@ def findings_for(check, file_path: str, text: str, cwd: str) -> list:
     lang = check.EXT_LANG.get(path.suffix.lower())
     if lang and text:
         rel = check.project_relative(path, root)
-        findings.extend(check.scan_text(text, lang, str(rel), allow))
+        findings.extend(check.scan_text(text, lang, str(rel), allow,
+                                        first_line=first_line_of(path, text)))
     return findings
 
 
@@ -178,6 +196,10 @@ def selftest() -> int:
             "tool_name": "Write", "cwd": cwd, "tool_input": {}}),
         ("payload without tool_input is ignored", False, {"tool_name": "Write", "cwd": cwd}),
         ("empty payload is ignored", False, {}),
+        ("missing file on disk still reports the path", True, {
+            "tool_name": "Edit", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/servicos/x.py", "old_string": "a",
+                           "new_string": "b = 1\n"}}),
     ]
     failed = []
     for name, should_report, payload in cases:

--- a/claude/skills/code-locale/SKILL.md
+++ b/claude/skills/code-locale/SKILL.md
@@ -19,14 +19,17 @@ description: >-
   translation.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
   The doctrine is language- and stack-agnostic and needs no runtime. The shipped detector
   `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package; it
-  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, and reports any
-  other file type as skipped rather than passing.
+  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, measures the path of
+  every file it is given, and reports the contents of any other file type as skipped rather than
+  passing. The optional write-time hook `claude/global/hooks/locale-rite.py` needs a harness that
+  emits a post-write tool event; it was built against Claude Code 2.1.246 and exits silently
+  anywhere else.
 ---
 
 Read and follow all instructions in ~/ai-skills/skills/code-locale/SKILL.md

--- a/cursor/rules/code-locale.mdc
+++ b/cursor/rules/code-locale.mdc
@@ -105,7 +105,8 @@ python3 references/check-identifier-locale.py src/orders/service.py
 
 Read the output as a prompt, not a verdict: every finding prints `path:line:token` plus the exact
 waiver line to add. A finding the author judges correct as written costs one `locale-ok:` comment
-with a reason. **The check declares what escapes it in its own docstring** — a curated word list is
+with a reason. **The waiver covers its own line and the next one** — put it on the offending line or
+immediately above it, never at the top of a block, where it will not reach. **The check declares what escapes it in its own docstring** — a curated word list is
 not a language model, so a passing run is not proof of compliance, and names outside its reach are
 reviewed by hand.
 

--- a/cursor/rules/code-locale.mdc
+++ b/cursor/rules/code-locale.mdc
@@ -109,8 +109,32 @@ with a reason. **The check declares what escapes it in its own docstring** — a
 not a language model, so a passing run is not proof of compliance, and names outside its reach are
 reviewed by hand.
 
+**The path is checked too**, because a file and a directory are named by the machine layer like any
+identifier. The path measured is the one relative to the working directory — a Portuguese folder
+*above* the project is not the project's machine layer. In `--diff` mode only files the diff **adds**
+have their path measured: renaming an existing file is the migration policy's decision, not the
+check's. A file name has nowhere to carry `# locale-ok:`, so its only waiver is the allowlist file
+`.identifier-locale-allow` — one path or segment per line — and the finding prints the line to add.
+
 Probed on 2026-08-14 with `Python 3.14.5`; the detector uses only the standard library, so it has no
 pinned dependency.
+
+## Catching it at the write, not at the review
+
+A review-time check catches the name after it is written, spread across a diff, when renaming costs
+the most. `claude/global/hooks/locale-rite.py` closes that distance: it runs on the harness event
+that follows a file write, feeds the written path and the written content to the same check, and
+returns the findings to the assistant before the next turn. Silent when the write is clean, never
+blocking — the rite informs, and the author decides.
+
+This exists because doctrine in context was measured to be insufficient: with this skill installed
+and the rule loaded, Portuguese identifiers and file names still reached code in new sessions. The
+same argument the repository already applies to its other rites applies here — enforcement must not
+depend on the assistant noticing a rule it already has.
+
+The findings travel in the field the harness reads for that event, not on plain standard output;
+the hook's own docstring records the probe that established which one. Wiring: the README's hooks
+section.
 
 ## Existing code
 

--- a/openspec/changes/add-locale-write-gate/design.md
+++ b/openspec/changes/add-locale-write-gate/design.md
@@ -1,0 +1,111 @@
+## Context
+
+O repositório já entrega dois ritos como hook: `claude/global/hooks/backlog-rite.py` e
+`claude/global/hooks/verify-rite.py`, ambos `UserPromptSubmit`, ambos justificados no próprio
+docstring — *"the harness runs this on every prompt, so enforcement does not depend on the assistant
+noticing a rule already in context"*. A capability `skills-catalog` especifica essa forma (cenários
+em `openspec/specs/skills-catalog/spec.md:209` e `:472`).
+
+O rito de locale não tem esse par. Ele existe como doutrina (`skills/code-locale/SKILL.md`), como
+seção das regras globais (`claude/global/personal-rules.md`) e como detector de revisão
+(`skills/code-locale/references/check-identifier-locale.py`), e mesmo assim o defeito reaparece.
+
+O detector, além disso, não lê o caminho do arquivo que recebe — o artefato que a própria doutrina
+lista primeiro entre os nomes que a máquina consome.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- O tier de caminho existe nos dois modos que o detector já expõe (arquivo e `--diff`).
+- Um nome de arquivo em português escrito pelo assistente é reportado no momento da escrita, em
+  qualquer repositório, sem depender de CI daquele repositório.
+- Nenhum falso positivo novo: as regras que já protegem identificadores (vendor, `MIN_SEGMENT`,
+  `DOMAIN_KEEP`, allowlist) valem igual para caminho.
+
+**Non-Goals**
+
+- Renomear nome existente, aqui ou em qualquer repositório. Os três tiers de
+  `skills/code-locale/references/migration.md` continuam valendo.
+- Ampliar `LEXICON`, cobrir espanhol/italiano/francês, ou mexer nos escapes deliberados listados no
+  KNOWN LIMIT do detector.
+- Bloquear a chamada de ferramenta. Como os outros dois ritos, este informa; a dispensa é do usuário.
+- Entregar template de pre-commit/CI para repositórios de destino (adiado deliberadamente — o hook
+  global já cobre toda sessão em todo repositório).
+
+## Decisions
+
+**D1 — O caminho é medido relativo ao diretório de trabalho, nunca absoluto.**
+Um caminho absoluto carrega segmentos que o projeto não escolheu (`/home/<usuário>`, um diretório de
+mount, o nome da máquina). Escanear `/home/diegops/ai-skills/...` inteiro produziria achado sobre o
+nome da pasta pessoal de alguém. A regra: quando o caminho está dentro do `cwd`, mede-se a parte
+relativa; quando não está, mede-se apenas o nome do próprio arquivo. Alternativa considerada e
+descartada: escanear tudo e listar exceções — transfere ao usuário o custo de uma decisão que a
+ferramenta consegue tomar sozinha.
+
+**D2 — Em `--diff`, só o caminho de arquivo ADICIONADO é medido.**
+Um diff que toca um arquivo legado de nome português reportaria o mesmo achado em todo commit até
+alguém renomear — e renomear é exatamente o que a política de migração proíbe fazer por si só. O
+sinal de "arquivo novo" já está no diff: o cabeçalho `--- /dev/null` que precede o `+++ b/<path>`.
+Alternativa descartada: medir todo `+++ b/`, que transforma o gate em ruído permanente sobre código
+que ele não deveria julgar.
+
+**D3 — A dispensa de um caminho é a allowlist, não um comentário.**
+Um nome de arquivo não tem onde carregar `# locale-ok: <motivo>`. O detector já tem o mecanismo:
+`ALLOWLIST_FILE = ".identifier-locale-allow"`, lido por `load_allowlist()` subindo a árvore, e o
+`Finding.render()` já imprime a linha a acrescentar. O achado de caminho reaproveita esse caminho de
+saída em vez de inventar um segundo formato de dispensa.
+
+**D4 — O hook devolve o achado por `hookSpecificOutput.additionalContext`, não por stdout puro.**
+Em `PostToolUse`, stdout simples vai para o debug log e o modelo não vê. Probado nas duas pontas:
+a documentação da versão instalada (`code.claude.com/docs/en/hooks`, lida em 2026-08-26) diz que as
+exceções em que stdout vira contexto são `UserPromptSubmit`, `UserPromptExpansion` e `SessionStart`
+— `PostToolUse` não está na lista; e o binário instalado (`claude 2.1.246`) lê o campo:
+`let {additionalContext:a,...l}=e.hookSpecificOutput` com o teto `additionalContext:8000`. O hook
+imprime JSON e sai 0. Alternativa descartada: `exit 2`, que a doc descreve como "shows stderr to
+Claude" — funciona, mas é a porta de erro, e este rito não é erro: é informação.
+
+**D5 — O hook importa o detector por caminho, não por subprocesso.**
+O detector é stdlib-only e o hook vive no mesmo repositório, dois níveis acima
+(`claude/global/hooks/` → `skills/code-locale/references/`). `importlib.util.spec_from_file_location`
+carrega um arquivo cujo nome tem hífens sem exigir pacote. Isso evita pagar um processo Python novo
+a cada `Write`/`Edit`. Se o detector não estiver presente (alguém copiou só o hook), o hook sai 0 em
+silêncio — um gate ausente nunca vira exceção na cara do usuário.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Regra transversal | Skill canônico (dono) | Ação nesta change |
+|---|---|---|
+| Fronteira prosa/máquina, exceção de termo de domínio, política de migração | `code-locale` | já canônico — a change altera o detector **dentro** do skill dono, não replica a doutrina em outro lugar |
+| Não improvisar tradução / afirmar sem probe | `verify-before-claiming` | link, sem restatement: o SKILL.md do `code-locale` já aponta para ele, e as decisões D4/D1 registram o probe em vez de recordar |
+| Rito backlog-first (o hook novo é irmão dos dois existentes) | `backlog` / `execute-backlog` | link: o `locale-rite.py` não repete o texto do rito de backlog; ele cita a doutrina do `code-locale` e nada mais |
+| Idioma de commit/PR | `conventional-commit` | intocado — esta change não altera regra de prosa de commit |
+
+## Risks / Trade-offs
+
+- **Ruído a cada escrita** → silencioso quando limpo; mede apenas o caminho tocado e o conteúdo
+  escrito, nunca a árvore.
+- **Latência em todo `Write`/`Edit`** → import de módulo em processo, stdlib, sem chamada a git e sem
+  travessia de diretório. O orçamento é um arquivo.
+- **Falso positivo em árvore legada** → D2 restringe o modo diff a arquivo adicionado, e o hook mede
+  o arquivo que está sendo escrito agora, não o repositório.
+- **A allowlist virar escape hatch ilimitado** → é o mesmo mecanismo já existente para
+  identificadores, com o mesmo custo social: entra no repositório, aparece no diff, um revisor lê.
+- **Hook é config do usuário; máquina sem wiring não ganha gate** → README documenta o wiring ao lado
+  dos outros dois, e o próprio hook reporta nada em vez de falhar quando o detector some.
+- **O tier de caminho não é modelo de língua** → o KNOWN LIMIT do detector ganha a linha
+  correspondente; um nome fora do léxico continua passando, como já acontece para identificadores.
+
+## Migration Plan
+
+Não há migração. O tier novo só fala sobre arquivo adicionado (D2) e sobre a escrita corrente (hook),
+então nenhuma árvore existente fica vermelha no dia seguinte. Rollback: remover o passo de CI e o
+wiring do hook; o detector volta ao comportamento anterior removendo a função de caminho.
+
+## Open Questions
+
+- Nenhuma pendente sobre o mecanismo: os dois pontos que dependiam de comportamento externo (campo
+  lido pelo harness em `PostToolUse`, e forma do payload) foram probados contra a versão instalada
+  (D4). O que **não** foi probado: como outros harnesses (Codex, Cursor) expõem um evento equivalente
+  — por isso a change entrega o hook apenas para o harness cujo contrato foi medido, e não afirma
+  nada sobre os demais.

--- a/openspec/changes/add-locale-write-gate/proposal.md
+++ b/openspec/changes/add-locale-write-gate/proposal.md
@@ -1,0 +1,80 @@
+# Change: Cobrir o caminho no detector de locale e fechar o gate na hora da escrita
+
+## Why
+
+A doutrina do `code-locale` nomeia "module, package, file and directory names" como camada máquina, e
+o docstring do detector afirma checar "identifiers, file and module names". O detector não lê o
+caminho: seu único uso de `path` é o filtro de vendor (`skills/code-locale/references/check-identifier-locale.py:302`).
+Medido em 2026-08-26 com Python 3.14.5:
+
+```
+$ python3 skills/code-locale/references/check-identifier-locale.py /tmp/.../servicos_pedido/calculo_frete.py
+findings: 0
+exit=0
+$ python3 skills/code-locale/references/check-identifier-locale.py --diff /tmp/.../fake.diff
+findings: 0
+exit=0
+```
+
+O corpo do arquivo está em inglês; `servicos` e `calculo` são exatamente o defeito que a doutrina
+nomeia, no artefato que o docstring diz cobrir, e os dois modos passam. Escopo documentado ≠ escopo
+implementado.
+
+Além disso, nada roda o detector no momento em que o nome é escrito. O detector é ferramenta de
+revisão que alguém precisa invocar, e o passo de CI deste repositório gata apenas o script contra si
+mesmo. Entre a doutrina estar no contexto e o código ser escrito não há medição — que é precisamente
+a falha que os dois ritos já entregues (`backlog-rite.py`, `verify-rite.py`) foram construídos para
+fechar nas suas próprias regras. Relato de campo do mantenedor (issue #95, 2026-08-26): nomes de
+arquivo e identificadores em português continuam aparecendo em sessões novas, com a skill instalada.
+
+## What Changes
+
+- `skills/code-locale/references/check-identifier-locale.py` ganha um **tier de caminho**: os
+  segmentos do caminho (diretórios + radical do arquivo) passam pelos mesmos tiers dos
+  identificadores, em modo arquivo e em modo `--diff`.
+- O tier de caminho respeita as regras já existentes: `is_vendored()`, `MIN_SEGMENT`, `DOMAIN_KEEP` e
+  a allowlist `.identifier-locale-allow`, que é a única dispensa possível para um nome de arquivo —
+  um arquivo não carrega comentário `locale-ok:`.
+- Em `--diff`, o caminho é checado **apenas para arquivos adicionados** (`--- /dev/null`), mantendo a
+  filosofia "código novo é inglês; nome existente migra por tier" do `references/migration.md`.
+- Novo `claude/global/hooks/locale-rite.py`: hook `PostToolUse` em `Write`/`Edit` que roda o detector
+  contra o caminho escrito e o conteúdo escrito, e devolve os achados ao assistente. Silencioso
+  quando limpo, nunca bloqueante.
+- `NOUNS` ganha `servico`, `servicos`, `calculo`, `relatorio`, `relatorios` — **desvio de escopo
+  autorizado pelo mantenedor em 2026-08-26**, registrado como comentário na issue #95. A issue
+  excluía ampliar o léxico; sem essas cinco palavras, `servicos_pedido/calculo_frete.py` era pego
+  apenas por `pedido` e um diretório `servicos/` puro passava batido, o que deixava o critério de
+  aceite falso. Nenhuma delas colide com palavra inglesa (`service`, `calculus`, `report` são as
+  formas inglesas), e a assertion do próprio script é o que mantém isso honesto.
+- `--selftest` cobre os tiers novos; `.github/workflows/ci.yml` gata o hook como gata os demais
+  ("the gate is itself gated").
+- `README.md` documenta o wiring do terceiro hook ao lado dos dois existentes.
+
+**Não é BREAKING.** Nenhum nome existente é renomeado, nenhum comando muda de forma, e o modo
+`--diff` continua sendo o modo de adoção.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Nenhum skill novo entra no catálogo.
+
+### Modified Capabilities
+
+- `skills-catalog`: duas requirements ADICIONADAS. A primeira fecha a distância entre o que o
+  detector declara cobrir e o que ele lê — o caminho é artefato da camada máquina como qualquer
+  identificador. A segunda estende ao locale a forma que a capability já especifica para os outros
+  dois ritos (hook entregue, condicional, sem estado): o rito de locale passa a ser medido no momento
+  da escrita, não apenas na revisão.
+
+## Impact
+
+- `skills/code-locale/references/check-identifier-locale.py`, `skills/code-locale/SKILL.md`,
+  `claude/global/hooks/locale-rite.py` (novo), `.github/workflows/ci.yml`, `README.md`.
+- `openspec/specs/skills-catalog/spec.md`, depois do archive.
+- Espelhos gerados por `./generate.sh` (`claude/ codex/ cursor/ copilot/ plugins/`) — o passo de CI
+  "Wrappers in sync with skills/" exige a regeneração.
+- Composição do catálogo: inalterada. Nenhum skill entra, sai ou muda de nome, então a descoberta via
+  `npx skills add` continua encontrando os mesmos 34.
+- Consumidores do catálogo: quem já usa o detector ganha achados novos apenas em caminho de arquivo
+  adicionado; quem não usa não muda nada. O hook é wiring do usuário em `~/.claude/settings.json`.

--- a/openspec/changes/add-locale-write-gate/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-locale-write-gate/specs/skills-catalog/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: The identifier-locale check reads the path it is given
+
+The shipped identifier-locale check SHALL apply its tiers to the **path** of the artifact it scans —
+directory names and the file stem — and not only to the artifact's contents, because file, directory
+and module names are named by the doctrine as part of the machine layer. A check whose documented
+scope names an artifact class it never reads SHALL be treated as a defect in the check, not as a
+property of the artifact class.
+
+The path tier SHALL reuse the exclusions the check already applies to identifiers — vendored and
+generated trees, the minimum segment length, the kept domain terms and the allowlist file — so that
+one rule change cannot make the two halves disagree.
+
+The path measured SHALL be the part the scanned project owns: the path relative to the working
+directory when the artifact lies inside it, and the file's own name otherwise. Segments above the
+working directory SHALL NOT be scanned, because they name the machine, the user or the mount point
+rather than anything the project chose.
+
+In diff mode the path SHALL be checked only for files the diff **adds**. A file that already exists
+SHALL NOT be reported on every diff that touches it, because renaming it is the migration policy's
+decision and not this check's.
+
+A path finding SHALL name the waiver that silences it. Since a file name carries no inline comment,
+that waiver SHALL be the allowlist file the check already reads.
+
+#### Scenario: A Portuguese file name with an English body is reported
+
+- **WHEN** the check scans a file whose body is English but whose path carries Portuguese segments
+- **THEN** it reports one finding per offending segment and exits non-zero
+- **AND** the finding names the path and the segment, in the same shape an identifier finding uses
+
+#### Scenario: An added path is measured and an existing one is not
+
+- **WHEN** a unified diff adds a file whose path carries a Portuguese segment
+- **THEN** the check reports it in diff mode
+- **AND** a diff that only modifies an already existing file with the same path reports nothing about
+  that path
+
+#### Scenario: The path above the working directory is out of scope
+
+- **WHEN** the artifact scanned lies inside the working directory
+- **THEN** only the segments relative to that directory are measured
+- **AND** an artifact outside the working directory has only its own file name measured
+
+#### Scenario: A path finding names its waiver
+
+- **WHEN** a path finding is printed
+- **THEN** it states the allowlist entry that silences it, because a file name cannot carry the
+  inline waiver an identifier uses
+
+#### Scenario: The path tier inherits the identifier exclusions
+
+- **WHEN** the scanned path lies in a vendored or generated tree, or its segments are shorter than
+  the minimum length, or they are kept domain terms, or they are listed in the allowlist
+- **THEN** the check reports nothing for that path, exactly as it already behaves for identifiers
+
+### Requirement: The code-locale rite is enforced at the moment of the write
+
+The catalog SHALL ship an enforcement artifact that measures the locale rule when a file is written,
+not only when a diff is reviewed. Doctrine held in context and a check that must be invoked by hand
+SHALL NOT be treated as enforcement: the repository already states, for its other two rites, that
+enforcement must not depend on the assistant noticing a rule already in context.
+
+The artifact SHALL run on the harness event that follows a file write, SHALL measure the written
+path and the written content with the shipped check, and SHALL return its findings through the field
+that harness reads for that event — established against the installed version, never assumed, since
+plain standard output is not carried into context for that event.
+
+The artifact SHALL be silent when the write is clean, SHALL NOT block the tool call, and SHALL
+persist nothing outside the repository. Where the shipped check is absent, it SHALL exit silently
+rather than fail, because a missing gate must not present itself as an error to the user.
+
+#### Scenario: A write that introduces a Portuguese name is reported
+
+- **WHEN** a file is written whose path or added content carries a Portuguese identifier
+- **THEN** the findings reach the assistant as context for the next turn, naming the offending
+  segments and the waiver that silences them
+
+#### Scenario: A clean write is silent
+
+- **WHEN** the written path and content are English
+- **THEN** the artifact produces no output at all, so the reminder never becomes background noise
+
+#### Scenario: The gate informs and never blocks
+
+- **WHEN** the artifact reports findings
+- **THEN** the tool call stands, and the decision to keep the name belongs to the user, as it does
+  for the catalog's other rites
+
+#### Scenario: A file type without a language profile still has its path measured
+
+- **WHEN** the written file's extension has no language profile in the check
+- **THEN** the path is still measured, and the content is reported as skipped rather than as passing
+
+#### Scenario: A payload the artifact cannot read produces no error
+
+- **WHEN** the payload is missing, malformed, or names no written file
+- **THEN** the artifact exits silently and successfully, writing no state and requiring no credentials

--- a/openspec/changes/add-locale-write-gate/tasks.md
+++ b/openspec/changes/add-locale-write-gate/tasks.md
@@ -1,0 +1,92 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos abertos e lidos, não recordados, no commit `3719a76` (2026-08-26):
+      `skills/code-locale/references/check-identifier-locale.py` (docstring, `MIN_SEGMENT`,
+      `ALLOWLIST_FILE`, `load_allowlist`, `is_vendored`, `classify`, `scan_text`, `scan_diff`,
+      `selftest`, `main`), `skills/code-locale/SKILL.md`, `claude/global/hooks/backlog-rite.py`,
+      `claude/global/hooks/verify-rite.py`, `.github/workflows/ci.yml` (linhas 81–120),
+      `openspec/specs/skills-catalog/spec.md` (linhas 195–245 e 520–568),
+      `openspec/schemas/skills-rite/schema.yaml`, `openspec/schemas/skills-rite/templates/tasks.md`,
+      `scripts/validate-rite.sh`, `scripts/validate-spec-rite.py`, `scripts/validate-rite-evidence.py`
+- [x] E.2 Probes contra a versão instalada, 2026-08-26:
+      `python3 --version` -> `Python 3.14.5`;
+      `claude --version` -> `2.1.246 (Claude Code)`;
+      `openspec --version` -> `1.6.0`;
+      `python3 skills/code-locale/references/check-identifier-locale.py <dir>/servicos_pedido/calculo_frete.py`
+      -> `findings: 0` com `exit=0` (corpo em inglês, caminho em português — o defeito que motiva a change);
+      `python3 skills/code-locale/references/check-identifier-locale.py --diff fake.diff` -> `findings: 0`, `exit=0`;
+      `grep -aoh "additionalContext.\{0,60\}" ~/.local/share/claude/versions/2.1.246`
+      -> `additionalContext:a,...l}=e.hookSpecificOutput` e `additionalContext:8000` — o campo que o
+      harness instalado lê em `PostToolUse`, e seu teto em caracteres
+- [x] E.3 Não probado, registrado como limite e não afirmado: como Codex, Cursor e Copilot expõem um
+      evento equivalente ao `PostToolUse` — nenhum deles foi medido, então a change entrega o hook
+      apenas para o harness cujo contrato foi lido, e o design registra isso em Open Questions. A
+      documentação de hooks foi lida em `code.claude.com/docs/en/hooks` (2026-08-26) e confirmada
+      contra o binário instalado; onde as duas fontes divergiriam, vale o binário.
+- [x] E.4 Escopo: um desvio, autorizado e registrado — ampliar o léxico estava em Out of scope na
+      issue #95, e o sweep de aceite mostrou que sem `servico(s)`, `calculo` e `relatorio(s)` o
+      critério AC1 era falso (`servicos_pedido/calculo_frete.py` era pego só por `pedido`). O
+      mantenedor autorizou em 2026-08-26 e a autorização está como comentário na issue.
+      `python3 skills/code-locale/references/check-identifier-locale.py .` -> `findings: 0` depois da
+      adição: nenhum falso positivo novo no repositório inteiro. Follow-ups listados e **não**
+      executados — (a) template de pre-commit/CI para repositórios de destino, fora de escopo na
+      issue; (b) `caveman-statusline.ps1` desatualizado em `~/.claude/hooks` (config pessoal, fora do
+      repositório); (c) as palavras que seguem escapando (`prazo`, `chave`), registradas no
+      KNOWN LIMIT em vez de adivinhadas por regra.
+
+## 2. Tier de caminho no detector
+
+- [x] 2.1 `scan_path()`: segmenta diretórios + radical do arquivo, aplica `segments()`/`classify()`,
+      devolve `Finding` com tier prefixado e a linha de dispensa da allowlist
+- [x] 2.2 Caminho medido relativo ao `cwd` quando dentro dele; apenas o nome do arquivo quando fora
+      (design D1)
+- [x] 2.3 Modo arquivo: `scan_path()` roda antes do teste de extensão, para que um tipo sem perfil de
+      língua ainda tenha o caminho medido e o conteúdo reportado como `skipped`
+- [x] 2.4 Modo `--diff`: caminho medido só quando o cabeçalho anterior é `--- /dev/null` (design D2)
+- [x] 2.5 Exclusões herdadas verificadas: `is_vendored`, `MIN_SEGMENT`, `DOMAIN_KEEP`, allowlist
+- [x] 2.6 KNOWN LIMIT do docstring ganha a linha do que o tier de caminho não alcança
+- [x] 2.7 Léxico ampliado com `servico(s)`, `calculo`, `relatorio(s)` (desvio autorizado, ver E.4);
+      assertion de colisão verde e field score do repositório em `findings: 0`
+
+## 3. Hook de escrita
+
+- [x] 3.1 `claude/global/hooks/locale-rite.py`: lê o payload `PostToolUse`, extrai `tool_name`,
+      `tool_input.file_path` e o conteúdo escrito (`content` no `Write`, `new_string` no `Edit`)
+- [x] 3.2 Importa o detector por `importlib.util.spec_from_file_location`; detector ausente → saída
+      silenciosa 0 (design D5)
+- [x] 3.3 Achados devolvidos em `hookSpecificOutput.additionalContext`, truncados ao teto medido;
+      `systemMessage` curto para o usuário (design D4)
+- [x] 3.4 Silêncio total quando limpo; payload ausente/malformado → exit 0 sem saída
+- [x] 3.5 `--selftest` do próprio hook: escrita limpa, escrita com caminho português, payload
+      malformado, tipo de arquivo sem perfil de língua
+
+## 4. Cobertura e wiring
+
+- [x] 4.1 `--selftest` do detector ganha os casos do tier de caminho (hit e clean)
+- [x] 4.2 `.github/workflows/ci.yml`: passo de self-test do hook, ao lado dos existentes
+- [x] 4.3 `README.md`: wiring do terceiro hook junto dos outros dois
+- [x] 4.4 `skills/code-locale/SKILL.md`: o gate de escrita e a dispensa por allowlist documentados
+- [x] 4.5 `./generate.sh` re-executado; espelhos idênticos ao `skills/`
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter do `skills/code-locale/SKILL.md` intacto e uniforme: `name == code-locale`,
+      descrição dobrada, `metadata.author: solvelab`, `metadata.version` semver bumpado,
+      `category` no conjunto controlado, `license: MIT`, `compatibility` presente e ainda verdadeira
+      (o detector continua stdlib-only)
+- [x] Q.2 Todo conteúdo tocado do skill em inglês (locale do catálogo)
+- [x] Q.3 Gatilhos da descrição continuam testáveis e sem colisão com skill irmão; a fronteira
+      "Do NOT use for" segue presente
+- [x] Q.4 Sem doutrina duplicada: o hook novo não repete a doutrina do `code-locale` nem o texto do
+      rito de backlog — ele aponta (design.md, tabela Canonical Home)
+- [x] Q.5 Todo exemplo de código tocado usa identificadores, rotas, chaves e nomes de evento em
+      inglês; termo mantido em outra língua carrega o motivo inline
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate add-locale-write-gate --strict` verde
+- [x] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde e os 34 skills
+      seguem publicados, sem órfão nem renomeado
+- [x] V.3 README/docs atualizados onde o uso muda (wiring do hook)
+- [ ] V.4 `openspec archive add-locale-write-gate --yes` depois que todos os grupos acima estiverem
+      `[x]` — executado após o merge do PR, não antes

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -132,7 +132,8 @@ python3 references/check-identifier-locale.py src/orders/service.py
 
 Read the output as a prompt, not a verdict: every finding prints `path:line:token` plus the exact
 waiver line to add. A finding the author judges correct as written costs one `locale-ok:` comment
-with a reason. **The check declares what escapes it in its own docstring** — a curated word list is
+with a reason. **The waiver covers its own line and the next one** — put it on the offending line or
+immediately above it, never at the top of a block, where it will not reach. **The check declares what escapes it in its own docstring** — a curated word list is
 not a language model, so a passing run is not proof of compliance, and names outside its reach are
 reviewed by hand.
 

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -19,14 +19,17 @@ description: >-
   translation.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
   The doctrine is language- and stack-agnostic and needs no runtime. The shipped detector
   `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package; it
-  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, and reports any
-  other file type as skipped rather than passing.
+  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, measures the path of
+  every file it is given, and reports the contents of any other file type as skipped rather than
+  passing. The optional write-time hook `claude/global/hooks/locale-rite.py` needs a harness that
+  emits a post-write tool event; it was built against Claude Code 2.1.246 and exits silently
+  anywhere else.
 ---
 
 # Code locale — prose follows the repo, the machine layer is English
@@ -133,8 +136,32 @@ with a reason. **The check declares what escapes it in its own docstring** — a
 not a language model, so a passing run is not proof of compliance, and names outside its reach are
 reviewed by hand.
 
+**The path is checked too**, because a file and a directory are named by the machine layer like any
+identifier. The path measured is the one relative to the working directory — a Portuguese folder
+*above* the project is not the project's machine layer. In `--diff` mode only files the diff **adds**
+have their path measured: renaming an existing file is the migration policy's decision, not the
+check's. A file name has nowhere to carry `# locale-ok:`, so its only waiver is the allowlist file
+`.identifier-locale-allow` — one path or segment per line — and the finding prints the line to add.
+
 Probed on 2026-08-14 with `Python 3.14.5`; the detector uses only the standard library, so it has no
 pinned dependency.
+
+## Catching it at the write, not at the review
+
+A review-time check catches the name after it is written, spread across a diff, when renaming costs
+the most. `claude/global/hooks/locale-rite.py` closes that distance: it runs on the harness event
+that follows a file write, feeds the written path and the written content to the same check, and
+returns the findings to the assistant before the next turn. Silent when the write is clean, never
+blocking — the rite informs, and the author decides.
+
+This exists because doctrine in context was measured to be insufficient: with this skill installed
+and the rule loaded, Portuguese identifiers and file names still reached code in new sessions. The
+same argument the repository already applies to its other rites applies here — enforcement must not
+depend on the assistant noticing a rule it already has.
+
+The findings travel in the field the harness reads for that event, not on plain standard output;
+the hook's own docstring records the probe that established which one. Wiring: the README's hooks
+section.
 
 ## Existing code
 

--- a/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
+++ b/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
@@ -27,7 +27,9 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        `agenda`, `media`, `mesa`, `favor`). `dataUsuario` is caught through `usuario`; a bare
        `data` is not, and never will be.
     2. This is a word list, not a language model. Open vocabulary escapes: any Portuguese noun
-       outside LEXICON passes.
+       outside LEXICON passes — in an identifier and in a path segment alike. A directory named
+       `prazos/` or a field named `chaveAcesso` is missed today, and the fix for one word is one
+       lexicon entry, never a rule that guesses.
     3. Suffixes -mento, -dor and -vel are NOT rules, because of `memento`, `vendor` and `level`.
        A CI blocker on `vendorId` would end the rule, so those families escape by design.
     4. Segments under MIN_SEGMENT characters are skipped, so abbreviations escape: `qtd`, `usr`,
@@ -45,14 +47,24 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        oversight: a fence of Portuguese commit-message examples is prose and must not be flagged.
     9. Branch names, PR titles and issue text are not files and are never scanned. They are
        convention-only.
-    10. Only the languages in COMMENT_SYNTAX are tokenized. Files with any other extension are
-       skipped and reported as skipped, never counted as passing.
+    10. Only the languages in COMMENT_SYNTAX are tokenized for CONTENT. Files with any other
+       extension have their path measured and their content reported as skipped, never as passing.
+    11. The path tier measures the path relative to the working directory, or the file's own name
+       when the file lies outside it. A Portuguese directory ABOVE the project — a home directory, a
+       mount point, a machine name — is never reported, because it is not the project's machine layer.
+    12. In --diff mode the path is measured only for files the diff ADDS, decided by the
+       `--- /dev/null` header the diff itself writes. A file that already exists is never reported on
+       its name: renaming it is the migration policy's decision (references/migration.md), not this
+       check's. A rename appears as an add, so the new name is measured and the old one is not.
+    13. A file name has nowhere to carry an inline `locale-ok:` comment, so ALLOWLIST_FILE is its only
+       waiver — the path or one of its segments, one per line.
 
 Exit code: 1 if any finding, else 0.
 """
 from __future__ import annotations
 
 import argparse
+import io
 import re
 import sys
 import unicodedata
@@ -86,6 +98,11 @@ NOUNS = {
     "cobranca", "cadastro", "empresa", "funcionario", "permissao", "tentativa", "quantidade",
     "preco", "desconto", "saldo", "corrida", "corridas", "compra", "venda", "estoque", "carrinho",
     "assinatura", "mensagem", "recibo", "apelido", "aniversario", "bairro", "estado", "codigo",
+    # Added 2026-08-26 with the path tier (issue #95): the three words that name a *file* more often
+    # than they name a variable in a Brazilian codebase, and the reason `servicos_pedido/` used to be
+    # caught only through its second half. None collides with an English word — `calculus`, `service`
+    # and `report` are the English forms, and the assertion below is what keeps that honest.
+    "servico", "servicos", "calculo", "relatorio", "relatorios",
 }
 # `pasta` was here and was removed: the field score below found it firing on the English noun.
 
@@ -200,6 +217,27 @@ class Finding:
             f"      # locale-ok: <why this term has no faithful English name>\n"
             f"    or grandfather it in {ALLOWLIST_FILE}:\n"
             f"      {self.token}"
+        )
+
+
+class PathFinding(Finding):
+    """A finding on the path itself — a directory name or the file's own name.
+
+    Rendered apart from an identifier finding for one mechanical reason: a file name has nowhere to
+    carry an inline `locale-ok:` comment, so the allowlist is the ONLY waiver available to it, and
+    printing the inline form here would name a waiver the author cannot apply.
+    """
+
+    def __init__(self, path: str, token: str, segment: str, tier: str):
+        super().__init__(path, 0, token, segment, f"path-{tier}")
+
+    def render(self) -> str:
+        return (
+            f"{self.path}: {self.token}  [{self.tier}: '{self.segment}']\n"
+            f"    file and directory names are machine layer and must be English (code-locale).\n"
+            f"    A file name carries no inline waiver — grandfather the path or the segment in "
+            f"{ALLOWLIST_FILE}:\n"
+            f"      {self.path}"
         )
 
 
@@ -319,6 +357,58 @@ def load_allowlist(start: Path) -> set:
     return allow
 
 
+def project_relative(path: Path, root: "Path | None") -> Path:
+    """The part of the path the scanned project owns.
+
+    An absolute path carries segments the project never chose — the home directory, the mount point,
+    the machine's own name — and scanning them reports on someone's user name rather than on code.
+    Inside `root` the relative path is measured; outside it, only the file's own name. `root=None`
+    means the caller already handed a project-relative path (diff mode does).
+    """
+    if root is None:
+        return path
+    try:
+        return path.resolve().relative_to(root.resolve())
+    except (ValueError, OSError):
+        return Path(path.name)
+
+
+def path_parts(rel: Path) -> list:
+    """Directory names plus the file's own name with its suffix chain removed.
+
+    The suffix is stripped by splitting on the FIRST dot rather than with `Path.stem`, because
+    `.d.ts` and `.spec.ts` leave a second suffix behind that would be scanned as a name segment.
+    """
+    name = rel.name.split(".", 1)[0]
+    return [p for p in (*rel.parts[:-1], name) if p]
+
+
+def scan_path(path: Path, allow: set, root: "Path | None" = None) -> list:
+    """Check the path itself — the artifact class the doctrine names first and the check used to skip.
+
+    Every exclusion that protects identifiers protects a path segment too (vendored trees, the
+    length floor, kept domain terms, the allowlist), so the two halves cannot drift apart.
+    """
+    if is_vendored(path):
+        return []
+    rel = project_relative(path, root)
+    rel_str = str(rel)
+    if rel_str in allow or rel_str.lower() in allow:
+        return []
+    findings = []
+    for part in path_parts(rel):
+        if part in allow or part.lower() in allow or part.lower() in DOMAIN_KEEP:
+            continue
+        for seg in segments(part):
+            tier = classify(seg)
+            if tier == "non-ascii" and deaccent(seg).lower() in DOMAIN_KEEP:
+                continue
+            if tier:
+                findings.append(PathFinding(rel_str, part, seg, tier))
+                break
+    return findings
+
+
 def scan_text(text: str, lang: str, path: str, allow: set, first_line: int = 1) -> list:
     findings = []
     lines = text.splitlines()
@@ -375,6 +465,7 @@ def scan_diff(stream, allow: set) -> list:
     """Added lines only. This is what makes the rule adoptable in a legacy repository."""
     findings, path, lineno, lang = [], "<diff>", 0, None
     run: list = []                                   # consecutive added lines, scanned together
+    adds_file = False                                # the previous `--- ` header said /dev/null
 
     def flush() -> None:
         if not run or not lang:
@@ -390,6 +481,12 @@ def scan_diff(stream, allow: set) -> list:
 
     for raw in stream:
         line = raw.rstrip("\n")
+        if line.startswith("--- "):
+            # `--- /dev/null` is the diff's own statement that the file is being ADDED. The path
+            # tier fires only there: a file that already exists would be reported on every diff
+            # that touches it, and renaming it is the migration policy's call, not this check's.
+            adds_file = line[4:].strip() == "/dev/null"
+            continue
         if line.startswith("+++ "):
             flush()
             candidate = line[4:].strip()
@@ -397,6 +494,9 @@ def scan_diff(stream, allow: set) -> list:
                 candidate = candidate[2:]
             path = candidate
             lang = EXT_LANG.get(Path(path).suffix.lower())
+            if adds_file and path != "/dev/null":
+                findings.extend(scan_path(Path(path), allow))
+            adds_file = False
             continue
         if line.startswith("@@"):
             flush()
@@ -458,6 +558,64 @@ SELFTEST_CLEAN = [
 ]
 
 
+SELFTEST_PATH_HITS = [
+    ("pt-noun dir", "servicos_pedido/shipping.py"),
+    ("pt-verb file", "orders/calcular_frete.py"),
+    ("pt-morphology file", "app/configuracao.ts"),
+    # `.xlsx` has no language profile, so the content scanner never opens this file. The lexicon
+    # word is deliberate: `relatorio` was tried first and is NOT in the lexicon (KNOWN LIMIT 2),
+    # which would have made this case prove nothing about the path tier.
+    ("no language profile", "reports/cadastro_mensal.xlsx"),
+    ("double suffix", "orders/pedido.spec.ts"),
+]
+
+SELFTEST_PATH_CLEAN = [
+    ("english path", "orders/shipping_cost.py"),
+    ("vendored PT path", "node_modules/servicos_pedido/calculo.js"),
+    ("short segments", "usr/qtd/end.py"),
+    ("english collisions", "data/media/local_total.py"),
+    ("BR domain term", "invoices/nota_fiscal.py"),
+    ("dotfile", "orders/.eslintrc.json"),
+]
+
+
+def selftest_paths() -> list:
+    """The path tier, exercised through the same public entry point the CLI uses."""
+    failed = []
+    for name, rel in SELFTEST_PATH_HITS:
+        got = scan_path(Path(rel), set())
+        print(f"  {'CAUGHT ' if got else 'MISSED '} path-hit/{name}")
+        if not got:
+            failed.append(f"path-hit/{name}")
+    for name, rel in SELFTEST_PATH_CLEAN:
+        got = scan_path(Path(rel), set())
+        print(f"  {'CLEAN  ' if not got else 'FALSE+ '} path-clean/{name}")
+        if got:
+            failed.append(f"path-clean/{name} -> {got[0].token}:{got[0].segment}")
+    # The allowlist is the only waiver a file name has; prove it actually silences one.
+    waived = scan_path(Path("servicos_pedido/shipping.py"), {"servicos_pedido/shipping.py"})
+    print(f"  {'CLEAN  ' if not waived else 'FALSE+ '} path-clean/allowlisted path")
+    if waived:
+        failed.append("path-clean/allowlisted path")
+    waived_seg = scan_path(Path("servicos_pedido/shipping.py"), {"servicos_pedido"})
+    print(f"  {'CLEAN  ' if not waived_seg else 'FALSE+ '} path-clean/allowlisted segment")
+    if waived_seg:
+        failed.append("path-clean/allowlisted segment")
+    # Diff mode: an ADDED Portuguese path fires, a MODIFIED one with the same path does not.
+    added = scan_diff(io.StringIO(
+        "--- /dev/null\n+++ b/servicos_pedido/shipping.py\n@@ -0,0 +1 @@\n+x = 1\n"), set())
+    print(f"  {'CAUGHT ' if added else 'MISSED '} path-hit/diff adds file")
+    if not added:
+        failed.append("path-hit/diff adds file")
+    modified = scan_diff(io.StringIO(
+        "--- a/servicos_pedido/shipping.py\n+++ b/servicos_pedido/shipping.py\n"
+        "@@ -1 +1,2 @@\n x = 1\n+y = 2\n"), set())
+    print(f"  {'CLEAN  ' if not modified else 'FALSE+ '} path-clean/diff modifies existing file")
+    if modified:
+        failed.append("path-clean/diff modifies existing file")
+    return failed
+
+
 def selftest() -> int:
     failed = []
     for name, lang, src in SELFTEST_HITS:
@@ -472,11 +630,16 @@ def selftest() -> int:
         print(f"  {status} clean/{name}")
         if got:
             failed.append(f"clean/{name} -> {got[0].token}:{got[0].segment}")
+    failed.extend(selftest_paths())
     print()
     if failed:
         print("selftest FAILED: " + "; ".join(failed))
         return 1
-    print(f"selftest OK: {len(SELFTEST_HITS)} tiers fire, {len(SELFTEST_CLEAN)} clean cases stay silent")
+    print(
+        f"selftest OK: {len(SELFTEST_HITS)} content tiers fire, {len(SELFTEST_CLEAN)} clean cases "
+        f"stay silent, {len(SELFTEST_PATH_HITS) + 1} path tiers fire, "
+        f"{len(SELFTEST_PATH_CLEAN) + 3} path cases stay silent"
+    )
     return 0
 
 
@@ -518,17 +681,22 @@ def main(argv: "list[str] | None" = None) -> int:
                                else sorted(f for f in path.rglob("*") if f.is_file()))
             else:
                 targets.append(path)
+        root = Path.cwd()
         for path in targets:
             if args.markdown_fences:
                 if path.suffix.lower() == ".md":
                     findings.extend(scan_markdown_fences(path, allow))
                 continue
+            if is_vendored(path):
+                vendored.append(str(path))
+                continue
+            # The path tier runs BEFORE the language test on purpose: a file type with no language
+            # profile still has a name, and skipping the whole file would let `relatorio.xlsx` and
+            # `cadastro.tf` through the one check that can read them.
+            findings.extend(scan_path(path, allow, root))
             lang = EXT_LANG.get(path.suffix.lower())
             if not lang:
                 skipped.append(str(path))
-                continue
-            if is_vendored(path):
-                vendored.append(str(path))
                 continue
             body = path.read_text(encoding="utf-8")
             if is_minified(body):

--- a/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
+++ b/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
@@ -58,6 +58,10 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        check's. A rename appears as an add, so the new name is measured and the old one is not.
     13. A file name has nowhere to carry an inline `locale-ok:` comment, so ALLOWLIST_FILE is its only
        waiver — the path or one of its segments, one per line.
+    14. An inline waiver covers ITS OWN line and the next one, nothing further. A waiver written at
+       the top of a multi-line construct does not reach the offending line three lines down, and the
+       finding stands. Measured while writing this tier: the same mistake was made twice, once in
+       this docstring and once in a test fixture.
 
 Exit code: 1 if any finding, else 0.
 """

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -132,7 +132,8 @@ python3 references/check-identifier-locale.py src/orders/service.py
 
 Read the output as a prompt, not a verdict: every finding prints `path:line:token` plus the exact
 waiver line to add. A finding the author judges correct as written costs one `locale-ok:` comment
-with a reason. **The check declares what escapes it in its own docstring** — a curated word list is
+with a reason. **The waiver covers its own line and the next one** — put it on the offending line or
+immediately above it, never at the top of a block, where it will not reach. **The check declares what escapes it in its own docstring** — a curated word list is
 not a language model, so a passing run is not proof of compliance, and names outside its reach are
 reviewed by hand.
 

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -19,14 +19,17 @@ description: >-
   translation.
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
   The doctrine is language- and stack-agnostic and needs no runtime. The shipped detector
   `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package; it
-  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, and reports any
-  other file type as skipped rather than passing.
+  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, measures the path of
+  every file it is given, and reports the contents of any other file type as skipped rather than
+  passing. The optional write-time hook `claude/global/hooks/locale-rite.py` needs a harness that
+  emits a post-write tool event; it was built against Claude Code 2.1.246 and exits silently
+  anywhere else.
 ---
 
 # Code locale — prose follows the repo, the machine layer is English
@@ -133,8 +136,32 @@ with a reason. **The check declares what escapes it in its own docstring** — a
 not a language model, so a passing run is not proof of compliance, and names outside its reach are
 reviewed by hand.
 
+**The path is checked too**, because a file and a directory are named by the machine layer like any
+identifier. The path measured is the one relative to the working directory — a Portuguese folder
+*above* the project is not the project's machine layer. In `--diff` mode only files the diff **adds**
+have their path measured: renaming an existing file is the migration policy's decision, not the
+check's. A file name has nowhere to carry `# locale-ok:`, so its only waiver is the allowlist file
+`.identifier-locale-allow` — one path or segment per line — and the finding prints the line to add.
+
 Probed on 2026-08-14 with `Python 3.14.5`; the detector uses only the standard library, so it has no
 pinned dependency.
+
+## Catching it at the write, not at the review
+
+A review-time check catches the name after it is written, spread across a diff, when renaming costs
+the most. `claude/global/hooks/locale-rite.py` closes that distance: it runs on the harness event
+that follows a file write, feeds the written path and the written content to the same check, and
+returns the findings to the assistant before the next turn. Silent when the write is clean, never
+blocking — the rite informs, and the author decides.
+
+This exists because doctrine in context was measured to be insufficient: with this skill installed
+and the rule loaded, Portuguese identifiers and file names still reached code in new sessions. The
+same argument the repository already applies to its other rites applies here — enforcement must not
+depend on the assistant noticing a rule it already has.
+
+The findings travel in the field the harness reads for that event, not on plain standard output;
+the hook's own docstring records the probe that established which one. Wiring: the README's hooks
+section.
 
 ## Existing code
 

--- a/skills/code-locale/references/check-identifier-locale.py
+++ b/skills/code-locale/references/check-identifier-locale.py
@@ -27,7 +27,9 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        `agenda`, `media`, `mesa`, `favor`). `dataUsuario` is caught through `usuario`; a bare
        `data` is not, and never will be.
     2. This is a word list, not a language model. Open vocabulary escapes: any Portuguese noun
-       outside LEXICON passes.
+       outside LEXICON passes — in an identifier and in a path segment alike. A directory named
+       `prazos/` or a field named `chaveAcesso` is missed today, and the fix for one word is one
+       lexicon entry, never a rule that guesses.
     3. Suffixes -mento, -dor and -vel are NOT rules, because of `memento`, `vendor` and `level`.
        A CI blocker on `vendorId` would end the rule, so those families escape by design.
     4. Segments under MIN_SEGMENT characters are skipped, so abbreviations escape: `qtd`, `usr`,
@@ -45,14 +47,24 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        oversight: a fence of Portuguese commit-message examples is prose and must not be flagged.
     9. Branch names, PR titles and issue text are not files and are never scanned. They are
        convention-only.
-    10. Only the languages in COMMENT_SYNTAX are tokenized. Files with any other extension are
-       skipped and reported as skipped, never counted as passing.
+    10. Only the languages in COMMENT_SYNTAX are tokenized for CONTENT. Files with any other
+       extension have their path measured and their content reported as skipped, never as passing.
+    11. The path tier measures the path relative to the working directory, or the file's own name
+       when the file lies outside it. A Portuguese directory ABOVE the project — a home directory, a
+       mount point, a machine name — is never reported, because it is not the project's machine layer.
+    12. In --diff mode the path is measured only for files the diff ADDS, decided by the
+       `--- /dev/null` header the diff itself writes. A file that already exists is never reported on
+       its name: renaming it is the migration policy's decision (references/migration.md), not this
+       check's. A rename appears as an add, so the new name is measured and the old one is not.
+    13. A file name has nowhere to carry an inline `locale-ok:` comment, so ALLOWLIST_FILE is its only
+       waiver — the path or one of its segments, one per line.
 
 Exit code: 1 if any finding, else 0.
 """
 from __future__ import annotations
 
 import argparse
+import io
 import re
 import sys
 import unicodedata
@@ -86,6 +98,11 @@ NOUNS = {
     "cobranca", "cadastro", "empresa", "funcionario", "permissao", "tentativa", "quantidade",
     "preco", "desconto", "saldo", "corrida", "corridas", "compra", "venda", "estoque", "carrinho",
     "assinatura", "mensagem", "recibo", "apelido", "aniversario", "bairro", "estado", "codigo",
+    # Added 2026-08-26 with the path tier (issue #95): the three words that name a *file* more often
+    # than they name a variable in a Brazilian codebase, and the reason `servicos_pedido/` used to be
+    # caught only through its second half. None collides with an English word — `calculus`, `service`
+    # and `report` are the English forms, and the assertion below is what keeps that honest.
+    "servico", "servicos", "calculo", "relatorio", "relatorios",
 }
 # `pasta` was here and was removed: the field score below found it firing on the English noun.
 
@@ -200,6 +217,27 @@ class Finding:
             f"      # locale-ok: <why this term has no faithful English name>\n"
             f"    or grandfather it in {ALLOWLIST_FILE}:\n"
             f"      {self.token}"
+        )
+
+
+class PathFinding(Finding):
+    """A finding on the path itself — a directory name or the file's own name.
+
+    Rendered apart from an identifier finding for one mechanical reason: a file name has nowhere to
+    carry an inline `locale-ok:` comment, so the allowlist is the ONLY waiver available to it, and
+    printing the inline form here would name a waiver the author cannot apply.
+    """
+
+    def __init__(self, path: str, token: str, segment: str, tier: str):
+        super().__init__(path, 0, token, segment, f"path-{tier}")
+
+    def render(self) -> str:
+        return (
+            f"{self.path}: {self.token}  [{self.tier}: '{self.segment}']\n"
+            f"    file and directory names are machine layer and must be English (code-locale).\n"
+            f"    A file name carries no inline waiver — grandfather the path or the segment in "
+            f"{ALLOWLIST_FILE}:\n"
+            f"      {self.path}"
         )
 
 
@@ -319,6 +357,58 @@ def load_allowlist(start: Path) -> set:
     return allow
 
 
+def project_relative(path: Path, root: "Path | None") -> Path:
+    """The part of the path the scanned project owns.
+
+    An absolute path carries segments the project never chose — the home directory, the mount point,
+    the machine's own name — and scanning them reports on someone's user name rather than on code.
+    Inside `root` the relative path is measured; outside it, only the file's own name. `root=None`
+    means the caller already handed a project-relative path (diff mode does).
+    """
+    if root is None:
+        return path
+    try:
+        return path.resolve().relative_to(root.resolve())
+    except (ValueError, OSError):
+        return Path(path.name)
+
+
+def path_parts(rel: Path) -> list:
+    """Directory names plus the file's own name with its suffix chain removed.
+
+    The suffix is stripped by splitting on the FIRST dot rather than with `Path.stem`, because
+    `.d.ts` and `.spec.ts` leave a second suffix behind that would be scanned as a name segment.
+    """
+    name = rel.name.split(".", 1)[0]
+    return [p for p in (*rel.parts[:-1], name) if p]
+
+
+def scan_path(path: Path, allow: set, root: "Path | None" = None) -> list:
+    """Check the path itself — the artifact class the doctrine names first and the check used to skip.
+
+    Every exclusion that protects identifiers protects a path segment too (vendored trees, the
+    length floor, kept domain terms, the allowlist), so the two halves cannot drift apart.
+    """
+    if is_vendored(path):
+        return []
+    rel = project_relative(path, root)
+    rel_str = str(rel)
+    if rel_str in allow or rel_str.lower() in allow:
+        return []
+    findings = []
+    for part in path_parts(rel):
+        if part in allow or part.lower() in allow or part.lower() in DOMAIN_KEEP:
+            continue
+        for seg in segments(part):
+            tier = classify(seg)
+            if tier == "non-ascii" and deaccent(seg).lower() in DOMAIN_KEEP:
+                continue
+            if tier:
+                findings.append(PathFinding(rel_str, part, seg, tier))
+                break
+    return findings
+
+
 def scan_text(text: str, lang: str, path: str, allow: set, first_line: int = 1) -> list:
     findings = []
     lines = text.splitlines()
@@ -375,6 +465,7 @@ def scan_diff(stream, allow: set) -> list:
     """Added lines only. This is what makes the rule adoptable in a legacy repository."""
     findings, path, lineno, lang = [], "<diff>", 0, None
     run: list = []                                   # consecutive added lines, scanned together
+    adds_file = False                                # the previous `--- ` header said /dev/null
 
     def flush() -> None:
         if not run or not lang:
@@ -390,6 +481,12 @@ def scan_diff(stream, allow: set) -> list:
 
     for raw in stream:
         line = raw.rstrip("\n")
+        if line.startswith("--- "):
+            # `--- /dev/null` is the diff's own statement that the file is being ADDED. The path
+            # tier fires only there: a file that already exists would be reported on every diff
+            # that touches it, and renaming it is the migration policy's call, not this check's.
+            adds_file = line[4:].strip() == "/dev/null"
+            continue
         if line.startswith("+++ "):
             flush()
             candidate = line[4:].strip()
@@ -397,6 +494,9 @@ def scan_diff(stream, allow: set) -> list:
                 candidate = candidate[2:]
             path = candidate
             lang = EXT_LANG.get(Path(path).suffix.lower())
+            if adds_file and path != "/dev/null":
+                findings.extend(scan_path(Path(path), allow))
+            adds_file = False
             continue
         if line.startswith("@@"):
             flush()
@@ -458,6 +558,64 @@ SELFTEST_CLEAN = [
 ]
 
 
+SELFTEST_PATH_HITS = [
+    ("pt-noun dir", "servicos_pedido/shipping.py"),
+    ("pt-verb file", "orders/calcular_frete.py"),
+    ("pt-morphology file", "app/configuracao.ts"),
+    # `.xlsx` has no language profile, so the content scanner never opens this file. The lexicon
+    # word is deliberate: `relatorio` was tried first and is NOT in the lexicon (KNOWN LIMIT 2),
+    # which would have made this case prove nothing about the path tier.
+    ("no language profile", "reports/cadastro_mensal.xlsx"),
+    ("double suffix", "orders/pedido.spec.ts"),
+]
+
+SELFTEST_PATH_CLEAN = [
+    ("english path", "orders/shipping_cost.py"),
+    ("vendored PT path", "node_modules/servicos_pedido/calculo.js"),
+    ("short segments", "usr/qtd/end.py"),
+    ("english collisions", "data/media/local_total.py"),
+    ("BR domain term", "invoices/nota_fiscal.py"),
+    ("dotfile", "orders/.eslintrc.json"),
+]
+
+
+def selftest_paths() -> list:
+    """The path tier, exercised through the same public entry point the CLI uses."""
+    failed = []
+    for name, rel in SELFTEST_PATH_HITS:
+        got = scan_path(Path(rel), set())
+        print(f"  {'CAUGHT ' if got else 'MISSED '} path-hit/{name}")
+        if not got:
+            failed.append(f"path-hit/{name}")
+    for name, rel in SELFTEST_PATH_CLEAN:
+        got = scan_path(Path(rel), set())
+        print(f"  {'CLEAN  ' if not got else 'FALSE+ '} path-clean/{name}")
+        if got:
+            failed.append(f"path-clean/{name} -> {got[0].token}:{got[0].segment}")
+    # The allowlist is the only waiver a file name has; prove it actually silences one.
+    waived = scan_path(Path("servicos_pedido/shipping.py"), {"servicos_pedido/shipping.py"})
+    print(f"  {'CLEAN  ' if not waived else 'FALSE+ '} path-clean/allowlisted path")
+    if waived:
+        failed.append("path-clean/allowlisted path")
+    waived_seg = scan_path(Path("servicos_pedido/shipping.py"), {"servicos_pedido"})
+    print(f"  {'CLEAN  ' if not waived_seg else 'FALSE+ '} path-clean/allowlisted segment")
+    if waived_seg:
+        failed.append("path-clean/allowlisted segment")
+    # Diff mode: an ADDED Portuguese path fires, a MODIFIED one with the same path does not.
+    added = scan_diff(io.StringIO(
+        "--- /dev/null\n+++ b/servicos_pedido/shipping.py\n@@ -0,0 +1 @@\n+x = 1\n"), set())
+    print(f"  {'CAUGHT ' if added else 'MISSED '} path-hit/diff adds file")
+    if not added:
+        failed.append("path-hit/diff adds file")
+    modified = scan_diff(io.StringIO(
+        "--- a/servicos_pedido/shipping.py\n+++ b/servicos_pedido/shipping.py\n"
+        "@@ -1 +1,2 @@\n x = 1\n+y = 2\n"), set())
+    print(f"  {'CLEAN  ' if not modified else 'FALSE+ '} path-clean/diff modifies existing file")
+    if modified:
+        failed.append("path-clean/diff modifies existing file")
+    return failed
+
+
 def selftest() -> int:
     failed = []
     for name, lang, src in SELFTEST_HITS:
@@ -472,11 +630,16 @@ def selftest() -> int:
         print(f"  {status} clean/{name}")
         if got:
             failed.append(f"clean/{name} -> {got[0].token}:{got[0].segment}")
+    failed.extend(selftest_paths())
     print()
     if failed:
         print("selftest FAILED: " + "; ".join(failed))
         return 1
-    print(f"selftest OK: {len(SELFTEST_HITS)} tiers fire, {len(SELFTEST_CLEAN)} clean cases stay silent")
+    print(
+        f"selftest OK: {len(SELFTEST_HITS)} content tiers fire, {len(SELFTEST_CLEAN)} clean cases "
+        f"stay silent, {len(SELFTEST_PATH_HITS) + 1} path tiers fire, "
+        f"{len(SELFTEST_PATH_CLEAN) + 3} path cases stay silent"
+    )
     return 0
 
 
@@ -518,17 +681,22 @@ def main(argv: "list[str] | None" = None) -> int:
                                else sorted(f for f in path.rglob("*") if f.is_file()))
             else:
                 targets.append(path)
+        root = Path.cwd()
         for path in targets:
             if args.markdown_fences:
                 if path.suffix.lower() == ".md":
                     findings.extend(scan_markdown_fences(path, allow))
                 continue
+            if is_vendored(path):
+                vendored.append(str(path))
+                continue
+            # The path tier runs BEFORE the language test on purpose: a file type with no language
+            # profile still has a name, and skipping the whole file would let `relatorio.xlsx` and
+            # `cadastro.tf` through the one check that can read them.
+            findings.extend(scan_path(path, allow, root))
             lang = EXT_LANG.get(path.suffix.lower())
             if not lang:
                 skipped.append(str(path))
-                continue
-            if is_vendored(path):
-                vendored.append(str(path))
                 continue
             body = path.read_text(encoding="utf-8")
             if is_minified(body):

--- a/skills/code-locale/references/check-identifier-locale.py
+++ b/skills/code-locale/references/check-identifier-locale.py
@@ -58,6 +58,10 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        check's. A rename appears as an add, so the new name is measured and the old one is not.
     13. A file name has nowhere to carry an inline `locale-ok:` comment, so ALLOWLIST_FILE is its only
        waiver — the path or one of its segments, one per line.
+    14. An inline waiver covers ITS OWN line and the next one, nothing further. A waiver written at
+       the top of a multi-line construct does not reach the offending line three lines down, and the
+       finding stands. Measured while writing this tier: the same mistake was made twice, once in
+       this docstring and once in a test fixture.
 
 Exit code: 1 if any finding, else 0.
 """


### PR DESCRIPTION
Closes #95

Spec-rite: add-locale-write-gate

## O que mudou

O `code-locale` tinha dois furos e os dois foram medidos, não supostos.

**1. O detector não lia o caminho.** O docstring dizia cobrir "file and module names"; o único uso de
`path` era o filtro de vendor. Antes:

```
$ check-identifier-locale.py servicos_pedido/calculo_frete.py   # corpo em inglês
findings: 0     exit=0
```

Agora `scan_path()` mede os segmentos do caminho com os mesmos tiers dos identificadores, herdando
`is_vendored`, `MIN_SEGMENT`, `DOMAIN_KEEP` e a allowlist. O caminho medido é o relativo ao diretório
de trabalho — uma pasta pessoal *acima* do projeto não é camada máquina dele. Em `--diff`, só o
arquivo **adicionado** (`--- /dev/null`) tem o caminho medido: renomear arquivo existente é decisão da
política de migração, não do check.

**2. Nada media no instante da escrita.** `claude/global/hooks/locale-rite.py` roda em `PostToolUse`
para `Write|Edit`, passa o caminho e o conteúdo escritos ao mesmo check e devolve os achados. Silencioso
quando limpo, nunca bloqueante, não persiste nada, e sai em silêncio se o check não existir.

A decisão que impedia o hook de ser inútil está probada, não recordada: em `PostToolUse` **stdout puro
não chega ao modelo** — os eventos que viram contexto são `UserPromptSubmit`, `UserPromptExpansion` e
`SessionStart`. O binário instalado (`claude 2.1.246`) lê `hookSpecificOutput.additionalContext`, com
teto de 8000 caracteres, e é por lá que os achados viajam.

## Evidência

| Critério de aceite | Verdict | Evidência |
|---|---|---|
| Caminho PT com corpo EN sai 1 e nomeia `servicos` e `calculo` | ✅ | `findings: 2`, `exit=1` (antes: `findings: 0`, `exit=0`) |
| Mesmo caso em `--diff` sai 1 | ✅ | `--diff` sobre patch com `--- /dev/null` → `findings: 1`, `exit=1` |
| Dispensa por allowlist silencia e é impressa no achado | ✅ | selftest `path-clean/allowlisted path` e `/allowlisted segment` |
| `--selftest` falha se o tier de caminho parar de disparar | ✅ | 6 tiers de caminho; um caso escrito errado apareceu como `MISSED` e reprovou a suíte |
| Zero falso positivo em vendor / `MIN_SEGMENT` | ✅ | 9 casos clean + field score do repositório inteiro: `findings: 0` |
| Write com nome PT reporta; write limpo não emite nada | ✅ | payload real por stdin → JSON com `additionalContext`; payload limpo → saída vazia |
| Hook sai 0 e silencioso em payload ausente/malformado/tipo sem perfil | ✅ | 11 decisões no `--selftest` do hook |
| CI roda self-test do hook | ✅ | passo novo em `.github/workflows/ci.yml` |
| KNOWN LIMIT declara o alcance do tier de caminho | ✅ | itens 10–13 do docstring |
| `SKILL.md` + spec descrevem o gate de escrita | ⏳ | `SKILL.md` feito; a spec principal recebe o delta no `openspec archive`, depois do merge (V.4) |
| Nomes novos seguem o Glossary e o `code-locale` | ✅ | o próprio diff deste PR passa no check: `findings: 0`, `exit=0` |

Suíte completa verde: `validate-skills` 34/0 · `selftest-validate-skills` 13/13 · detector `--selftest`
(7 tiers de conteúdo, 16 clean, 6 tiers de caminho, 9 clean) · hook `--selftest` 11/11 · `scan-secrets`
0 · `repo-hygiene` 0 (+2/2) · `validate-rite.sh` OK · `rite-evidence` 0 (+4/4) · `spec-rite` 3/3 +
6/6 + 6/6 · `openspec validate --strict` valid · wrappers regerados e idempotentes.

## Desvio de escopo (autorizado)

Ampliar o `LEXICON` estava em **Out of scope** na issue. O sweep de aceite mostrou que o AC1 era falso
sem isso: `servicos_pedido/calculo_frete.py` era pego só por `pedido`, e um diretório `servicos/` puro
passava batido. O mantenedor autorizou cinco palavras — `servico`, `servicos`, `calculo`, `relatorio`,
`relatorios` — e a autorização está registrada como comentário na issue (#95). Nenhuma colide com
palavra inglesa, a assertion `_overlap` gata isso, e o field score do repositório continua em
`findings: 0`.

## Known gaps

- **Spec principal**: `openspec/specs/skills-catalog/spec.md` só recebe as duas requirements no
  `openspec archive add-locale-write-gate --yes`, que roda **depois** do merge — é o V.4 do rito, o
  único box do `tasks.md` ainda aberto, e é também o critério de aceite não ticado na issue.
- **Escapes que permanecem**: `prazo`, `chave` e qualquer substantivo fora do léxico continuam
  passando, em identificador e em caminho. Registrado no KNOWN LIMIT em vez de virar regra que
  adivinha — uma regra por sufixo já foi medida e rejeitada neste script (`-mento`, `-dor`, `-vel`).
- **Só um harness**: o hook foi construído contra o contrato do Claude Code 2.1.246. Codex, Cursor e
  Copilot não foram medidos e a change não afirma nada sobre eles (design.md, Open Questions).
- **Wiring é do usuário**: o hook vive em `~/.claude/settings.json`; máquina sem wiring não ganha o
  gate. O README documenta o bloco.
