### PR TITLE
✨ feat(ci): cumpre os limites da spec Agent Skills e os mede no validador e no CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,34 @@ jobs:
 
       - name: Skill content checks (paths, cross-refs, code blocks, pins)
         run: |
-          python3 -m pip install --quiet pyyaml
+          python3 -m pip install --quiet pyyaml skills-ref==0.1.1
           sudo apt-get install -y -qq lua5.4 >/dev/null 2>&1 || true
           python3 scripts/validate-skills.py
 
       - name: Skill validator self-test (the gate is itself gated)
         run: python3 scripts/selftest-validate-skills.py
+
+      - name: Agent Skills reference validator (skills-ref, pinned, blocking)
+        # README.md says the catalog follows the open Agent Skills standard; this is the standard's
+        # own validator (PyPI `skills-ref`, binary `agentskills` — not `skills-ref`), installed on
+        # the pip line above so a missing package fails loudly. Measured on 2026-09-04 with 0.1.1:
+        # it rejected 5 of 35 skills for a description over 1024 characters before this step existed.
+        #
+        # The version is pinned on purpose: skills_ref/validator.py:15-22 whitelists the frontmatter
+        # fields it accepts, so a newer release could reject a field this catalog uses and fail the
+        # build on someone else's release schedule. Bump it deliberately, after running it locally
+        # over skills/*.
+        #
+        # WHAT THIS COVERS AND WHAT IT DOES NOT: name (length, charset, == directory), description
+        # and compatibility limits, and the field whitelist — per skill, frontmatter only. It reads
+        # nothing below the frontmatter: bodies, references/, cross-skill links and code blocks stay
+        # with scripts/validate-skills.py, whose C10 measures the same two limits so the two agree.
+        run: |
+          fail=0
+          for d in skills/*/; do
+            agentskills validate "$d" || fail=1
+          done
+          exit $fail
 
       - name: Identifier-locale detector self-test (the shipped script is itself gated)
         run: python3 skills/code-locale/references/check-identifier-locale.py --selftest

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Supports **Claude Code**, **OpenAI Codex**, **Cursor**, and **GitHub Copilot** f
 
 ## 🚀 Install
 
-Skills follow the open [Agent Skills](https://github.com/vercel-labs/skills) standard (`skills/<name>/SKILL.md`), so every mainstream install path works.
+Skills follow the open [Agent Skills](https://agentskills.io/specification) standard (`skills/<name>/SKILL.md`), so every mainstream install path works — including the [`npx skills`](https://github.com/vercel-labs/skills) CLI of Option A.
 
 ### Option A — `npx skills` (recommended, works with 70+ agents)
 
@@ -378,7 +378,7 @@ ai-skills/
 
 ## 🔀 Multi-Tool Architecture
 
-The canonical skill lives in `skills/<name>/SKILL.md` — a **self-contained** file following the open [Agent Skills](https://github.com/vercel-labs/skills) standard (YAML frontmatter + full instructions + optional `references/`). Because it's self-contained, `npx skills`, the Claude Code plugin, and plain directory copies all work without this repo being present at a fixed path.
+The canonical skill lives in `skills/<name>/SKILL.md` — a **self-contained** file following the open [Agent Skills](https://agentskills.io/specification) standard (YAML frontmatter + full instructions + optional `references/`). Because it's self-contained, `npx skills`, the Claude Code plugin, and plain directory copies all work without this repo being present at a fixed path.
 
 `generate.sh` derives all tool-specific wrappers from it:
 

--- a/claude/skills/api-resilience-testing/SKILL.md
+++ b/claude/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/assettoserver-csp-lua/SKILL.md
+++ b/claude/skills/assettoserver-csp-lua/SKILL.md
@@ -4,18 +4,17 @@ description: >-
   Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the
   zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API
   in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte
-  with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry,
-  and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a
-  production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD,
-  toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or
-  overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently
-  never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands,
-  publishing (that is assettoserver-plugin), for server configuration/deploy (that is
-  assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different
-  permissions), or for FiveM Lua (that is fivem-lua).
+  with the C# plugin, remote images and audio loaded by URL, local car telemetry, and the
+  mockup-first workflow for visuals you cannot render outside the game. Use when writing or
+  reviewing a .lua online script (overlay, HUD, toast, in-game sound, login UI), when a CSP
+  overlay renders wrong (empty flat box, glued or overlapping text, missing glyphs, sound plays
+  only once), or when an OnlineEvent packet silently never arrives. Do NOT use for the C# plugin
+  side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for
+  server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts
+  (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 metadata:
   author: solvelab
-  version: 1.0.1
+  version: 1.1.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -1,24 +1,20 @@
 ---
 name: backlog
 description: >-
-  Turn a natural-language idea into a structured GitHub backlog item: analyze the current
-  repository (or multi-repo workspace) for real context, draft a rich issue (context, problem,
-  scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create
-  the GitHub issue and add it to the configured GitHub Project v2 with fields set
-  (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
-  "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
-  idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite:
-  the item created here is what execute-backlog turns into a branch and a pull request. In a
-  repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also
-  declares its spec verdict — the change that will register the work, or a written waiver —
-  so execute-backlog inherits a decision instead of making a new one.
-  First run per repo/workspace launches a
-  config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
-  use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
-  for non-GitHub trackers (Jira, Linear, Trello).
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the repository (or
+  multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance
+  criteria, risks, affected files/repos), preview it for approval, then create the issue and add
+  it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the
+  gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to
+  the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in
+  a GitHub Project. Entry point of the backlog-first rite: execute-backlog turns the item created
+  here into a branch and a pull request. In a repository with a spec-driven workflow (an openspec/
+  directory) the item also declares its spec verdict: a change id or a written waiver. Do NOT use
+  for implementing an existing issue (that is execute-backlog), for creating pull requests, or for
+  non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.4.0
+  version: 1.5.0
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/code-locale/SKILL.md
+++ b/claude/skills/code-locale/SKILL.md
@@ -1,36 +1,29 @@
 ---
 name: code-locale
 description: >-
-  Decides which natural language each artifact of a change is written in: prose follows the
-  repository's working language, and anything a machine parses is English. Use when naming a
-  variable, function, class, file, module, REST route segment, query param, DB table or column,
-  enum value, event or topic name, config key or log field; when reviewing a diff or PR that
-  introduces names; when a backlog item written in another language is about to become code; when
-  deciding whether a domain term like CPF, CNPJ, boleto, PIX or nota fiscal keeps its name; when an
-  external API's payload fields are in another language; or when the user says "código em
-  português", "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador
-  em inglês", "should this be in English", "our code is half Portuguese", "naming convention",
-  "ubiquitous language", "anti-corruption layer". Covers the prose/machine boundary, the
-  untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only
-  migration policy, and a shipped detector a repository can wire into CI. Do NOT use for the
-  language of commit subjects or PR bodies (that is conventional-commit), for the language of
-  documentation prose (that is documentation), for format-level naming conventions like case style
-  or test-method patterns (those live in each stack's skill), or for i18n and user-facing
-  translation.
+  Decides which natural language each artifact is written in: prose follows the repository's
+  working language, anything a machine parses is English. Use when naming a variable, function,
+  class, file, route, query param, DB table or column, enum value, event, config key or log field;
+  when reviewing a diff that introduces names; when a backlog item in another language becomes
+  code; when a domain term like CPF, CNPJ, boleto, PIX or nota fiscal may keep its name; when an
+  external API's payload is in another language; or when the user says "código em português",
+  "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador em
+  inglês", "should this be in English", "our code is half Portuguese", "naming convention",
+  "ubiquitous language", "anti-corruption layer". Do NOT use for commit subjects or PR bodies
+  (that is conventional-commit), for docs prose (that is documentation), for case style or test
+  naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
   The doctrine is language- and stack-agnostic and needs no runtime. The shipped detector
-  `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package; it
-  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, measures the path of
-  every file it is given, reports the contents of any other file type as skipped rather than
-  passing, and ships the public-domain word list that answers its second question (read with the
-  standard library's gzip module, so there is still no third-party package). The optional write-time hook `claude/global/hooks/locale-rite.py` needs a harness that
-  emits a post-write tool event; it was built against Claude Code 2.1.246 and exits silently
-  anywhere else.
+  `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package (its word
+  list is read with the standard library's gzip module); it tokenizes Python, Lua, JavaScript,
+  TypeScript, C#, SQL, YAML, JSON and Bash and reports any other file type as skipped. The
+  optional hook `claude/global/hooks/locale-rite.py` was built against Claude Code 2.1.246 and
+  exits silently anywhere else.
 ---
 
 Read and follow all instructions in ~/ai-skills/skills/code-locale/SKILL.md

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -2,23 +2,19 @@
 name: execute-backlog
 description: >-
   Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search),
-  validate it is complete enough to execute, re-analyze the current repo/workspace state, present
-  an implementation plan for approval BEFORE touching code, implement on a dedicated branch
-  following the repo's conventions, add/update tests, run the repo's discoverable validations
-  (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by
-  evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to
-  the review column. Use when the user invokes /execute-backlog <n>, says
-  "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
-  issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced
-  by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a
-  spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code:
-  the item's spec verdict is re-checked, the change is created and validated strict, and only then
-  does the plan go to approval. Uses the backlog skill's
-  config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items
-  (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+  validate it is complete enough, re-analyze the repo/workspace, present an implementation plan
+  for approval BEFORE touching code, implement on a dedicated branch with tests, run the repo's
+  discoverable validations, tick the acceptance criteria proven by evidence, open pull request(s)
+  with Closes #n, and move the GitHub Project item to the review column. Use when the user invokes
+  /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this
+  ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite:
+  consumes the item the backlog skill produced. In a repository with a spec-driven workflow (an
+  openspec/ directory) it re-checks the item's spec verdict and validates the change strict before
+  the plan goes to approval. Do NOT use for creating backlog items (that is backlog), for merging
+  PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.7.0
+  version: 1.8.0
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/verify-before-claiming/SKILL.md
+++ b/claude/skills/verify-before-claiming/SKILL.md
@@ -1,22 +1,20 @@
 ---
 name: verify-before-claiming
 description: >-
-  Anti-guessing rite: research before asserting, label every claim with its source, and report what
-  could not be found instead of producing a plausible substitute. Use when about to state or use an
-  API, CLI flag, config key, env var, path, version or behavior not read in this session; when a fact
-  depends on a library version; when the answer cannot be found and the gap has to be reported; or
-  when the user says "you invented that", "don't guess", "achismo", "não inventa", "chutou",
-  "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not
-  exist", "out of scope", "não foi isso que eu pedi". Covers the cheapest-first research ladder
-  (session context, this repo, the installed dependency, the tool itself, version-pinned docs, web
-  search, the user), verified/inferred/unknown claim labelling, the not-found report, and the
-  scope-restatement guard against delivering work nobody asked for. Do NOT use for adversarially
-  testing code already written (that is bug-hunter), for designing an API test suite (that is
-  api-resilience-testing), for writing a project's documentation pages (that is documentation), or
+  Anti-guessing rite: research before asserting, label every claim with its source, and report
+  what could not be found instead of producing a plausible substitute. Use when about to state or
+  use an API, CLI flag, config key, env var, path, version or behavior not read in this session;
+  when a fact depends on a library version; when the answer cannot be found and the gap has to be
+  reported; or when the user says "you invented that", "don't guess", "achismo", "não inventa",
+  "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that
+  flag does not exist", "out of scope", "não foi isso que eu pedi". Covers the research ladder,
+  claim labelling, the not-found report and the scope-restatement guard. Do NOT use for
+  adversarially testing code already written (that is bug-hunter), for designing an API test suite
+  (that is api-resilience-testing), for writing documentation pages (that is documentation), or
   for the plan-approval gate of a backlog item (that is execute-backlog).
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/api-resilience-testing.mdc
+++ b/cursor/rules/api-resilience-testing.mdc
@@ -35,16 +35,6 @@ Avoid vague "QA security testing" in formal docs — it is informal and ambiguou
 
 ---
 
-## When to use this skill
-
-Trigger whenever the work involves a REST/HTTP API: adding or changing an
-endpoint, reviewing an API PR, writing API tests, designing request/response
-schemas, or the user asks to "test", "harden", "break", "audit", or "review"
-an API. Default to running the workflow below before an API change is
-considered done — happy-path tests alone are not sufficient.
-
----
-
 ## The workflow (10 steps)
 
 Run these in order. Produce concrete, runnable tests and a checklist — not prose.

--- a/cursor/rules/assettoserver-csp-lua.mdc
+++ b/cursor/rules/assettoserver-csp-lua.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry, and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD, toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different permissions), or for FiveM Lua (that is fivem-lua).
+  Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte with the C# plugin, remote images and audio loaded by URL, local car telemetry, and the mockup-first workflow for visuals you cannot render outside the game. Use when writing or reviewing a .lua online script (overlay, HUD, toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 alwaysApply: false
 ---
 
@@ -9,8 +9,9 @@ alwaysApply: false
 
 Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
 client by the server itself. Zero-install is the point — the player installs nothing; art, sound
-and code all arrive over the server's HTTP port. Every rule below was paid for with an in-game
-iteration; in this stack a wrong guess costs a deploy plus a human driving session to observe it.
+and code all arrive over the server's HTTP port. Distilled from a production DriveZone server:
+every rule below was paid for with an in-game iteration, and in this stack a wrong guess costs a
+deploy plus a human driving session to observe it.
 
 ## What an online script is
 

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Turn a natural-language idea into a structured GitHub backlog item: analyze the current repository (or multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create the GitHub issue and add it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite: the item created here is what execute-backlog turns into a branch and a pull request. In a repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also declares its spec verdict — the change that will register the work, or a written waiver — so execute-backlog inherits a decision instead of making a new one. First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT use for implementing an existing issue (that is execute-backlog), for creating pull requests, or for non-GitHub trackers (Jira, Linear, Trello).
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the repository (or multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create the issue and add it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite: execute-backlog turns the item created here into a branch and a pull request. In a repository with a spec-driven workflow (an openspec/ directory) the item also declares its spec verdict: a change id or a written waiver. Do NOT use for implementing an existing issue (that is execute-backlog), for creating pull requests, or for non-GitHub trackers (Jira, Linear, Trello).
 alwaysApply: false
 ---
 
@@ -9,7 +9,9 @@ alwaysApply: false
 
 Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
 configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
-codebase.
+codebase. The first run per repo/workspace launches a config wizard that writes
+`.github/backlog.yml` (repo mode) or `backlog.yml` (workspace mode). The spec verdict the item
+declares is what `execute-backlog` inherits, instead of making a new decision.
 
 - **Issue section template + writing guidance**: `references/issue-template.md`
 - **Config schema (both modes, precedence, wizard, `spec_rite`)**: `references/backlog-config.md`

--- a/cursor/rules/code-locale.mdc
+++ b/cursor/rules/code-locale.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Decides which natural language each artifact of a change is written in: prose follows the repository's working language, and anything a machine parses is English. Use when naming a variable, function, class, file, module, REST route segment, query param, DB table or column, enum value, event or topic name, config key or log field; when reviewing a diff or PR that introduces names; when a backlog item written in another language is about to become code; when deciding whether a domain term like CPF, CNPJ, boleto, PIX or nota fiscal keeps its name; when an external API's payload fields are in another language; or when the user says "código em português", "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador em inglês", "should this be in English", "our code is half Portuguese", "naming convention", "ubiquitous language", "anti-corruption layer". Covers the prose/machine boundary, the untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only migration policy, and a shipped detector a repository can wire into CI. Do NOT use for the language of commit subjects or PR bodies (that is conventional-commit), for the language of documentation prose (that is documentation), for format-level naming conventions like case style or test-method patterns (those live in each stack's skill), or for i18n and user-facing translation.
+  Decides which natural language each artifact is written in: prose follows the repository's working language, anything a machine parses is English. Use when naming a variable, function, class, file, route, query param, DB table or column, enum value, event, config key or log field; when reviewing a diff that introduces names; when a backlog item in another language becomes code; when a domain term like CPF, CNPJ, boleto, PIX or nota fiscal may keep its name; when an external API's payload is in another language; or when the user says "código em português", "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador em inglês", "should this be in English", "our code is half Portuguese", "naming convention", "ubiquitous language", "anti-corruption layer". Do NOT use for commit subjects or PR bodies (that is conventional-commit), for docs prose (that is documentation), for case style or test naming (each stack's skill), or for i18n and user-facing translation.
 alwaysApply: false
 ---
 
@@ -8,6 +8,9 @@ alwaysApply: false
 # Code locale — prose follows the repo, the machine layer is English
 
 **Prose follows the repository's working language. Anything a machine parses is English.**
+This skill covers the prose/machine boundary, the untranslatable-domain-term exception and its
+gate, the grooming glossary, the new-code-only migration policy, and a shipped detector a
+repository can wire into CI.
 
 The boundary is drawn by *what consumes the artifact*, not by who wrote it. A commit body and a
 code comment have the same audience, so they land on the same side. A route segment and a database
@@ -17,7 +20,8 @@ without a taste debate.
 - **Per-stack enumeration, wrong → right pairs**: `references/boundary-map.md`
 - **Producing and consuming the PT→EN glossary**: `references/glossary-protocol.md`
 - **Existing names: the three migration tiers**: `references/migration.md`
-- **The detector**: `references/check-identifier-locale.py`
+- **The detector** — measures the path of every file it is given and the contents of the types
+  it tokenizes: `references/check-identifier-locale.py`
 
 ## The two layers
 

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search), validate it is complete enough to execute, re-analyze the current repo/workspace state, present an implementation plan for approval BEFORE touching code, implement on a dedicated branch following the repo's conventions, add/update tests, run the repo's discoverable validations (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code: the item's spec verdict is re-checked, the change is created and validated strict, and only then does the plan go to approval. Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+  Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search), validate it is complete enough, re-analyze the repo/workspace, present an implementation plan for approval BEFORE touching code, implement on a dedicated branch with tests, run the repo's discoverable validations, tick the acceptance criteria proven by evidence, open pull request(s) with Closes #n, and move the GitHub Project item to the review column. Use when the user invokes /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite: consumes the item the backlog skill produced. In a repository with a spec-driven workflow (an openspec/ directory) it re-checks the item's spec verdict and validates the change strict before the plan goes to approval. Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
 alwaysApply: false
 ---
 
@@ -8,7 +8,9 @@ alwaysApply: false
 # Execute-backlog — backlog item → implemented, validated PR
 
 Drive an existing issue to a reviewable pull request while keeping the board in sync. Companion
-to the `backlog` skill; consumes the same config.
+to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,
+`backlog.yml` in workspace mode), follows the repo's own conventions, and runs the validations
+it can discover there (tests/lint/build/typecheck).
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
 - **Spec-driven gate: detection, verdict, upgrade/downgrade, archive timing**: `references/spec-rite.md`

--- a/cursor/rules/verify-before-claiming.mdc
+++ b/cursor/rules/verify-before-claiming.mdc
@@ -1,6 +1,6 @@
 ---
 description: >-
-  Anti-guessing rite: research before asserting, label every claim with its source, and report what could not be found instead of producing a plausible substitute. Use when about to state or use an API, CLI flag, config key, env var, path, version or behavior not read in this session; when a fact depends on a library version; when the answer cannot be found and the gap has to be reported; or when the user says "you invented that", "don't guess", "achismo", "não inventa", "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not exist", "out of scope", "não foi isso que eu pedi". Covers the cheapest-first research ladder (session context, this repo, the installed dependency, the tool itself, version-pinned docs, web search, the user), verified/inferred/unknown claim labelling, the not-found report, and the scope-restatement guard against delivering work nobody asked for. Do NOT use for adversarially testing code already written (that is bug-hunter), for designing an API test suite (that is api-resilience-testing), for writing a project's documentation pages (that is documentation), or for the plan-approval gate of a backlog item (that is execute-backlog).
+  Anti-guessing rite: research before asserting, label every claim with its source, and report what could not be found instead of producing a plausible substitute. Use when about to state or use an API, CLI flag, config key, env var, path, version or behavior not read in this session; when a fact depends on a library version; when the answer cannot be found and the gap has to be reported; or when the user says "you invented that", "don't guess", "achismo", "não inventa", "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not exist", "out of scope", "não foi isso que eu pedi". Covers the research ladder, claim labelling, the not-found report and the scope-restatement guard. Do NOT use for adversarially testing code already written (that is bug-hunter), for designing an API test suite (that is api-resilience-testing), for writing documentation pages (that is documentation), or for the plan-approval gate of a backlog item (that is execute-backlog).
 alwaysApply: false
 ---
 
@@ -13,7 +13,9 @@ endpoint nobody asked for — it claims the user wanted it.
 
 Every claim is one of three things: **verified** against a source you opened in this session,
 **inferred** and labelled as such, or **unknown** and reported. There is no fourth option. A
-plausible sentence with no source is the defect this skill exists to prevent.
+plausible sentence with no source is the defect this skill exists to prevent. The research
+ladder is cheapest-first: session context, this repo, the installed dependency, the tool itself,
+version-pinned docs, web search, the user.
 
 - **Per-ecosystem commands for each rung, offline degradation**: `references/research-ladder.md`
 - **Claim labels, the not-found report, scope blocks**: `references/report-templates.md`

--- a/openspec/changes/add-agent-skills-limits/.openspec.yaml
+++ b/openspec/changes/add-agent-skills-limits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-04

--- a/openspec/changes/add-agent-skills-limits/design.md
+++ b/openspec/changes/add-agent-skills-limits/design.md
@@ -40,7 +40,7 @@ limite.
 ### D1 — C10 mede o valor YAML parseado, em caracteres, com os mesmos números do validador de referência
 
 O C4 mede o bloco cru (`fm[1]` de `text.split("---", 2)`), que carrega a indentação e as quebras
-do folded scalar: 26–36 caracteres a mais que o valor parseado, medido sobre as 35 skills
+do folded scalar: 6–26 caracteres a mais que o valor parseado, medido sobre as 35 skills
 (`svg-animation` dá 1024 cru contra 998 parseado). Um gate sobre o bloco cru reprovaria uma
 skill que o validador de referência aceita. C10 faz `yaml.safe_load` do bloco — o PyYAML já é
 dependência do C3 — e compara `len(description)` e `len(compatibility)` com

--- a/openspec/changes/add-agent-skills-limits/design.md
+++ b/openspec/changes/add-agent-skills-limits/design.md
@@ -1,0 +1,133 @@
+## Context
+
+O catálogo diz seguir o padrão Agent Skills (`README.md:25`, `:381`), cuja especificação fixa
+`description` em 1–1024 caracteres e `compatibility` em 1–500. O validador de referência do
+padrão é o pacote PyPI `skills-ref` (0.1.1), binário `agentskills`; em `skills_ref/validator.py`
+os limites são `MAX_DESCRIPTION_LENGTH = 1024` e `MAX_COMPATIBILITY_LENGTH = 500`, medidos com
+`len()` sobre o valor parseado do frontmatter, e há uma whitelist de campos aceitos
+(`ALLOWED_FIELDS`, linhas 15-22).
+
+Cinco skills estouram o teto de description e uma delas também o de compatibility. Três gates do
+repositório olham para o frontmatter e nenhum mede tamanho: o loop de shell do CI (presença e
+valor de campos), `scripts/validate-skills.py` C4 (description contra o corpo, sobre o bloco cru
+em `:223`) e `claude plugin validate --strict` (aceita 2000 caracteres, medido na issue #112).
+
+O spec `skills-authoring` tem um requisito que produz o excesso — *Triggers live in the
+description, not the body* manda dobrar todo gatilho do corpo para a description — e nenhum que o
+limite.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Todas as 35 skills passam em `agentskills validate` (skills-ref 0.1.1).
+- O teto fica escrito no spec ao lado do requisito que dobra gatilhos, com a regra de para onde
+  vai o que não cabe.
+- O CI mede o teto duas vezes, por caminhos independentes: um check próprio auto-testado (C10) e
+  o validador de referência pinado.
+- Nenhuma frase de gatilho entre aspas se perde nas 5 descriptions encurtadas.
+
+**Non-Goals:**
+
+- Tornar fatal a linha `checks skipped` de `validate-skills.py`: o spec exige que a falta de
+  ferramenta seja reportada, não que falhe (*A missing tool is reported, not passed over*).
+- Reduzir o orçamento total de tokens das 35 descriptions abaixo do teto da spec.
+- Mudar como o Claude Code roteia skills, ou mexer em `ci.yml:84` (`|| true` do `apt-get`).
+- Cobrir a whitelist de campos do validador de referência em C10: isso é o que o step pinado faz.
+
+## Decisions
+
+### D1 — C10 mede o valor YAML parseado, em caracteres, com os mesmos números do validador de referência
+
+O C4 mede o bloco cru (`fm[1]` de `text.split("---", 2)`), que carrega a indentação e as quebras
+do folded scalar: 26–36 caracteres a mais que o valor parseado, medido sobre as 35 skills
+(`svg-animation` dá 1024 cru contra 998 parseado). Um gate sobre o bloco cru reprovaria uma
+skill que o validador de referência aceita. C10 faz `yaml.safe_load` do bloco — o PyYAML já é
+dependência do C3 — e compara `len(description)` e `len(compatibility)` com
+`MAX_DESCRIPTION_CHARS = 1024` e `MAX_COMPATIBILITY_CHARS = 500`, nomes do Glossary da issue #112
+que espelham `MAX_DESCRIPTION_LENGTH`/`MAX_COMPATIBILITY_LENGTH` de `skills_ref/validator.py`.
+`len()` em Python conta code points, não bytes, exatamente como o validador de referência — as
+descriptions carregam `ã`, `ç`, `—`, e uma contagem em bytes divergiria.
+
+Quando o PyYAML não está instalado, C10 entra na lista `checks skipped`, como o C3 já faz, e não
+conta como aprovado (Non-Goal 1).
+
+### D2 — Dois medidores independentes, não um
+
+O step pinado do CI prova conformidade com o padrão pelo mesmo binário que um consumidor usaria;
+C10 prova que o repositório entende a própria regra e a auto-testa por mutação. Se só o step
+existisse, a regra viveria fora do repositório e mudaria no calendário do upstream; se só o C10
+existisse, "seguimos o padrão" continuaria uma afirmação sem probe. Os dois divergirem no limite
+é o risco listado na issue; a mitigação é os dois contarem `len()` do valor parseado (D1).
+
+### D3 — O pin é exato e o comentário do step diz por quê
+
+`skills-ref==0.1.1` na mesma linha de `pip` de `ci.yml` que instala o PyYAML, para que a falta
+do pacote falhe alto no primeiro step que o usa. O comentário do step segue o estilo das linhas
+127-128 do workflow (o pin do `claude-code`): um upstream novo poderia alargar ou apertar a
+whitelist de campos (`validator.py:15-22`) e quebrar o build no calendário de outro. O step
+declara o que cobre (nome, description, compatibility, whitelist) e o que não cobre (corpo,
+referências, cross-refs, blocos de código — que ficam com `validate-skills.py`).
+
+### D4 — A dobra respeita o teto; o que não cabe vai para o corpo ou para `references/`
+
+O requisito *Triggers live in the description* fica; ganha a cláusula de que a dobra respeita o
+teto de *Uniform frontmatter metadata*. Regra de precedência quando não cabe tudo: ficam na
+description as frases de gatilho entre aspas, as condições "Use when" e a cláusula "Do NOT use"
+(são o que roteia); saem primeiro as sentenças "Covers …" e os detalhes de configuração
+(caminhos de arquivo, listas de degraus), que vão para a primeira linha do corpo ou para
+`references/`. A tabela antes/depois das frases entre aspas fica em `tasks.md` e é o critério de
+"nada se perdeu".
+
+### D5 — `When to use this skill` entra na lista de headings meta
+
+`skills/api-resilience-testing/SKILL.md:43` carrega uma seção `## When to use this skill` que
+repete a description palavra por palavra e escapa do C8 porque `META_HEADING` só casa quatro
+títulos. O regex ganha esse quinto título e a seção é removida — o conteúdo já está na
+description, então nada é dobrado. A mutação nova do selftest injeta exatamente esse título.
+
+### D6 — Ordem: gate primeiro, edição depois, no mesmo PR
+
+O C10 é escrito antes das descriptions serem editadas e reprova as 5 (TR4 da issue). O commit
+que encurta as descriptions é o que deixa o validador verde. Assim a história do branch mostra o
+gate falhando sobre o estado real, não só passando sobre o estado corrigido.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Teto de caracteres de `description` e `compatibility` | `skills-authoring` (spec do repositório), requisito *Uniform frontmatter metadata* | move: a regra passa a morar no spec; C10 e o step do CI só a aplicam |
+| Gatilhos moram na description, não no corpo | `skills-authoring`, requisito *Triggers live in the description, not the body* | already canonical — ganha a cláusula de teto, sem duplicar a regra em nenhuma skill |
+| Um check declara o que não cobre | `skills-catalog` (*The uncovered part is declared, not implied*) + `skills-authoring` (*Partial coverage is declared, not implied*) | already canonical — C10 e o step novo aplicam a regra dentro de si |
+| Prova observada, não esperada, antes de declarar entrega | `verify-before-claiming` | already canonical — o grupo de simulação de `tasks.md` cita, não reescreve |
+| Prose em português, camada de máquina em inglês | `code-locale` | already canonical — os identificadores novos (`MAX_DESCRIPTION_CHARS`, `C10 frontmatter limits`) vêm do Glossary da issue #112 |
+| Conteúdo que sai da description de `code-locale` (o que a skill cobre) | `code-locale` | move: da description para o primeiro parágrafo do corpo da própria skill |
+| Conteúdo que sai da description de `verify-before-claiming` (degraus da escada) | `verify-before-claiming` | already canonical — os degraus já estão em `## The research ladder` e `references/research-ladder.md`; a description passa a só nomear a escada |
+| Conteúdo que sai das descriptions de `backlog` / `execute-backlog` (arquivos de config, wizard) | `backlog` (`references/backlog-config.md`) | already canonical — o corpo das duas skills já aponta para lá; a description deixa de repetir os caminhos |
+| `When to use this skill` de `api-resilience-testing` | `api-resilience-testing` (description) | move: seção removida, conteúdo já estava na description |
+
+Nenhuma skill passa a reescrever doutrina de outra: as edições são só na description, no primeiro
+parágrafo do corpo e na `compatibility`.
+
+## Risks / Trade-offs
+
+- **Cortar gatilho muda roteamento.** Mitigação: a tabela antes/depois das frases entre aspas
+  (D4) é critério de aceitação, e o grupo de simulação roda 3 prompts realistas por skill editada
+  contra as descriptions novas, registrando para qual skill cada um roteia.
+- **`skills-ref` 0.1.x muda a whitelist ou o limite.** Mitigação: pin exato e comentário no step
+  (D3); bump deliberado depois de rodar localmente.
+- **C10 e o validador de referência divergem no limite.** Mitigação: ambos contam `len()` do
+  valor parseado (D1); a simulação roda os dois sobre a mesma cópia inflada e registra os dois
+  números.
+- **O binário `agentskills` pode não estar no PATH do runner depois de `python3 -m pip install`.**
+  Não há como probar o runner daqui; fica registrado como lacuna em `tasks.md` E.3 e o primeiro
+  run do CI é a prova. Não existe `python -m skills_ref` como alternativa (probado: `No module
+  named skills_ref.__main__`); `python -m skills_ref.cli` existe e é o fallback se o PATH falhar.
+- **`backlog` fica em 1000 caracteres, a 24 do teto.** A próxima dobra de gatilho nessa skill
+  tem de seguir D4 (tirar antes de pôr). O C10 é o que avisa.
+
+## Open Questions
+
+Nenhuma sobre o comportamento das ferramentas: os limites, o nome do binário, o modo de contagem
+e a whitelist foram lidos no pacote instalado e a página da especificação foi baixada. A única
+incerteza é a de ambiente do runner (PATH), registrada acima como risco e em `tasks.md` E.3.

--- a/openspec/changes/add-agent-skills-limits/proposal.md
+++ b/openspec/changes/add-agent-skills-limits/proposal.md
@@ -34,7 +34,7 @@ qualquer consumidor que use o validador de referência rejeita um sexto do catá
   caracteres do valor YAML parseado, e a cláusula de que a dobra de gatilhos respeita o teto: o que
   não cabe vai para a primeira linha do corpo ou para `references/`, nunca fica na description.
 - `scripts/validate-skills.py` ganha o check `C10 frontmatter limits`, que mede o valor parseado
-  (o C4 mede o bloco cru, que dá 26–36 caracteres a mais) com `len()` em caracteres, como
+  (o C4 mede o bloco cru, que dá 6–26 caracteres a mais) com `len()` em caracteres, como
   `skills_ref/validator.py`, e declara dentro de si o que não cobre.
 - `META_HEADING` (C8) passa a casar também `## When to use this skill`, que hoje escapa; a seção
   com esse título em `skills/api-resilience-testing/SKILL.md` é removida porque seu conteúdo já

--- a/openspec/changes/add-agent-skills-limits/proposal.md
+++ b/openspec/changes/add-agent-skills-limits/proposal.md
@@ -1,0 +1,75 @@
+# Change: Cumprir os limites da spec Agent Skills e medi-los no CI
+
+## Why
+
+`README.md:25` e `README.md:381` afirmam que o catálogo segue o padrão aberto Agent Skills. A
+especificação desse padrão (agentskills.io/specification) fixa `description` em 1–1024 caracteres e
+`compatibility` em 1–500. O validador de referência do padrão — o pacote `skills-ref` 0.1.1, cujo
+binário se chama `agentskills` — reprova 5 das 35 skills do catálogo, medido em 2026-09-04 sobre
+`d2918ed`:
+
+```
+skills/assettoserver-csp-lua   rc=1 :: Description exceeds 1024 character limit (1076 chars)
+skills/backlog                 rc=1 :: Description exceeds 1024 character limit (1265 chars)
+skills/code-locale             rc=1 :: Description exceeds 1024 character limit (1398 chars)
+                                       Compatibility exceeds 500 character limit (728 chars)
+skills/execute-backlog         rc=1 :: Description exceeds 1024 character limit (1344 chars)
+skills/verify-before-claiming  rc=1 :: Description exceeds 1024 character limit (1222 chars)
+ok=30 bad=5 total=35
+```
+
+Nenhum gate do repositório mede isso. `scripts/validate-skills.py` só compara a description com
+o corpo (C4); `claude plugin validate --strict` aceita uma description de 2000 caracteres (medido
+na issue #112). E o próprio spec do catálogo empurra na direção contrária: o requisito *Triggers
+live in the description, not the body* manda dobrar todo gatilho e toda cláusula "Do NOT use" para
+dentro da description, sem teto. Um gate de tamanho sozinho brigaria com esse requisito na próxima
+dobra — por isso o teto e a reconciliação com a dobra entram no spec juntos.
+
+O impacto hoje é de conformidade e portabilidade: o Claude Code carrega a description inteira, mas
+qualquer consumidor que use o validador de referência rejeita um sexto do catálogo.
+
+## What Changes
+
+- `skills-authoring` ganha os tetos de 1024 (`description`) e 500 (`compatibility`), medidos em
+  caracteres do valor YAML parseado, e a cláusula de que a dobra de gatilhos respeita o teto: o que
+  não cabe vai para a primeira linha do corpo ou para `references/`, nunca fica na description.
+- `scripts/validate-skills.py` ganha o check `C10 frontmatter limits`, que mede o valor parseado
+  (o C4 mede o bloco cru, que dá 26–36 caracteres a mais) com `len()` em caracteres, como
+  `skills_ref/validator.py`, e declara dentro de si o que não cobre.
+- `META_HEADING` (C8) passa a casar também `## When to use this skill`, que hoje escapa; a seção
+  com esse título em `skills/api-resilience-testing/SKILL.md` é removida porque seu conteúdo já
+  está na description.
+- `scripts/selftest-validate-skills.py` ganha uma mutação por check novo ou alargado: C10 com
+  description inflada e C8 com a heading alargada. 13/13 vira 15/15.
+- `.github/workflows/ci.yml` instala `skills-ref==0.1.1` na mesma linha de `pip` que já instala o
+  PyYAML e ganha um step, logo depois do self-test do validador, que roda `agentskills validate`
+  sobre cada diretório de `skills/` — pinado, com comentário explicando o pin.
+- As 5 descriptions saem para ≤1024 e a `compatibility` de `code-locale` para ≤500 sem perder
+  nenhuma frase de gatilho entre aspas; a tabela antes/depois fica em `tasks.md`.
+- `README.md:25` e `:381`: o link "Agent Skills" passa a apontar para a especificação;
+  `vercel-labs/skills` fica como o CLI `npx skills` da Opção A.
+- `metadata.version` sobe (minor) nas 6 skills editadas; `./generate.sh` regenera os wrappers.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: *Uniform frontmatter metadata* ganha os tetos de caracteres; *Triggers live
+  in the description, not the body* ganha a cláusula de que a dobra respeita o teto e alarga a
+  lista de headings proibidas com `When to use this skill`; *Authoring rules are machine-enforced*
+  ganha o cenário em que uma description acima do teto falha o build nomeando skill, check e
+  tamanhos, e o cenário em que o validador de referência pinado roda no CI.
+
+## Impact
+
+- Skills afetadas (description encurtada, `metadata.version` minor): `code-locale` (também a
+  `compatibility`), `execute-backlog`, `backlog`, `verify-before-claiming`,
+  `assettoserver-csp-lua`. `api-resilience-testing` perde a seção `## When to use this skill` e
+  também sobe de versão. Nenhuma skill é adicionada, removida ou renomeada: a composição do
+  catálogo (35) e a descoberta via `npx skills` ficam idênticas.
+- `scripts/validate-skills.py`, `scripts/selftest-validate-skills.py`: check novo, heading
+  alargada, duas mutações.
+- `.github/workflows/ci.yml`: um step novo e uma dependência pinada na linha de `pip`.
+- `README.md:25,381`; wrappers gerados em `claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/`.
+- Fora de escopo, por decisão da issue #112: tornar fatal a linha `checks skipped` do validador;
+  reduzir o orçamento total de tokens das descriptions; mudar como o Claude Code roteia skills.

--- a/openspec/changes/add-agent-skills-limits/specs/skills-authoring/spec.md
+++ b/openspec/changes/add-agent-skills-limits/specs/skills-authoring/spec.md
@@ -1,0 +1,152 @@
+## MODIFIED Requirements
+
+### Requirement: Uniform frontmatter metadata
+
+Every `skills/<name>/SKILL.md` SHALL carry: `name` (== directory), `description` (folded block scalar),
+`metadata.author: solvelab`, `metadata.version` (semver), `metadata.category` from the controlled set
+{backend, testing, fivem, game, devops, docs, git, process, nui, frontend, tooling}, `license: MIT`,
+and `compatibility`.
+
+The controlled set is the one the CI frontmatter check enforces. When the two disagree, the gate is
+authoritative and this document is corrected, because a contributor who follows a document that is
+behind its gate writes a change the build rejects.
+
+All seven SHALL be enforced by that check, each with a file-specific error naming the field. Where a
+value is fixed by this requirement — `metadata.author: solvelab`, `license: MIT`, and the folded
+`description` — the check SHALL assert the **value**, not merely the presence of the key, because a
+key present with the wrong value satisfies a presence check while violating the requirement.
+
+The catalog declares itself an implementation of the open Agent Skills standard
+(agentskills.io/specification), so the size limits that standard fixes SHALL hold for every skill:
+`description` is at most 1024 characters and `compatibility` at most 500. Both limits are measured
+on the **YAML-parsed value** — the string a consumer receives after the folded scalar is unfolded —
+counted in characters (code points), never on the raw frontmatter block and never in bytes. The raw
+block carries the indentation and line breaks of the folded scalar and measures 26–36 characters
+more than the value, so a gate on the raw block would reject a skill the standard accepts.
+
+#### Scenario: CI rejects incomplete frontmatter
+
+- **WHEN** a skill is added or edited without `name` matching its directory, without `description`,
+  `metadata.author`, `metadata.version`, `license` or `compatibility`, with a category outside the
+  controlled set, with `metadata.author` or `license` set to anything other than the value fixed
+  above, or with a `description` that is not a folded block scalar
+- **THEN** the CI validate job fails with a file-specific error naming the field
+
+#### Scenario: The documented set matches the enforced set
+
+- **WHEN** a category is added to the CI frontmatter check
+- **THEN** this requirement is updated in the same change, so no contributor reads a controlled set
+  that is narrower than the one the build accepts
+
+#### Scenario: A field the document mandates is not left to review alone
+
+- **WHEN** this requirement names a field that the frontmatter check does not verify
+- **THEN** either the check is extended to cover it, or the field is identified as review-only, so
+  that the gap between the document and the gate is never silent
+
+#### Scenario: A description over the limit fails the build with its measured size
+
+- **WHEN** a skill's parsed `description` exceeds 1024 characters, or its parsed `compatibility`
+  exceeds 500
+- **THEN** the catalog validator fails naming the skill, the check and the measured size next to the
+  limit, so the author knows how much has to move out of the frontmatter
+
+#### Scenario: The limit is measured the way the standard measures it
+
+- **WHEN** a `description` measures 1024 characters on the raw frontmatter block and 998 once parsed
+- **THEN** the skill passes, because the limit applies to the parsed value — the same value the
+  standard's reference validator measures — and not to the block as written in the file
+
+### Requirement: Authoring rules are machine-enforced
+
+The mechanically checkable authoring rules SHALL be enforced by a script wired into CI, and that
+script SHALL carry a self-test that injects one known defect per check and asserts detection. Rules
+that cannot be checked mechanically SHALL be identified as review-only rather than left to imply
+coverage. A check that covers only **part** of its rule SHALL state the uncovered part in the check
+itself, so that a passing run is not read as full coverage.
+
+Conformance with an external standard the catalog claims SHALL be measured by two independent
+paths: the catalog's own check, which the self-test can break on purpose, and the standard's
+reference validator, pinned to an exact version and run over every skill in CI. The pin SHALL carry
+the reason it exists next to it, because a blocking gate on an unpinned upstream fails the build on
+someone else's release schedule.
+
+#### Scenario: A violation fails the build
+
+- **WHEN** a change introduces a broken reference, an unparseable code block, a mistagged fence, a
+  description that contradicts its body, or a `description` or `compatibility` longer than the
+  standard allows
+- **THEN** the CI validate job fails and names the skill, the check and the offending content
+
+#### Scenario: A disabled check is caught
+
+- **WHEN** a change to the validator silently stops one of its checks from firing
+- **THEN** the self-test fails, because a catalog with zero findings and a check that cannot fire are
+  otherwise indistinguishable
+
+#### Scenario: A missing tool is reported, not passed over
+
+- **WHEN** a checker dependency is unavailable in the environment
+- **THEN** the affected check is reported as skipped in the output instead of counting as a pass
+
+#### Scenario: Partial coverage is declared, not implied
+
+- **WHEN** a check enforces its rule only under some condition (a size threshold, a file type, a
+  language it can parse)
+- **THEN** the condition and what escapes it are stated in the check, and skills falling outside it
+  are reviewed by hand rather than assumed compliant
+
+#### Scenario: The frontmatter-limits check is itself gated
+
+- **WHEN** the self-test injects a `description` of more than 1024 parsed characters into a copy of
+  the catalog
+- **THEN** the validator reports the frontmatter-limits check for that skill, and a validator that
+  stays silent fails the self-test
+
+#### Scenario: The reference validator runs pinned, over every skill
+
+- **WHEN** the CI validate job runs
+- **THEN** the standard's reference validator, installed at an exact pinned version, is executed
+  once per `skills/<name>/` directory and any finding fails the job, and the step states what the
+  reference validator covers and what it leaves to the catalog's own checks
+
+### Requirement: Triggers live in the description, not the body
+
+A skill SHALL NOT carry a `How to Use`, `When to use this skill`, `Trigger Test Cases`, `Prompt` or
+`Usage` section in its `SKILL.md`. Such a section is read only after the skill has already been
+selected, so it cannot influence routing, and it costs context on every invocation. Trigger and
+anti-trigger information SHALL live in the frontmatter `description`, which is what the model reads
+when choosing a skill.
+
+Folding a trigger into the description SHALL respect the size limit fixed by *Uniform frontmatter
+metadata*. When the description cannot hold everything, what stays is what routes: the quoted
+phrases a user would say, the "Use when" conditions and the "Do NOT use for" boundary. What moves
+out first is what does not route: sentences describing what the skill covers, file paths,
+configuration detail and enumerations that the body or a reference already carries. The overflow
+goes to the first paragraph of the body or to a file under `references/`, never to a body section
+that restates triggers.
+
+#### Scenario: A trigger case not present in the description is folded in, not filed away
+
+- **WHEN** a skill's body lists a trigger or anti-trigger case that its description does not cover
+- **THEN** the case is added to the description, where it can affect selection
+- **AND** the body section is removed rather than kept as a duplicate
+
+#### Scenario: Every skill states where it does not apply
+
+- **WHEN** another skill in the catalog covers an adjacent area
+- **THEN** the description names it, either as an explicit "Do NOT use for … (that is `<skill>`)"
+  clause or as a redirect ("for X use `<skill>`"), so the two do not compete for the same prompt
+
+#### Scenario: The fold does not push the description over the limit
+
+- **WHEN** adding a trigger to a description would take it past 1024 parsed characters
+- **THEN** non-routing content is moved out of the description first — to the body's first
+  paragraph or to `references/` — and every quoted trigger phrase present before the edit is still
+  present after it, recorded as a before/after table in the change that made the edit
+
+#### Scenario: A body section that duplicates the description is removed, not folded
+
+- **WHEN** a skill carries a body section whose trigger content already appears in its description
+- **THEN** the section is removed and nothing is added to the description, because the fold exists
+  to carry information into the description, not to repeat it

--- a/openspec/changes/add-agent-skills-limits/specs/skills-authoring/spec.md
+++ b/openspec/changes/add-agent-skills-limits/specs/skills-authoring/spec.md
@@ -21,8 +21,9 @@ The catalog declares itself an implementation of the open Agent Skills standard
 `description` is at most 1024 characters and `compatibility` at most 500. Both limits are measured
 on the **YAML-parsed value** — the string a consumer receives after the folded scalar is unfolded —
 counted in characters (code points), never on the raw frontmatter block and never in bytes. The raw
-block carries the indentation and line breaks of the folded scalar and measures 26–36 characters
-more than the value, so a gate on the raw block would reject a skill the standard accepts.
+block carries the indentation and line breaks of the folded scalar and measures more than the
+value — 6–26 characters more across this catalog, 1024 raw against 998 parsed on one skill — so a
+gate on the raw block would reject a skill the standard accepts.
 
 #### Scenario: CI rejects incomplete frontmatter
 

--- a/openspec/changes/add-agent-skills-limits/tasks.md
+++ b/openspec/changes/add-agent-skills-limits/tasks.md
@@ -1,0 +1,195 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `d2918ed` (topo de `master`, 2026-09-04), no worktree do branch
+      `backlog/112-agent-skills-limits`:
+
+      - `scripts/validate-skills.py` — 9 checks C1–C9; C4 mede a description sobre o bloco cru
+        (`fm = text.split("---", 2)`, `re.search(r"^description:..."` em `:223`); `META_HEADING`
+        em `:277` casa só `How to Use|Trigger Test Cases|Prompt|Usage`; a lista `skipped` no
+        `main()` já reporta `yaml parse (PyYAML not installed)`.
+      - `scripts/selftest-validate-skills.py` — dict `MUTATIONS` com 13 entradas, uma por check;
+        `caught = check.split()[0] in out and check in out`.
+      - `.github/workflows/ci.yml` — `pip install --quiet pyyaml` em `:83`, `|| true` do `apt-get`
+        em `:84` (intocado), step `Skill validator self-test` em `:87-88`, comentário-modelo do pin
+        em `:120-128`.
+      - `skills/api-resilience-testing/SKILL.md:43-49` — seção `## When to use this skill` que
+        repete a description.
+      - `skills/{code-locale,execute-backlog,backlog,verify-before-claiming,assettoserver-csp-lua}/SKILL.md`
+        — frontmatter e primeiro parágrafo do corpo de cada uma.
+      - `openspec/specs/skills-authoring/spec.md` — requisitos *Uniform frontmatter metadata*
+        (`:48`), *Authoring rules are machine-enforced* (`:259`), *Triggers live in the
+        description, not the body* (`:320`), copiados integralmente para o delta.
+      - `openspec/specs/skills-catalog/spec.md:480-500` — cenário *The uncovered part is declared,
+        not implied* e o requisito *The repository itself is gated*.
+      - `README.md:25` e `:381` — os dois links "Agent Skills" para `vercel-labs/skills`.
+      - `generate.sh` — o wrapper de `claude/skills/<n>/SKILL.md` copia o frontmatter inteiro, logo
+        a description encurtada propaga por `./generate.sh`.
+      - `openspec/changes/archive/2026-08-30-fix-release-race/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md` — modelo de estilo desta change.
+
+- [x] E.2 Ferramentas, versões e comportamentos probados contra a versão instalada
+
+      ```
+      python3 -m venv <scratch>/venv-A && <venv>/bin/pip install skills-ref==0.1.1
+      <venv>/bin/agentskills --version
+      -> agentskills, version 0.1.1
+      cat <venv>/.../skills_ref-0.1.1.dist-info/entry_points.txt
+      -> [console_scripts]
+      -> agentskills = skills_ref.cli:main
+      ```
+
+      ```
+      sed -n '10,22p' <venv>/lib/python3.14/site-packages/skills_ref/validator.py
+      -> MAX_SKILL_NAME_LENGTH = 64
+      -> MAX_DESCRIPTION_LENGTH = 1024
+      -> MAX_COMPATIBILITY_LENGTH = 500
+      -> ALLOWED_FIELDS = { "name", "description", "license", "allowed-tools", "metadata", "compatibility", }
+      grep -n "len(description)\|len(compatibility)" validator.py
+      -> if len(description) > MAX_DESCRIPTION_LENGTH:
+      -> if len(compatibility) > MAX_COMPATIBILITY_LENGTH:
+      ```
+
+      ```
+      curl -sL https://agentskills.io/specification | (strip html) | grep -E '1024|500 characters'
+      -> description   Yes  Max 1024 characters
+      -> compatibility   No  Max 500 characters
+      -> Must be 1-1024 characters
+      -> Must be 1-500 characters if provided
+      ```
+
+      ```
+      bash <scratch>/run-agentskills.sh      # agentskills validate skills/<d>, um dir por chamada
+      -> skills/assettoserver-csp-lua   rc=1 :: Description exceeds 1024 character limit (1076 chars)
+      -> skills/backlog                 rc=1 :: Description exceeds 1024 character limit (1265 chars)
+      -> skills/code-locale             rc=1 :: Description exceeds 1024 character limit (1398 chars)   - Compatibility exceeds 500 character limit (728 chars)
+      -> skills/execute-backlog         rc=1 :: Description exceeds 1024 character limit (1344 chars)
+      -> skills/verify-before-claiming  rc=1 :: Description exceeds 1024 character limit (1222 chars)
+      -> ok=30 bad=5 total=35
+      ```
+
+      ```
+      python3 -c 'yaml.safe_load(frontmatter); len(description)' sobre as 35   (valor parseado)
+      -> code-locale desc=1398 compat=728 · execute-backlog 1344 · backlog 1265
+      -> verify-before-claiming 1222 · assettoserver-csp-lua 1076 · svg-animation 998
+      ```
+
+      ```
+      python3 scripts/validate-skills.py          (baseline, antes desta change)
+      -> skills checked: 35   findings: 0
+      python3 scripts/selftest-validate-skills.py
+      -> 13/13 defect classes detected
+      ```
+
+      ```
+      <venv>/bin/python -m skills_ref validate skills/r3f-geometry
+      -> No module named skills_ref.__main__; 'skills_ref' is a package and cannot be directly executed
+      <venv>/bin/python -m skills_ref.cli validate skills/r3f-geometry
+      -> Valid skill: skills/r3f-geometry
+      ```
+
+      ```
+      openspec --version -> 1.6.0        claude --version -> 2.1.260 (Claude Code)
+      which luac -> /home/linuxbrew/.linuxbrew/bin/luac        python3 -c 'import yaml' -> 6.0.3
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      Uma lacuna: se o binário `agentskills` fica no `PATH` do runner `ubuntu-latest` depois de
+      `python3 -m pip install`. Não há como executar o runner daqui; o primeiro run do CI deste
+      branch é a prova. O fallback, se falhar, é `python3 -m skills_ref.cli validate` (probado
+      acima). O comportamento de `claude plugin validate` com description de 2000 caracteres não foi
+      re-medido aqui — é a medição da issue #112 (2.1.246 no CI, 2.1.260 local) e a change não
+      depende dela.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a issue #112 pediu. Notados pelo caminho e **não** feitos, como
+      follow-up:
+
+      - `svg-animation` está em 998 caracteres parseados (26 do teto); não é editada porque só as
+        5 fora do teto mudam (fora de escopo da issue).
+      - As 35 descriptions somam ~23k caracteres; reduzir o orçamento total fica fora de escopo.
+      - `selftest-validate-skills.py` copia o repositório inteiro 15 vezes (uma por mutação); é
+        lento mas não é assunto desta change.
+      - `python -m skills_ref` não existe no pacote (só `skills_ref.cli`); um `__main__.py` seria
+        contribuição upstream, não daqui.
+
+## 2. Gate: C10, C8 alargado, selftest e validador de referência no CI
+
+- [ ] 2.1 `scripts/validate-skills.py`: check `C10 frontmatter limits` mede `len()` do valor
+      parseado de `description` (≤ `MAX_DESCRIPTION_CHARS` = 1024) e `compatibility`
+      (≤ `MAX_COMPATIBILITY_CHARS` = 500), nomeia skill, check e tamanhos, declara dentro de si o
+      que não cobre, e entra em `checks skipped` sem PyYAML (D1)
+- [ ] 2.2 `META_HEADING` passa a casar `When to use this skill` (D5)
+- [ ] 2.3 `scripts/selftest-validate-skills.py`: mutação C10 (description inflada acima de 1024
+      parseados) e mutação C8 com o título alargado; 15/15
+- [ ] 2.4 `.github/workflows/ci.yml`: `skills-ref==0.1.1` na linha de `pip` de `:83`; step novo
+      logo após `Skill validator self-test` rodando `agentskills validate` por diretório, com o
+      comentário do pin e do que não cobre (D3)
+- [ ] 2.5 Gate primeiro: com C10 no lugar e as descriptions ainda intocadas, o validador reprova
+      exatamente as 5 skills (D6) — saída registrada em S.1
+
+## 3. Descriptions dentro do teto sem perder gatilho
+
+- [ ] 3.1 As 5 descriptions ≤ 1024 e a `compatibility` de `code-locale` ≤ 500, medidas no valor
+      parseado; o que saiu foi para o primeiro parágrafo do corpo (D4)
+- [ ] 3.2 Tabela antes/depois das frases entre aspas, por skill — nenhuma perdida:
+
+      | Skill | Frases entre aspas antes | Depois | Perdidas |
+      |---|---|---|---|
+      | `code-locale` | "código em português", "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador em inglês", "should this be in English", "our code is half Portuguese", "naming convention", "ubiquitous language", "anti-corruption layer" (10) | as mesmas 10 | nenhuma |
+      | `execute-backlog` | "implement issue #N", "execute this backlog item", "pick up this ticket" (3) | as mesmas 3 | nenhuma |
+      | `backlog` | "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea" (4) | as mesmas 4 | nenhuma |
+      | `verify-before-claiming` | "you invented that", "don't guess", "achismo", "não inventa", "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not exist", "out of scope", "não foi isso que eu pedi" (12) | as mesmas 12 | nenhuma |
+      | `assettoserver-csp-lua` | nenhuma frase entre aspas; gatilhos parentéticos (overlay, HUD, toast, in-game sound, login UI) e (empty flat box, glued or overlapping text, missing glyphs, sound plays only once) | os mesmos dois parênteses | nenhuma |
+
+      O que saiu de cada description e para onde foi:
+
+      | Skill | Saiu | Foi para |
+      |---|---|---|
+      | `code-locale` | "Covers the prose/machine boundary, the untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only migration policy, and a shipped detector…"; enumeração longa de tipos de identificador (module, REST route segment, topic name) | primeiro parágrafo do corpo; a enumeração completa já está na tabela *The two layers* |
+      | `code-locale` (compat) | "measures the path of every file it is given"; "needs a harness that emits a post-write tool event" | bullet *The detector* no corpo |
+      | `execute-backlog` | "following the repo's conventions", "(tests/lint/build/typecheck)", "Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml)" | primeiro parágrafo do corpo (já dizia "consumes the same config"; ganha os nomes dos arquivos) |
+      | `backlog` | "so execute-backlog inherits a decision instead of making a new one"; "First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode)" | primeiro parágrafo do corpo; a seção `## Setup wizard` já existe |
+      | `verify-before-claiming` | os sete degraus da escada entre parênteses; "verified/inferred/unknown claim labelling" | `## The research ladder` e o primeiro parágrafo do corpo já os carregam |
+      | `assettoserver-csp-lua` | "Distilled from a production DriveZone server."; "from the server" | primeiro parágrafo do corpo |
+
+- [ ] 3.3 `## When to use this skill` removida de `skills/api-resilience-testing/SKILL.md` (conteúdo
+      já na description; nada dobrado)
+- [ ] 3.4 `metadata.version` minor nas 6 skills editadas: `code-locale` 1.2.0→1.3.0,
+      `execute-backlog` 1.7.0→1.8.0, `backlog` 1.4.0→1.5.0, `verify-before-claiming` 1.0.0→1.1.0,
+      `assettoserver-csp-lua` 1.0.1→1.1.0, `api-resilience-testing` 1.2.1→1.3.0
+
+## 4. README e wrappers
+
+- [ ] 4.1 `README.md:25` e `:381`: "Agent Skills" aponta para `https://agentskills.io/specification`;
+      `vercel-labs/skills` fica citado só como o CLI `npx skills` da Opção A
+- [ ] 4.2 `./generate.sh` rodado; `git diff --exit-code` limpo depois
+
+## 5. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 O artefato foi exercitado pelo caminho real; comando e fragmento da saída observada
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+## 6. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: name == diretório, description dobrada,
+      author solvelab, version semver, category no conjunto, license MIT, compatibility presente
+- [ ] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
+- [ ] Q.3 Gatilhos de descrição testáveis: as frases roteiam para esta skill e não colidem com
+      uma irmã; "Do NOT use for" presente onde há sobreposição
+- [ ] Q.4 Sem doutrina duplicada: nada reescrito inline; ver a tabela de Canonical Home em
+      `design.md`
+- [ ] Q.5 Todo exemplo de código em skill tocada usa identificadores em inglês; identificadores
+      novos do script vêm do Glossary da issue #112 (`code-locale`)
+
+## 7. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-agent-skills-limits --strict` verde
+- [ ] V.2 Descoberta do catálogo intacta: 35 skills, nenhum órfão ou renomeado
+- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+- [ ] V.4 `openspec archive add-agent-skills-limits --yes` depois que todos os grupos acima
+      estiverem `[x]` — PR separado, depois do merge

--- a/openspec/changes/add-agent-skills-limits/tasks.md
+++ b/openspec/changes/add-agent-skills-limits/tasks.md
@@ -118,24 +118,177 @@
 
 ## 2. Gate: C10, C8 alargado, selftest e validador de referência no CI
 
-- [ ] 2.1 `scripts/validate-skills.py`: check `C10 frontmatter limits` mede `len()` do valor
+- [x] 2.1 `scripts/validate-skills.py`: check `C10 frontmatter limits` mede `len()` do valor
       parseado de `description` (≤ `MAX_DESCRIPTION_CHARS` = 1024) e `compatibility`
       (≤ `MAX_COMPATIBILITY_CHARS` = 500), nomeia skill, check e tamanhos, declara dentro de si o
       que não cobre, e entra em `checks skipped` sem PyYAML (D1)
-- [ ] 2.2 `META_HEADING` passa a casar `When to use this skill` (D5)
-- [ ] 2.3 `scripts/selftest-validate-skills.py`: mutação C10 (description inflada acima de 1024
+
+      ```
+      grep -n "MAX_DESCRIPTION_CHARS\|MAX_COMPATIBILITY_CHARS\|KNOWN LIMIT" scripts/validate-skills.py
+      -> 298:MAX_DESCRIPTION_CHARS = 1024
+      -> 299:MAX_COMPATIBILITY_CHARS = 500
+      -> 318:    KNOWN LIMIT — what this check does NOT cover:
+      ```
+
+      Cópia do catálogo com a description de `r3f-geometry` inflada (valor parseado 1466):
+
+      ```
+      python3 scripts/validate-skills.py            (na cópia inflada)
+      -> skills checked: 35   findings: 1
+      ->   C10 frontmatter limits 1
+      -> r3f-geometry
+      ->    [C10 frontmatter limits] description is 1466 chars, limit 1024 (parsed value; 442 over)
+      -> rc=1
+      agentskills validate skills/r3f-geometry      (mesma cópia — os dois medem o mesmo número)
+      -> Validation failed for skills/r3f-geometry:
+      ->   - Description exceeds 1024 character limit (1466 chars)
+      ```
+
+      Sem PyYAML (import de `yaml` bloqueado com `sys.modules['yaml'] = None`):
+
+      ```
+      -> skills checked: 35   findings: 0
+      ->   checks skipped: yaml parse (PyYAML not installed); frontmatter limits (PyYAML not installed)
+      -> rc= 0
+      ```
+
+      A medida bruto-vs-parseado que justifica D1, re-medida com o `re.search` do C4 e o
+      `yaml.safe_load` do C10 sobre as 35 skills:
+
+      ```
+      python3 <scratch>/measure-raw.py             (catálogo deste branch)
+      -> svg-animation   raw= 1024 raw_strip= 1023 parsed=  998 delta= 26
+      -> n=35 delta(raw C4 group1 - parsed): min=6 max=26
+      python3 <scratch>/measure-raw.py d2918ed     (catálogo em master, antes do encurtamento)
+      -> n=35 delta(raw C4 group1 - parsed): min=6 max=36
+      ```
+
+      A docstring, o `design.md`, a `proposal.md` e o delta diziam 26–36; corrigidos para 6–26
+      no commit `abdc815`.
+
+- [x] 2.2 `META_HEADING` passa a casar `When to use this skill` (D5)
+
+      ```
+      python3 -c 'META_HEADING.search(h + "\n")' para cada título
+      -> '## When to use this skill' -> True
+      -> '## When To Use This Skill' -> True
+      -> '## How to Use' -> True
+      -> '## When to use' -> False
+      ```
+
+- [x] 2.3 `scripts/selftest-validate-skills.py`: mutação C10 (description inflada acima de 1024
       parseados) e mutação C8 com o título alargado; 15/15
-- [ ] 2.4 `.github/workflows/ci.yml`: `skills-ref==0.1.1` na linha de `pip` de `:83`; step novo
+
+      ```
+      python3 scripts/selftest-validate-skills.py
+      -> [...]
+      ->   CAUGHT  C8 meta section
+      ->   CAUGHT  C8 meta section (when-to-use heading)
+      ->   CAUGHT  C9 identifier locale
+      ->   CAUGHT  C10 frontmatter limits
+      -> 15/15 defect classes detected
+      -> rc=0
+      ```
+
+- [x] 2.4 `.github/workflows/ci.yml`: `skills-ref==0.1.1` na linha de `pip` de `:83`; step novo
       logo após `Skill validator self-test` rodando `agentskills validate` por diretório, com o
       comentário do pin e do que não cobre (D3)
-- [ ] 2.5 Gate primeiro: com C10 no lugar e as descriptions ainda intocadas, o validador reprova
+
+      ```
+      git diff d2918ed -- .github/workflows/ci.yml
+      -> -          python3 -m pip install --quiet pyyaml
+      -> +          python3 -m pip install --quiet pyyaml skills-ref==0.1.1
+      -> +      - name: Agent Skills reference validator (skills-ref, pinned, blocking)
+      -> +        # The version is pinned on purpose: skills_ref/validator.py:15-22 whitelists the frontmatter
+      -> +        # WHAT THIS COVERS AND WHAT IT DOES NOT: name (length, charset, == directory), description
+      -> +          for d in skills/*/; do
+      -> +            agentskills validate "$d" || fail=1
+      ```
+
+      O laço do step, rodado literalmente com o `agentskills` do venv no `PATH`:
+
+      ```
+      fail=0; for d in skills/*/; do agentskills validate "$d" || fail=1; done; echo "exit fail=$fail"
+      -> Valid skill: skills/api-resilience-testing
+      -> [...]
+      -> Valid skill: skills/verify-before-claiming
+      -> exit fail=0
+      ```
+
+- [x] 2.5 Gate primeiro: com C10 no lugar e as descriptions ainda intocadas, o validador reprova
       exatamente as 5 skills (D6) — saída registrada em S.1
+
+      Árvore do commit `2ac99fe` (o commit do gate, anterior ao encurtamento) extraída com
+      `git archive` e validada:
+
+      ```
+      python3 scripts/validate-skills.py            (árvore de 2ac99fe)
+      -> skills checked: 35   findings: 7
+      ->   C10 frontmatter limits 6
+      ->   C8 meta section        1
+      -> api-resilience-testing   [C8 meta section] `## When to use this skill` — move its content to the description
+      -> assettoserver-csp-lua    [C10 frontmatter limits] description is 1076 chars, limit 1024 (parsed value; 52 over)
+      -> backlog                  [C10 frontmatter limits] description is 1265 chars, limit 1024 (parsed value; 241 over)
+      -> code-locale              [C10 frontmatter limits] compatibility is 728 chars, limit 500 (parsed value; 228 over)
+      -> code-locale              [C10 frontmatter limits] description is 1398 chars, limit 1024 (parsed value; 374 over)
+      -> execute-backlog          [C10 frontmatter limits] description is 1344 chars, limit 1024 (parsed value; 320 over)
+      -> verify-before-claiming   [C10 frontmatter limits] description is 1222 chars, limit 1024 (parsed value; 198 over)
+      -> rc=1
+      ```
+
+      Os 6 achados de C10 caem nas 5 skills da issue (duas linhas para `code-locale`); o sétimo
+      é o C8 alargado pegando a seção que 3.3 remove.
 
 ## 3. Descriptions dentro do teto sem perder gatilho
 
-- [ ] 3.1 As 5 descriptions ≤ 1024 e a `compatibility` de `code-locale` ≤ 500, medidas no valor
+- [x] 3.1 As 5 descriptions ≤ 1024 e a `compatibility` de `code-locale` ≤ 500, medidas no valor
       parseado; o que saiu foi para o primeiro parágrafo do corpo (D4)
-- [ ] 3.2 Tabela antes/depois das frases entre aspas, por skill — nenhuma perdida:
+
+      ```
+      yaml.safe_load(frontmatter) sobre master (d2918ed) e HEAD
+      -> code-locale             desc 1398->996  compat 728->487
+      -> execute-backlog         desc 1344->994  compat 234->234
+      -> backlog                 desc 1265->1000 compat 182->182
+      -> verify-before-claiming  desc 1222->1012 compat 229->229
+      -> assettoserver-csp-lua   desc 1076->1003 compat  76->76
+      ```
+
+      Onde o que saiu aterrissou, no corpo de cada skill em HEAD:
+
+      ```
+      grep -n "grooming glossary\|path of every file" skills/code-locale/SKILL.md
+      -> 33:gate, the grooming glossary, the new-code-only migration policy, and a shipped detector a
+      -> 44:- **The detector** — measures the path of every file it is given and the contents of the types
+      grep -n "\.github/backlog.yml" skills/execute-backlog/SKILL.md
+      -> 29:to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,
+      grep -n "config wizard" skills/backlog/SKILL.md
+      -> 29:codebase. The first run per repo/workspace launches a config wizard that writes
+      grep -n "research ladder\|inferred" skills/verify-before-claiming/SKILL.md
+      -> 33:**inferred** and labelled as such, or **unknown** and reported. There is no fourth option. A
+      -> 65:## The research ladder
+      grep -n "production DriveZone" skills/assettoserver-csp-lua/SKILL.md
+      -> 27:and code all arrive over the server's HTTP port. Distilled from a production DriveZone server:
+      ```
+
+- [x] 3.2 Tabela antes/depois das frases entre aspas, por skill — nenhuma perdida:
+
+      Extraída por script (`re.findall(r'"([^"]+)"', description)`) sobre o valor parseado em
+      `d2918ed` (antes) e em HEAD (depois); `LOST` é o conjunto antes − depois:
+
+      ```
+      python3 <scratch>/quotes.py
+      -> == code-locale: desc 1398->996 chars; compat 728->487
+      ->    quoted before (10) [...]  quoted after (10) [...]  LOST: []  NEW: []
+      -> == execute-backlog: desc 1344->994 chars
+      ->    quoted before (3)  quoted after (3)   LOST: []  NEW: []
+      -> == backlog: desc 1265->1000 chars
+      ->    quoted before (4)  quoted after (4)   LOST: []  NEW: []
+      -> == verify-before-claiming: desc 1222->1012 chars
+      ->    quoted before (12) quoted after (12)  LOST: []  NEW: []
+      -> == assettoserver-csp-lua: desc 1076->1003 chars
+      ->    quoted before (0)  quoted after (0)   LOST: []  NEW: []
+      ->    LOST parens: ['different Lua contexts with different permissions']
+      ```
 
       | Skill | Frases entre aspas antes | Depois | Perdidas |
       |---|---|---|---|
@@ -143,53 +296,271 @@
       | `execute-backlog` | "implement issue #N", "execute this backlog item", "pick up this ticket" (3) | as mesmas 3 | nenhuma |
       | `backlog` | "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this idea" (4) | as mesmas 4 | nenhuma |
       | `verify-before-claiming` | "you invented that", "don't guess", "achismo", "não inventa", "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not exist", "out of scope", "não foi isso que eu pedi" (12) | as mesmas 12 | nenhuma |
-      | `assettoserver-csp-lua` | nenhuma frase entre aspas; gatilhos parentéticos (overlay, HUD, toast, in-game sound, login UI) e (empty flat box, glued or overlapping text, missing glyphs, sound plays only once) | os mesmos dois parênteses | nenhuma |
+      | `assettoserver-csp-lua` | nenhuma frase entre aspas; gatilhos parentéticos (overlay, HUD, toast, in-game sound, login UI) e (empty flat box, glued or overlapping text, missing glyphs, sound plays only once) | os mesmos dois parênteses, byte a byte | nenhuma — o único parêntese que mudou é a explicação do "Do NOT use" ("with different permissions" → "and permissions"), não um gatilho |
 
       O que saiu de cada description e para onde foi:
 
       | Skill | Saiu | Foi para |
       |---|---|---|
-      | `code-locale` | "Covers the prose/machine boundary, the untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only migration policy, and a shipped detector…"; enumeração longa de tipos de identificador (module, REST route segment, topic name) | primeiro parágrafo do corpo; a enumeração completa já está na tabela *The two layers* |
-      | `code-locale` (compat) | "measures the path of every file it is given"; "needs a harness that emits a post-write tool event" | bullet *The detector* no corpo |
-      | `execute-backlog` | "following the repo's conventions", "(tests/lint/build/typecheck)", "Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml)" | primeiro parágrafo do corpo (já dizia "consumes the same config"; ganha os nomes dos arquivos) |
-      | `backlog` | "so execute-backlog inherits a decision instead of making a new one"; "First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode)" | primeiro parágrafo do corpo; a seção `## Setup wizard` já existe |
-      | `verify-before-claiming` | os sete degraus da escada entre parênteses; "verified/inferred/unknown claim labelling" | `## The research ladder` e o primeiro parágrafo do corpo já os carregam |
-      | `assettoserver-csp-lua` | "Distilled from a production DriveZone server."; "from the server" | primeiro parágrafo do corpo |
+      | `code-locale` | "Covers the prose/machine boundary, the untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only migration policy, and a shipped detector…"; enumeração longa de tipos de identificador (module, REST route segment, topic name) | primeiro parágrafo do corpo (`:33`); a enumeração completa já está na tabela *The two layers* |
+      | `code-locale` (compat) | "measures the path of every file it is given"; "needs a harness that emits a post-write tool event" | bullet *The detector* no corpo (`:44`) |
+      | `execute-backlog` | "following the repo's conventions", "(tests/lint/build/typecheck)", "Uses the backlog skill's config (.github/backlog.yml or workspace backlog.yml)" | primeiro parágrafo do corpo (`:29`; já dizia "consumes the same config", ganha os nomes dos arquivos) |
+      | `backlog` | "so execute-backlog inherits a decision instead of making a new one"; "First run per repo/workspace launches a config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode)" | primeiro parágrafo do corpo (`:29`); a seção `## Setup wizard` já existe |
+      | `verify-before-claiming` | os sete degraus da escada entre parênteses; "verified/inferred/unknown claim labelling" | primeiro parágrafo do corpo (a escada, degrau a degrau) e `## The research ladder` (`:65`); os três rótulos já estavam em `:33` |
+      | `assettoserver-csp-lua` | "Distilled from a production DriveZone server."; "from the server" | primeiro parágrafo do corpo (`:27`) |
 
-- [ ] 3.3 `## When to use this skill` removida de `skills/api-resilience-testing/SKILL.md` (conteúdo
+- [x] 3.3 `## When to use this skill` removida de `skills/api-resilience-testing/SKILL.md` (conteúdo
       já na description; nada dobrado)
-- [ ] 3.4 `metadata.version` minor nas 6 skills editadas: `code-locale` 1.2.0→1.3.0,
+
+      ```
+      git diff d2918ed HEAD -- skills/api-resilience-testing/SKILL.md | grep '^-'
+      -> -## When to use this skill
+      -> -Trigger whenever the work involves a REST/HTTP API: adding or changing an
+      -> [...]
+      grep -n "When to use" skills/api-resilience-testing/SKILL.md claude/skills/api-resilience-testing/SKILL.md
+      -> (nenhuma linha) grep rc=1
+      ```
+
+- [x] 3.4 `metadata.version` minor nas 6 skills editadas: `code-locale` 1.2.0→1.3.0,
       `execute-backlog` 1.7.0→1.8.0, `backlog` 1.4.0→1.5.0, `verify-before-claiming` 1.0.0→1.1.0,
       `assettoserver-csp-lua` 1.0.1→1.1.0, `api-resilience-testing` 1.2.1→1.3.0
 
+      ```
+      grep -m1 '^  version:' em master (d2918ed) e HEAD, por skill
+      -> code-locale              master=1.2.0 HEAD=1.3.0
+      -> execute-backlog          master=1.7.0 HEAD=1.8.0
+      -> backlog                  master=1.4.0 HEAD=1.5.0
+      -> verify-before-claiming   master=1.0.0 HEAD=1.1.0
+      -> assettoserver-csp-lua    master=1.0.1 HEAD=1.1.0
+      -> api-resilience-testing   master=1.2.1 HEAD=1.3.0
+      ```
+
 ## 4. README e wrappers
 
-- [ ] 4.1 `README.md:25` e `:381`: "Agent Skills" aponta para `https://agentskills.io/specification`;
+- [x] 4.1 `README.md:25` e `:381`: "Agent Skills" aponta para `https://agentskills.io/specification`;
       `vercel-labs/skills` fica citado só como o CLI `npx skills` da Opção A
-- [ ] 4.2 `./generate.sh` rodado; `git diff --exit-code` limpo depois
+
+      ```
+      sed -n 25p README.md
+      -> Skills follow the open [Agent Skills](https://agentskills.io/specification) standard (`skills/<name>/SKILL.md`), so every mainstream install path works — including the [`npx skills`](https://github.com/vercel-labs/skills) CLI of Option A.
+      sed -n 381p README.md
+      -> The canonical skill lives in `skills/<name>/SKILL.md` — a **self-contained** file following the open [Agent Skills](https://agentskills.io/specification) standard [...]
+      grep -n "vercel-labs/skills" README.md
+      -> 25:[...] (única ocorrência)
+      ```
+
+- [x] 4.2 `./generate.sh` rodado; `git diff --exit-code` limpo depois
+
+      ```
+      bash generate.sh
+      -> Generated 10 category plugins in plugins/
+      git diff --exit-code --stat
+      -> diff rc=0
+      git status --porcelain | wc -l
+      -> 0
+      ```
 
 ## 5. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 O artefato foi exercitado pelo caminho real; comando e fragmento da saída observada
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado
+- [x] S.1 O artefato foi exercitado pelo caminho real; comando e fragmento da saída observada
+
+      **Validador de referência sobre as 35 skills** (`skills-ref==0.1.1` em venv, binário
+      `agentskills`, uma chamada por diretório — o mesmo laço do step do CI):
+
+      ```
+      bash <scratch>/run-agentskills.sh
+      -> skills/api-resilience-testing  rc=0 :: Valid skill: skills/api-resilience-testing
+      -> skills/assettoserver-csp-lua   rc=0 :: Valid skill: skills/assettoserver-csp-lua
+      -> skills/backlog                 rc=0 :: Valid skill: skills/backlog
+      -> skills/code-locale             rc=0 :: Valid skill: skills/code-locale
+      -> skills/execute-backlog         rc=0 :: Valid skill: skills/execute-backlog
+      -> [...]
+      -> skills/svg-animation           rc=0 :: Valid skill: skills/svg-animation
+      -> skills/verify-before-claiming  rc=0 :: Valid skill: skills/verify-before-claiming
+      -> ok=35 bad=0 total=35
+      -> rc=0
+      ```
+
+      Antes do encurtamento o mesmo laço dava `ok=30 bad=5 total=35` (E.2).
+
+      **C10 pelo caminho real** — dispara na cópia inflada e fica mudo no catálogo:
+
+      ```
+      python3 scripts/validate-skills.py            (cópia com r3f-geometry inflada a 1466)
+      ->    [C10 frontmatter limits] description is 1466 chars, limit 1024 (parsed value; 442 over)
+      -> rc=1
+      python3 scripts/validate-skills.py            (catálogo)
+      -> skills checked: 35   findings: 0
+      -> rc=0
+      ```
+
+      **Simulação de roteamento por gatilho** — 3 prompts realistas por skill encurtada, 15 no
+      total, pontuados contra as 35 descriptions de `master` (antes) e de HEAD (depois) por um
+      roteador léxico (`<scratch>/route-sim.py`: frases entre aspas casadas ×3 + bigramas de
+      conteúdo + unigramas/4). O roteador real é o modelo; o que se mede aqui é se o sinal
+      lexical que cada description carrega para esses prompts sobreviveu ao corte:
+
+      | Skill | Prompt | Antes → Depois | Vice |
+      |---|---|---|---|
+      | `code-locale` | "O PR introduz a rota /clientes/{id}/pedidos — rota em português é aceitável aqui ou traduz esse nome?" | code-locale 10.50 → 10.50 | verify-before-claiming 0.00 |
+      | `code-locale` | "Should this be in English? The DB column is called data_nascimento and the enum values are PENDENTE/PAGO — our code is half Portuguese." | code-locale 9.75 → 9.50 | execute-backlog 0.75 → 0.50 |
+      | `code-locale` | "Vamos criar a tabela de notas fiscais: o campo pode se chamar nota_fiscal_number ou o domain term tem que virar invoice? Qual a naming convention?" | code-locale 6.00 → 6.00 | verify-before-claiming 0.25 |
+      | `execute-backlog` | "implement issue #112 end to end and open the PR with Closes" | execute-backlog 2.00 → 2.00 | backlog 0.25 |
+      | `execute-backlog` | "pick up this ticket please: https://github.com/solvelab/ai-skills/issues/98" | execute-backlog 4.50 → 4.50 | verify-before-claiming 0.00 |
+      | `execute-backlog` | "execute this backlog item, the one about the release race, on a dedicated branch" | execute-backlog 7.25 → 7.25 | verify-before-claiming 1.75 |
+      | `backlog` | "add this to the backlog: the validator should also measure tokens, not only characters" | backlog 4.75 → 4.75 | svg-animation 0.50 |
+      | `backlog` | "turn this idea into an issue in the GitHub Project: run agentskills validate in CI" | backlog 8.75 → 8.50 | execute-backlog 2.50 |
+      | `backlog` | "groom this idea before I forget — a config wizard for backlog.yml in workspace mode" | backlog **8.75 → 4.75** | execute-backlog 1.00 → verify-before-claiming 0.50 |
+      | `verify-before-claiming` | "de onde tirou essa flag --strict-sections? acho que ela não existe, não inventa" | verify-before-claiming 9.75 → 9.75 | conventional-commit 0.25 |
+      | `verify-before-claiming` | "don't guess: which version of skills-ref does the CI install and where did you see that?" | verify-before-claiming 12.00 → 12.00 | openspec-drivezone 0.25 |
+      | `verify-before-claiming` | "não foi isso que eu pedi — eu pedi só o diff, não pra reescrever o script; isso é out of scope" | verify-before-claiming 13.50 → 13.50 | openspec-drivezone 0.25 |
+      | `assettoserver-csp-lua` | "my CSP overlay renders as an empty flat box with glued or overlapping text; the lua online script is served by AssettoServer" | assettoserver-csp-lua 13.50 → 13.50 | fivem-nui-react 0.50 |
+      | `assettoserver-csp-lua` | "the ac.OnlineEvent packet from my toast script silently never arrives on the client, the C# plugin sends it fine" | assettoserver-csp-lua 2.75 → 2.75 | react-api-client 0.25 |
+      | `assettoserver-csp-lua` | "write a HUD lua online script for the login UI with a remote image loaded by URL and DirectWrite text" | assettoserver-csp-lua 6.50 → 6.50 | openspec-drivezone 0.25 |
+
+      ```
+      python3 <scratch>/route-sim.py
+      -> prompts=15  intended-top before=15/15  after=15/15  same-top before/after=15/15
+      ```
+
+      Leitura observada, prompt a prompt: em 12 dos 15 a pontuação é idêntica antes e depois,
+      porque o que roteia é a frase entre aspas ou o parêntese de sintomas, e nenhum saiu. Em 2
+      cai 0,25 — um unigrama de ruído que a description antiga tinha e a nova não ("are" em
+      `code-locale`, "run" em `backlog`, medidos por diferença de conjuntos). Em 1 cai
+      4,00: o prompt do wizard casava a frase "config wizard that writes .github/backlog.yml
+      (repo mode) or backlog.yml (workspace mode)", que saiu da description e foi para o corpo;
+      ainda assim `backlog` ganha por "groom this idea" com 4,75 contra 0,50 do segundo colocado.
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | `agentskills validate` sai 0 em cada skill | 35/35 | `ok=35 bad=0 total=35` (antes do corte: 30/35) |
+      | C10 tinha de disparar e disparou | 1/1 | cópia inflada: `description is 1466 chars, limit 1024` |
+      | C10 e `agentskills` medem o mesmo número | 1/1 | 1466 nos dois, na mesma cópia |
+      | C10 tinha de ficar mudo e ficou | 35/35 | catálogo: `findings: 0` |
+      | Selftest detecta cada classe | 15/15 | `15/15 defect classes detected` |
+      | Gate primeiro reprova exatamente as 5 | 5/5 | árvore de `2ac99fe`: 6 achados C10 em 5 skills, nenhuma outra |
+      | Frases entre aspas preservadas | 29/29 | 10+3+4+12+0, `LOST: []` nas 5 |
+      | Roteamento léxico mantém a skill alvo | 15/15 antes, 15/15 depois | `same-top before/after=15/15` |
+      | Prompt cuja margem caiu | 1/15 | wizard do `backlog`: 8,75 → 4,75, ainda primeiro |
+      | Escape conhecido ficou mudo | 1/1 | description de 998 caracteres com ~1,3k tokens — ver S.3 |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      1. **Um gatilho não citado enfraqueceu.** A frase do wizard (`backlog`) não estava entre
+         aspas e saiu da description; um prompt que descreva o wizard sem dizer "groom this idea"
+         ou "add this to the backlog" perde 4 pontos de sinal lexical. A skill continua a ganhar
+         (4,75 contra 0,50), e a seção `## Setup wizard` do corpo carrega o conteúdo — mas é o
+         único ponto onde o corte mudou uma medida.
+      2. **Um parêntese mudou de forma.** Em `assettoserver-csp-lua`, "different Lua contexts
+         with different permissions" virou "different Lua contexts and permissions". É a
+         explicação de uma cláusula "Do NOT use", não um gatilho; o extrator de parênteses o
+         lista como `LOST` e a tabela 3.2 o declara.
+      3. **O que o gate não vê, declarado no próprio check:** C10 mede caracteres, não tokens. Uma
+         description de 998 caracteres (`svg-animation`) passa; se alguém dobrar mais um gatilho
+         nela cai fora por 1 e o gate avisa, mas o orçamento de ~100 tokens por skill que a spec
+         sugere não é medido por ninguém — fora de escopo da issue.
+      4. **Roteador léxico ≠ roteador real.** A simulação mede sobrevivência do sinal, não a
+         decisão do modelo; um prompt sem nenhuma frase citada (o de `implement issue #112`)
+         roteia por um único bigrama com pontuação 2,00, antes e depois. É o mesmo antes e
+         depois, portanto não é regressão desta change, mas é margem fina que já existia.
+      5. **`agentskills` no `PATH` do runner** continua sendo a lacuna de E.3: provado localmente
+         com o venv no `PATH`, provado no CI só pelo primeiro run deste branch.
 
 ## 6. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: name == diretório, description dobrada,
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: name == diretório, description dobrada,
       author solvelab, version semver, category no conjunto, license MIT, compatibility presente
-- [ ] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
-- [ ] Q.3 Gatilhos de descrição testáveis: as frases roteiam para esta skill e não colidem com
+
+      ```
+      laço de frontmatter do ci.yml (mesmos 8 testes), sobre skills/*/SKILL.md
+      -> PASS frontmatter
+      agentskills validate                          (name charset/comprimento e whitelist de campos)
+      -> ok=35 bad=0 total=35
+      ```
+
+- [x] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
+
+      As linhas adicionadas aos corpos das 6 skills (diff `d2918ed..HEAD`, fora do frontmatter)
+      estão em inglês; as únicas sequências em português nas descriptions são as frases de
+      gatilho entre aspas que já existiam em `master` (tabela 3.2). Detector de locale sobre os
+      arquivos de script tocados:
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py scripts/validate-skills.py scripts/selftest-validate-skills.py .github/workflows/ci.yml
+      -> findings: 0
+      python3 scripts/validate-skills.py            (C9 identifier locale sobre os blocos de código das skills)
+      -> skills checked: 35   findings: 0
+      ```
+
+- [x] Q.3 Gatilhos de descrição testáveis: as frases roteiam para esta skill e não colidem com
       uma irmã; "Do NOT use for" presente onde há sobreposição
