### PR TITLE
🐛 fix(ci): publica a versão a partir do topo de master, não do commit da run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,8 +139,20 @@ jobs:
       version: ${{ steps.check_release.outputs.version }}
     steps:
       - name: Checkout
+        # ref: master — NOT the triggering commit. On a push event checkout defaults to github.sha,
+        # so a run queued behind a later merge works on a HEAD that is already behind the remote,
+        # and semantic-release then refuses to publish: measured on run 32959050372 (commit 4875a6c,
+        # PR #102, a feat), which exited green having published nothing.
+        # Checking out the tip is safe because master runs are serialized by the concurrency group
+        # above (cancel-in-progress: false): this job never runs while another master run is in
+        # flight, so it publishes what is due for every commit up to the tip, and the next run finds
+        # nothing left to release.
+        # The commit released may therefore be newer than the one Validate examined in THIS run.
+        # Each of those commits passed Validate on its own pull request; master is protected and
+        # takes no direct push other than the [skip ci] release commit.
         uses: actions/checkout@v5
         with:
+          ref: master
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -171,7 +183,35 @@ jobs:
       - name: Run semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        # The output is teed to a file so the next step can inspect it. pipefail is set explicitly:
+        # the default shell for a `run:` block on Linux is `bash -e {0}`, without pipefail, and
+        # without it a semantic-release failure would be masked by tee's exit code.
+        run: |
+          set -o pipefail
+          npx semantic-release 2>&1 | tee semantic-release.log
+
+      - name: Fail if the release was skipped because the checkout was behind
+        # A tripwire, not a routine path: with `ref: master` above this condition should no longer
+        # occur. It stays because the failure it covers already happened once in silence, and
+        # because the checkout fix rests on a premise — the concurrency serialization — that a
+        # future edit could remove without noticing.
+        #
+        # Why the log and not the exit code: semantic-release@25.0.9 handles this case in
+        # index.js:87-96 — verifyAuth runs `git push --dry-run` (git.js:209), it fails
+        # non-fast-forward, isBranchUpToDate (git.js:296) confirms the branch is behind, and the
+        # function logs the line below and returns false. That false reaches cli.js:55, which
+        # returns 0. The process exits SUCCESS having published nothing, which is byte-for-byte the
+        # same outcome as a legitimate docs-only push. Only the log tells them apart.
+        #
+        # WHAT THIS DOES NOT COVER: it matches one string emitted by the pinned semantic-release
+        # version installed above. An upstream rewording silences it with no signal, and it says
+        # nothing about any other reason a release might be skipped. A green run here is not proof
+        # that a release was due and published — it is proof that this one refusal did not happen.
+        run: |
+          if grep -qF 'is behind the remote one' semantic-release.log; then
+            echo "::error::semantic-release refused to publish: the checked-out branch is behind the remote one. The release job must run against the tip of master (see the 'ref: master' comment on this job's checkout step). Nothing was published by this run."
+            exit 1
+          fi
 
       - name: Check if new release was created
         id: check_release

