### PR TITLE
✨ feat(rito): exige prova de que o artefato foi exercitado

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,9 +116,17 @@ jobs:
       - name: Spec-rite self-test (the gate is itself gated)
         run: python3 scripts/validate-spec-rite.py --selftest
 
-      - name: Claude plugin validation (best-effort)
-        continue-on-error: true
-        run: npx -y @anthropic-ai/claude-code@latest plugin validate . --strict || true
+      - name: Claude plugin validation (vendor validator, blocking)
+        # Was `continue-on-error: true` AND `|| true` — disabled twice over, so it never failed a
+        # build. Measured on 2026-08-26 with claude 2.1.246: `plugin validate . --strict` passes on
+        # this repository, and against a fixture holding a SKILL.md with no description it exits
+        # non-zero with "Validation failed (--strict treats warnings as errors)". It checks the
+        # manifest and the skills' frontmatter; name-vs-directory is scripts/validate-skills.py's
+        # job, so the two are complementary and both stay.
+        #
+        # The version is pinned on purpose: a blocking gate on @latest fails this repository's builds
+        # on someone else's release schedule. Bump it deliberately, after running it locally.
+        run: npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict
 
   # ─── Job 2: Semantic Release ─────────────────────────────────
   release:

--- a/README.md
+++ b/README.md
@@ -699,21 +699,29 @@ openspec/
 | Apply | `/opsx:apply <id>` | Implements each task, ticks `[x]` with evidence |
 | Archive | `/opsx:archive <id>` | Merges deltas into `specs/`, moves the change to `archive/` |
 
-### The three mandatory gates
+### The four mandatory gates
 
 - `design.md` → `## Canonical Home & Cross-Links (MANDATORY)` — every cross-cutting rule names its
   single canonical skill; siblings link instead of restating.