-- [ ] Q.4 Sem doutrina duplicada: nada reescrito inline; ver a tabela de Canonical Home em
+
+      Simulação de S.1: 15/15 roteiam para a skill alvo, o segundo colocado nunca passa de 2,50
+      (execute-backlog para um prompt de `backlog`, cuja cláusula "Do NOT use for implementing
+      an existing issue (that is execute-backlog)" está preservada). As cláusulas "Do NOT use"
+      das 5 descriptions permanecem, com os mesmos nomes de skill irmã:
+
+      ```
+      re.search(r"Do NOT use.*", description) sobre o valor parseado em HEAD
+      -> code-locale: Do NOT use for commit subjects or PR bodies (that is conventional-commit), for docs prose (that is documentation), for case style or test naming (each stack's skill), or for i18n and user-facing translation.
+      -> execute-backlog: Do NOT use for creating backlog items (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+      -> backlog: Do NOT use for implementing an existing issue (that is execute-backlog), for creating pull requests, or for non-GitHub trackers (Jira, Linear, Trello).
+      -> verify-before-claiming: Do NOT use for adversarially testing code already written (that is bug-hunter), for designing an API test suite (that is api-resilience-testing), for writing documentation pages (that is documentation), or for the plan-approval gate of a backlog item (that is execute-backlog).
+      -> assettoserver-csp-lua: Do NOT use for the C# plugin side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
+      ```
+
+- [x] Q.4 Sem doutrina duplicada: nada reescrito inline; ver a tabela de Canonical Home em
       `design.md`
-- [ ] Q.5 Todo exemplo de código em skill tocada usa identificadores em inglês; identificadores
+
+      `design.md:95` — `## Canonical Home & Cross-Links (MANDATORY)`. O limite de 1024/500 mora
+      no delta de `skills-authoring` e é citado (não repetido) pela docstring de C10 e pelo
+      comentário do step do CI, ambos apontando para `skills_ref/validator.py`. A seção
+      `## When to use this skill` removida em 3.3 era a duplicata que sobrava.
+
+- [x] Q.5 Todo exemplo de código em skill tocada usa identificadores em inglês; identificadores
       novos do script vêm do Glossary da issue #112 (`code-locale`)
+
+      ```
+      grep -n "MAX_DESCRIPTION_CHARS\|MAX_COMPATIBILITY_CHARS\|C10 frontmatter limits" scripts/*.py
+      -> scripts/validate-skills.py:298:MAX_DESCRIPTION_CHARS = 1024
+      -> scripts/validate-skills.py:299:MAX_COMPATIBILITY_CHARS = 500
+      -> scripts/validate-skills.py:347:            add(skill, "C10 frontmatter limits",
+      -> scripts/selftest-validate-skills.py:48: "C10 frontmatter limits": ("skills/r3f-geometry/SKILL.md",
+      ```
+
+      Os três nomes são os da tabela Glossary da issue (`MAX_DESCRIPTION_CHARS`,
+      `MAX_COMPATIBILITY_CHARS`, `C10 frontmatter limits`); o quarto (`agentskills validate`) é
+      o binário real. Nenhum exemplo de código foi adicionado às skills tocadas.
 
 ## 7. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-agent-skills-limits --strict` verde
-- [ ] V.2 Descoberta do catálogo intacta: 35 skills, nenhum órfão ou renomeado
-- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+- [x] V.1 `openspec validate add-agent-skills-limits --strict` verde
+
+      ```
+      openspec validate add-agent-skills-limits --strict
+      -> Change 'add-agent-skills-limits' is valid
+      GITHUB_EVENT_PATH=<event com "Spec-rite: add-agent-skills-limits"> bash scripts/validate-rite.sh
+      -> rite gate OK
+      ```
+
+- [x] V.2 Descoberta do catálogo intacta: 35 skills, nenhum órfão ou renomeado
+
+      ```
+      diff <(git ls-tree --name-only d2918ed skills/) <(git ls-tree --name-only HEAD skills/)
+      -> (sem diff) same 35 dirs: 35
+      ls claude/skills | wc -l ; ls codex/skills | wc -l
+      -> 35 ; 35
+      python3 scripts/validate-skills.py            (C7 orphan wrapper incluso)
+      -> skills checked: 35   findings: 0
+      ```
+
+- [x] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+
+      A composição não muda; o uso sim — o padrão que o catálogo declara seguir passa a ser
+      linkado pela especificação (4.1, `README.md:25` e `:381`). O validador de referência é
+      documentado no próprio step do CI e no delta de `skills-authoring`.
+
 - [ ] V.4 `openspec archive add-agent-skills-limits --yes` depois que todos os grupos acima
       estiverem `[x]` — PR separado, depois do merge

--- a/plugins/game/skills/assettoserver-csp-lua/SKILL.md
+++ b/plugins/game/skills/assettoserver-csp-lua/SKILL.md
@@ -4,18 +4,17 @@ description: >-
   Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the
   zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API
   in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte
-  with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry,
-  and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a
-  production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD,
-  toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or
-  overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently
-  never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands,
-  publishing (that is assettoserver-plugin), for server configuration/deploy (that is
-  assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different
-  permissions), or for FiveM Lua (that is fivem-lua).
+  with the C# plugin, remote images and audio loaded by URL, local car telemetry, and the
+  mockup-first workflow for visuals you cannot render outside the game. Use when writing or
+  reviewing a .lua online script (overlay, HUD, toast, in-game sound, login UI), when a CSP
+  overlay renders wrong (empty flat box, glued or overlapping text, missing glyphs, sound plays
+  only once), or when an OnlineEvent packet silently never arrives. Do NOT use for the C# plugin
+  side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for
+  server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts
+  (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 metadata:
   author: solvelab
-  version: 1.0.1
+  version: 1.1.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -25,8 +24,9 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 
 Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
 client by the server itself. Zero-install is the point — the player installs nothing; art, sound
-and code all arrive over the server's HTTP port. Every rule below was paid for with an in-game
-iteration; in this stack a wrong guess costs a deploy plus a human driving session to observe it.
+and code all arrive over the server's HTTP port. Distilled from a production DriveZone server:
+every rule below was paid for with an in-game iteration, and in this stack a wrong guess costs a
+deploy plus a human driving session to observe it.
 
 ## What an online script is
 

--- a/plugins/testing/skills/api-resilience-testing/SKILL.md
+++ b/plugins/testing/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -37,16 +37,6 @@ sub-disciplines precisely:
 Avoid vague "QA security testing" in formal docs — it is informal and ambiguous.
 ("Bug-Hunter" is fine as the name of the internal adversarial-testing rite — see the
 `bug-hunter` skill — but use the precise terms above when writing formal test docs.)
-
----
-
-## When to use this skill
-
-Trigger whenever the work involves a REST/HTTP API: adding or changing an
-endpoint, reviewing an API PR, writing API tests, designing request/response
-schemas, or the user asks to "test", "harden", "break", "audit", or "review"
-an API. Default to running the workflow below before an API change is
-considered done — happy-path tests alone are not sufficient.
 
 ---
 

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -1,24 +1,20 @@
 ---
 name: backlog
 description: >-
-  Turn a natural-language idea into a structured GitHub backlog item: analyze the current
-  repository (or multi-repo workspace) for real context, draft a rich issue (context, problem,
-  scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create
-  the GitHub issue and add it to the configured GitHub Project v2 with fields set
-  (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
-  "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
-  idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite:
-  the item created here is what execute-backlog turns into a branch and a pull request. In a
-  repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also
-  declares its spec verdict — the change that will register the work, or a written waiver —
-  so execute-backlog inherits a decision instead of making a new one.
-  First run per repo/workspace launches a
-  config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
-  use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
-  for non-GitHub trackers (Jira, Linear, Trello).
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the repository (or
+  multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance
+  criteria, risks, affected files/repos), preview it for approval, then create the issue and add
+  it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the
+  gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to
+  the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in
+  a GitHub Project. Entry point of the backlog-first rite: execute-backlog turns the item created
+  here into a branch and a pull request. In a repository with a spec-driven workflow (an openspec/
+  directory) the item also declares its spec verdict: a change id or a written waiver. Do NOT use
+  for implementing an existing issue (that is execute-backlog), for creating pull requests, or for
+  non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.4.0
+  version: 1.5.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,7 +26,9 @@ compatibility: >-
 
 Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
 configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
-codebase.
+codebase. The first run per repo/workspace launches a config wizard that writes
+`.github/backlog.yml` (repo mode) or `backlog.yml` (workspace mode). The spec verdict the item
+declares is what `execute-backlog` inherits, instead of making a new decision.
 
 - **Issue section template + writing guidance**: `references/issue-template.md`
 - **Config schema (both modes, precedence, wizard, `spec_rite`)**: `references/backlog-config.md`

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -1,41 +1,37 @@
 ---
 name: code-locale
 description: >-
-  Decides which natural language each artifact of a change is written in: prose follows the
-  repository's working language, and anything a machine parses is English. Use when naming a
-  variable, function, class, file, module, REST route segment, query param, DB table or column,
-  enum value, event or topic name, config key or log field; when reviewing a diff or PR that
-  introduces names; when a backlog item written in another language is about to become code; when
-  deciding whether a domain term like CPF, CNPJ, boleto, PIX or nota fiscal keeps its name; when an
-  external API's payload fields are in another language; or when the user says "código em
-  português", "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador
-  em inglês", "should this be in English", "our code is half Portuguese", "naming convention",
-  "ubiquitous language", "anti-corruption layer". Covers the prose/machine boundary, the
-  untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only
-  migration policy, and a shipped detector a repository can wire into CI. Do NOT use for the
-  language of commit subjects or PR bodies (that is conventional-commit), for the language of
-  documentation prose (that is documentation), for format-level naming conventions like case style
-  or test-method patterns (those live in each stack's skill), or for i18n and user-facing
-  translation.
+  Decides which natural language each artifact is written in: prose follows the repository's
+  working language, anything a machine parses is English. Use when naming a variable, function,
+  class, file, route, query param, DB table or column, enum value, event, config key or log field;
+  when reviewing a diff that introduces names; when a backlog item in another language becomes
+  code; when a domain term like CPF, CNPJ, boleto, PIX or nota fiscal may keep its name; when an
+  external API's payload is in another language; or when the user says "código em português",
+  "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador em
+  inglês", "should this be in English", "our code is half Portuguese", "naming convention",
+  "ubiquitous language", "anti-corruption layer". Do NOT use for commit subjects or PR bodies
+  (that is conventional-commit), for docs prose (that is documentation), for case style or test
+  naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
   The doctrine is language- and stack-agnostic and needs no runtime. The shipped detector
-  `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package; it
-  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, measures the path of
-  every file it is given, reports the contents of any other file type as skipped rather than
-  passing, and ships the public-domain word list that answers its second question (read with the
-  standard library's gzip module, so there is still no third-party package). The optional write-time hook `claude/global/hooks/locale-rite.py` needs a harness that
-  emits a post-write tool event; it was built against Claude Code 2.1.246 and exits silently
-  anywhere else.
+  `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package (its word
+  list is read with the standard library's gzip module); it tokenizes Python, Lua, JavaScript,
+  TypeScript, C#, SQL, YAML, JSON and Bash and reports any other file type as skipped. The
+  optional hook `claude/global/hooks/locale-rite.py` was built against Claude Code 2.1.246 and
+  exits silently anywhere else.
 ---
 
 # Code locale — prose follows the repo, the machine layer is English
 
 **Prose follows the repository's working language. Anything a machine parses is English.**
+This skill covers the prose/machine boundary, the untranslatable-domain-term exception and its
+gate, the grooming glossary, the new-code-only migration policy, and a shipped detector a
+repository can wire into CI.
 
 The boundary is drawn by *what consumes the artifact*, not by who wrote it. A commit body and a
 code comment have the same audience, so they land on the same side. A route segment and a database
@@ -45,7 +41,8 @@ without a taste debate.
 - **Per-stack enumeration, wrong → right pairs**: `references/boundary-map.md`
 - **Producing and consuming the PT→EN glossary**: `references/glossary-protocol.md`
 - **Existing names: the three migration tiers**: `references/migration.md`
-- **The detector**: `references/check-identifier-locale.py`
+- **The detector** — measures the path of every file it is given and the contents of the types
+  it tokenizes: `references/check-identifier-locale.py`
 
 ## The two layers
 

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -2,23 +2,19 @@
 name: execute-backlog
 description: >-
   Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search),
-  validate it is complete enough to execute, re-analyze the current repo/workspace state, present
-  an implementation plan for approval BEFORE touching code, implement on a dedicated branch
-  following the repo's conventions, add/update tests, run the repo's discoverable validations
-  (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by
-  evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to
-  the review column. Use when the user invokes /execute-backlog <n>, says
-  "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
-  issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced
-  by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a
-  spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code:
-  the item's spec verdict is re-checked, the change is created and validated strict, and only then
-  does the plan go to approval. Uses the backlog skill's
-  config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items
-  (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+  validate it is complete enough, re-analyze the repo/workspace, present an implementation plan
+  for approval BEFORE touching code, implement on a dedicated branch with tests, run the repo's
+  discoverable validations, tick the acceptance criteria proven by evidence, open pull request(s)
+  with Closes #n, and move the GitHub Project item to the review column. Use when the user invokes
+  /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this
+  ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite:
+  consumes the item the backlog skill produced. In a repository with a spec-driven workflow (an
+  openspec/ directory) it re-checks the item's spec verdict and validates the change strict before
+  the plan goes to approval. Do NOT use for creating backlog items (that is backlog), for merging
+  PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.7.0
+  version: 1.8.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,7 +26,9 @@ compatibility: >-
 # Execute-backlog — backlog item → implemented, validated PR
 
 Drive an existing issue to a reviewable pull request while keeping the board in sync. Companion
-to the `backlog` skill; consumes the same config.
+to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,
+`backlog.yml` in workspace mode), follows the repo's own conventions, and runs the validations
+it can discover there (tests/lint/build/typecheck).
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
 - **Spec-driven gate: detection, verdict, upgrade/downgrade, archive timing**: `references/spec-rite.md`

--- a/plugins/workflow/skills/verify-before-claiming/SKILL.md
+++ b/plugins/workflow/skills/verify-before-claiming/SKILL.md
@@ -1,22 +1,20 @@
 ---
 name: verify-before-claiming
 description: >-
-  Anti-guessing rite: research before asserting, label every claim with its source, and report what
-  could not be found instead of producing a plausible substitute. Use when about to state or use an
-  API, CLI flag, config key, env var, path, version or behavior not read in this session; when a fact
-  depends on a library version; when the answer cannot be found and the gap has to be reported; or
-  when the user says "you invented that", "don't guess", "achismo", "não inventa", "chutou",
-  "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not
-  exist", "out of scope", "não foi isso que eu pedi". Covers the cheapest-first research ladder
-  (session context, this repo, the installed dependency, the tool itself, version-pinned docs, web
-  search, the user), verified/inferred/unknown claim labelling, the not-found report, and the
-  scope-restatement guard against delivering work nobody asked for. Do NOT use for adversarially
-  testing code already written (that is bug-hunter), for designing an API test suite (that is
-  api-resilience-testing), for writing a project's documentation pages (that is documentation), or
+  Anti-guessing rite: research before asserting, label every claim with its source, and report
+  what could not be found instead of producing a plausible substitute. Use when about to state or
+  use an API, CLI flag, config key, env var, path, version or behavior not read in this session;
+  when a fact depends on a library version; when the answer cannot be found and the gap has to be
+  reported; or when the user says "you invented that", "don't guess", "achismo", "não inventa",
+  "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that
+  flag does not exist", "out of scope", "não foi isso que eu pedi". Covers the research ladder,
+  claim labelling, the not-found report and the scope-restatement guard. Do NOT use for
+  adversarially testing code already written (that is bug-hunter), for designing an API test suite
+  (that is api-resilience-testing), for writing documentation pages (that is documentation), or
   for the plan-approval gate of a backlog item (that is execute-backlog).
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
@@ -33,7 +31,9 @@ endpoint nobody asked for — it claims the user wanted it.
 
 Every claim is one of three things: **verified** against a source you opened in this session,
 **inferred** and labelled as such, or **unknown** and reported. There is no fourth option. A
-plausible sentence with no source is the defect this skill exists to prevent.
+plausible sentence with no source is the defect this skill exists to prevent. The research
+ladder is cheapest-first: session context, this repo, the installed dependency, the tool itself,
+version-pinned docs, web search, the user.
 
 - **Per-ecosystem commands for each rung, offline degradation**: `references/research-ladder.md`
 - **Claim labels, the not-found report, scope blocks**: `references/report-templates.md`

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -1,5 +1,9 @@
 """Adversarial self-test: inject one known defect per check into a copy of the catalog
-and assert the validator fires. A checker that never fails is not a checker."""
+and assert the validator fires. A checker that never fails is not a checker.
+
+Each entry is  label: (relpath, mutate, expect)  — `expect` is the check name the validator must
+print for that label, plus an optional fragment its finding must carry. It exists because one
+check can own more than one defect class (C8 has five headings) and a dict cannot repeat a key."""
 import shutil, subprocess, sys, tempfile, pathlib, re, os
 
 SRC = pathlib.Path(__file__).resolve().parent.parent
@@ -30,15 +34,26 @@ MUTATIONS = {
  "C7 orphan wrapper": (None, None),
  "C8 meta section": ("skills/openspec/SKILL.md",
      lambda s: s + "\n## Trigger Test Cases\n\nShould trigger on:\n- \"do the thing\"\n"),
+ # The heading that escaped C8 for months: same content as the description, read after routing.
+ "C8 meta section (when-to-use heading)": ("skills/openspec/SKILL.md",
+     lambda s: s + "\n## When to use this skill\n\nUse when the user asks for a proposal.\n",
+     ("C8 meta section", "When to use this skill")),
  # Valid Python so C3 stays silent. The dict *value* 'endereco' is a string literal and must NOT
  # be flagged — this mutation therefore also asserts that literal stripping still works.
  "C9 identifier locale": ("skills/python-rest-api/SKILL.md",
      lambda s: s + "\n```python\ndef criar_pedido(id_usuario):\n"
                    "    return {'x': 'endereco'}\n```\n"),
+ # 1100 characters of PARSED value on top of a short description: the folded scalar keeps the
+ # indentation out of the count, so the padding is what the reference validator would measure too.
+ "C10 frontmatter limits": ("skills/r3f-geometry/SKILL.md",
+     lambda s: s.replace("description: >-", "description: >-\n  " + "Use when the user says so. " * 44, 1),
+     ("C10 frontmatter limits", "description is")),
 }
 
 fails = []
-for check, (relpath, mutate) in MUTATIONS.items():
+for check, entry in MUTATIONS.items():
+    relpath, mutate = entry[0], entry[1]
+    expect, fragment = (entry[2] if len(entry) > 2 else (check, ""))
     with tempfile.TemporaryDirectory() as td:
         dst = pathlib.Path(td) / "repo"
         shutil.copytree(SRC, dst, ignore=shutil.ignore_patterns(".git", "node_modules"))
@@ -49,7 +64,7 @@ for check, (relpath, mutate) in MUTATIONS.items():
             p = dst / relpath
             p.write_text(mutate(p.read_text()))
         out = subprocess.run([sys.executable, str(dst / "scripts" / "validate-skills.py")], cwd=dst, capture_output=True, text=True).stdout
-        caught = check.split()[0] in out and check in out
+        caught = expect.split()[0] in out and expect in out and fragment in out
         print(f"  {'CAUGHT ' if caught else 'MISSED '} {check}")
         if not caught:
             fails.append(check)

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -11,6 +11,7 @@ Implements the mechanically checkable half of openspec/specs/skills-authoring:
   C7 no orphan wrapper skills               (every generated skill has a canonical source)
   C8 no meta sections in SKILL.md           (triggers belong in the description, not the body)
   C9 identifier locale                      (English identifiers in code examples)
+  C10 frontmatter limits                    (parsed description <= 1024 chars, compatibility <= 500)
 
 Exit 1 on any finding. Run from the repo root.
 """
@@ -274,7 +275,10 @@ def check_tags(skill: str, text: str) -> None:
 
 
 # ── C8: meta sections ─────────────────────────────────────────────────────
-META_HEADING = re.compile(r"^## (How to Use|Trigger Test Cases|Prompt|Usage)\s*$", re.M | re.I)
+# "When to use this skill" was added after skills/api-resilience-testing shipped one for months
+# under the four original titles' noses: same content as its description, read only after routing.
+META_HEADING = re.compile(r"^## (How to Use|When to use this skill|Trigger Test Cases|Prompt|Usage)\s*$",
+                          re.M | re.I)
 
 
 def check_meta(skill: str, text: str) -> None:
@@ -284,6 +288,64 @@ def check_meta(skill: str, text: str) -> None:
     reads when choosing a skill."""
     for m in META_HEADING.finditer(text):
         add(skill, "C8 meta section", f"`{m.group(0).strip()}` — move its content to the description")
+
+
+# ── C10: frontmatter limits ───────────────────────────────────────────────
+# The Agent Skills specification (agentskills.io/specification) fixes description at 1-1024
+# characters and compatibility at 1-500. The names mirror MAX_DESCRIPTION_LENGTH and
+# MAX_COMPATIBILITY_LENGTH in skills_ref/validator.py (skills-ref 0.1.1, the reference validator
+# CI runs in its own step), which measures len() of the parsed value — so does this check.
+MAX_DESCRIPTION_CHARS = 1024
+MAX_COMPATIBILITY_CHARS = 500
+FRONTMATTER_LIMITS = (("description", MAX_DESCRIPTION_CHARS),
+                      ("compatibility", MAX_COMPATIBILITY_CHARS))
+
+try:
+    import yaml as _yaml
+except ImportError:                                 # reported as skipped in main(), never as a pass
+    _yaml = None
+
+
+def check_limits(skill: str, text: str) -> None:
+    """Measure the PARSED frontmatter value, in characters, against the spec limits.
+
+    Why parsed and not the raw block C4 slices out of the file: a folded scalar (`>-`) carries its
+    indentation and line breaks in the file and loses them when a consumer reads it. Measured over
+    the 35 skills on 2026-09-04, the raw block is 26-36 characters longer than the value —
+    svg-animation is 1024 raw and 998 parsed. A gate on the raw block would reject a skill the
+    reference validator accepts. len() counts code points, not bytes, exactly like skills-ref;
+    the descriptions carry non-ASCII quoted triggers, so a byte count would disagree with it.
+
+    KNOWN LIMIT — what this check does NOT cover:
+      - Only `description` and `compatibility` are measured. The name length/charset rule (64,
+        lowercase) and the spec's whitelist of frontmatter fields are the reference validator's
+        job, run pinned in CI; name-vs-directory is the CI frontmatter loop's.
+      - It measures characters against the spec's hard limit, not tokens against the ~100-token
+        budget the spec suggests; a description under 1024 characters can still be expensive.
+      - The frontmatter is located with the same `split("---", 2)` C4 uses; a `---` inside a
+        frontmatter value would truncate the block and is not handled here.
+      - Skipped entirely without PyYAML, and reported as skipped rather than counted as a pass.
+    """
+    if _yaml is None:
+        return
+    fm = text.split("---", 2)
+    if len(fm) < 3:
+        return                                       # C4 already reports the missing frontmatter
+    try:
+        data = _yaml.safe_load(fm[1])
+    except _yaml.YAMLError as exc:
+        add(skill, "C10 frontmatter limits", f"frontmatter does not parse as YAML: {str(exc)[:90]}")
+        return
+    if not isinstance(data, dict):
+        return                                       # the CI frontmatter loop reports the shape
+    for field, limit in FRONTMATTER_LIMITS:
+        value = data.get(field)
+        if not isinstance(value, str):
+            continue                                 # presence is the CI frontmatter loop's job
+        n = len(value)
+        if n > limit:
+            add(skill, "C10 frontmatter limits",
+                f"{field} is {n} chars, limit {limit} (parsed value; {n - limit} over)")
 
 
 # ── C7: no orphan wrapper skills ──────────────────────────────────────────
@@ -312,6 +374,7 @@ def main() -> int:
         check_pin(skill, text)
         check_tags(skill, text)
         check_meta(skill, text)
+        check_limits(skill, text)
         for ref in (p.parent / "references").glob("*.md"):
             rtext = ref.read_text(encoding="utf-8")
             check_refs(f"{skill}/{ref.name}", ref, rtext)
@@ -329,6 +392,7 @@ def main() -> int:
         import yaml  # noqa: F401
     except ImportError:
         skipped.append("yaml parse (PyYAML not installed)")
+        skipped.append("frontmatter limits (PyYAML not installed)")
     print(f"skills checked: {len(SKILLS)}   findings: {len(findings)}")
     if skipped:
         print("  checks skipped: " + "; ".join(skipped))

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -311,7 +311,7 @@ def check_limits(skill: str, text: str) -> None:
 
     Why parsed and not the raw block C4 slices out of the file: a folded scalar (`>-`) carries its
     indentation and line breaks in the file and loses them when a consumer reads it. Measured over
-    the 35 skills on 2026-09-04, the raw block is 26-36 characters longer than the value —
+    the 35 skills on 2026-09-04, the raw block is 6-26 characters longer than the value —
     svg-animation is 1024 raw and 998 parsed. A gate on the raw block would reject a skill the
     reference validator accepts. len() counts code points, not bytes, exactly like skills-ref;
     the descriptions carry non-ASCII quoted triggers, so a byte count would disagree with it.

--- a/skills/api-resilience-testing/SKILL.md
+++ b/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.3.0
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -37,16 +37,6 @@ sub-disciplines precisely:
 Avoid vague "QA security testing" in formal docs — it is informal and ambiguous.
 ("Bug-Hunter" is fine as the name of the internal adversarial-testing rite — see the
 `bug-hunter` skill — but use the precise terms above when writing formal test docs.)
-
----
-
-## When to use this skill
-
-Trigger whenever the work involves a REST/HTTP API: adding or changing an
-endpoint, reviewing an API PR, writing API tests, designing request/response
-schemas, or the user asks to "test", "harden", "break", "audit", or "review"
-an API. Default to running the workflow below before an API change is
-considered done — happy-path tests alone are not sufficient.
 
 ---
 

--- a/skills/assettoserver-csp-lua/SKILL.md
+++ b/skills/assettoserver-csp-lua/SKILL.md
@@ -4,18 +4,17 @@ description: >-
   Conventions for CSP Lua online scripts served by AssettoServer (CSPServerScriptProvider) — the
   zero-install in-game UI layer of an AC server: overlays/HUDs/toasts drawn with the draw-list API
   in a single transparentWindow, DirectWrite text, ac.OnlineEvent packets mirrored byte-for-byte
-  with the C# plugin, remote images and audio loaded by URL from the server, local car telemetry,
-  and the mockup-first workflow for visuals you cannot render outside the game. Distilled from a
-  production DriveZone server. Use when writing or reviewing a .lua online script (overlay, HUD,
-  toast, in-game sound, login UI), when a CSP overlay renders wrong (empty flat box, glued or
-  overlapping text, missing glyphs, sound plays only once), or when an OnlineEvent packet silently
-  never arrives. Do NOT use for the C# plugin side — packet classes, config, chat commands,
-  publishing (that is assettoserver-plugin), for server configuration/deploy (that is
-  assettoserver-ops), for CSP apps or track scripts (different Lua contexts with different
-  permissions), or for FiveM Lua (that is fivem-lua).
+  with the C# plugin, remote images and audio loaded by URL, local car telemetry, and the
+  mockup-first workflow for visuals you cannot render outside the game. Use when writing or
+  reviewing a .lua online script (overlay, HUD, toast, in-game sound, login UI), when a CSP
+  overlay renders wrong (empty flat box, glued or overlapping text, missing glyphs, sound plays
+  only once), or when an OnlineEvent packet silently never arrives. Do NOT use for the C# plugin
+  side — packet classes, config, chat commands, publishing (that is assettoserver-plugin), for
+  server configuration/deploy (that is assettoserver-ops), for CSP apps or track scripts
+  (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 metadata:
   author: solvelab
-  version: 1.0.1
+  version: 1.1.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -25,8 +24,9 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 
 Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
 client by the server itself. Zero-install is the point — the player installs nothing; art, sound
-and code all arrive over the server's HTTP port. Every rule below was paid for with an in-game
-iteration; in this stack a wrong guess costs a deploy plus a human driving session to observe it.
+and code all arrive over the server's HTTP port. Distilled from a production DriveZone server:
+every rule below was paid for with an in-game iteration, and in this stack a wrong guess costs a
+deploy plus a human driving session to observe it.
 
 ## What an online script is
 

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -1,24 +1,20 @@
 ---
 name: backlog
 description: >-
-  Turn a natural-language idea into a structured GitHub backlog item: analyze the current
-  repository (or multi-repo workspace) for real context, draft a rich issue (context, problem,
-  scope, acceptance criteria, risks, affected files/repos), preview it for approval, then create
-  the GitHub issue and add it to the configured GitHub Project v2 with fields set
-  (Status/Priority/Size/Estimate) via the gh CLI. Use when the user invokes /backlog <idea>, says
-  "create a backlog item", "add this to the backlog", "turn this idea into an issue", "groom this
-  idea", or wants an idea registered in a GitHub Project. Entry point of the backlog-first rite:
-  the item created here is what execute-backlog turns into a branch and a pull request. In a
-  repository that runs a spec-driven workflow (an openspec/ directory) the drafted item also
-  declares its spec verdict — the change that will register the work, or a written waiver —
-  so execute-backlog inherits a decision instead of making a new one.
-  First run per repo/workspace launches a
-  config wizard that writes .github/backlog.yml (repo mode) or backlog.yml (workspace mode). Do NOT
-  use for implementing an existing issue (that is execute-backlog), for creating pull requests, or
-  for non-GitHub trackers (Jira, Linear, Trello).
+  Turn a natural-language idea into a structured GitHub backlog item: analyze the repository (or
+  multi-repo workspace) for real context, draft a rich issue (context, problem, scope, acceptance
+  criteria, risks, affected files/repos), preview it for approval, then create the issue and add
+  it to the configured GitHub Project v2 with fields set (Status/Priority/Size/Estimate) via the
+  gh CLI. Use when the user invokes /backlog <idea>, says "create a backlog item", "add this to
+  the backlog", "turn this idea into an issue", "groom this idea", or wants an idea registered in
+  a GitHub Project. Entry point of the backlog-first rite: execute-backlog turns the item created
+  here into a branch and a pull request. In a repository with a spec-driven workflow (an openspec/
+  directory) the item also declares its spec verdict: a change id or a written waiver. Do NOT use
+  for implementing an existing issue (that is execute-backlog), for creating pull requests, or for
+  non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.4.0
+  version: 1.5.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,7 +26,9 @@ compatibility: >-
 
 Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
 configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
-codebase.
+codebase. The first run per repo/workspace launches a config wizard that writes
+`.github/backlog.yml` (repo mode) or `backlog.yml` (workspace mode). The spec verdict the item
+declares is what `execute-backlog` inherits, instead of making a new decision.
 
 - **Issue section template + writing guidance**: `references/issue-template.md`
 - **Config schema (both modes, precedence, wizard, `spec_rite`)**: `references/backlog-config.md`

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -1,41 +1,37 @@
 ---
 name: code-locale
 description: >-
-  Decides which natural language each artifact of a change is written in: prose follows the
-  repository's working language, and anything a machine parses is English. Use when naming a
-  variable, function, class, file, module, REST route segment, query param, DB table or column,
-  enum value, event or topic name, config key or log field; when reviewing a diff or PR that
-  introduces names; when a backlog item written in another language is about to become code; when
-  deciding whether a domain term like CPF, CNPJ, boleto, PIX or nota fiscal keeps its name; when an
-  external API's payload fields are in another language; or when the user says "código em
-  português", "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador
-  em inglês", "should this be in English", "our code is half Portuguese", "naming convention",
-  "ubiquitous language", "anti-corruption layer". Covers the prose/machine boundary, the
-  untranslatable-domain-term exception and its gate, the grooming glossary, the new-code-only
-  migration policy, and a shipped detector a repository can wire into CI. Do NOT use for the
-  language of commit subjects or PR bodies (that is conventional-commit), for the language of
-  documentation prose (that is documentation), for format-level naming conventions like case style
-  or test-method patterns (those live in each stack's skill), or for i18n and user-facing
-  translation.
+  Decides which natural language each artifact is written in: prose follows the repository's
+  working language, anything a machine parses is English. Use when naming a variable, function,
+  class, file, route, query param, DB table or column, enum value, event, config key or log field;
+  when reviewing a diff that introduces names; when a backlog item in another language becomes
+  code; when a domain term like CPF, CNPJ, boleto, PIX or nota fiscal may keep its name; when an
+  external API's payload is in another language; or when the user says "código em português",
+  "nome de variável em inglês", "rota em português", "traduz esse nome", "identificador em
+  inglês", "should this be in English", "our code is half Portuguese", "naming convention",
+  "ubiquitous language", "anti-corruption layer". Do NOT use for commit subjects or PR bodies
+  (that is conventional-commit), for docs prose (that is documentation), for case style or test
+  naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.2.0
+  version: 1.3.0
   category: process
 license: MIT
 compatibility: >-
   The doctrine is language- and stack-agnostic and needs no runtime. The shipped detector
-  `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package; it
-  tokenizes Python, Lua, JavaScript, TypeScript, C#, SQL, YAML, JSON and Bash, measures the path of
-  every file it is given, reports the contents of any other file type as skipped rather than
-  passing, and ships the public-domain word list that answers its second question (read with the
-  standard library's gzip module, so there is still no third-party package). The optional write-time hook `claude/global/hooks/locale-rite.py` needs a harness that
-  emits a post-write tool event; it was built against Claude Code 2.1.246 and exits silently
-  anywhere else.
+  `references/check-identifier-locale.py` needs Python 3.9+ and no third-party package (its word
+  list is read with the standard library's gzip module); it tokenizes Python, Lua, JavaScript,
+  TypeScript, C#, SQL, YAML, JSON and Bash and reports any other file type as skipped. The
+  optional hook `claude/global/hooks/locale-rite.py` was built against Claude Code 2.1.246 and
+  exits silently anywhere else.
 ---
 
 # Code locale — prose follows the repo, the machine layer is English
 
 **Prose follows the repository's working language. Anything a machine parses is English.**
+This skill covers the prose/machine boundary, the untranslatable-domain-term exception and its
+gate, the grooming glossary, the new-code-only migration policy, and a shipped detector a
+repository can wire into CI.
 
 The boundary is drawn by *what consumes the artifact*, not by who wrote it. A commit body and a
 code comment have the same audience, so they land on the same side. A route segment and a database
@@ -45,7 +41,8 @@ without a taste debate.
 - **Per-stack enumeration, wrong → right pairs**: `references/boundary-map.md`
 - **Producing and consuming the PT→EN glossary**: `references/glossary-protocol.md`
 - **Existing names: the three migration tiers**: `references/migration.md`
-- **The detector**: `references/check-identifier-locale.py`
+- **The detector** — measures the path of every file it is given and the contents of the types
+  it tokenizes: `references/check-identifier-locale.py`
 
 ## The two layers
 

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -2,23 +2,19 @@
 name: execute-backlog
 description: >-
   Execute an existing GitHub backlog item end-to-end: locate the issue (number, URL or search),
-  validate it is complete enough to execute, re-analyze the current repo/workspace state, present
-  an implementation plan for approval BEFORE touching code, implement on a dedicated branch
-  following the repo's conventions, add/update tests, run the repo's discoverable validations
-  (tests/lint/build/typecheck), tick the issue's acceptance-criteria checkboxes that are proven by
-  evidence, open pull request(s) linking the issue (Closes #n), and move the GitHub Project item to
-  the review column. Use when the user invokes /execute-backlog <n>, says
-  "implement issue #N", "execute this backlog item", "pick up this ticket", or wants an existing
-  issue turned into a PR. Second half of the backlog-first rite: the item it consumes is produced
-  by the backlog skill, and this skill carries it to a reviewable PR. In a repository that runs a
-  spec-driven workflow (an openspec/ directory), it gates on that workflow before touching code:
-  the item's spec verdict is re-checked, the change is created and validated strict, and only then
-  does the plan go to approval. Uses the backlog skill's
-  config (.github/backlog.yml or workspace backlog.yml). Do NOT use for creating backlog items
-  (that is backlog), for merging PRs, for deploying, or for non-GitHub trackers.
+  validate it is complete enough, re-analyze the repo/workspace, present an implementation plan
+  for approval BEFORE touching code, implement on a dedicated branch with tests, run the repo's
+  discoverable validations, tick the acceptance criteria proven by evidence, open pull request(s)
+  with Closes #n, and move the GitHub Project item to the review column. Use when the user invokes
+  /execute-backlog <n>, says "implement issue #N", "execute this backlog item", "pick up this
+  ticket", or wants an existing issue turned into a PR. Second half of the backlog-first rite:
+  consumes the item the backlog skill produced. In a repository with a spec-driven workflow (an
+  openspec/ directory) it re-checks the item's spec verdict and validates the change strict before
+  the plan goes to approval. Do NOT use for creating backlog items (that is backlog), for merging
+  PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.7.0
+  version: 1.8.0
   category: process
 license: MIT
 compatibility: >-
@@ -30,7 +26,9 @@ compatibility: >-
 # Execute-backlog — backlog item → implemented, validated PR
 
 Drive an existing issue to a reviewable pull request while keeping the board in sync. Companion
-to the `backlog` skill; consumes the same config.
+to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,
+`backlog.yml` in workspace mode), follows the repo's own conventions, and runs the validations
+it can discover there (tests/lint/build/typecheck).
 
 - **Gates, plan format, scope-change protocol, multi-repo orchestration**: `references/execution-flow.md`
 - **Spec-driven gate: detection, verdict, upgrade/downgrade, archive timing**: `references/spec-rite.md`

--- a/skills/verify-before-claiming/SKILL.md
+++ b/skills/verify-before-claiming/SKILL.md
@@ -1,22 +1,20 @@
 ---
 name: verify-before-claiming
 description: >-
-  Anti-guessing rite: research before asserting, label every claim with its source, and report what
-  could not be found instead of producing a plausible substitute. Use when about to state or use an
-  API, CLI flag, config key, env var, path, version or behavior not read in this session; when a fact
-  depends on a library version; when the answer cannot be found and the gap has to be reported; or
-  when the user says "you invented that", "don't guess", "achismo", "não inventa", "chutou",
-  "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that flag does not
-  exist", "out of scope", "não foi isso que eu pedi". Covers the cheapest-first research ladder
-  (session context, this repo, the installed dependency, the tool itself, version-pinned docs, web
-  search, the user), verified/inferred/unknown claim labelling, the not-found report, and the
-  scope-restatement guard against delivering work nobody asked for. Do NOT use for adversarially
-  testing code already written (that is bug-hunter), for designing an API test suite (that is
-  api-resilience-testing), for writing a project's documentation pages (that is documentation), or
+  Anti-guessing rite: research before asserting, label every claim with its source, and report
+  what could not be found instead of producing a plausible substitute. Use when about to state or
+  use an API, CLI flag, config key, env var, path, version or behavior not read in this session;
+  when a fact depends on a library version; when the answer cannot be found and the gap has to be
+  reported; or when the user says "you invented that", "don't guess", "achismo", "não inventa",
+  "chutou", "pesquisa antes", "de onde tirou", "where did you see that", "cite the source", "that
+  flag does not exist", "out of scope", "não foi isso que eu pedi". Covers the research ladder,
+  claim labelling, the not-found report and the scope-restatement guard. Do NOT use for
+  adversarially testing code already written (that is bug-hunter), for designing an API test suite
+  (that is api-resilience-testing), for writing documentation pages (that is documentation), or
   for the plan-approval gate of a backlog item (that is execute-backlog).
 metadata:
   author: solvelab
-  version: 1.0.0
+  version: 1.1.0
   category: process
 license: MIT
 compatibility: >-
@@ -33,7 +31,9 @@ endpoint nobody asked for — it claims the user wanted it.
 
 Every claim is one of three things: **verified** against a source you opened in this session,
 **inferred** and labelled as such, or **unknown** and reported. There is no fourth option. A
-plausible sentence with no source is the defect this skill exists to prevent.
+plausible sentence with no source is the defect this skill exists to prevent. The research
+ladder is cheapest-first: session context, this repo, the installed dependency, the tool itself,
+version-pinned docs, web search, the user.
 
 - **Per-ecosystem commands for each rung, offline degradation**: `references/research-ladder.md`
 - **Claim labels, the not-found report, scope blocks**: `references/report-templates.md`


### PR DESCRIPTION
Closes #112

`README.md:25` e `:381` dizem que o catálogo segue o padrão aberto Agent Skills. A especificação
desse padrão (agentskills.io/specification) fixa `description` em 1–1024 caracteres e
`compatibility` em 1–500, e o validador de referência do padrão (`skills-ref` 0.1.1, binário
`agentskills`) reprovava 5 das 35 skills — nenhum gate do repositório media isso, e o próprio spec
`skills-authoring` empurrava na direção contrária ("Triggers live in the description", sem teto).

Medido antes desta change, um diretório por chamada:

```
skills/assettoserver-csp-lua   rc=1 :: Description exceeds 1024 character limit (1076 chars)
skills/backlog                 rc=1 :: Description exceeds 1024 character limit (1265 chars)
skills/code-locale             rc=1 :: Description exceeds 1024 character limit (1398 chars) - Compatibility exceeds 500 character limit (728 chars)
skills/execute-backlog         rc=1 :: Description exceeds 1024 character limit (1344 chars)
skills/verify-before-claiming  rc=1 :: Description exceeds 1024 character limit (1222 chars)
ok=30 bad=5 total=35
```

## O que muda

- **`C10 frontmatter limits` em `scripts/validate-skills.py`.** Mede `len()` do valor YAML
  **parseado** de `description` (≤ 1024) e `compatibility` (≤ 500), em caracteres, como
  `skills_ref/validator.py` — não o bloco cru que o C4 fatia, que é 6–26 caracteres mais longo
  (`svg-animation`: 1024 cru contra 998 parseado; um gate sobre o cru reprovaria uma skill que o
  padrão aceita). Sem PyYAML entra em `checks skipped`, nunca conta como aprovado. O que não cobre
  está declarado na própria docstring.
- **`META_HEADING` (C8) passa a casar `## When to use this skill`**, que escapava há meses em
  `skills/api-resilience-testing/SKILL.md` duplicando a description; a seção é removida.
- **Selftest com 15 classes** (era 13): mutação C10 (description inflada) e C8 com o título novo.
- **Step novo no CI, pinado e bloqueante:** `skills-ref==0.1.1` na linha de `pip` (falta do pacote
  falha alto) e `agentskills validate` por diretório, com o comentário explicando o pin (o
  validador tem whitelist de campos em `validator.py:15-22`; um upstream novo quebraria o build no
  calendário de outro) e o que o step não lê (nada abaixo do frontmatter).
- **Gate primeiro, edição depois, no mesmo PR:** o commit `2ac99fe` reprova as 5; o `e2fa08a`
  encurta as 5 descriptions (e a `compatibility` de `code-locale`) para dentro do teto **sem perder
  nenhuma frase entre aspas** — o que saiu foi para o primeiro parágrafo do corpo. `version` minor
  nas 6 skills tocadas; wrappers regenerados.
- **Delta em `skills-authoring`:** o teto entra ao lado do requisito que dobra gatilhos na
  description, com a cláusula de que a dobra respeita o teto (o que não cabe vira corpo ou
  `references/`, nunca fica na description).
- **`README.md:25` e `:381`** apontam "Agent Skills" para a especificação; `vercel-labs/skills`
  fica só como o CLI `npx skills` da Opção A.

A composição do catálogo não muda: 35 skills, mesmos diretórios, nenhum órfão.

## Simulação — saída observada

| Expectativa | Casos | Resultado |
|---|---|---|
| `agentskills validate` sai 0 por skill | **35/35** | `ok=35 bad=0 total=35` (antes: 30/35) |
| C10 tinha de disparar e disparou | **1/1** | cópia com `r3f-geometry` inflada: `description is 1466 chars, limit 1024 (parsed value; 442 over)`, rc=1 |
| C10 e o validador de referência medem o mesmo número | **1/1** | 1466 nos dois, na mesma cópia |
| C10 tinha de ficar mudo e ficou | **35/35** | catálogo: `findings: 0` |
| Gate primeiro reprova exatamente as 5 | **5/5** | árvore de `2ac99fe`: 6 achados C10 nas 5 skills da issue (duas linhas em `code-locale`) + 1 C8 na seção removida |
| Selftest detecta cada classe | **15/15** | `15/15 defect classes detected` |
| Frases entre aspas preservadas | **29/29** | 10 + 3 + 4 + 12 + 0, `LOST: []` nas 5 (tabela em `tasks.md` 3.2) |
| Roteamento léxico mantém a skill alvo (3 prompts × 5 skills) | **15/15 antes, 15/15 depois** | `same-top before/after=15/15`; segundo colocado nunca acima de 2,50 |
| Margem que caiu | **1/15** | prompt do wizard de `backlog`: 8,75 → 4,75, ainda primeiro (0,50 o segundo) |
| Escape conhecido ficou mudo | **1/1** | C10 conta caracteres, não tokens: 998 caracteres passam com ~1,3k tokens |

A medida bruto-vs-parseado que justifica medir o valor parseado foi re-medida sobre as 35 skills
com o mesmo `re.search` do C4 e o `yaml.safe_load` do C10: `min=6 max=26` no catálogo deste
branch, `min=6 max=36` em `master` — a change dizia 26–36 e foi corrigida (`abdc815`).

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Wrappers em sincronia | `bash generate.sh && git diff --exit-code` | `Generated 10 category plugins`, diff rc=0 |
| Versão | `VERSION` vs `plugin.json`/`marketplace.json` | OK |
| Frontmatter (laço do CI) | 8 testes por `SKILL.md` | OK |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | `15/15 defect classes detected` |
| Validador de referência (step novo, verbatim) | `for d in skills/*/; do agentskills validate "$d"; done` | 35 × `Valid skill`, `exit fail=0` |
| C10 sem PyYAML | `sys.modules['yaml']=None` + validador | `checks skipped: [...] frontmatter limits (PyYAML not installed)` |
| Locale de identificadores | `check-identifier-locale.py --selftest` | OK |
| Hook de locale | `claude/global/hooks/locale-rite.py --selftest` | OK |
| Segredos | `python3 scripts/scan-secrets.py` | `no credentials found` |
| Higiene do repo | `validate-repo-hygiene.py` + `--selftest` | `0 findings`, `2/2` |
| Rito | `bash scripts/validate-rite.sh` | `rite gate OK` |
| Evidência do rito | `validate-rite-evidence.py --selftest` | `7/7` |
| Spec-rite | `validate-spec-rite.py --selftest` | `3/3, 6/6, 6/6` |
| OpenSpec estrito | `openspec validate add-agent-skills-limits --strict` | `Change 'add-agent-skills-limits' is valid` |
| Validador do vendor | `claude plugin validate . --strict` | `Validation passed` |
| Árvore limpa ao final | `git status --porcelain \| wc -l` | `0` |

## Rito

Spec-rite: add-agent-skills-limits

Capability `skills-authoring` (MODIFIED: *Uniform frontmatter metadata*, *Triggers live in the
description, not the body*, *Authoring rules are machine-enforced*). Grupos 1–7 de `tasks.md`
ticados com a saída observada; V.4 (arquivamento) fica aberta.

## Known gaps

- **`agentskills` no `PATH` do runner.** Provado localmente com o venv no `PATH`; se o console
  script não ficar no `PATH` do `ubuntu-latest` depois de `python3 -m pip install`, o primeiro run
  deste branch é onde isso aparece. Fallback já probado: `python3 -m skills_ref.cli validate`.
- **A simulação de roteamento é léxica, não é a decisão do modelo.** Ela prova que o sinal
  lexical de cada description sobreviveu ao corte (15/15 antes e depois), não como o Claude Code
  roteia. A única margem que estreitou é a do wizard de `backlog` (frase não citada que foi para o
  corpo, seção `## Setup wizard`).
- **C10 mede caracteres, não tokens.** `svg-animation` fica em 998 (26 do teto) e não é tocada —
  só as 5 fora do teto mudam, como a issue delimita; o orçamento de ~100 tokens por skill que a
  spec sugere não é medido por nenhum gate.
- A change `add-agent-skills-limits` fica **ativa**; o arquivamento
  (`openspec archive add-agent-skills-limits --yes`, V.4) é PR separado, depois do merge.
- Follow-ups notados em E.4 do `tasks.md` e não feitos: orçamento total das descriptions (~23k
  caracteres), lentidão do selftest (copia o repo 15 vezes), `python -m skills_ref` inexistente
  no pacote upstream.