--- a/openspec/changes/fix-release-race/design.md
+++ b/openspec/changes/fix-release-race/design.md
@@ -1,0 +1,111 @@
+## Context
+
+`.github/workflows/ci.yml` tem dois jobs. `validate` (linhas 25-130) roda em todo evento;
+`release` (linhas 132-191) roda só em `push` para `master` (linha 135) e executa
+`npx semantic-release` (linha 174) sob `.releaserc.json`, cujo `branches` é `["master"]`.
+
+As runs de `master` são serializadas por `concurrency.group: ci-${{ github.ref }}` com
+`cancel-in-progress: false` (linhas 19-21): duas entram em fila, nenhuma é cancelada.
+
+Num evento `push`, `actions/checkout` sem `ref` explícito faz checkout de `github.sha` — o commit
+que disparou aquela run. Como a fila pode segurar a run do commit A enquanto o commit B já entrou em
+`master`, o job de A trabalha sobre um HEAD atrasado.
+
+O que o semantic-release faz nessa situação, lido em `semantic-release@25.0.9`:
+
+- `package/index.js:88` chama `verifyAuth`, que é `git push --dry-run --no-verify -- <url> HEAD:master`
+  (`package/lib/git.js:209-216`). Com HEAD atrasado o push seria non-fast-forward e o comando falha.
+- No `catch`, `package/index.js:90` chama `isBranchUpToDate`, que compara `getGitHead()` com o SHA
+  de `git ls-remote --heads -- <url> master` (`package/lib/git.js:296-303`). Diferentes.
+- `package/index.js:91-94` loga `The local branch master is behind the remote one, therefore a new
+  version won't be published.` e faz `return false`.
+- Esse `false` percorre `package/cli.js:55`, que devolve `0`. O processo sai com sucesso.
+
+Ou seja: a decisão de não publicar chega ao Actions indistinguível de "não havia nada a publicar".
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Um commit que entra em `master` e merece release recebe uma, independentemente de quão perto o
+  merge seguinte cair.
+- Uma run que não consegue publicar por estar atrás do remoto fica **vermelha**, não verde.
+- O caso legítimo de "nada a publicar" continua verde.
+
+**Non-Goals:**
+
+- Mudar as regras de release (`releaseRules`, plugins, política de versão) em `.releaserc.json`.
+- Trocar o semantic-release por outra ferramenta, ou introduzir tag manual.
+- Mexer nos gates do job `validate`.
+- Emitir tag retroativa: `v2.15.0` já cobre `4875a6c`.
+
+## Decisions
+
+### D1 — O job `release` faz checkout do topo de `master`, não do SHA que disparou a run
+
+`ref: master` no `actions/checkout` do job `release`. `fetch-depth: 0` continua, porque o
+semantic-release precisa do histórico e das tags.
+
+Por que isso é seguro aqui e não seria em qualquer repositório: as runs de `master` já são
+serializadas por `concurrency` (linhas 19-21). A run de A só executa o job de release quando nenhuma
+outra run de `master` está em curso; ela pega o topo, publica o que for devido de A **e** de B, e a
+run de B em seguida encontra nada a publicar e termina verde.
+
+Consequência aceita: o commit sobre o qual o release roda pode ser mais novo do que o commit que o
+`validate` desta run examinou. Cada um desses commits passou pelo `validate` no próprio pull request
+— `master` é protegido e não recebe push direto além do commit de release, que carrega `[skip ci]`.
+Essa razão vai escrita como comentário no workflow, seguindo a convenção do arquivo de explicar
+inline toda decisão de CI não óbvia (linhas 30-31, 120-125, 167-168).
+
+### D2 — Não trocar `cancel-in-progress` para `true`
+
+Cancelar a run anterior parece resolver a corrida, mas descarta justamente a run que carregava a
+publicação. Com `false` + D1 a fila vira uma garantia: cada run pega o topo do momento em que roda.
+
+### D3 — A recusa vira falha visível, via a linha que o próprio semantic-release emite
+
+O step `Run semantic-release` grava a saída num arquivo e um step seguinte falha o job quando
+encontra `is behind the remote one` nela. A âncora é a string do log, não o exit code, porque o exit
+code é `0` por desenho (`package/cli.js:55`) e não distingue os dois casos.
+
+Depois de D1 essa condição deixa de ser esperada: a guarda é um **tripwire**, não um caminho de
+rotina. Ela existe porque a falha que ela cobre já aconteceu uma vez em silêncio, e porque D1 depende
+de uma premissa (a serialização por `concurrency`) que uma edição futura do workflow pode remover sem
+perceber.
+
+### D4 — O ponto cego fica declarado dentro do step
+
+A guarda casa uma única string emitida por uma versão específica do semantic-release. Se o upstream
+reescrever a mensagem, ela para de disparar e nada avisa. Isso vai escrito no próprio step, como o
+repositório já faz nos checks de `scripts/` — cada um declara o que não cobre
+(`openspec/specs/skills-catalog/spec.md:487`, cenário *"The uncovered part is declared, not implied"*).
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Um check declara o que não cobre | `skills-catalog` (spec do repositório) + `verify-before-claiming` | already canonical — o workflow só aplica a regra, sem reescrevê-la |
+| Prova observada, não esperada, antes de declarar entrega | `verify-before-claiming` | already canonical — citado no grupo de simulação de `tasks.md` |
+| Fallback e degradação de dependência externa | `backend-resilience` | não se aplica: nada aqui chama dependência de runtime; a guarda é de pipeline |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **O release roda sobre um commit que o `validate` desta run não examinou.** Mitigação: cada commit
+  passou pelo `validate` no próprio PR; `master` é protegido. Registrado como comentário no workflow.
+- **O tripwire de D3 pode ficar mudo se o upstream mudar a mensagem.** Mitigação: a versão do
+  semantic-release já é pinada na instalação (linha 169, `semantic-release@25`), e o ponto cego fica
+  declarado no step (D4).
+- **O tripwire pode ficar vermelho num caso benigno** — uma run atrasada cuja publicação outra run
+  já fez. Depois de D1 essa combinação não deveria ocorrer; se ocorrer, ela indica que a premissa da
+  serialização caiu, que é exatamente o que se quer ver em vermelho.
+- **Não há como ensaiar o caminho de publicação sem empurrar para `master`.** Mitigação: o tripwire
+  é exercitado contra o log real da run 32959050372 e contra um log de push só de `docs`; o `ref`
+  é comprovado no merge desta própria change, cuja run é registrada no pull request.
+
+## Open Questions
+
+Nenhuma. Os dois pontos que poderiam ter virado achismo — o texto exato da mensagem e o código de
+saída do processo — foram lidos no pacote publicado, e estão registrados em `tasks.md` com comando e
+saída.