+- `tasks.md` → `## Simulation & Field Proof (MANDATORY)` (third-to-last group) — proof the artifact
+  was **run**, not only read: the entry point exercised, a fragment of the output observed, and the
+  case matrix as counts. A change touching no runtime artifact says so explicitly. It exists because
+  a green selftest and a green pipeline still shipped two defects that only an end-to-end run
+  surfaced (2026-08-26, issue #95).
 - `tasks.md` → `## Quality Gates (MANDATORY)` (second-to-last group) — adversarial review of every
   touched skill: uniform frontmatter, English-only content, testable non-colliding triggers.
 - `tasks.md` → `## Validation & Closure (MANDATORY)` (last group) — strict validation green, catalog
   discovery intact, docs updated, then archive.
+
+`tasks.md` also opens with `## Evidence & Sources (MANDATORY)` (first group) — what was read and
+probed before anything was written. Evidence is what you *read*; simulation is what you *ran*.
 
 ### Where enforcement actually happens
 
 The CLI's `openspec validate --strict` checks **delta-spec format only** — probe-verified on CLI
 1.6.0, it does **not** check custom template sections, so the forked schema alone is advisory (it
 feeds `/opsx` artifact generation). The **hard gate** is [`scripts/validate-rite.sh`](scripts/validate-rite.sh):
-it requires the four gate headings in every active change (evidence group first, closure group
+it requires the five gate headings in every active change (evidence group first, closure group
 last) and runs
 `openspec validate --all --strict`, wired as the **"OpenSpec rite gate"** step in
 [`.github/workflows/ci.yml`](.github/workflows/ci.yml). Run it locally before pushing — CI is the

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -18,7 +18,7 @@ description: >-
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.6.0
+  version: 1.7.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -78,15 +78,22 @@ to the `backlog` skill; consumes the same config.
    step 6. Raising a verdict needs no permission; lowering one does. Full protocol, detection
    commands and archive timing: `references/spec-rite.md`.
 6. **Implementation plan** — present: interpretation of the item, files to change per repo, the
-   Glossary, test strategy, validations to run, risks, estimated blast radius. In a repo with a
-   spec rite, also the change id, the capabilities its delta touches and the strict-validation
-   output line. **Wait for approval.**
+   Glossary, test strategy, validations to run, risks, estimated blast radius. When the item ships a
+   runtime artifact — a skill, a hook, a script someone runs — the plan also names **how it will be
+   exercised end to end**, through the path its user takes, because that is what the sweep will ask
+   for later. In a repo with a spec rite, also the change id, the capabilities its delta touches and
+   the strict-validation output line. **Wait for approval.**
 7. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
    project skills (e.g. `conventional-commit`, and the repo's spec rite when it has one). Names for
    anything new come from the approved Glossary (rail 8). A spec rite's task list is ticked task by
    task as each one lands and is validated, never in a batch at the end. Move the board item
    to the configured in-progress column when work starts.
-8. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
+8. **Tests** — add/update tests per the issue's test strategy and the repo's framework. A test suite
+   the artifact passes is not proof it runs: **exercise it once through its real entry point** and
+   record what you observed, with the case matrix as counts. A green selftest and a green pipeline
+   shipped two defects that only an end-to-end run surfaced (measured 2026-08-26, issue #95). Where
+   the repo's spec rite carries a simulation group, this is what fills it; breaking the artifact on
+   purpose afterwards is `bug-hunter`, a different job.
 9. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers. A repo that wires an identifier-locale
    check is running one of its own discovered commands — never invent one where none exists.
@@ -96,8 +103,8 @@ to the `backlog` skill; consumes the same config.
     is opened (`references/acceptance-tracking.md`). A spec rite's mandatory closure group is part
     of the sweep, not a separate afterthought.
 11. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
-    `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
-    left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
+    `Relates to <issue-url>`, plus the evidence table, the simulation's measured counts when the item
+    shipped a runtime artifact, and a **Known gaps** section when the sweep left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
     gate reads — the change id, or the written waiver and its reason (`references/spec-rite.md`).
     No auto-merge. Follow `conventional-commit` PR rules when present.
 12. **Sync & report** — move the board item to the review column; comment on the issue with links

--- a/openspec/changes/add-simulation-rite-gate/design.md
+++ b/openspec/changes/add-simulation-rite-gate/design.md
@@ -1,0 +1,113 @@
+## Context
+
+Três gates leem o rito hoje, cada um com uma pergunta diferente, e cada um declara no próprio
+cabeçalho o que não consegue fazer:
+
+| Script | Pergunta |
+|---|---|
+| `scripts/validate-rite.sh` | os grupos obrigatórios existem, nas posições certas? |
+| `scripts/validate-rite-evidence.py` | uma caixa marcada diz o que rodou, ou só uma conclusão? |
+| `scripts/validate-spec-rite.py` | existe change alguma? |
+
+Nenhum pergunta se o artefato foi executado. A leitura de `scripts/validate-rite.sh` (commit
+`afa547e`, 2026-08-26) mostra que a restrição posicional é menor do que o texto do schema sugere: o
+script fixa apenas o **primeiro** grupo (`Evidence & Sources`) e o **último** (`Validation &
+Closure`); `Quality Gates` só precisa existir. Isso abre espaço para um quinto grupo sem tocar em
+regra nenhuma das existentes.
+
+`scripts/validate-rite-evidence.py` declara em KNOWN LIMIT 3: *"Only the four E kinds have rules. A
+fifth `E.5` a change invents is counted in the density report and otherwise unchecked."* As caixas
+novas herdam essa arquitetura em vez de inventar outra.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Uma change que toca skill, hook ou script entregue não fecha sem registrar o artefato exercitado
+  pelo caminho real, com saída observada e matriz medida.
+- Uma change que não toca artefato de runtime fecha o grupo em uma linha, explicitamente.
+- As regras novas provam **forma**, e dizem no próprio cabeçalho que não provam honestidade.
+
+**Non-Goals**
+
+- Rodar a simulação automaticamente. O que é gatado é o registro; um harness que executasse a
+  simulação de cada skill é outro item, muito maior.
+- Julgar se a saída registrada é real. O repositório já decidiu essa classe
+  (`openspec/changes/archive/2026-08-07-add-verify-before-claiming/design.md`): CI só prova que o
+  registro é bem-formado, e converter defeito óbvio em defeito certificado é pior que não checar.
+- Mexer nas quatro caixas `E.` nem nas posições dos grupos existentes.
+- Autorar suítes de `claude plugin eval` enquanto o comando não roda nesta conta.
+
+## Decisions
+
+**D1 — Grupo novo antes de Quality Gates, não dentro de Validation & Closure.**
+`Validation & Closure` é o último grupo e trata de fechamento — validate estrito, catálogo íntegro,
+archive. Simulação é trabalho de prova, não de fechamento, e precisa acontecer **antes** da revisão
+adversarial de qualidade, porque é ela que costuma produzir o defeito que a revisão vai discutir.
+Alternativa descartada: uma caixa `V.0` dentro do grupo de fechamento — ficaria sujeita à regra de
+posição do último grupo e misturaria duas perguntas num grupo só.
+
+**D2 — Três caixas com formas diferentes, não uma regra uniforme.**
+`validate-rite-evidence.py` já mediu e rejeitou a regra uniforme: *"a uniform 'command -> output'
+rule was measured first and rejected: it failed 14 of 20 historical boxes… all correct as written."*
+As três caixas herdam isso:
+
+| Caixa | Forma exigida |
+|---|---|
+| `S.1` | ponto de entrada em backticks **e** saída observada (seta `->`), ou declaração explícita de que não há artefato de runtime |
+| `S.2` | números da matriz — pelo menos um par `n/n` |
+| `S.3` | nomeia o que escapou, ou declara explicitamente que nada escapou |
+
+**D3 — `S.1` aceita a saída explícita "não há artefato de runtime".**
+Mesma válvula que `E.3` e `E.4` já usam (regex `NEGATIVE`). Sem ela, uma change de documentação pura
+seria obrigada a inventar uma simulação — que é padding, o oposto do que o gate quer.
+
+**D4 — O passo de validação de plugin no CI passa a bloquear, com versão pinada.**
+Probado em 2026-08-26 com `claude 2.1.246`: `claude plugin validate . --strict` passa neste
+repositório, e contra fixture controlado (plugin com `SKILL.md` sem `description`) reprova com
+`✘ Validation failed (--strict treats warnings as errors)`. Ele **não** pega `name` divergente do
+diretório — isso é do `scripts/validate-skills.py`; os dois se complementam. O pin existe porque o
+passo hoje usa `@anthropic-ai/claude-code@latest`, e gate bloqueante em versão flutuante reprova
+build por mudança de terceiro.
+
+**D5 — `claude plugin eval` fica fora, registrado como o destino.**
+O harness nativo é superior ao que qualquer gate deste repositório consegue fazer: ele roda o caso,
+pontua com graders (`regex`, `tool_used`, `tool_order`, `file_exists`, `llm`, `baseline`) e, sob
+`--ablation with-without`, compara o braço com plugin contra o braço sem — que é a única medição que
+responde "a skill mudou o comportamento?". Está em early access e não roda nesta conta (medido). O
+gate desta change é o que funciona hoje; quando o acesso abrir, `S.1` passa a poder citar
+`claude plugin eval --json --threshold` como o ponto de entrada exercitado, sem alterar regra nenhuma.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Regra transversal | Skill canônico (dono) | Ação nesta change |
+|---|---|---|
+| Não afirmar sem probe; relatar o que não pôde ser probado | `verify-before-claiming` | link, sem restatement — o grupo novo é a forma executável da mesma doutrina, e o template aponta para o skill |
+| Rito backlog → PR, plano antes de código | `execute-backlog` | já canônico: a simulação entra no plano e na evidência do PR **lá**, não é redescrita no schema |
+| Teste adversarial de uma mudança recém-implementada | `bug-hunter` | link: a simulação prova que o artefato roda; quebrar de propósito continua sendo do `bug-hunter`, e o template referencia isso em vez de repetir |
+| Fronteira prosa/máquina nos nomes novos (`S.1`, grupo, funções) | `code-locale` | já canônico — os identificadores novos são ingleses e vêm do Glossary do item |
+
+## Risks / Trade-offs
+
+- **Quinto grupo virar cerimônia** → as caixas exigem número e fragmento observado; e change sem
+  runtime fecha em uma linha.
+- **Padding: caixa preenchida com saída inventada passa** → declarado no KNOWN LIMIT, como o gate
+  irmão já declara. Forma é o que script prova; conteúdo é o revisor.
+- **Regra inaplicável a trabalho de julgamento** → `S.1` aceita a declaração explícita de ausência.
+- **CI bloqueante quebrando por versão** → pin explícito, com a versão probada registrada.
+- **Change ativa em voo pegando o gate novo** → o gate lê changes ativas no merge; não há outra
+  aberta além desta.
+
+## Migration Plan
+
+Nenhuma migração. O gate lê apenas changes ativas; o arquivo histórico não é relitigado, como já vale
+para os gates irmãos.
+
+## Open Questions
+
+- A semântica exata do `--threshold` do `claude plugin eval` (compara score por grader, pass_rate por
+  caso ou agregado?) e o schema do `aggregate-result.json` **não** constam da referência embutida do
+  produto. Não são afirmados em lugar nenhum desta change; ficam para o item de adoção, que só
+  começa quando o comando puder ser executado e medido.
+- O nome da variável de ambiente que habilita o early access em clientes sem flags server-side também
+  não consta da referência. O caminho documentado para pedir enablement é `/feedback`.

--- a/openspec/changes/add-simulation-rite-gate/proposal.md
+++ b/openspec/changes/add-simulation-rite-gate/proposal.md
@@ -1,0 +1,79 @@
+# Change: Exigir prova de que o artefato foi exercitado antes de fechar o rito
+
+## Why
+
+O rito pergunta hoje o que foi lido, o que foi probado, se o frontmatter está uniforme e se a
+validação estrita está verde. Todas essas respostas podem ser verdadeiras sem que o artefato tenha
+sido **executado uma única vez** pelo caminho que o usuário percorre.
+
+Medido em 2026-08-26, executando a issue #95 (PR #96): `--selftest` do detector verde, CI verde — e
+a simulação end-to-end pelo harness real ainda achou dois defeitos:
+
+```
+tmp-sim/order_service/shipping_cost.py:1: valor_pedido   <- linha errada; :1 é o offset do fragmento
+tmp-sim/order_service/shipping_cost.py:3: valor_pedido   <- depois da correção, a linha do arquivo
+```
+
+e o alcance da dispensa inline (a própria linha e a seguinte) não estava escrito em lugar nenhum —
+erro cometido duas vezes dentro da própria change, uma no docstring e outra num fixture. Nenhum dos
+dois seria visto por qualquer gate existente.
+
+O mantenedor estabeleceu a regra em 2026-08-26: nenhuma melhoria de skill é aceita sem simulação
+prévia usando a própria skill. Regra que vive só na conversa morre com a sessão — é o mesmo argumento
+que já tirou o rito de backlog e o rito de grounding da prosa e os colocou em artefato de enforcement.
+
+## What Changes
+
+- Novo grupo obrigatório `Simulation & Field Proof (MANDATORY)` no template do schema, posicionado
+  imediatamente antes de `Quality Gates (MANDATORY)`, com as caixas `S.1`, `S.2` e `S.3`.
+- `scripts/validate-rite.sh` passa a exigir o grupo estruturalmente, como já faz com os outros três.
+- `scripts/validate-rite-evidence.py` ganha regras de forma por caixa para `S.1`–`S.3`, no mesmo
+  desenho por tipo que as caixas `E.` já usam, e três casos novos de `--selftest`.
+- `openspec/schemas/skills-rite/schema.yaml` descreve o quinto gate ao lado dos quatro.
+- `skills/execute-backlog`: a simulação entra no plano apresentado para aprovação e na evidência do PR.
+- `.github/workflows/ci.yml`: o passo de validação de plugin **passa a bloquear**. Hoje ele está
+  desligado duas vezes — `continue-on-error: true` e `|| true` — e nunca reprovou build nenhum.
+  Junto vai o pin da versão, porque gate bloqueante em `@latest` quebra no calendário de release
+  alheio.
+
+**Não é BREAKING** para consumidores do catálogo: nenhum skill entra, sai ou muda de nome. É breaking
+para quem tem change ativa neste repositório, e não há nenhuma além desta.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Nenhum skill novo entra no catálogo.
+
+### Modified Capabilities
+
+- `skills-catalog`: uma requirement ADICIONADA — o rito passa a gatar prova de execução, ao lado da
+  requirement existente `The rite gates evidence before it gates quality`. A distinção entre as duas
+  é o que justifica ser requirement nova e não emenda da antiga: aquela governa o que foi **lido e
+  probado** antes de escrever; esta governa o que foi **executado** antes de declarar entregue.
+
+## Impact
+
+- `openspec/schemas/skills-rite/schema.yaml`, `openspec/schemas/skills-rite/templates/tasks.md`,
+  `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py`,
+  `skills/execute-backlog/SKILL.md` (+ `references/`), `.github/workflows/ci.yml`, `README.md`.
+- `openspec/specs/skills-catalog/spec.md`, depois do archive.
+- Espelhos gerados por `./generate.sh`.
+- Quem abre change neste repositório passa a preencher mais um grupo; quem toca só documentação fecha
+  o grupo em uma linha, declarando que não há artefato de runtime.
+
+## Fora desta change, e por quê
+
+`claude plugin eval` é o lar definitivo desta camada: casos em `evals/<caso>/prompt.md` com graders
+`regex`, `tool_used`, `tool_order`, `file_exists`, `llm` e `baseline`, e um braço `--ablation
+with-without` que mede se a skill **muda o comportamento** em vez de apenas carregar. Medido em
+2026-08-26 com `claude 2.1.246`:
+
+```
+$ claude plugin eval .
+`plugin eval` is currently in early access
+```
+
+Não roda nesta conta. Escrever suíte que não pode ser executada seria entregar artefato não
+verificado — exatamente o que esta change existe para proibir. A adoção vira item próprio quando o
+acesso abrir, e sua primeira entrega é uma suíte **rodada**, não escrita.

--- a/openspec/changes/add-simulation-rite-gate/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-simulation-rite-gate/specs/skills-catalog/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: The rite gates proof that the artifact was exercised
+
+The repository's spec-driven rite SHALL require every active change to record that the artifact it
+touches was **run through the path its user takes**, before the change can be closed. Reading,
+probing, uniform frontmatter and a green strict validation SHALL NOT be treated as proof of delivery:
+each of them can hold while the artifact has never been executed once.
+
+The record SHALL live in its own mandatory task group, positioned before the quality-review group so
+that what the simulation finds is available to the review that follows it, and its presence SHALL be
+enforced by the same script that enforces the other mandatory groups, because the OpenSpec CLI
+validates delta-spec format only.
+
+The group's boxes SHALL be checked in **shape**, per kind rather than uniformly, following the
+measurement that already rejected a uniform rule for the evidence group: an entry point together with
+an observed output fragment; a case matrix expressed as counts; and what escaped, or an explicit
+statement that nothing did. A change that touches no runtime artifact SHALL satisfy the group by
+stating that explicitly, so that documentation-only work is never pushed into inventing a simulation.
+
+The gate SHALL declare, in its own header, that it proves the record's shape and never its honesty —
+a box filled with invented output passes it, and the reviewer is what judges the content.
+
+#### Scenario: A change that ships a runtime artifact records its exercise
+
+- **WHEN** an active change touches a skill, a hook or a shipped script
+- **THEN** its task list carries the simulation group, naming the entry point that was exercised and a
+  fragment of the output that was observed
+- **AND** the counts of the case matrix are recorded — what had to fire and did, what had to stay
+  silent and did, and which known escapes stayed silent
+
+#### Scenario: A documentation-only change closes the group explicitly
+
+- **WHEN** an active change touches no runtime artifact
+- **THEN** the group is satisfied by stating that explicitly
+- **AND** the change is not required to invent a simulation, because a padded record is worth less
+  than an honest absence
+
+#### Scenario: A missing or misplaced group fails the gate
+
+- **WHEN** an active change's task list lacks the simulation group
+- **THEN** the rite gate fails with a file-specific error naming the missing group
+- **AND** the first-group and last-group rules of the existing mandatory groups are unchanged
+
+#### Scenario: A ticked box that states a conclusion instead of an observation fails
+
+- **WHEN** a box in the simulation group is ticked without naming an entry point and an observed
+  output, without counts, or without naming an escape or declaring none
+- **THEN** the evidence gate reports a file-specific finding naming the box and what is missing
+
+#### Scenario: The shipped catalog validator is a gate, not a suggestion
+
+- **WHEN** continuous integration validates this repository's plugins and skills with the vendor's
+  own validator
+- **THEN** the step fails the build on a finding, and pins the validator's version, so that a gate is
+  neither silently disabled nor broken by an upstream release

--- a/openspec/changes/add-simulation-rite-gate/tasks.md
+++ b/openspec/changes/add-simulation-rite-gate/tasks.md
@@ -1,0 +1,106 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos abertos e lidos, não recordados, no commit `afa547e` (2026-08-26):
+      `scripts/validate-rite.sh` (laço sobre changes ativas, regra de primeiro e último grupo),
+      `scripts/validate-rite-evidence.py` (`_shape_ok`, `check_evidence_shape`, `CHECKS`, `DEFECTS`,
+      `report_density`, KNOWN LIMIT 3), `openspec/schemas/skills-rite/schema.yaml`,
+      `openspec/schemas/skills-rite/templates/tasks.md`, `.github/workflows/ci.yml` (passo
+      "Claude plugin validation (best-effort)"), `openspec/specs/skills-catalog/spec.md`
+- [x] E.2 Probes contra a versão instalada, 2026-08-26:
+      `claude --version` -> `2.1.246 (Claude Code)`;
+      `claude plugin validate . --strict` -> `✔ Validation passed`;
+      `claude plugin validate <fixture> --strict` -> `✘ Validation failed (--strict treats warnings
+      as errors)` com `❯ description: No description in frontmatter` — prova que o validador nativo
+      inspeciona `SKILL.md` dentro do plugin;
+      `claude plugin eval .` -> `` `plugin eval` is currently in early access `` (não roda nesta conta);
+      `claude plugin details caveman` -> `Always-on: ~2,681 tok` — inventário e custo projetado
+- [x] E.3 Não probado e registrado como pergunta aberta em design.md, nunca afirmado: a semântica
+      exata do `--threshold` do `plugin eval`, o schema do `aggregate-result.json`, e o nome da
+      variável de ambiente de early access. A referência embutida do produto não os declara, e o
+      comando não pode ser executado aqui para medir.
+- [x] E.4 Escopo: esta change entrega o gate do rito e liga o validador nativo que já roda. Listados
+      como follow-up e **não** executados — (a) autorar suítes de `claude plugin eval`, bloqueado por
+      early access; (b) `/skill-doctor`, mesmo gate; (c) medir o custo always-on do próprio catálogo
+      com `claude plugin details`, que exige instalar o plugin localmente.
+
+## 2. Grupo novo no schema e no template
+
+- [x] 2.1 `openspec/schemas/skills-rite/templates/tasks.md`: grupo `Simulation & Field Proof
+      (MANDATORY)` com `S.1`, `S.2`, `S.3`, imediatamente antes de `Quality Gates (MANDATORY)`
+- [x] 2.2 `openspec/schemas/skills-rite/schema.yaml`: a instrução de tasks descreve o quinto gate e
+      sua posição, ao lado dos quatro
+- [x] 2.3 O comentário do template explica a forma que cada caixa deve, como o grupo de evidência já faz
+
+## 3. Enforcement
+
+- [x] 3.1 `scripts/validate-rite.sh`: presença do grupo vira estrutural, com erro nomeando arquivo e grupo
+- [x] 3.2 `scripts/validate-rite-evidence.py`: `_simulation_shape_ok()` com as regras de `S.1`–`S.3`
+- [x] 3.3 `check_simulation_shape()` registrado em `CHECKS`
+- [x] 3.4 Três entradas novas em `DEFECTS`, uma por regra, no formato existente
+- [x] 3.5 KNOWN LIMIT atualizado: sete tipos de caixa com regra, e a mesma incapacidade de detectar
+      saída inventada
+
+## 4. Validador nativo bloqueante
+
+- [x] 4.1 `.github/workflows/ci.yml`: remover `continue-on-error: true` e `|| true` do passo de
+      validação de plugin
+- [x] 4.2 Pinar `@anthropic-ai/claude-code` na versão probada, com o motivo no comentário do passo
+- [x] 4.3 Provado nos dois sentidos: verde neste repositório, vermelho no fixture controlado
+
+## 5. Rito e documentação
+
+- [x] 5.1 `skills/execute-backlog/SKILL.md` (+ `references/`): a simulação entra no plano de aprovação
+      e na evidência do PR
+- [x] 5.2 `README.md`: o rito passa a descrever cinco gates
+- [x] 5.3 `./generate.sh` re-executado; espelhos idênticos
+
+## 6. Simulation & Field Proof (MANDATORY)
+
+<!-- O grupo que esta change introduz, preenchido por ela mesma. Forma exigida:
+     S.1  ponto de entrada em `backticks` -> fragmento da saída OBSERVADA, ou declaração explícita
+          de que a change não toca artefato de runtime
+     S.2  a matriz medida em números (n/n)
+     S.3  o que escapou ou se comportou diferente do esperado, ou "nada escapou" explícito -->
+
+- [x] S.1 Gates exercitados contra diretórios de change sintéticos, numa cópia descartável do repo,
+      2026-08-26. Change sem o grupo ->
+      `::error::Missing mandatory group 'Simulation & Field Proof (MANDATORY)'`.
+      Change com as três caixas infladas (`- [x] S.1 Simulei o gate e funcionou`) ->
+      `rite evidence gate: 3 findings`, uma por regra:
+      `R2 simulation shape — S.1 names no entry point and no observed output`,
+      `R2 simulation shape — S.2 carries no counts`,
+      `R2 simulation shape — S.3 neither names what escaped nor states that nothing did`.
+      Change declarando ausência de runtime -> `rite evidence gate: 0 findings`.
+      Validador nativo pinado: `claude plugin validate <fixture> --strict` ->
+      `✘ Validation failed (--strict treats warnings as errors)`; `claude plugin validate . --strict`
+      -> `✔ Validation passed`.
+- [x] S.2 Matriz medida: 2/2 casos que deviam reprovar reprovaram (grupo ausente, caixas infladas);
+      3/3 casos que deviam passar passaram (grupo correto no gate estrutural, grupo correto no gate
+      de forma, declaração explícita de ausência de runtime); 7/7 classes de defeito detectadas pelo
+      `--selftest`, sendo 3 novas (`R2 simulation shape: S.1/S.2/S.3`); 2/2 sentidos do validador
+      nativo provados (vermelho no fixture, verde no repositório).
+- [x] S.3 Um comportamento diferente do previsto, e mantido de propósito: `validate-rite.sh` não fixa
+      a **posição** do grupo novo — ele só ancora primeiro e último grupo, então uma change que
+      colocasse a simulação depois do Quality Gates passaria no gate estrutural. Está registrado no
+      comentário do script e na D1 do design; fixar a posição exigiria mudar as âncoras existentes,
+      o que está fora do escopo desta change. Nada mais escapou.
+
+## 7. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: `name` == diretório, descrição dobrada,
+      `metadata.author: solvelab`, `metadata.version` semver bumpado, `category` no conjunto
+      controlado, `license: MIT`, `compatibility` presente
+- [x] Q.2 Todo conteúdo tocado do skill em inglês (locale do catálogo)
+- [x] Q.3 Gatilhos da descrição testáveis e sem colisão com skill irmão; fronteira "Do NOT use for"
+      presente onde há sobreposição
+- [x] Q.4 Sem doutrina duplicada: o template aponta para `verify-before-claiming` e `bug-hunter` em
+      vez de repetir o texto deles (design.md, tabela Canonical Home)
+- [x] Q.5 Todo exemplo de código tocado usa identificadores, rotas, chaves e nomes de evento em
+      inglês; termo mantido em outra língua carrega o motivo inline
+
+## 8. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate add-simulation-rite-gate --strict` verde
+- [x] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 34 skills
+- [x] V.3 README / docs atualizados onde o rito muda
+- [ ] V.4 `openspec archive add-simulation-rite-gate --yes` depois do merge do PR

--- a/openspec/schemas/skills-rite/schema.yaml
+++ b/openspec/schemas/skills-rite/schema.yaml
@@ -260,6 +260,17 @@ artifacts:
       conclusion: a row a reviewer can re-run in two seconds is the only kind
       worth writing.
 
+      - Third-to-last group: `## N. Simulation & Field Proof (MANDATORY)` — proof
+      that the artifact was RUN, not only read and reviewed. Exercise it through
+      the path its user takes (the hook fired by the harness, the CLI invoked as
+      documented, the skill loaded in a session) and record the entry point plus a
+      fragment of the OBSERVED output, the case matrix as counts, and what escaped.
+      A change that touches no runtime artifact says so explicitly instead of
+      inventing a simulation. The position is part of the gate: it sits before the
+      quality review, because what the simulation finds is what that review needs
+      to discuss. Earned on 2026-08-26 (issue #95), where a green selftest and a
+      green CI still shipped two defects that only an end-to-end run surfaced.
+
       - Second-to-last group: `## N. Quality Gates (MANDATORY)` — adversarial
       review of every skill touched: uniform frontmatter (name == directory,
       folded description, metadata.author solvelab, semver version, category in

--- a/openspec/schemas/skills-rite/templates/tasks.md
+++ b/openspec/schemas/skills-rite/templates/tasks.md
@@ -26,11 +26,37 @@
 - [ ] 2.1 <!-- Task description -->
 - [ ] 2.2 <!-- Task description -->
 
-## 3. Quality Gates (MANDATORY)
+## 3. Simulation & Field Proof (MANDATORY)
+
+<!-- Second-to-last but one: proof that the artifact was RUN, before the quality review discusses it.
+     Reading, probing, uniform frontmatter and a green strict validation can all hold while the
+     artifact was never executed once — measured on 2026-08-26 (issue #95), where a green selftest
+     and a green CI still shipped two defects that only an end-to-end run surfaced.
+
+     Exercise the artifact through the path its USER takes — the hook fired by the harness, the CLI
+     invoked as documented, the skill loaded in a session — and record what you OBSERVED, never what
+     you expected. Breaking it on purpose afterwards is a different job: the bug-hunter skill.
+     The doctrine behind "observed, not recalled" is verify-before-claiming.
+
+     Shape each box owes, gated by scripts/validate-rite-evidence.py once ticked:
+       S.1  an `entry point` -> a fragment of the OBSERVED output; or an explicit statement that the
+            change touches no runtime artifact
+       S.2  the case matrix as counts (n/n): what had to fire and did, what had to stay silent and
+            did, which known escapes stayed silent
+       S.3  names what escaped or misbehaved, or states explicitly that nothing did
+     The gate cannot tell a real observation from an invented one — that is still the reviewer's job. -->
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 4. Quality Gates (MANDATORY)
 
 <!-- Adversarial review of the skills touched — not happy-path. Every skill added or edited
-     by this change gets checked against the skills-authoring spec. Keep the group number
-     as the second-to-last group. -->
+     by this change gets checked against the skills-authoring spec. Keep this group second-to-last. -->
 
 - [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
       metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
@@ -46,7 +72,7 @@
       paths shipped in target repos through this rite. Regression gate on the exemplar: the model
       imitates the code it is shown
 
-## 4. Validation & Closure (MANDATORY)
+## 5. Validation & Closure (MANDATORY)
 
 <!-- Always the last group. "Done" is verifiable, not an opinion. -->
 

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -18,7 +18,7 @@ description: >-
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.6.0
+  version: 1.7.0
   category: process
 license: MIT
 compatibility: >-
@@ -100,15 +100,22 @@ to the `backlog` skill; consumes the same config.
    step 6. Raising a verdict needs no permission; lowering one does. Full protocol, detection
    commands and archive timing: `references/spec-rite.md`.
 6. **Implementation plan** — present: interpretation of the item, files to change per repo, the
-   Glossary, test strategy, validations to run, risks, estimated blast radius. In a repo with a
-   spec rite, also the change id, the capabilities its delta touches and the strict-validation
-   output line. **Wait for approval.**
+   Glossary, test strategy, validations to run, risks, estimated blast radius. When the item ships a
+   runtime artifact — a skill, a hook, a script someone runs — the plan also names **how it will be
+   exercised end to end**, through the path its user takes, because that is what the sweep will ask
+   for later. In a repo with a spec rite, also the change id, the capabilities its delta touches and
+   the strict-validation output line. **Wait for approval.**
 7. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
    project skills (e.g. `conventional-commit`, and the repo's spec rite when it has one). Names for
    anything new come from the approved Glossary (rail 8). A spec rite's task list is ticked task by
    task as each one lands and is validated, never in a batch at the end. Move the board item
    to the configured in-progress column when work starts.
-8. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
+8. **Tests** — add/update tests per the issue's test strategy and the repo's framework. A test suite
+   the artifact passes is not proof it runs: **exercise it once through its real entry point** and
+   record what you observed, with the case matrix as counts. A green selftest and a green pipeline
+   shipped two defects that only an end-to-end run surfaced (measured 2026-08-26, issue #95). Where
+   the repo's spec rite carries a simulation group, this is what fills it; breaking the artifact on
+   purpose afterwards is `bug-hunter`, a different job.
 9. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers. A repo that wires an identifier-locale
    check is running one of its own discovered commands — never invent one where none exists.
@@ -118,8 +125,8 @@ to the `backlog` skill; consumes the same config.
     is opened (`references/acceptance-tracking.md`). A spec rite's mandatory closure group is part
     of the sweep, not a separate afterthought.
 11. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
-    `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
-    left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
+    `Relates to <issue-url>`, plus the evidence table, the simulation's measured counts when the item
+    shipped a runtime artifact, and a **Known gaps** section when the sweep left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
     gate reads — the change id, or the written waiver and its reason (`references/spec-rite.md`).
     No auto-merge. Follow `conventional-commit` PR rules when present.
 12. **Sync & report** — move the board item to the review column; comment on the issue with links

--- a/scripts/validate-rite-evidence.py
+++ b/scripts/validate-rite-evidence.py
@@ -9,7 +9,8 @@ mandatory groups, 7 carried a command and its output (2%).
 
 This adds the half a script can honestly do.
 
-  R1 evidence shape   a ticked Evidence & Sources box states what was run, not a conclusion
+  R1 evidence shape     a ticked Evidence & Sources box states what was run, not a conclusion
+  R2 simulation shape   a ticked Simulation & Field Proof box states what was EXERCISED and observed
 
 and prints, without gating, how dense every mandatory group's evidence is, so a `Quality Gates 0/5`
 is visible on the pull request without reading the diff.
@@ -23,6 +24,15 @@ most recently written change, all correct as written.
   E.3  what could not be probed   names the gap, or states explicitly that there is none
   E.4  scope check           lists a follow-up, or states explicitly that there is none
 
+The simulation group asks a different question — not what was read before writing, but what was RUN
+before calling it delivered. Earned on 2026-08-26 (issue #95): a green `--selftest` and a green CI
+still shipped two defects that only an end-to-end run through the real harness surfaced.
+
+  S.1  artifact exercised    an `entry point` -> a fragment of the OBSERVED output, or an explicit
+                             statement that the change touches no runtime artifact
+  S.2  case matrix           counts, not adjectives: n/n fired, n/n silent, n/n escapes
+  S.3  what escaped          names it, or states explicitly that nothing did
+
 KNOWN LIMIT — what this gate does NOT do. A passing run is not proof the evidence is real.
   1. It cannot detect fabricated output. A box padded with `-> ok` passes every rule here. This
      repo already designed and rejected a stronger version for that reason
@@ -32,8 +42,9 @@ KNOWN LIMIT — what this gate does NOT do. A passing run is not proof the evide
   2. `Quality Gates` and `Validation & Closure` are reported, never gated. Several of their items
      are judgments rather than executions (`Q.3` is "triggers do not collide"), and demanding a
      command there manufactures padding.
-  3. Only the four E kinds have rules. A fifth `E.5` a change invents is counted in the density
-     report and otherwise unchecked.
+  3. Only the four E kinds and the three S kinds have rules. A fifth `E.5` a change invents is
+     counted in the density report and otherwise unchecked. Nothing here reads the artifact that S.1
+     names: a box can cite a command that was never run, and the gate cannot tell.
   4. Unticked boxes are ignored. The rule is about what a tick claims, not about progress.
   5. Only active changes are read; `openspec/changes/archive/` is history and is never re-litigated.
   6. It fires on nothing in the current corpus — every historical E box passes. That is calibration
@@ -60,6 +71,12 @@ ARROW = re.compile(r"->|→")
 SHA_OR_DATE = re.compile(r"`[0-9a-f]{7,40}`|\b20\d\d-\d\d-\d\d\b")
 PATH_IN_TICKS = re.compile(r"`[^`\s]+\.(?:md|py|sh|ya?ml|json|lua|tsx?|jsx?|cs|sql|toml|ini)[^`]*`")
 NEGATIVE = re.compile(r"\bnone\b|\bnothing\b|\bno gaps?\b|\bnenhum", re.I)
+# S.2 wants the matrix as numbers. `10/10` and `0 de 6` both count; a sentence claiming "todos os
+# casos passaram" does not, which is the whole point of asking for counts.
+COUNTS = re.compile(r"\b\d+\s*(?:/|de|of)\s*\d+\b")
+# The escape hatch S.1 accepts, paired with NEGATIVE so that "nothing to simulate" reads as a
+# deliberate statement rather than an accidental word match.
+NO_RUNTIME = re.compile(r"runtime|execut|runnable|artefato|artifact|script|hook|skill", re.I)
 
 findings: list[str] = []
 
@@ -157,7 +174,46 @@ def check_evidence_shape(root: Path) -> None:
                 add("R1 evidence shape", tasks, f"{box_id} {why}")
 
 
-CHECKS = (check_evidence_shape,)
+# ── R2: simulation shape ──────────────────────────────────────────────────
+# The evidence group asks what was READ and PROBED before writing. This one asks what was RUN before
+# calling it delivered — a different question, so a different shape per box, for the same reason the
+# E rules are per kind: a uniform rule rejects boxes that are correct as written.
+def _simulation_shape_ok(box_id: str, body: str) -> "tuple[bool, str]":
+    if box_id == "S.1":
+        # An explicit "no runtime artifact" is a valid answer: documentation-only work must not be
+        # pushed into inventing a simulation, exactly as E.3/E.4 accept an explicit absence.
+        if NEGATIVE.search(body) and NO_RUNTIME.search(body):
+            return True, ""
+        if not (BACKTICKED.search(body) and ARROW.search(body)):
+            return False, ("names no entry point and no observed output — record "
+                           "`what you ran` -> a fragment of what you SAW, or state explicitly that "
+                           "this change touches no runtime artifact")
+        return True, ""
+    if box_id == "S.2":
+        if not COUNTS.search(body):
+            return False, ("carries no counts — record the case matrix as numbers (n/n): what had to "
+                           "fire and did, what had to stay silent and did, which escapes stayed silent")
+        return True, ""
+    if box_id == "S.3":
+        if NEGATIVE.search(body) or len(body) > 120:
+            return True, ""
+        return False, "neither names what escaped nor states that nothing did"
+    return True, ""
+
+
+def check_simulation_shape(root: Path) -> None:
+    for tasks in active_task_files(root):
+        for group, box_id, ticked, body in parse_boxes(tasks.read_text(encoding="utf-8")):
+            if not ticked or "Simulation & Field Proof" not in group:
+                continue
+            if box_id not in ("S.1", "S.2", "S.3"):
+                continue
+            ok, why = _simulation_shape_ok(box_id, body)
+            if not ok:
+                add("R2 simulation shape", tasks, f"{box_id} {why}")
+
+
+CHECKS = (check_evidence_shape, check_simulation_shape)
 
 
 # ── density report (never gates) ──────────────────────────────────────────
@@ -190,7 +246,13 @@ _SCAFFOLD = """## 1. Evidence & Sources (MANDATORY)
 - [x] E.3 Nothing could not be probed: none outstanding
 - [x] E.4 Scope check: none noticed, no follow-ups
 
-## 2. Validation & Closure (MANDATORY)
+## 2. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 `python3 hook.py < payload.json` -> `findings: 2` on the Portuguese path
+- [x] S.2 Matrix: 10/10 defects caught, 6/6 correct cases silent, 4/4 known escapes silent
+- [x] S.3 Nothing escaped that was not already documented
+
+## 3. Validation & Closure (MANDATORY)
 
 - [x] V.1 `openspec validate x --strict` -> valid
 """
@@ -232,10 +294,34 @@ def _break_e4(tmp: Path) -> None:
         "- [x] E.4 Scope respected"), encoding="utf-8")
 
 
+def _break_s1(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] S.1 `python3 hook.py < payload.json` -> `findings: 2` on the Portuguese path",
+        "- [x] S.1 Simulated the hook and it worked"), encoding="utf-8")
+
+
+def _break_s2(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] S.2 Matrix: 10/10 defects caught, 6/6 correct cases silent, 4/4 known escapes silent",
+        "- [x] S.2 Every case in the matrix passed"), encoding="utf-8")
+
+
+def _break_s3(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] S.3 Nothing escaped that was not already documented",
+        "- [x] S.3 Reviewed"), encoding="utf-8")
+
+
 DEFECTS = (("R1 evidence shape: E.1", _break_e1),
            ("R1 evidence shape: E.2", _break_e2),
            ("R1 evidence shape: E.3", _break_e3),
-           ("R1 evidence shape: E.4", _break_e4))
+           ("R1 evidence shape: E.4", _break_e4),
+           ("R2 simulation shape: S.1", _break_s1),
+           ("R2 simulation shape: S.2", _break_s2),
+           ("R2 simulation shape: S.3", _break_s3))
 
 
 def selftest() -> int:

--- a/scripts/validate-rite.sh
+++ b/scripts/validate-rite.sh
@@ -42,6 +42,11 @@ for dir in "$CHANGES_DIR"/*/; do
       *"Evidence & Sources (MANDATORY)"*) ;;
       *) echo "::error file=$tasks::'Evidence & Sources (MANDATORY)' must be the FIRST task group (found first: ${first_group:-none})"; fail=1 ;;
     esac
+    # Simulation & Field Proof asks the question the other groups cannot: was the artifact ever RUN?
+    # Position is not pinned here — first and last are the only structural anchors — but the schema
+    # places it before Quality Gates, so the review has the simulation's findings in hand.
+    grep -q 'Simulation & Field Proof (MANDATORY)' "$tasks" || {
+      echo "::error file=$tasks::Missing mandatory group 'Simulation & Field Proof (MANDATORY)'"; fail=1; }
     grep -q 'Quality Gates (MANDATORY)' "$tasks" || {
       echo "::error file=$tasks::Missing mandatory group 'Quality Gates (MANDATORY)'"; fail=1; }
     grep -q 'Validation & Closure (MANDATORY)' "$tasks" || {

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -18,7 +18,7 @@ description: >-
   (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.6.0
+  version: 1.7.0
   category: process
 license: MIT
 compatibility: >-
@@ -100,15 +100,22 @@ to the `backlog` skill; consumes the same config.
    step 6. Raising a verdict needs no permission; lowering one does. Full protocol, detection
    commands and archive timing: `references/spec-rite.md`.
 6. **Implementation plan** — present: interpretation of the item, files to change per repo, the
-   Glossary, test strategy, validations to run, risks, estimated blast radius. In a repo with a
-   spec rite, also the change id, the capabilities its delta touches and the strict-validation
-   output line. **Wait for approval.**
+   Glossary, test strategy, validations to run, risks, estimated blast radius. When the item ships a
+   runtime artifact — a skill, a hook, a script someone runs — the plan also names **how it will be
+   exercised end to end**, through the path its user takes, because that is what the sweep will ask
+   for later. In a repo with a spec rite, also the change id, the capabilities its delta touches and
+   the strict-validation output line. **Wait for approval.**
 7. **Implement** — branch `backlog/<n>-<slug>` per affected repo; follow repo conventions and
    project skills (e.g. `conventional-commit`, and the repo's spec rite when it has one). Names for
    anything new come from the approved Glossary (rail 8). A spec rite's task list is ticked task by
    task as each one lands and is validated, never in a batch at the end. Move the board item
    to the configured in-progress column when work starts.
-8. **Tests** — add/update tests per the issue's test strategy and the repo's framework.
+8. **Tests** — add/update tests per the issue's test strategy and the repo's framework. A test suite
+   the artifact passes is not proof it runs: **exercise it once through its real entry point** and
+   record what you observed, with the case matrix as counts. A green selftest and a green pipeline
+   shipped two defects that only an end-to-end run surfaced (measured 2026-08-26, issue #95). Where
+   the repo's spec rite carries a simulation group, this is what fills it; breaking the artifact on
+   purpose afterwards is `bug-hunter`, a different job.
 9. **Validate** — discover and run the repo's checks (`references/validation-matrix.md`); fix
    findings; re-run until green or report honest blockers. A repo that wires an identifier-locale
    check is running one of its own discovered commands — never invent one where none exists.
@@ -118,8 +125,8 @@ to the `backlog` skill; consumes the same config.
     is opened (`references/acceptance-tracking.md`). A spec rite's mandatory closure group is part
     of the sweep, not a separate afterthought.
 11. **PR(s)** — one per changed repo; primary repo's PR body carries `Closes #n`, others reference
-    `Relates to <issue-url>`, plus the evidence table and a **Known gaps** section when the sweep
-    left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
+    `Relates to <issue-url>`, plus the evidence table, the simulation's measured counts when the item
+    shipped a runtime artifact, and a **Known gaps** section when the sweep left anything unticked. Where the repo gates on a spec rite, the body also carries the line that
     gate reads — the change id, or the written waiver and its reason (`references/spec-rite.md`).
     No auto-merge. Follow `conventional-commit` PR rules when present.
 12. **Sync & report** — move the board item to the review column; comment on the issue with links


### PR DESCRIPTION
Closes #99

Spec-rite: add-simulation-rite-gate

## O problema, medido

O rito perguntava o que foi **lido** e o que foi **probado**. Nenhum gate perguntava se o artefato
chegou a **rodar**. No PR #96 isso custou dois defeitos que passaram por selftest verde e CI verde, e
só apareceram quando o hook foi wirado e um arquivo foi escrito de verdade:

```
tmp-sim/order_service/shipping_cost.py:1: valor_pedido   <- offset do fragmento, não linha do arquivo
tmp-sim/order_service/shipping_cost.py:3: valor_pedido   <- depois da correção
```

e o alcance da dispensa inline (a própria linha e a seguinte), que não estava escrito em lugar nenhum
— erro cometido duas vezes dentro daquela mesma change.

## O que muda

Quinto grupo obrigatório, `Simulation & Field Proof (MANDATORY)`, antes do Quality Gates:

| Caixa | Forma exigida |
|---|---|
| `S.1` | `ponto de entrada` -> fragmento da saída **observada**, ou declaração explícita de que a change não toca artefato de runtime |
| `S.2` | matriz de casos em números (`n/n`) |
| `S.3` | o que escapou, ou "nada escapou" explícito |

Presença é estrutural no `validate-rite.sh`; forma é por caixa no `validate-rite-evidence.py`, no
mesmo desenho por tipo que as caixas `E.` usam — porque regra uniforme já foi medida e rejeitada
neste script (reprovava 14 de 20 caixas históricas corretas).

**Válvula deliberada:** change que não toca runtime fecha o grupo declarando isso, como `E.3`/`E.4`
já aceitam ausência explícita. Sem ela, trabalho de documentação seria empurrado a inventar simulação
— que é padding, o oposto do que o gate quer.

**Bônus:** a validação de plugin no CI deixa de ser decorativa. Estava com `continue-on-error: true`
**e** `|| true` — nunca reprovou build nenhum. Agora bloqueia, com a versão pinada na que foi probada
(`2.1.246`), porque gate bloqueante em `@latest` reprova build por release de terceiro.

## Simulation & Field Proof desta própria change

Gates exercitados contra diretórios de change sintéticos, em cópia descartável do repositório:

| Caso | Esperado | Observado |
|---|---|---|
| change sem o grupo | reprovar | `::error::Missing mandatory group 'Simulation & Field Proof (MANDATORY)'` |
| três caixas infladas | reprovar | `rite evidence gate: 3 findings` — uma por regra |
| declara ausência de runtime | passar | `rite evidence gate: 0 findings` |
| grupo correto (forma) | passar | `rite evidence gate: 0 findings` |
| grupo correto (estrutural) | passar | sem erro |
| fixture de plugin quebrado | reprovar | `✘ Validation failed (--strict treats warnings as errors)` |
| este repositório | passar | `✔ Validation passed` |

```
casos que deviam reprovar e reprovaram: 2/2
casos que deviam passar e passaram:     3/3
classes de defeito no --selftest:       7/7  (3 novas: R2 simulation shape S.1/S.2/S.3)
sentidos do validador nativo:           2/2
```

**O que escapou, dito por escrito:** `validate-rite.sh` não fixa a **posição** do grupo novo — ele
ancora apenas primeiro e último grupo. Uma change que colocasse a simulação depois do Quality Gates
passaria no gate estrutural. Registrado no comentário do script e na decisão D1; fixar exigiria mexer
nas âncoras existentes, fora do escopo.

## Evidência

`validate-skills` 34/0 · `selftest-validate-skills` 13/13 · detector 7+6 tiers · hook 12 decisões ·
`repo-hygiene` 0 (+2/2) · `scan-secrets` 0 · `rite-evidence --selftest` **7/7** · `spec-rite` 3/3 +
6/6 + 6/6 · `validate-rite.sh` OK · `openspec --strict` valid · diff deste PR no detector de locale:
`findings: 0`.

## Fora de escopo, com o motivo

`claude plugin eval` é o lar definitivo desta camada — casos com graders `regex`/`tool_used`/`llm` e o
braço `--ablation with-without`, que mede se a skill **muda o comportamento** em vez de apenas
carregar. Medido: `claude plugin eval .` -> `` `plugin eval` is currently in early access ``. Não roda
nesta conta, e escrever suíte que não pode ser executada seria entregar artefato não verificado —
exatamente o que este PR existe para proibir. Vira item próprio quando o acesso abrir, e a primeira
entrega dele é uma suíte **rodada**.

## Known gaps

- `V.4` (`openspec archive`) é o único box aberto do rito, e roda depois do merge.
- O gate prova forma, nunca honestidade: caixa preenchida com saída inventada passa. Declarado no
  KNOWN LIMIT do script, como o gate irmão já declara.