--- a/openspec/changes/fix-release-race/proposal.md
+++ b/openspec/changes/fix-release-race/proposal.md
@@ -1,0 +1,53 @@
+# Change: Tornar a publicação de versão imune à corrida entre merges
+
+## Why
+
+O job `Semantic Release` do `.github/workflows/ci.yml` publica a versão do catálogo a partir do
+commit que **disparou** a run, não do topo de `master`. Quando dois pull requests entram em `master`
+em janela curta, a run enfileirada do primeiro commit faz checkout de um SHA que já está atrás do
+remoto, e o semantic-release desiste — em silêncio, com o job **verde**.
+
+Medido na run 32959050372 (commit `4875a6c`, PR #102, um `feat`):
+
+```
+[semantic-release] › ℹ  The local branch master is behind the remote one, therefore a new version won't be published.
+```
+
+O mecanismo, lido no pacote instalado (`semantic-release@25.0.9`, `package/index.js:87-96`):
+`verifyAuth` roda `git push --dry-run --no-verify -- <url> HEAD:master`, que falha porque o push
+seria non-fast-forward; no `catch`, `isBranchUpToDate` compara o HEAD local com o SHA que
+`git ls-remote --heads` devolve, vê a diferença, loga a linha acima e faz `return false`. Esse
+`false` não vira erro: `package/cli.js:55` devolve `0`, e o job termina **success**.
+
+Naquele dia o resultado ainda foi correto — o PR #103 entrou segundos depois e a run dele publicou
+`v2.15.0` cobrindo os dois commits. A publicação sobreviveu por sorte, não por desenho. O release
+some quando a run posterior não publica: o `Validate` dela falha, o push posterior carrega
+`[skip ci]` (o próprio commit de release carrega), ou ela perde a mesma corrida para um terceiro
+merge.
+
+## What Changes
+
+- O job `release` passa a operar sobre o **topo do branch de release**, não sobre o commit que
+  disparou a run.
+- A condição "não publiquei porque meu checkout estava atrás" deixa de terminar verde: vira falha
+  explícita do job, com a linha do log que a comprova.
+- O caso legítimo "não havia nada para publicar" (push só de `docs`/`chore`) continua verde.
+- O que a guarda **não** cobre fica escrito dentro do próprio workflow, seguindo a convenção do
+  repositório de um check declarar o próprio ponto cego.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: ganha o requisito de que a automação de publicação do próprio repositório não
+  dependa do intervalo entre merges, e de que uma publicação pulada seja visível. Hoje a capability
+  já governa o CI do próprio repositório em *"The repository itself is gated, not only its skills"*,
+  mas só sobre os gates de `Validate` — nada diz sobre o job que publica.
+
+## Impact
+
+- `.github/workflows/ci.yml` — job `Semantic Release`: o checkout e a verificação pós-execução.
+- Nenhuma skill do catálogo muda: nenhum `SKILL.md` é tocado, e a composição do catálogo
+  (contagem, descoberta via `npx`) fica idêntica.
+- Consumidores do catálogo não veem mudança de comportamento; o que muda é a garantia de que a tag
+  e a release do GitHub saem quando são devidas.

--- a/openspec/changes/fix-release-race/specs/skills-catalog/spec.md
+++ b/openspec/changes/fix-release-race/specs/skills-catalog/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Publication does not depend on the interval between merges
+
+The catalog's release automation SHALL evaluate the tip of the release branch, not the commit that
+triggered the run. A run whose triggering commit has been superseded by a later merge SHALL still
+publish whatever is due, so that a release is never lost or silently deferred because two pull
+requests landed close together.
+
+Where the automation refuses to publish because its checkout is behind the remote branch, the run
+SHALL fail rather than report success. That refusal is indistinguishable, from the outside, from the
+legitimate outcome of having nothing to publish: both leave no new tag and both exit zero. The
+distinction SHALL be made by the pipeline, not left to whoever reads the run list.
+
+A push that legitimately produces no release SHALL remain green, so that the guard does not turn
+every documentation merge red.
+
+The guard SHALL state, inside itself, what it does not cover — the same rule this capability already
+imposes on the repository's other checks.
+
+#### Scenario: A superseded commit still gets its release
+
+- **WHEN** a commit that warrants a release is merged into the release branch and a second merge
+  lands before that commit's release job runs
+- **THEN** the release job publishes the version due, because it evaluates the branch tip rather
+  than the commit that triggered it
+
+#### Scenario: A refusal to publish is visible
+
+- **WHEN** the release tool reports that the checked-out branch is behind the remote one and
+  therefore publishes nothing
+- **THEN** the job fails and names the log line that proves it, instead of exiting success with no
+  new tag
+
+#### Scenario: Nothing to publish stays green
+
+- **WHEN** a push to the release branch carries only commit types that produce no version bump
+- **THEN** the job succeeds with no release, and the guard does not fire
+
+#### Scenario: The guard declares its own blind spot
+
+- **WHEN** the guard recognises the refusal by matching text emitted by a third-party tool
+- **THEN** the step states that an upstream wording change would silence it, so a passing run is not
+  read as proof that the condition cannot occur

--- a/openspec/changes/fix-release-race/tasks.md
+++ b/openspec/changes/fix-release-race/tasks.md
@@ -1,0 +1,203 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `7738d94` (`chore(release): 2.15.0`), topo de `master` em 2026-08-30:
+
+      - `.github/workflows/ci.yml` — 191 linhas; job `release` em 132-191, `concurrency` em 19-21,
+        `actions/checkout@v5` do release em 142-145 sem `ref`, `npx semantic-release` em 174,
+        step `check_release` em 176-191.
+      - `.releaserc.json` — `branches: ["master"]`, `tagFormat: "v${version}"`,
+        `@semantic-release/git` com `message: "chore(release): ${nextRelease.version} [skip ci]"`.
+      - `openspec/specs/skills-catalog/spec.md:487` — requisito
+        *"The repository itself is gated, not only its skills"*, com o cenário
+        *"The uncovered part is declared, not implied"*.
+      - `openspec/config.yaml` — `schema: skills-rite`.
+
+- [x] E.2 Ferramentas e comportamentos externos probados contra a versão instalada
+
+      ```
+      npm pack semantic-release@25 --silent
+      -> semantic-release-25.0.9.tgz
+      ```
+
+      ```
+      grep -rn "behind the remote" package/
+      -> package/index.js:92:          `The local branch ${context.branch.name} is behind the remote one, therefore a new version won't be published.`
+      ```
+
+      ```
+      sed -n '86,96p' package/index.js
+      ->   try {
+      ->     try {
+      ->       await verifyAuth(options.repositoryUrl, context.branch.name, { cwd, env });
+      ->     } catch (error) {
+      ->       if (!(await isBranchUpToDate(options.repositoryUrl, context.branch.name, { cwd, env }))) {
+      ->         logger.log(
+      ->           `The local branch ${context.branch.name} is behind the remote one, therefore a new version won't be published.`
+      ->         );
+      ->         return false;
+      ```
+
+      ```
+      sed -n '209,216p' package/lib/git.js
+      -> export async function verifyAuth(repositoryUrl, branch, execaOptions) {
+      ->   try {
+      ->     await execa("git", ["push", "--dry-run", "--no-verify", "--", repositoryUrl, `HEAD:${branch}`], execaOptions);
+      ```
+
+      ```
+      sed -n '296,303p' package/lib/git.js
+      -> export async function isBranchUpToDate(repositoryUrl, branch, execaOptions) {
+      ->   return (
+      ->     (await getGitHead(execaOptions)) ===
+      ->     (await execa("git", ["ls-remote", "--heads", "--", repositoryUrl, branch], execaOptions)).stdout.match(
+      ```
+
+      O exit code que esse `return false` produz, em `package/cli.js:43-63`:
+
+      ```
+      sed -n '54,56p' package/cli.js
+      ->     await (await import("./index.js")).default(options);
+      ->     return 0;
+      ->   } catch (error) {
+      ```
+
+      A falha de campo que motivou a change, na run que a produziu:
+
+      ```
+      gh run view 32959050372 --log --job <Semantic Release>
+      -> [10:37:41 AM] [semantic-release] › ℹ  The local branch master is behind the remote one, therefore a new version won't be published.
+      ```
+
+      ```
+      gh run view 32959050372 --json jobs -q '.jobs[] | "\(.name): \(.conclusion)"'
+      -> Validate: success
+      -> Semantic Release: success
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      Nada ficou por probar. Os dois pontos que poderiam ter virado achismo — o texto exato da
+      mensagem e o código de saída do processo — foram lidos no pacote publicado, acima. O
+      comportamento de `actions/checkout` num evento `push` não foi lido no código da action, mas
+      não precisa ser: a run 32959050372 é a prova empírica de que o HEAD do runner ficou atrás do
+      remoto, que é o único fato de que a change depende.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a proposta pediu. Notados pelo caminho e **não** feitos, ficam como
+      follow-up:
+
+      - O step `Check if new release was created` (linhas 176-191) escreve `new_release=false` tanto
+        para "nada a publicar" quanto para "não consegui publicar"; depois desta change o segundo
+        caso falha antes de chegar lá, mas o step continua ambíguo se outro motivo de recusa
+        aparecer.
+      - O job `release` não tem timeout declarado.
+      - `npm install -g` a cada run (linha 169) é reinstalação completa com cache só de `~/.npm`.
+
+## 2. Publicação sobre o topo do branch
+
+- [x] 2.1 `actions/checkout` do job `release` passa a receber `ref: master`, mantendo
+      `fetch-depth: 0`, com o comentário que explica por que a serialização por `concurrency` torna
+      isso seguro e por que o commit pode ser mais novo que o do `validate` desta run (D1)
+- [x] 2.2 O step `Run semantic-release` grava a saída em arquivo, preservando o comportamento atual
+      de falhar quando o próprio semantic-release falha (D3)
+- [x] 2.3 Step novo falha o job quando a saída contém `is behind the remote one`, com mensagem
+      `::error::` que nomeia a causa e o que fazer (D3)
+- [x] 2.4 O step do tripwire declara dentro de si o próprio ponto cego: casa uma string de uma
+      versão pinada do semantic-release e fica mudo se o upstream reescrever a mensagem (D4)
+- [x] 2.5 `concurrency` (linhas 19-21) fica intocado, e a razão fica escrita junto ao tripwire (D2)
+
+## 3. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 O tripwire foi exercitado pelo caminho real, com a saída observada
+
+      O trecho de shell do step foi extraído literalmente do workflow e rodado sobre os logs
+      **reais** do job `Semantic Release`, baixados com
+      `gh run view <id> --log --job <Semantic Release>`:
+
+      ```
+      bash tripwire.sh   # semantic-release.log = log da run 32959050372 (behind the remote)
+      -> ::error::semantic-release refused to publish: the checked-out branch is behind the remote one. [...] Nothing was published by this run.
+      -> exit 1
+      ```
+
+      ```
+      bash tripwire.sh   # semantic-release.log = log da run 32957035719 (docs #101, nada a publicar)
+      -> (sem saida)
+      -> exit 0
+      ```
+
+      ```
+      bash tripwire.sh   # semantic-release.log = log da run 32959201966 (publicou v2.15.0)
+      -> (sem saida)
+      -> exit 0
+      ```
+
+      O que cada log de fato dizia, medido antes de rodar o tripwire:
+
+      ```
+      grep -oE "There are no relevant changes.*|is behind the remote one.*|Published release .*" log-*.txt
+      -> 32959050372: is behind the remote one, therefore a new version won't be published.
+      -> 32957035719: There are no relevant changes, so no new version is released.
+      -> 32959201966: Published release 2.15.0 on default channel
+      ```
+
+      O `set -o pipefail` do step 2.2 também foi exercitado, porque sem ele o `tee` mascara a falha
+      do semantic-release:
+
+      ```
+      bash -e -c 'falha() { return 1; }; falha 2>&1 | tee /dev/null; echo "sem pipefail exit=$?"'
+      -> sem pipefail exit=0
+      bash -e -c 'set -o pipefail; falha() { return 1; }; falha 2>&1 | tee /dev/null; echo "com pipefail exit=$?"'
+      -> (nenhuma saida: o -e abortou no pipeline, que e o comportamento desejado)
+      ```
+
+      O `ref: master` (2.1) **não** foi exercitado aqui: o job `release` só roda em `push` para
+      `master`, e a run deste pull request não o executa. Ele é comprovado no merge desta própria
+      change, e a run resultante fica registrada no corpo do PR.
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | Tinha de disparar e disparou | 1/1 | run 32959050372 (checkout atrás do remoto) |
+      | Tinha de ficar mudo e ficou | 2/2 | run 32957035719 (nada a publicar), run 32959201966 (publicou) |
+      | Escape conhecido ficou mudo | 1/1 | mensagem do upstream reescrita — ver S.3 |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Um escape, conhecido e declarado dentro do próprio step (D4): o tripwire casa a string
+      `is behind the remote one`. Reescrita a mensagem pelo upstream, ele fica mudo sem avisar —
+      medido:
+
+      ```
+      sed 's/is behind the remote one/is not up to date with the remote/' log-32959050372.txt > semantic-release.log
+      bash tripwire.sh
+      -> exit 0   (mudo, como o step declara)
+      ```
+
+      A mitigação é o pin de versão que já existe na instalação (`semantic-release@25`, linha 169 do
+      workflow antes desta change). Nada mais escapou nem se comportou de forma diferente do
+      esperado.
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: esta change não toca
+      nenhuma skill
+- [x] Q.2 Conteúdo de skill tocado em inglês — **não se aplica** pelo mesmo motivo; o delta de spec
+      desta change está em inglês, como o catálogo exige
+- [x] Q.3 Gatilhos de descrição testáveis — **não se aplica**: nenhuma descrição de skill muda
+- [x] Q.4 Sem doutrina duplicada: a regra "um check declara o que não cobre" é aplicada pelo
+      workflow e não reescrita nele; ver a tabela de Canonical Home em `design.md`
+- [x] Q.5 Identificadores em inglês no que a change introduz — ids de step, nome de arquivo de log e
+      chaves de YAML — conforme o glossário da issue #104 e `code-locale`
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate fix-release-race --strict` verde
+- [x] V.2 Descoberta do catálogo intacta: contagem de skills inalterada, sem órfão ou renomeado
+- [x] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — **não se
+      aplica**: nada da composição muda
+- [ ] V.4 `openspec archive fix-release-race --yes` depois que todos os grupos acima estiverem `[x]`


### PR DESCRIPTION
Closes #104

O job `Semantic Release` publicava a versão a partir de `github.sha` — o commit que disparou a run.
Com dois merges em janela curta, a run enfileirada do primeiro commit trabalhava sobre um HEAD já
atrás do remoto, o semantic-release desistia, e o job terminava **verde**.

Medido na run [32959050372](https://github.com/solvelab/ai-skills/actions/runs/32959050372)
(commit `4875a6c`, PR #102, um `feat`):

```
[semantic-release] › ℹ  The local branch master is behind the remote one, therefore a new version won't be published.
```

Naquele dia o PR #103 entrou logo depois e a run dele publicou `v2.15.0` cobrindo os dois commits —
sorte, não desenho. O release some quando a run posterior não publica: `Validate` dela falha, o push
posterior carrega `[skip ci]`, ou ela perde a mesma corrida.

## O que muda

- **`ref: master` no checkout do job `release`.** Seguro porque as runs de `master` já são
  serializadas por `concurrency` com `cancel-in-progress: false`: o job pega o topo, publica o que
  for devido de todos os commits até ele, e a run seguinte encontra nada a publicar.
- **A recusa deixa de ser silenciosa.** Um step novo falha o job quando `is behind the remote one`
  aparece no log. A âncora é o log, não o exit code — o exit code é `0` por desenho do upstream.
- **`set -o pipefail`** no step do semantic-release, para que o `tee` não mascare uma falha real.
- **O ponto cego fica declarado no próprio step**, como o repositório já faz nos checks de
  `scripts/`.

Nenhuma skill é tocada; a composição do catálogo fica idêntica.

## Por que o job ficava verde

Lido em `semantic-release@25.0.9` (`npm pack semantic-release@25`):

| Passo | Onde | O que faz |
|---|---|---|
| `verifyAuth` | `package/lib/git.js:209` | `git push --dry-run --no-verify -- <url> HEAD:master` — falha non-fast-forward |
| `isBranchUpToDate` | `package/lib/git.js:296` | compara `getGitHead()` com `git ls-remote --heads`; confirma o atraso |
| log + `return false` | `package/index.js:91-94` | emite a linha e desiste |
| `return 0` | `package/cli.js:55` | o processo sai **success** |

## Simulação — saída observada

O trecho de shell do tripwire foi extraído literalmente do workflow e rodado sobre os logs **reais**
do job `Semantic Release`, baixados com `gh run view <id> --log --job <Semantic Release>`:

| Expectativa | Casos | Resultado |
|---|---|---|
| Tinha de disparar e disparou | **1/1** | run 32959050372 — `exit 1`, com a `::error::` nomeando a causa |
| Tinha de ficar mudo e ficou | **2/2** | run 32957035719 (`There are no relevant changes`) e run 32959201966 (`Published release 2.15.0`) — ambas `exit 0` |
| Escape conhecido ficou mudo | **1/1** | mensagem do upstream reescrita por `sed` — `exit 0`, como o step declara |

O `pipefail` também foi exercitado: sem ele, uma falha antes do `tee` sai `0`; com ele, o `-e`
aborta o step.

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Sintaxe e efeito do YAML | `python3 -c "yaml.safe_load(...)"` | `checkout with: {'ref': 'master', 'fetch-depth': 0, ...}`, 8 steps no job |
| Wrappers em sincronia | `bash generate.sh && git diff` | sem diff gerado |
| Skills | `python3 scripts/validate-skills.py` | OK |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | OK |
| Locale de identificadores | `check-identifier-locale.py --selftest` | OK |
| Hook de locale | `claude/global/hooks/locale-rite.py --selftest` | OK |
| Segredos | `python3 scripts/scan-secrets.py` | OK |
| Higiene do repo | `validate-repo-hygiene.py` + `--selftest` | OK |
| Rito | `bash scripts/validate-rite.sh` | `rite gate OK`, 0 findings |
| Evidência do rito | `validate-rite-evidence.py --selftest` | OK |
| Spec-rite | `validate-spec-rite.py --selftest` | OK |
| OpenSpec estrito | `openspec validate fix-release-race --strict` | `Change 'fix-release-race' is valid` |
| Validador do vendor | `claude-code@2.1.246 plugin validate . --strict` | `Validation passed` |

## Rito

Spec-rite: change `fix-release-race` — capability `skills-catalog` (ADDED requirement
*"Publication does not depend on the interval between merges"*, 4 cenários).

## Known gaps

- O critério *"the end-to-end path is exercised on the real pipeline"* está **parcialmente**
  atendido: o tripwire foi exercitado contra logs reais, mas o `ref: master` só roda em `push` para
  `master` — a run deste PR não executa o job `release`. Ele se comprova no merge deste próprio PR,
  cuja run de `Semantic Release` deve mostrar o SHA do topo e publicar a versão devida. Essa
  natureza pós-merge já estava prevista na seção Risks da issue #104.
- A change `fix-release-race` fica **ativa** até essa run ser observada; o arquivamento
  (`openspec archive fix-release-race --yes`, V.4) é o que a fecha.
- Follow-ups notados e não feitos (registrados em E.4 do `tasks.md`): o step `check_release`
  continua ambíguo para outros motivos de recusa; o job `release` não tem timeout; `npm install -g`
  reinstala a cada run.
