### PR TITLE
🐛 fix(scripts): endurece install.sh e update.sh contra árvore suja e divergência

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
       - name: Repo hygiene self-test (the gate is itself gated)
         run: python3 scripts/validate-repo-hygiene.py --selftest
 
+      - name: Distribution scripts smoke test (install.sh + update.sh under a temporary HOME)
+        # Runs both scripts through their documented invocations against a local bare clone of this
+        # checkout's HEAD, never the network, and prints the case matrix as counts. Before this step
+        # nothing in CI executed either script (issue #113).
+        run: bash scripts/smoke-install-scripts.sh
+
       - name: OpenSpec rite gate (skills-rite schema)
         # The spec-rite gate reads the waiver line from the event payload the runner already wrote
         # (GITHUB_EVENT_PATH). Handing the pull request body over through this step's `env:` block

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ cp ~/ai-skills/copilot/instructions/*.instructions.md /path/to/project/.github/i
 
 ## ♻️ Update
 
-Pull the latest skills/rules into `~/ai-skills` and regenerate the Cursor wrappers:
+Pull the latest skills/rules into `~/ai-skills` and regenerate all tool wrappers:
 
 ```bash
 # One-line (no clone needed)

--- a/install.sh
+++ b/install.sh
@@ -11,11 +11,26 @@
 #   codex    appends the Skills block to ~/.codex/AGENTS.md
 #   cursor   points at cursor/rules/*.mdc (copy per project)
 #   copilot  points at copilot/instructions/ (copy per project)
+#
+# `--tool` is validated before anything is cloned or pulled, so a typo never leaves a clone
+# behind. On a re-run over an existing ~/ai-skills the pull is fast-forward only: a clone that
+# diverged from origin is refused with the same message and recovery hint update.sh gives.
+#
+# WHAT THE GUARD DOES NOT COVER: this script never inspects the working tree. Uncommitted edits in
+# ~/ai-skills are neither refused nor discarded here (a fast-forward pull that touches the same
+# file fails on git's side, and that failure is reported under the divergence message). Only
+# update.sh decides whether the wrappers can be regenerated; install.sh regenerates nothing.
+# There is no interactive prompt on purpose: the README runs this script via `curl | bash`, where
+# stdin is the script itself.
+#
+# AI_SKILLS_REPO_URL overrides the clone source. It exists for scripts/smoke-install-scripts.sh,
+# which clones from a local bare repository instead of the network; unset, nothing changes.
 set -euo pipefail
 
-REPO_URL="https://github.com/solvelab/ai-skills.git"
+REPO_URL="${AI_SKILLS_REPO_URL:-https://github.com/solvelab/ai-skills.git}"
 INSTALL_DIR="$HOME/ai-skills"
 LEGACY=0
+SUPPORTED_TOOLS="claude codex cursor copilot all"
 
 # --- Tool-specific configurations ---
 
@@ -105,7 +120,11 @@ TOOL="claude"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --tool)
-            TOOL="$2"
+            TOOL="${2:-}"
+            if [ -z "$TOOL" ]; then
+                echo "❌ --tool requires a value. Supported: ${SUPPORTED_TOOLS// /, }"
+                exit 1
+            fi
             shift 2
             ;;
         --legacy)
@@ -136,6 +155,15 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Validate --tool BEFORE touching the network or the disk: a bad value must not leave a clone behind.
+case " $SUPPORTED_TOOLS " in
+    *" $TOOL "*) ;;
+    *)
+        echo "❌ Unknown tool: $TOOL. Supported: ${SUPPORTED_TOOLS// /, }"
+        exit 1
+        ;;
+esac
+
 # Check git is installed
 if ! command -v git &> /dev/null; then
     echo "❌ Error: git is not installed. Please install git first."
@@ -145,7 +173,14 @@ fi
 # Clone or pull the repository
 if [ -d "$INSTALL_DIR" ]; then
     echo "📦 ~/ai-skills already exists. Pulling latest changes..."
-    git -C "$INSTALL_DIR" pull
+    # Same contract as update.sh: fast-forward only, own message first, git's `fatal:` line as an
+    # indented detail (advice.diverging=false drops the nine `hint:` lines that precede it).
+    if ! PULL_ERR="$(git -C "$INSTALL_DIR" -c advice.diverging=false pull --ff-only --quiet 2>&1)"; then
+        echo "  ❌ Fast-forward failed — local changes diverge from origin."
+        echo "     Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force"
+        [ -z "$PULL_ERR" ] || printf '     git: %s\n' "$PULL_ERR"
+        exit 1
+    fi
 else
     echo "📦 Cloning ai-skills into ~/ai-skills..."
     git clone "$REPO_URL" "$INSTALL_DIR"
@@ -173,10 +208,6 @@ case "$TOOL" in
         setup_codex
         setup_cursor
         setup_copilot
-        ;;
-    *)
-        echo "❌ Unknown tool: $TOOL. Supported: claude, codex, cursor, copilot, all"
-        exit 1
         ;;
 esac
 

--- a/openspec/changes/harden-distribution-scripts/.openspec.yaml
+++ b/openspec/changes/harden-distribution-scripts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-04

--- a/openspec/changes/harden-distribution-scripts/design.md
+++ b/openspec/changes/harden-distribution-scripts/design.md
@@ -1,0 +1,132 @@
+## Context
+
+`install.sh` (185 linhas em `d2918ed`) clona `~/ai-skills` ou faz `git pull` quando o diretório já
+existe (linhas 146-152), e só depois entra no `case "$TOOL"` (158-181) que rejeita um valor
+desconhecido. `--tool` lê `$2` direto (108) sob `set -u`.
+
+`update.sh` (70 linhas) faz `fetch`, depois `reset --hard` (com `--force`) ou `pull --ff-only`
+(47-51), e em seguida `bash generate.sh >/dev/null && echo "  ✅ Wrappers regenerated."` (59).
+
+`generate.sh` lê `VERSION` e `skills/*/SKILL.md` e reescreve `claude/skills/`, `codex/skills/`,
+`cursor/rules/`, `copilot/instructions/` e `plugins/` — este último com `rm -rf` e o valor de
+`VERSION` gravado em cada `plugins/<group>/.claude-plugin/plugin.json`. Ou seja: as **entradas** do
+gerador são `VERSION` e `skills/`; tudo o mais é saída.
+
+`README.md:145` roda `update.sh` via `curl | bash`; `README.md:216` manda o usuário editar
+`claude/global/personal-rules.md` no clone. Os dois fatos limitam o desenho: não há stdin para
+perguntar nada, e a árvore do usuário pode estar legitimamente suja fora das entradas do gerador.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Um `update.sh` sobre `VERSION` ou `skills/` editados faz o pull, não regenera, diz o que está
+  sujo e como limpar, e sai 0 sem tocar nenhum `plugin.json`.
+- Uma falha do `generate.sh` durante o update é visível: exit ≠ 0 com a saída do erro.
+- `install.sh` re-executado sobre um clone divergente falha com a mesma mensagem e dica de
+  `update.sh`, em vez do `fatal:` cru do git.
+- `install.sh --tool bogus` e `install.sh --tool` falham antes de qualquer `git clone`/`git pull`,
+  listando os valores suportados.
+- Um teste de fumaça sem rede, em `HOME` temporário, prova cada um desses comportamentos e roda no CI.
+
+**Non-Goals:**
+
+- Guarda de semver ou qualquer edição em `generate.sh` — pertence à issue que reescreve o bloco dos
+  `plugin.json`.
+- Prompt interativo em `--force`.
+- Bloquear o update quando a árvore está suja fora de `VERSION`/`skills/`: o README documenta essa
+  edição.
+- Fazer `install.sh` delegar o re-run a `update.sh`.
+
+## Decisions
+
+### D1 — A guarda olha as entradas do gerador, não a árvore inteira
+
+`git status --porcelain --untracked-files=no -- VERSION skills/`. Probado em `d2918ed` com
+`VERSION` editado, `skills/untracked.txt` criado e `README.md` editado: o filtro devolve só
+` M VERSION`. Uma edição em `claude/global/personal-rules.md` — o uso do `README.md:216` — não
+aparece, e a regeneração segue normal, porque a saída do gerador não depende dela.
+
+Por que **pular** a regeneração e não abortar o update: o pull é a parte útil para o usuário e não
+é ela que corrompe nada; o dano medido na issue vem só do `generate.sh` rodando sobre `VERSION`
+sujo. Pular com mensagem preserva o pull e elimina o dano.
+
+### D2 — O que a guarda não vê fica escrito no cabeçalho do script
+
+`--untracked-files=no` ignora arquivos novos (`skills/nova-skill/SKILL.md` não commitado não bloqueia
+a regeneração, e o gerador vai criar wrappers para ele); o pathspec ignora edições fora de
+`VERSION`/`skills/`. Os dois pontos cegos vão no cabeçalho de `update.sh`, seguindo a regra que o
+catálogo já impõe aos checks de `scripts/` (*"The uncovered part is declared, not implied"*,
+`openspec/specs/skills-catalog/spec.md:487`).
+
+### D3 — A falha do gerador sai do `&&`
+
+`bash generate.sh` passa a rodar como comando próprio, com a saída capturada e impressa só em caso
+de falha. Sob `set -e`, um comando que falha à esquerda de `&&` não aborta o script — probado:
+`f >/dev/null && echo ok; echo after` imprime `after` e sai 0. O `if`/`else` explícito devolve o
+exit code e a saída do erro.
+
+### D4 — `install.sh` valida `--tool` no parse, com `${2:-}`
+
+A lista de valores suportados vira uma variável única (`SUPPORTED_TOOLS`) usada pela validação,
+pela mensagem de erro e pelo `--help`, para que as três não divirjam. A validação roda logo depois
+do loop de argumentos, antes de `command -v git` e do clone. `--tool` sem valor cai em `${2:-}`
+vazio e produz erro de uso, não `unbound variable`.
+
+### D5 — Os dois scripts dão a mesma mensagem de divergência, com o detalhe do git indentado
+
+`git -c advice.diverging=false pull --ff-only --quiet` com stderr capturado. Na falha, o script
+imprime a própria mensagem e a dica (`cd ~/ai-skills && ./update.sh --force`), e só então o stderr
+do git, indentado, como detalhe. O `advice.diverging=false` suprime as nove linhas de `hint:` que o
+git 2.47.3 emite antes do `fatal:`; o `fatal:` fica, porque num erro de rede ele é a única
+informação útil, e indentado sob a mensagem própria não é mais "cru".
+
+### D6 — O teste de fumaça clona de um bare local construído a partir do HEAD
+
+`scripts/smoke-install-scripts.sh` cria `origin.git` com `git init --bare`, aponta `HEAD` para
+`refs/heads/master` explicitamente (não depende de `init.defaultBranch`, que num `HOME` vazio já é
+`master` — probado — mas no runner pode não ser) e faz `git push <bare> HEAD:refs/heads/master` a
+partir do checkout. Isso funciona tanto num branch local quanto no HEAD destacado que o
+`actions/checkout` produz num `pull_request`. `install.sh` ganha `AI_SKILLS_REPO_URL` como override
+do `REPO_URL`, documentado no cabeçalho; sem a variável o comportamento é o de hoje. A alternativa
+— `sed` sobre o script antes de testá-lo — testaria outro script.
+
+Cada caso roda com `HOME=<tmp>/home-<caso>` exportado só para aquele processo; `~/.claude`,
+`~/.codex` e a rede não são tocados. Os commits de "upstream" e "local" usam
+`-c user.name -c user.email`, porque o `HOME` falso não tem `.gitconfig`.
+
+### D7 — O teste imprime a matriz como contagens
+
+Cada caso termina em `PASS`/`FAIL` com o motivo, e o resumo final separa "tinha de recusar e
+recusou" de "tinha de passar e passou", em `n/n`, que é o formato que o grupo de simulação do rito
+pede.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Um check declara o que não cobre | `skills-catalog` (spec do repositório) + `verify-before-claiming` | already canonical — os cabeçalhos dos scripts só aplicam a regra |
+| Prova observada, não esperada, antes de declarar entrega | `verify-before-claiming` | already canonical — citado no grupo de simulação de `tasks.md` |
+| Identificadores, nomes de arquivo e chaves em inglês | `code-locale` | already canonical — `smoke-install-scripts.sh`, `AI_SKILLS_REPO_URL`, `SUPPORTED_TOOLS` seguem o glossário da issue #113 |
+| Fallback e degradação de dependência externa | `backend-resilience` | não se aplica: nada aqui chama dependência de runtime; as guardas são de estado local |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **Pular a regeneração pode passar despercebido** num `update.sh` rodado via `curl | bash` sem
+  olhar a saída. Mitigação: a mensagem lista os arquivos sujos e o comando que limpa; o resumo
+  final do script continua imprimindo a versão, e a regeneração volta no próximo update limpo.
+- **Um `skills/` com arquivo novo não rastreado regenera mesmo assim** (D2). Aceito: o resultado é
+  um wrapper a mais, não um arquivo rastreado corrompido; e está declarado no cabeçalho.
+- **O teste de fumaça depende de `git push` local para um bare** e de `generate.sh` rodando dentro
+  do clone. Se o `generate.sh` do HEAD estiver quebrado, o caso "update limpo" falha — o que é
+  correto, porque o step *Wrappers in sync* já teria falhado antes.
+- **`AI_SKILLS_REPO_URL` é uma superfície nova em `install.sh`.** Aceito: sem a variável nada
+  muda, e ela está documentada no cabeçalho como o gancho do teste.
+
+## Open Questions
+
+Nenhuma. Os pontos que poderiam virar achismo — o texto do `fatal:` do git, o comportamento do
+`&&` sob `set -e`, o `unbound variable`, o filtro do `--porcelain` — foram probados e estão em
+`tasks.md` com comando e saída.

--- a/openspec/changes/harden-distribution-scripts/proposal.md
+++ b/openspec/changes/harden-distribution-scripts/proposal.md
@@ -1,0 +1,74 @@
+# Change: Endurecer install.sh e update.sh contra árvore suja e divergência
+
+## Why
+
+Os dois scripts de distribuição aceitam estados que não conseguem honrar e falham de forma muda ou
+crua. Medido em `d2918ed` (topo de `master` em 2026-09-04), num `HOME` falso:
+
+- `update.sh:47` só protege contra divergência de commit (`git pull --ff-only`). Uma linha a mais
+  em `VERSION`, sem commit, não barra o update; `generate.sh` roda em seguida e grava a versão suja
+  em 10 `plugins/*/.claude-plugin/plugin.json` rastreados. O marketplace é servido do GitHub e o CI
+  regenera de um checkout limpo, então o dano fica no clone local — mas fica até o release seguinte.
+- `update.sh:59` executa `bash generate.sh >/dev/null && echo ...`. Sob `set -e` uma falha do
+  `generate.sh` é engolida, porque o comando que falha está à esquerda do `&&`:
+
+  ```
+  bash -c 'set -e; f() { echo "generate boom" >&2; return 3; }; f >/dev/null && echo ok; echo "after"'
+  -> generate boom
+  -> after: still running
+  -> exit=0
+  ```
+
+- `install.sh:148` usa `git pull` sem `--ff-only`; com divergência morre com
+  `fatal: Need to specify how to reconcile divergent branches.` (exit 128) e nenhuma dica de
+  recuperação, ao contrário de `update.sh:48-50`.
+- `install.sh:108` lê `$2` sem guarda: `bash install.sh --tool` morre com `$2: unbound variable`.
+  O valor de `--tool` só é validado depois do clone (`install.sh:158-180`): `--tool bogus` clona
+  antes de falhar.
+- `update.sh:6`, `update.sh:20` e `README.md:141` dizem que o update regenera "Cursor rules";
+  `generate.sh` regenera `claude/`, `codex/`, `cursor/`, `copilot/` e `plugins/`.
+- Nenhum step do CI executa `install.sh` ou `update.sh`. O que a documentação promete sobre eles
+  não tem gate.
+
+E a restrição que define o desenho: `README.md:216` manda o usuário editar
+`claude/global/personal-rules.md` no próprio clone. Uma guarda de árvore suja que bloqueasse o
+update, ou que empurrasse para `--force` (`reset --hard`), destruiria exatamente esse uso.
+
+## What Changes
+
+- `update.sh` continua fazendo o pull sempre. A regeneração de wrappers passa a rodar só quando as
+  **entradas** do `generate.sh` estão limpas (`git status --porcelain --untracked-files=no --
+  VERSION skills/` vazio); caso contrário imprime a lista e como limpar, pula a regeneração e sai 0.
+  Uma falha do `generate.sh` deixa de ser engolida: vira exit ≠ 0 com a saída do erro.
+- `install.sh` valida `--tool` antes de qualquer clone ou pull, rejeita `--tool` sem valor com erro
+  de uso, e no re-run faz `git pull --ff-only` com a mesma mensagem e dica de `update.sh`.
+- Os dois scripts declaram no cabeçalho o que a guarda não cobre.
+- `update.sh:6`, `update.sh:20` e `README.md:141` passam a dizer "todos os wrappers".
+- `scripts/smoke-install-scripts.sh` (novo): teste de fumaça em `HOME` temporário, clonando de um
+  bare local (nunca da URL do GitHub), cobrindo cada comportamento acima; step correspondente em
+  `.github/workflows/ci.yml`.
+
+Fora de escopo, por decisão da issue: guarda de semver em `generate.sh` (outra issue reescreve esse
+bloco), prompt interativo em `--force` (`curl | bash` não tem stdin), e delegar o re-run de
+`install.sh` para `update.sh`.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: ganha o requisito de que os scripts de distribuição recusam, ou contornam com
+  mensagem, os estados que não podem honrar, e de que o CI os exercita. Hoje a capability governa o
+  CI do repositório em *"The repository itself is gated, not only its skills"* e a publicação em
+  *"Publication does not depend on the interval between merges"*, mas nada diz sobre o caminho de
+  instalação e atualização que o README documenta.
+
+## Impact
+
+- `install.sh`, `update.sh` — guardas, mensagens, cabeçalhos.
+- `scripts/smoke-install-scripts.sh` (novo), `.github/workflows/ci.yml` — um step novo no job
+  `validate`, logo após o self-test de higiene.
+- `README.md:141` — uma linha de texto.
+- Nenhuma skill do catálogo muda: nenhum `SKILL.md` é tocado, a contagem de skills e a descoberta
+  via `npx` ficam idênticas. `generate.sh` não é tocado.
+- Consumidores: quem roda `update.sh` com `VERSION` ou `skills/` editados passa a ver a regeneração
+  pulada com a lista; quem roda `install.sh --tool bogus` passa a falhar antes de clonar.

--- a/openspec/changes/harden-distribution-scripts/specs/skills-catalog/spec.md
+++ b/openspec/changes/harden-distribution-scripts/specs/skills-catalog/spec.md
@@ -1,0 +1,73 @@
+## ADDED Requirements
+
+### Requirement: Distribution scripts refuse what they cannot honor, and CI exercises them
+
+The catalog's distribution scripts — the installer and the updater the README documents — SHALL
+refuse, or route around with a stated reason, every state they cannot honor, instead of failing
+silently or with the underlying tool's raw error.
+
+The updater SHALL always attempt the fast-forward pull, and SHALL regenerate the tool wrappers only
+when the generator's inputs (the version file and the canonical skills tree) are clean in the
+index. When they are not, it SHALL print which files are dirty and how to clean them, skip the
+regeneration, and still exit success, so that a user who edits the clone the way the README
+allows is neither blocked nor pushed toward a hard reset. A failure of the generator SHALL surface
+as a non-zero exit with the generator's output, never be swallowed by the shell.
+
+The installer SHALL validate its tool argument before any clone or pull, SHALL reject a missing
+value with a usage error that lists the supported tools, and on a re-run over an existing clone
+SHALL pull fast-forward only, giving the same message and recovery hint the updater gives when the
+clone has diverged.
+
+Neither script SHALL prompt: both are documented as piped into `bash` from `curl`, where standard
+input is the script itself. Each script SHALL state, in its own header, what its guard does not
+cover.
+
+The catalog's CI SHALL exercise both scripts through their real entry points, in a temporary home
+directory, cloning from a local repository rather than the network, covering every behavior this
+requirement names, and SHALL print the case matrix as counts.
+
+#### Scenario: A dirty generator input skips regeneration without blocking the update
+
+- **WHEN** the updater runs over a clone whose version file or canonical skills tree carries an
+  uncommitted, tracked modification
+- **THEN** the pull happens, the regeneration is skipped, the dirty files and the cleaning command
+  are printed, the script exits zero, and no generated plugin manifest is modified
+
+#### Scenario: An edit outside the generator's inputs does not skip regeneration
+
+- **WHEN** the updater runs over a clone whose only uncommitted change is outside the version file
+  and the canonical skills tree — such as the personal rules file the README tells users to edit
+- **THEN** the wrappers are regenerated as usual
+
+#### Scenario: A generator failure is visible
+
+- **WHEN** the generator exits non-zero during an update
+- **THEN** the updater exits non-zero and prints the generator's output, instead of reporting the
+  wrappers as regenerated
+
+#### Scenario: A diverged clone is refused with the recovery hint, by both scripts
+
+- **WHEN** the clone carries a local commit that the remote branch does not, and either the updater
+  without `--force` or the installer on a re-run is executed
+- **THEN** the script exits one with its own message naming the divergence and the `--force`
+  recovery command, and the tool's own error appears only as an indented detail under that message
+
+#### Scenario: An unsupported or missing tool value fails before any clone
+
+- **WHEN** the installer is invoked with a tool value outside the supported list, or with the tool
+  flag and no value at all
+- **THEN** it exits one listing the supported tools, and no clone directory is created and no pull
+  is attempted
+
+#### Scenario: The scripts are exercised in CI without the network
+
+- **WHEN** the catalog's validation job runs
+- **THEN** a smoke test clones from a local repository into a temporary home directory, runs the
+  installer and the updater through their documented invocations for every scenario above, prints
+  the case matrix as counts, and fails the job when any case regresses
+
+#### Scenario: The guard declares its own blind spot
+
+- **WHEN** the updater decides whether to regenerate by reading the index for a fixed set of paths
+- **THEN** its header states that untracked files and edits outside those paths are not seen, so a
+  regeneration that ran is not read as proof that the inputs were pristine

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -156,25 +156,140 @@
 
 ## 5. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
-      observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
-      silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
-      explicitly that nothing did
+- [x] S.1 Os scripts foram exercitados pelo caminho real, com a saída observada
+
+      Os dois scripts rodados como o usuário roda (`bash install.sh ...`, `bash update.sh ...`),
+      num `HOME` temporário, clonando de um bare local construído do HEAD (`cd3c39e`):
+
+      ```
+      HOME=<tmp> AI_SKILLS_REPO_URL=<bare> bash install.sh --tool bogus
+      -> ❌ Unknown tool: bogus. Supported: claude, codex, cursor, copilot, all
+      -> exit=1
+      ls $HOME
+      -> (vazio: nada clonado)
+      ```
+
+      ```
+      HOME=<tmp> AI_SKILLS_REPO_URL=<bare> bash install.sh --tool
+      -> ❌ --tool requires a value. Supported: claude, codex, cursor, copilot, all
+      -> exit=1
+      ```
+
+      ```
+      HOME=<tmp> AI_SKILLS_REPO_URL=<bare> bash install.sh
+      ->   ✏️  Claude Code: 35 skill(s) symlinked into ~/.claude/skills/ (0 already up to date).
+      -> ✅ ai-skills installed successfully for claude! Restart your tool to apply.
+      -> exit=0
+      ```
+
+      ```
+      echo dirtychange >> $HOME/ai-skills/VERSION; HOME=<tmp> bash update.sh
+      -> ⏭️  Skipping wrapper regeneration: the generator's inputs have uncommitted changes:
+      ->       M VERSION
+      ->      Clean them with: git -C ~/ai-skills checkout -- VERSION skills/
+      ->      (or discard every local change with: cd ~/ai-skills && ./update.sh --force)
+      -> exit=0
+      git -C $HOME/ai-skills status --porcelain
+      ->  M VERSION
+      grep -c dirtychange $HOME/ai-skills/plugins/*/.claude-plugin/plugin.json | grep -v ':0$'
+      -> (nenhuma linha: nenhum plugin.json carrega a versão suja)
+      ```
+
+      ```
+      (commit local no clone + commit upstream no bare) HOME=<tmp> bash update.sh
+      -> 📦 Updating ~/ai-skills (current: v2.16.0)...
+      ->   ❌ Fast-forward failed — local changes diverge from origin.
+      ->      Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force
+      ->      git: fatal: Not possible to fast-forward, aborting.
+      -> exit=1
+      HOME=<tmp> AI_SKILLS_REPO_URL=<bare> bash install.sh
+      -> 📦 ~/ai-skills already exists. Pulling latest changes...
+      ->   ❌ Fast-forward failed — local changes diverge from origin.
+      ->      Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force
+      ->      git: fatal: Not possible to fast-forward, aborting.
+      -> exit=1
+      HOME=<tmp> bash update.sh --force
+      ->   ⚠️  --force: discarding local changes, resetting to origin/master
+      -> 🔧 Regenerating tool wrappers...
+      ```
+
+      O teste de fumaça pelo próprio ponto de entrada, no checkout e no oldroot (os scripts de
+      `188bdaa`, anteriores a esta change, com o mesmo teste copiado para dentro):
+
+      ```
+      bash scripts/smoke-install-scripts.sh
+      -> smoke: origin=/tmp/ai-skills-smoke.IjMZdd/origin.git head=188bdaa skills=35
+      -> PASS  [accept] install: default (claude symlinks)
+      -> (mais 13 linhas PASS)
+      -> PASS  [accept] update: diverged, --force (reset to origin)
+      -> smoke: 15/15 cases passed — refusals that had to fire: 6/6, paths that had to succeed: 9/9
+      -> exit=0
+      ```
+
+      ```
+      bash oldroot/scripts/smoke-install-scripts.sh   # scripts antigos, antes do bloqueio de transporte
+      -> FAIL  [refuse] install: --tool bogus (exit 1, nothing cloned)
+      ->         - output must not contain: Cloning
+      ->         - no clone directory was created
+      -> FAIL  [refuse] install: --tool without a value (exit 1, nothing cloned)
+      ->         - output must not contain: unbound variable
+      -> FAIL  [accept] update: dirty VERSION (pull, skip regeneration, exit 0)
+      ->         - no plugin.json carries the dirty version
+      -> FAIL  [refuse] update: failing generate.sh (exit 7 with its output)
+      ->         - expected exit 7, got 0
+      -> FAIL  [refuse] update: diverged, no --force (exit 1 with hint)
+      ->         - expected exit 1, got 0
+      -> smoke: 5/15 cases passed — refusals that had to fire: 0/6, paths that had to succeed: 5/9
+      -> exit=1
+      ```
+
+      ```
+      bash oldroot/scripts/smoke-install-scripts.sh   # scripts antigos, com o bloqueio de transporte
+      ->         | fatal: transport 'https' not allowed
+      -> ::error::smoke aborted at line 178: BEFORE="$(head_of "$INSTALL")"
+      -> exit=128
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | Tinha de recusar e recusou (scripts novos) | 6/6 | `--tool bogus` ×2, `--tool` sem valor, `generate.sh` falhando, divergência sem `--force` (update e install) |
+      | Tinha de passar e passou (scripts novos) | 9/9 | install padrão, re-run idempotente (0 linked / 35 up to date), `--legacy`, `--tool codex`, `--tool all`, update limpo, `VERSION` sujo, edição fora das entradas, `--force` |
+      | Controle negativo: o mesmo teste sobre os scripts antigos tinha de reprovar e reprovou | 10/15 reprovados, 0/6 recusas | ver S.1 |
+      | Escape conhecido ficou mudo | 1/1 | arquivo novo não rastreado em `skills/` não pula a regeneração — declarado no cabeçalho de `update.sh`, ver S.3 |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Dois pontos, nenhum deles um defeito desta change:
+
+      - O `install.sh` antigo, rodado pelo teste antes do bloqueio de transporte, **clonou do
+        GitHub** (o caso 1 reprovou em "origin is the local bare"). O risco que a issue nomeia —
+        teste dependendo de rede — era real para qualquer script que ignore o override. Por isso
+        o `run` do teste desliga `protocol.https.allow` e `protocol.ssh.allow`; com isso o mesmo
+        script antigo morre em `fatal: transport 'https' not allowed` sem baixar nada (S.1).
+      - O banner `current: v$(cat VERSION)` de `update.sh` imprime a `VERSION` suja com a quebra de
+        linha extra (`current: v2.16.0\ndirtychange`). Cosmético, só ocorre com o arquivo que o
+        próprio usuário sujou, e o script logo abaixo diz que ele está sujo. Não tocado.
+
+      O escape declarado (D2) ficou mudo como esperado: `--untracked-files=no` não vê um
+      `skills/<novo>/` não rastreado, e a regeneração roda. Está escrito no cabeçalho de
+      `update.sh`; o teste exercita só a direção prometida (edição fora das entradas regenera).
 
 ## 6. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
-      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
-      compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
-      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
-      its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
-      names; a term kept in another language carries its reason inline (`code-locale`)
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: esta change não toca
+      nenhuma skill (`git diff --name-only master...HEAD` -> nenhum caminho sob `skills/`)
+- [x] Q.2 Conteúdo de skill tocado em inglês — **não se aplica** pelo mesmo motivo; o delta de spec
+      e os cabeçalhos dos scripts estão em inglês, como o catálogo exige
+- [x] Q.3 Gatilhos de descrição testáveis — **não se aplica**: nenhuma descrição de skill muda
+- [x] Q.4 Sem doutrina duplicada: a regra "um check declara o que não cobre" é aplicada nos
+      cabeçalhos de `install.sh`, `update.sh` e do teste de fumaça, não reescrita; ver a tabela de
+      Canonical Home em `design.md`
+- [x] Q.5 Identificadores em inglês no que a change introduz — `SUPPORTED_TOOLS`,
+      `AI_SKILLS_REPO_URL`, `DIRTY_INPUTS`, `PULL_ERR`, `GEN_OUT`, `smoke-install-scripts.sh`, o
+      nome do step — conforme o glossário da issue #113 e `code-locale`; o hook de locale só
+      apontou `TMPDIR` como palavra desconhecida (é a variável de ambiente POSIX)
 
 ## 7. Validation & Closure (MANDATORY)
 

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -293,7 +293,17 @@
 
 ## 7. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate harden-distribution-scripts --strict` green
-- [ ] V.2 Catalog discovery intact: skill count unchanged, no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [x] V.1 `openspec validate harden-distribution-scripts --strict` verde — em `5cc6d6a`:
+      `Change 'harden-distribution-scripts' is valid`, `exit=0`
+- [x] V.2 Descoberta do catálogo intacta: contagem de skills inalterada, sem órfão ou renomeado —
+      `ls -d skills/*/ | wc -l` -> `35` no branch; `git ls-tree --name-only master skills/ | wc -l`
+      -> `35`; `diff` das duas listas de nomes -> idêntico; `npx -y skills add . --list` ->
+      `Found 35 skills` (rodado com rede disponível; não foi provado que resolve offline). O único
+      caminho extra sob `skills/` é `skills/code-locale/references/__pycache__/`, ignorado pelo git
+      (`!!` em `git status --ignored`), produto do self-test do detector de locale, não do catálogo
+- [x] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a
+      composição não muda; o uso (`update.sh`) muda de texto: `git diff master...HEAD -- README.md`
+      -> `-... regenerate the Cursor wrappers:` / `+... regenerate all tool wrappers:`;
+      `sed -n 141p README.md` -> `Pull the latest skills/rules into ~/ai-skills and regenerate
+      all tool wrappers:`. `update.sh` linhas 6 e 33 dizem o mesmo (2.4)
 - [ ] V.4 `openspec archive harden-distribution-scripts --yes` after all groups above are `[x]`

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -1,0 +1,172 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `d2918ed` (`docs(openspec): arquiva as duas changes de svg-animation`), topo de
+      `master` em 2026-09-04:
+
+      - `install.sh` — 185 linhas; `--tool` lê `$2` em 108; `git pull` sem `--ff-only` em 148;
+        `case "$TOOL"` com a rejeição de valor desconhecido em 158-181, depois do clone.
+      - `update.sh` — 70 linhas; "Cursor rules" em 6 e 20; `pull --ff-only` com mensagem e dica em
+        47-51; `bash generate.sh >/dev/null && echo` em 59.
+      - `generate.sh` — lê `VERSION` (linha 180, `VERSION_STR`) e `skills/*/SKILL.md` (78, 170);
+        `rm -rf "$PLUGINS_OUT"` em 149; grava `"version": "${VERSION_STR}"` (189) em cada
+        `plugins/<group>/.claude-plugin/plugin.json` (185-195). Não é editado por esta change.
+      - `README.md` — linha 141 ("regenerate the Cursor wrappers"), 145 (`curl | bash`), 154 ("all
+        tool wrappers"), 216 ("edit `~/ai-skills/claude/global/personal-rules.md`").
+      - `.github/workflows/ci.yml` — 231 linhas; step `Repo hygiene self-test` em 102-103; o step
+        novo entra logo depois dele.
+      - `openspec/specs/skills-catalog/spec.md:487` — *"The repository itself is gated, not only
+        its skills"*, cenário *"The uncovered part is declared, not implied"*.
+      - `openspec/config.yaml` — `schema: skills-rite`.
+      - `openspec/changes/archive/2026-08-30-fix-release-race/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md` — modelo de estilo desta change.
+      - `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py`,
+        `scripts/validate-spec-rite.py` — o que os gates exigem de `tasks.md` e do diff.
+
+- [x] E.2 Ferramentas e comportamentos externos probados contra a versão instalada
+
+      ```
+      git --version
+      -> git version 2.47.3
+      openspec --version
+      -> 1.6.0
+      ```
+
+      O `&&` engole a falha sob `set -e` (motivo de D3):
+
+      ```
+      bash -c 'set -e; f() { echo "generate boom" >&2; return 3; }; f >/dev/null && echo "  ok"; echo "after: still running"'
+      -> generate boom
+      -> after: still running
+      -> exit=0
+      ```
+
+      `--tool` sem valor sob `set -u` (motivo de D4):
+
+      ```
+      bash -c 'set -euo pipefail; while [[ $# -gt 0 ]]; do case "$1" in --tool) TOOL="$2"; shift 2;; esac; done' probe --tool
+      -> probe: line 1: $2: unbound variable
+      -> exit=1
+      ```
+
+      O que o git diz num clone divergente, com e sem `--ff-only` (motivo de D5):
+
+      ```
+      git -C b pull
+      -> hint: You have divergent branches and need to specify how to reconcile them.
+      -> fatal: Need to specify how to reconcile divergent branches.
+      -> exit=128
+      git -C b pull --ff-only --quiet
+      -> hint: Diverging branches can't be fast-forwarded, you need to either:
+      -> (mais 8 linhas de hint:)
+      -> fatal: Not possible to fast-forward, aborting.
+      -> exit=128
+      ```
+
+      O filtro da guarda, num clone de `d2918ed` com `VERSION` editado, `skills/untracked.txt`
+      criado e `README.md` editado (motivo de D1 e D2):
+
+      ```
+      git status --porcelain --untracked-files=no -- VERSION skills/
+      ->  M VERSION
+      git status --porcelain
+      ->  M README.md
+      ->  M VERSION
+      -> ?? skills/untracked.txt
+      ```
+
+      O branch inicial de `git init` num `HOME` vazio (motivo de fixar `HEAD` do bare em D6):
+
+      ```
+      HOME=<vazio> git init -q dflt && git -C dflt symbolic-ref HEAD
+      -> refs/heads/master
+      ```
+
+      Contagem de skills que o caso idempotente tem de reportar:
+
+      ```
+      ls skills | wc -l
+      -> 35
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      O comportamento de `actions/checkout` num `pull_request` (HEAD destacado no commit de merge)
+      não foi lido no código da action; D6 não depende dele, porque o teste faz
+      `git push <bare> HEAD:refs/heads/master`, que funciona com HEAD destacado ou não. A run de CI
+      do pull request é o que fecha essa lacuna. Nada mais ficou por probar.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a issue #113 pediu. Notados pelo caminho e **não** feitos, ficam como
+      follow-up:
+
+      - `generate.sh` grava em `plugin.json` qualquer conteúdo de `VERSION` sem validar semver —
+        pertence à issue que reescreve esse bloco, como a #113 registra em "Fora de escopo".
+      - `install.sh` e `update.sh` duplicam o bloco de pull/mensagem em vez de compartilhar uma
+        função; como os dois rodam via `curl | bash` sem o repositório presente, não há de onde
+        carregar um arquivo comum.
+      - O README (`README.md:154`) já dizia o certo; só a linha 141 contradizia.
+
+## 2. update.sh — guarda de entradas, falha visível, texto
+
+- [ ] 2.1 A regeneração roda só quando `git status --porcelain --untracked-files=no -- VERSION
+      skills/` está vazio; caso contrário imprime a lista, o comando que limpa, pula a regeneração e
+      não aborta o update (D1)
+- [ ] 2.2 `bash generate.sh` sai do `&&`: falha vira exit ≠ 0 com a saída capturada (D3)
+- [ ] 2.3 O `pull --ff-only` captura o stderr do git e o imprime indentado sob a mensagem própria e
+      a dica, com `advice.diverging=false` (D5)
+- [ ] 2.4 Cabeçalho e `--help` dizem "all tool wrappers" e o cabeçalho declara o que a guarda não
+      cobre (D2)
+
+## 3. install.sh — validação antes do clone, ff-only no re-run
+
+- [ ] 3.1 `--tool` lê `${2:-}`; valor vazio é erro de uso com a lista suportada, exit 1 (D4)
+- [ ] 3.2 `SUPPORTED_TOOLS` valida o valor logo após o parse, antes de `command -v git` e do clone;
+      `--help` e a mensagem de erro usam a mesma lista (D4)
+- [ ] 3.3 Re-run faz `git pull --ff-only` com a mesma mensagem, dica e detalhe indentado de
+      `update.sh` (D5)
+- [ ] 3.4 `AI_SKILLS_REPO_URL` sobrepõe `REPO_URL`, documentado no cabeçalho junto com o que a
+      guarda não cobre (D6)
+
+## 4. Teste de fumaça e gate
+
+- [ ] 4.1 `scripts/smoke-install-scripts.sh`: bare local a partir do HEAD, `HOME` temporário por
+      caso, cobrindo install padrão, re-run idempotente, `--legacy`, `--tool codex`, `--tool all`,
+      `--tool bogus`, `--tool` sem valor, update limpo, update com `VERSION` sujo, update com
+      `generate.sh` falhando, divergência sem `--force` (update e install) e com `--force` (D6)
+- [ ] 4.2 O resumo final imprime a matriz em contagens `n/n` e o script sai 1 se qualquer caso
+      falhar (D7)
+- [ ] 4.3 Step novo em `.github/workflows/ci.yml`, logo após `Repo hygiene self-test`, rodando o
+      teste de fumaça
+- [ ] 4.4 `README.md:141` diz "all tool wrappers"
+
+## 5. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 6. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`)
+
+## 7. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate harden-distribution-scripts --strict` green
+- [ ] V.2 Catalog discovery intact: skill count unchanged, no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive harden-distribution-scripts --yes` after all groups above are `[x]`

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -138,14 +138,19 @@
 
 ## 4. Teste de fumaça e gate
 
-- [ ] 4.1 `scripts/smoke-install-scripts.sh`: bare local a partir do HEAD, `HOME` temporário por
+- [x] 4.1 `scripts/smoke-install-scripts.sh`: bare local a partir do HEAD, `HOME` temporário por
       caso, cobrindo install padrão, re-run idempotente, `--legacy`, `--tool codex`, `--tool all`,
-      `--tool bogus`, `--tool` sem valor, update limpo, update com `VERSION` sujo, update com
-      `generate.sh` falhando, divergência sem `--force` (update e install) e com `--force` (D6)
-- [ ] 4.2 O resumo final imprime a matriz em contagens `n/n` e o script sai 1 se qualquer caso
-      falhar (D7)
-- [ ] 4.3 Step novo em `.github/workflows/ci.yml`, logo após `Repo hygiene self-test`, rodando o
-      teste de fumaça
+      `--tool bogus` (HOME vazio e clone existente), `--tool` sem valor, update limpo, update com
+      `VERSION` sujo, update com edição fora das entradas, update com `generate.sh` falhando,
+      divergência sem `--force` (update e install) e com `--force` (D6). Os transportes https/ssh
+      ficam desligados em cada invocação (`protocol.<name>.allow=never`), probado:
+      `git clone https://github.com/solvelab/ai-skills.git` -> `fatal: transport 'https' not
+      allowed`, `exit=128`; clone e pull por caminho local com o mesmo env -> `exit=0`
+- [x] 4.2 O resumo final imprime a matriz em contagens `n/n` e o script sai 1 se qualquer caso
+      falhar (D7) — `bash scripts/smoke-install-scripts.sh` -> `smoke: 15/15 cases passed —
+      refusals that had to fire: 6/6, paths that had to succeed: 9/9`
+- [x] 4.3 Step novo em `.github/workflows/ci.yml`, logo após `Repo hygiene self-test`, rodando o
+      teste de fumaça — `grep -n 'smoke-install' .github/workflows/ci.yml` -> linha 109
 - [x] 4.4 `README.md:141` diz "all tool wrappers" — `sed -n 141p README.md` -> `Pull the latest
       skills/rules into ~/ai-skills and regenerate all tool wrappers:`
 

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -111,14 +111,15 @@
 
 ## 2. update.sh — guarda de entradas, falha visível, texto
 
-- [ ] 2.1 A regeneração roda só quando `git status --porcelain --untracked-files=no -- VERSION
+- [x] 2.1 A regeneração roda só quando `git status --porcelain --untracked-files=no -- VERSION
       skills/` está vazio; caso contrário imprime a lista, o comando que limpa, pula a regeneração e
-      não aborta o update (D1)
-- [ ] 2.2 `bash generate.sh` sai do `&&`: falha vira exit ≠ 0 com a saída capturada (D3)
-- [ ] 2.3 O `pull --ff-only` captura o stderr do git e o imprime indentado sob a mensagem própria e
-      a dica, com `advice.diverging=false` (D5)
-- [ ] 2.4 Cabeçalho e `--help` dizem "all tool wrappers" e o cabeçalho declara o que a guarda não
-      cobre (D2)
+      não aborta o update (D1) — `update.sh`, bloco `DIRTY_INPUTS`
+- [x] 2.2 `bash generate.sh` sai do `&&`: falha vira exit ≠ 0 com a saída capturada (D3) —
+      `update.sh`, `if GEN_OUT="$(bash generate.sh 2>&1)"` com `exit "$GEN_RC"` no `else`
+- [x] 2.3 O `pull --ff-only` captura o stderr do git e o imprime indentado sob a mensagem própria e
+      a dica, com `advice.diverging=false` (D5) — `update.sh`, bloco `PULL_ERR`
+- [x] 2.4 Cabeçalho e `--help` dizem "all tool wrappers" e o cabeçalho declara o que a guarda não
+      cobre (D2) — `update.sh` linhas 6, 16-20 e 33
 
 ## 3. install.sh — validação antes do clone, ff-only no re-run
 
@@ -140,7 +141,8 @@
       falhar (D7)
 - [ ] 4.3 Step novo em `.github/workflows/ci.yml`, logo após `Repo hygiene self-test`, rodando o
       teste de fumaça
-- [ ] 4.4 `README.md:141` diz "all tool wrappers"
+- [x] 4.4 `README.md:141` diz "all tool wrappers" — `sed -n 141p README.md` -> `Pull the latest
+      skills/rules into ~/ai-skills and regenerate all tool wrappers:`
 
 ## 5. Simulation & Field Proof (MANDATORY)
 

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -123,13 +123,18 @@
 
 ## 3. install.sh — validação antes do clone, ff-only no re-run
 
-- [ ] 3.1 `--tool` lê `${2:-}`; valor vazio é erro de uso com a lista suportada, exit 1 (D4)
-- [ ] 3.2 `SUPPORTED_TOOLS` valida o valor logo após o parse, antes de `command -v git` e do clone;
-      `--help` e a mensagem de erro usam a mesma lista (D4)
-- [ ] 3.3 Re-run faz `git pull --ff-only` com a mesma mensagem, dica e detalhe indentado de
-      `update.sh` (D5)
-- [ ] 3.4 `AI_SKILLS_REPO_URL` sobrepõe `REPO_URL`, documentado no cabeçalho junto com o que a
-      guarda não cobre (D6)
+- [x] 3.1 `--tool` lê `${2:-}`; valor vazio é erro de uso com a lista suportada, exit 1 (D4) —
+      `bash install.sh --tool` -> `❌ --tool requires a value. Supported: claude, codex, cursor,
+      copilot, all`, `exit=1`
+- [x] 3.2 `SUPPORTED_TOOLS` valida o valor logo após o parse, antes de `command -v git` e do clone;
+      a mensagem de erro deriva da mesma variável (D4) — `bash install.sh --tool bogus` num HOME
+      vazio -> `❌ Unknown tool: bogus. Supported: claude, codex, cursor, copilot, all`, `exit=1`,
+      `ls $HOME` -> vazio (nada clonado). O texto do `--help` continua literal.
+- [x] 3.3 Re-run faz `git pull --ff-only` com a mesma mensagem, dica e detalhe indentado de
+      `update.sh` (D5) — `install.sh`, bloco `PULL_ERR`; o `case` final perde o ramo `*)`, que
+      nunca mais é alcançado
+- [x] 3.4 `AI_SKILLS_REPO_URL` sobrepõe `REPO_URL`, documentado no cabeçalho junto com o que a
+      guarda não cobre (D6) — `install.sh` linhas 15-27 e 30
 
 ## 4. Teste de fumaça e gate
 

--- a/openspec/changes/harden-distribution-scripts/tasks.md
+++ b/openspec/changes/harden-distribution-scripts/tasks.md
@@ -141,14 +141,20 @@
 - [x] 4.1 `scripts/smoke-install-scripts.sh`: bare local a partir do HEAD, `HOME` temporário por
       caso, cobrindo install padrão, re-run idempotente, `--legacy`, `--tool codex`, `--tool all`,
       `--tool bogus` (HOME vazio e clone existente), `--tool` sem valor, update limpo, update com
-      `VERSION` sujo, update com edição fora das entradas, update com `generate.sh` falhando,
-      divergência sem `--force` (update e install) e com `--force` (D6). Os transportes https/ssh
+      `VERSION` sujo, update com `skills/` sujo (edição rastreada e deleção em stage — as duas
+      metades do pathspec da guarda), update com edição fora das entradas, update com `generate.sh`
+      falhando, divergência sem `--force` (update e install) e com `--force` (D6). Os transportes https/ssh
       ficam desligados em cada invocação (`protocol.<name>.allow=never`), probado:
       `git clone https://github.com/solvelab/ai-skills.git` -> `fatal: transport 'https' not
       allowed`, `exit=128`; clone e pull por caminho local com o mesmo env -> `exit=0`
 - [x] 4.2 O resumo final imprime a matriz em contagens `n/n` e o script sai 1 se qualquer caso
-      falhar (D7) — `bash scripts/smoke-install-scripts.sh` -> `smoke: 15/15 cases passed —
-      refusals that had to fire: 6/6, paths that had to succeed: 9/9`
+      falhar (D7) — `bash scripts/smoke-install-scripts.sh` -> `smoke: 17/17 cases passed —
+      refusals that had to fire: 6/6, paths that had to succeed: 11/11`, `exit=0`.
+      Controle por mutação (revisão round 2): com o pathspec da guarda reduzido a `-- VERSION`
+      (`sed -i 's|-- VERSION skills/)"|-- VERSION)"|' update.sh` num clone de `91f583a`), o teste
+      de 15 casos passava `15/15`; com os casos 10b/10c -> `FAIL  [accept] update: dirty skills/
+      tree`, `FAIL  [accept] update: staged deletion under skills/`, `smoke: 15/17 cases passed`,
+      `exit=1`
 - [x] 4.3 Step novo em `.github/workflows/ci.yml`, logo após `Repo hygiene self-test`, rodando o
       teste de fumaça — `grep -n 'smoke-install' .github/workflows/ci.yml` -> linha 109
 - [x] 4.4 `README.md:141` diz "all tool wrappers" — `sed -n 141p README.md` -> `Pull the latest
@@ -218,16 +224,33 @@
 
       ```
       bash scripts/smoke-install-scripts.sh
-      -> smoke: origin=/tmp/ai-skills-smoke.IjMZdd/origin.git head=188bdaa skills=35
+      -> smoke: origin=/tmp/ai-skills-smoke.WEyXKw/origin.git head=91f583a skills=35
       -> PASS  [accept] install: default (claude symlinks)
-      -> (mais 13 linhas PASS)
+      -> [...] (mais 8 linhas PASS)
+      -> PASS  [accept] update: dirty VERSION (pull, skip regeneration, exit 0)
+      -> PASS  [accept] update: dirty skills/ tree (pull, skip regeneration, exit 0)
+      -> PASS  [accept] update: staged deletion under skills/ (skip regeneration, exit 0)
+      -> [...] (mais 4 linhas PASS)
       -> PASS  [accept] update: diverged, --force (reset to origin)
-      -> smoke: 15/15 cases passed — refusals that had to fire: 6/6, paths that had to succeed: 9/9
+      -> smoke: 17/17 cases passed — refusals that had to fire: 6/6, paths that had to succeed: 11/11
+      -> exit=0
+      ```
+
+      Os dois casos de `skills/` sujo, na mão, antes de entrarem no teste:
+
+      ```
+      echo x >> $HOME/ai-skills/skills/backlog/SKILL.md; HOME=<tmp> bash update.sh
+      -> ⏭️  Skipping wrapper regeneration: the generator's inputs have uncommitted changes:
+      ->       M skills/backlog/SKILL.md
+      -> exit=0
+      git -C $HOME/ai-skills rm -q skills/backlog/SKILL.md; HOME=<tmp> bash update.sh
+      -> ⏭️  Skipping wrapper regeneration: the generator's inputs have uncommitted changes:
+      ->      D  skills/backlog/SKILL.md
       -> exit=0
       ```
 
       ```
-      bash oldroot/scripts/smoke-install-scripts.sh   # scripts antigos, antes do bloqueio de transporte
+      bash oldroot/scripts/smoke-install-scripts.sh   # scripts antigos, teste de 15 casos, antes do bloqueio de transporte
       -> FAIL  [refuse] install: --tool bogus (exit 1, nothing cloned)
       ->         - output must not contain: Cloning
       ->         - no clone directory was created
@@ -255,8 +278,9 @@
       | Expectativa | Casos | Resultado |
       |---|---|---|
       | Tinha de recusar e recusou (scripts novos) | 6/6 | `--tool bogus` ×2, `--tool` sem valor, `generate.sh` falhando, divergência sem `--force` (update e install) |
-      | Tinha de passar e passou (scripts novos) | 9/9 | install padrão, re-run idempotente (0 linked / 35 up to date), `--legacy`, `--tool codex`, `--tool all`, update limpo, `VERSION` sujo, edição fora das entradas, `--force` |
-      | Controle negativo: o mesmo teste sobre os scripts antigos tinha de reprovar e reprovou | 10/15 reprovados, 0/6 recusas | ver S.1 |
+      | Tinha de passar e passou (scripts novos) | 11/11 | install padrão, re-run idempotente (0 linked / 35 up to date), `--legacy`, `--tool codex`, `--tool all`, update limpo, `VERSION` sujo, `skills/` sujo (edição rastreada), `skills/` com deleção em stage, edição fora das entradas, `--force` |
+      | Controle negativo: o teste de 15 casos sobre os scripts antigos tinha de reprovar e reprovou | 10/15 reprovados, 0/6 recusas | ver S.1; o teste de 17 casos sobre os mesmos scripts aborta no bloqueio de transporte (`exit=128`), como já registrado |
+      | Controle por mutação: pathspec da guarda sem `skills/` tinha de reprovar e reprovou | 2/17 reprovados (10b, 10c) | ver 4.2; com o teste de 15 casos a mesma mutação passava `15/15` |
       | Escape conhecido ficou mudo | 1/1 | arquivo novo não rastreado em `skills/` não pula a regeneração — declarado no cabeçalho de `update.sh`, ver S.3 |
 
 - [x] S.3 O que escapou ou se comportou diferente do esperado
@@ -275,6 +299,12 @@
       O escape declarado (D2) ficou mudo como esperado: `--untracked-files=no` não vê um
       `skills/<novo>/` não rastreado, e a regeneração roda. Está escrito no cabeçalho de
       `update.sh`; o teste exercita só a direção prometida (edição fora das entradas regenera).
+
+      Notado ao cobrir a deleção em stage (caso 10c, revisão round 2): a dica impressa pela guarda
+      (`git checkout -- VERSION skills/`) restaura o worktree a partir do índice, então não desfaz
+      um `git rm` — para esse estado é preciso `git checkout HEAD -- skills/` (é o que o teste usa
+      para restaurar a fixture). A guarda recusa corretamente; só a dica é incompleta para esse
+      caso. Não tocado nesta change: fica como follow-up, ao lado dos itens de E.4.
 
 ## 6. Quality Gates (MANDATORY)
 

--- a/scripts/smoke-install-scripts.sh
+++ b/scripts/smoke-install-scripts.sh
@@ -210,6 +210,37 @@ want "only VERSION is dirty" test "$(git -C "$INSTALL" status --porcelain)" = " 
 finish accept "update: dirty VERSION (pull, skip regeneration, exit 0)"
 git -C "$INSTALL" checkout -q -- VERSION
 
+# ── 10b. update with a dirty skills/ tree: the other half of the pathspec ──
+# Case 10 alone let a pathspec reduced to `-- VERSION` pass the whole matrix (round-2 review of
+# issue #113): nothing dirtied skills/. A tracked edit under skills/ has to trip the same guard.
+echo "# smoke: dirty skill" >> "$INSTALL/skills/backlog/SKILL.md"
+run "$H1" bash "$ROOT/update.sh"
+want_rc 0
+want_out "Skipping wrapper regeneration"
+want_out " M skills/backlog/SKILL.md"
+want_out "checkout -- VERSION skills/"
+want_no_out "Wrappers regenerated"
+want_out "Already up to date"
+want "only the skill file is dirty" test "$(git -C "$INSTALL" status --porcelain)" = " M skills/backlog/SKILL.md"
+finish accept "update: dirty skills/ tree (pull, skip regeneration, exit 0)"
+git -C "$INSTALL" checkout -q -- skills/
+
+# ── 10c. update with a staged deletion under skills/: the index is read too ─
+# `--porcelain` reports the index as well as the worktree, so a `git rm` (worktree clean, index
+# dirty) must also skip the regeneration: generate.sh reads skills/ from the worktree, where the
+# file is gone, and would drop that skill's wrappers. Restored with `checkout HEAD --` because
+# the printed hint (`checkout -- ...`) reads the index, which no longer carries the file.
+git -C "$INSTALL" rm -q skills/backlog/SKILL.md
+run "$H1" bash "$ROOT/update.sh"
+want_rc 0
+want_out "Skipping wrapper regeneration"
+want_out "D  skills/backlog/SKILL.md"
+want_no_out "Wrappers regenerated"
+want "only the staged deletion is pending" test "$(git -C "$INSTALL" status --porcelain)" = "D  skills/backlog/SKILL.md"
+git -C "$INSTALL" checkout -q HEAD -- skills/
+want "fixture restored: tree clean" test -z "$(git -C "$INSTALL" status --porcelain)"
+finish accept "update: staged deletion under skills/ (skip regeneration, exit 0)"
+
 # ── 11. update with an edit outside the generator's inputs: regenerates ───
 echo "# local customization" >> "$INSTALL/claude/global/personal-rules.md"
 run "$H1" bash "$ROOT/update.sh"

--- a/scripts/smoke-install-scripts.sh
+++ b/scripts/smoke-install-scripts.sh
@@ -1,0 +1,279 @@
+#!/usr/bin/env bash
+# smoke-install-scripts.sh — end-to-end smoke test for install.sh and update.sh.
+#
+# The two distribution scripts had no gate: nothing in CI ever ran them, so the behaviors the
+# README promises (fast-forward sync, wrapper regeneration, --tool validation) were assertions.
+# Measured on 2026-09-04 (issue #113): an uncommitted line in VERSION did not stop update.sh, and
+# generate.sh wrote that line into ten tracked plugin.json files; a failing generate.sh exited 0;
+# `install.sh --tool` died with `$2: unbound variable`; `--tool bogus` cloned before failing.
+#
+# How it runs — the same way a user runs them, minus the network:
+#   - a bare repository is built from this checkout's HEAD (`git push <bare> HEAD:refs/heads/master`,
+#     which works on a branch and on the detached HEAD actions/checkout produces for a pull request);
+#   - install.sh clones from it through AI_SKILLS_REPO_URL, never from the GitHub URL, and the
+#     https/ssh transports are disabled for every invocation, so a script that ignores the override
+#     fails instead of reaching the network;
+#   - every invocation gets HOME=<temp dir>, so ~/.claude and ~/.codex are never touched;
+#   - "upstream" commits are pushed from a second clone, "local" commits are made in the install.
+#
+# Output: one PASS/FAIL line per case and a final matrix as counts — refusals that had to fire,
+# paths that had to succeed. Exit 1 when any case fails.
+#
+# WHAT THIS DOES NOT COVER: the real clone URL (network is never used); `curl | bash` as a
+# transport; macOS/BSD userland (this runs on GNU tools); a --legacy install on a HOME that has no
+# CLAUDE.md yet is covered, but a pre-existing CLAUDE.md with a foreign `## Skills` block is not;
+# the guard's own declared blind spots — untracked files under skills/ and edits outside
+# VERSION/skills/ — are exercised only in the direction the scripts promise (regeneration runs),
+# not judged. The "update clean" case also requires the committed wrappers to match generate.sh's
+# output, which the "Wrappers in sync" CI step guarantees for the same HEAD.
+#
+# Usage: bash scripts/smoke-install-scripts.sh   (from anywhere; CI runs it on every PR)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/ai-skills-smoke.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+# A fixture step that fails (a clone that never happened, a push that was refused) aborts the run
+# under set -e before the matrix is printed; name the line so the abort is diagnosable from CI.
+trap 'echo "::error::smoke aborted at line $LINENO: $BASH_COMMAND" >&2' ERR
+
+ORIGIN="$WORK/origin.git"
+AUTHOR="$WORK/author"
+GIT_ID=(-c user.name=smoke -c user.email=smoke@example.invalid)
+
+# ── bookkeeping ───────────────────────────────────────────────────────────
+refused=0; refused_total=0
+accepted=0; accepted_total=0
+failures=()
+CASE_ERRORS=()
+OUT=""; RC=0
+
+# run <home> <cmd...>: run one script invocation under a fake HOME, capture output and exit code.
+# The network transports are switched off for the invocation (protocol.<name>.allow=never): a script
+# that reaches for the GitHub URL fails at once with `fatal: transport 'https' not allowed` instead
+# of downloading the catalog, and the local-path transport is unaffected. Probed on git 2.47.3.
+run() {
+    local home="$1"; shift
+    mkdir -p "$home"
+    set +e
+    OUT="$(HOME="$home" AI_SKILLS_REPO_URL="$ORIGIN" \
+           GIT_CONFIG_COUNT=2 \
+           GIT_CONFIG_KEY_0=protocol.https.allow GIT_CONFIG_VALUE_0=never \
+           GIT_CONFIG_KEY_1=protocol.ssh.allow   GIT_CONFIG_VALUE_1=never \
+           "$@" 2>&1)"
+    RC=$?
+    set -e
+}
+
+want_rc()      { [ "$RC" -eq "$1" ] || CASE_ERRORS+=("expected exit $1, got $RC"); }
+want_rc_not()  { [ "$RC" -ne "$1" ] || CASE_ERRORS+=("expected exit != $1, got $RC"); }
+want_out()     { grep -qF -- "$1" <<<"$OUT" || CASE_ERRORS+=("output lacks: $1"); }
+want_no_out()  { ! grep -qF -- "$1" <<<"$OUT" || CASE_ERRORS+=("output must not contain: $1"); }
+want()         { local desc="$1"; shift; "$@" || CASE_ERRORS+=("$desc"); }
+
+# finish <refuse|accept> <name>: record the case, print its verdict, reset the error list.
+finish() {
+    local kind="$1" name="$2"
+    if [ "$kind" = refuse ]; then refused_total=$((refused_total + 1)); else accepted_total=$((accepted_total + 1)); fi
+    if [ "${#CASE_ERRORS[@]}" -eq 0 ]; then
+        if [ "$kind" = refuse ]; then refused=$((refused + 1)); else accepted=$((accepted + 1)); fi
+        printf 'PASS  [%s] %s\n' "$kind" "$name"
+    else
+        printf 'FAIL  [%s] %s\n' "$kind" "$name"
+        local e; for e in "${CASE_ERRORS[@]}"; do printf '        - %s\n' "$e"; done
+        printf '        --- output ---\n%s\n        --------------\n' "$(sed 's/^/        | /' <<<"$OUT")"
+        failures+=("$name")
+    fi
+    CASE_ERRORS=()
+}
+
+# upstream_commit <name>: push one new commit to the bare origin from the author clone.
+upstream_commit() {
+    echo "$1" > "$AUTHOR/smoke-upstream-$1.txt"
+    git -C "$AUTHOR" add "smoke-upstream-$1.txt"
+    git -C "$AUTHOR" "${GIT_ID[@]}" commit -q -m "smoke: upstream $1"
+    git -C "$AUTHOR" push -q origin HEAD:master
+}
+
+head_of() { git -C "$1" rev-parse HEAD; }
+
+# ── fixture: a local origin built from this checkout's HEAD ───────────────
+git init -q --bare "$ORIGIN"
+git -C "$ORIGIN" symbolic-ref HEAD refs/heads/master
+git -C "$ROOT" push -q "$ORIGIN" HEAD:refs/heads/master
+git clone -q "$ORIGIN" "$AUTHOR"
+SKILL_COUNT="$(find "$AUTHOR/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d ' ')"
+echo "smoke: origin=$ORIGIN head=$(head_of "$AUTHOR" | cut -c1-7) skills=$SKILL_COUNT"
+
+H1="$WORK/home-main"
+INSTALL="$H1/ai-skills"
+
+# ── 1. default install into an empty HOME ─────────────────────────────────
+run "$H1" bash "$ROOT/install.sh"
+want_rc 0
+want_out "Cloning ai-skills into ~/ai-skills"
+want_out "$SKILL_COUNT skill(s) symlinked into ~/.claude/skills/ (0 already up to date)"
+want "origin is the local bare, not the network" \
+    test "$(git -C "$INSTALL" remote get-url origin)" = "$ORIGIN"
+want "one symlink per skill" \
+    test "$(find "$H1/.claude/skills" -mindepth 1 -maxdepth 1 -type l | wc -l | tr -d ' ')" = "$SKILL_COUNT"
+want "symlinks point into the clone" \
+    test "$(readlink "$H1/.claude/skills/backlog")" = "$INSTALL/skills/backlog"
+finish accept "install: default (claude symlinks)"
+
+# ── 2. idempotent re-run ──────────────────────────────────────────────────
+run "$H1" bash "$ROOT/install.sh"
+want_rc 0
+want_out "already exists. Pulling latest changes"
+want_out "0 skill(s) symlinked into ~/.claude/skills/ ($SKILL_COUNT already up to date)"
+finish accept "install: idempotent re-run (0 linked / $SKILL_COUNT up to date)"
+
+# ── 3. --legacy ───────────────────────────────────────────────────────────
+run "$H1" bash "$ROOT/install.sh" --legacy
+want_rc 0
+want_out "Adding Skills section to ~/.claude/CLAUDE.md"
+want "CLAUDE.md carries the Skills block" grep -q "## Skills" "$H1/.claude/CLAUDE.md"
+finish accept "install: --legacy"
+
+# ── 4. --tool codex ───────────────────────────────────────────────────────
+run "$H1" bash "$ROOT/install.sh" --tool codex
+want_rc 0
+want_out "Adding Skills section to ~/.codex/AGENTS.md"
+want "AGENTS.md carries the block" grep -q "# AI Skills" "$H1/.codex/AGENTS.md"
+finish accept "install: --tool codex"
+
+# ── 5. --tool all ─────────────────────────────────────────────────────────
+run "$H1" bash "$ROOT/install.sh" --tool all
+want_rc 0
+want_out "0 skill(s) symlinked into ~/.claude/skills/ ($SKILL_COUNT already up to date)"
+want_out "Codex: Skills section already exists"
+want_out "Cursor: rules are in"
+want_out "Copilot: instructions are in"
+want_out "installed successfully for all"
+finish accept "install: --tool all"
+
+# ── 6. --tool bogus: refused before any clone ─────────────────────────────
+H2="$WORK/home-bogus"
+run "$H2" bash "$ROOT/install.sh" --tool bogus
+want_rc 1
+want_out "Unknown tool: bogus"
+want_out "Supported: claude, codex, cursor, copilot, all"
+want_no_out "Cloning"
+want "no clone directory was created" test ! -e "$H2/ai-skills"
+finish refuse "install: --tool bogus (exit 1, nothing cloned)"
+
+# ── 7. --tool with no value: usage error, not `unbound variable` ──────────
+H3="$WORK/home-novalue"
+run "$H3" bash "$ROOT/install.sh" --tool
+want_rc 1
+want_out "--tool requires a value"
+want_out "Supported: claude, codex, cursor, copilot, all"
+want_no_out "unbound variable"
+want_no_out "Cloning"
+want "no clone directory was created" test ! -e "$H3/ai-skills"
+finish refuse "install: --tool without a value (exit 1, nothing cloned)"
+
+# ── 8. --tool bogus over an existing clone: no pull either ────────────────
+upstream_commit 1
+BEFORE="$(head_of "$INSTALL")"
+run "$H1" bash "$ROOT/install.sh" --tool bogus
+want_rc 1
+want_no_out "Pulling"
+want "HEAD unchanged (no pull ran)" test "$(head_of "$INSTALL")" = "$BEFORE"
+finish refuse "install: --tool bogus over an existing clone (no pull)"
+
+# ── 9. update over a clean clone with origin ahead ────────────────────────
+run "$H1" bash "$ROOT/update.sh"
+want_rc 0
+want_out "Regenerating tool wrappers"
+want_out "Wrappers regenerated"
+want_out "Updated to v"
+want_out "smoke: upstream 1"
+want "HEAD moved to origin/master" test "$(head_of "$INSTALL")" = "$(head_of "$AUTHOR")"
+want "tree clean after regeneration" test -z "$(git -C "$INSTALL" status --porcelain)"
+finish accept "update: clean clone, origin ahead (pull + regenerate)"
+
+# ── 10. update with a dirty VERSION: pull yes, regeneration no ────────────
+echo "dirtychange" >> "$INSTALL/VERSION"
+upstream_commit 2
+run "$H1" bash "$ROOT/update.sh"
+want_rc 0
+want_out "Skipping wrapper regeneration"
+want_out " M VERSION"
+want_out "checkout -- VERSION skills/"
+want_no_out "Wrappers regenerated"
+want_out "smoke: upstream 2"
+want "HEAD moved to origin/master (pull still ran)" test "$(head_of "$INSTALL")" = "$(head_of "$AUTHOR")"
+want "no plugin.json modified" test -z "$(git -C "$INSTALL" status --porcelain | grep -F plugin.json || true)"
+want "no plugin.json carries the dirty version" test -z "$(grep -rl dirtychange "$INSTALL"/plugins/*/.claude-plugin/plugin.json 2>/dev/null || true)"
+want "only VERSION is dirty" test "$(git -C "$INSTALL" status --porcelain)" = " M VERSION"
+finish accept "update: dirty VERSION (pull, skip regeneration, exit 0)"
+git -C "$INSTALL" checkout -q -- VERSION
+
+# ── 11. update with an edit outside the generator's inputs: regenerates ───
+echo "# local customization" >> "$INSTALL/claude/global/personal-rules.md"
+run "$H1" bash "$ROOT/update.sh"
+want_rc 0
+want_out "Wrappers regenerated"
+want_out "Already up to date"
+want_no_out "Skipping wrapper regeneration"
+want "the personal edit survived" test "$(git -C "$INSTALL" status --porcelain)" = " M claude/global/personal-rules.md"
+finish accept "update: edit outside VERSION/skills/ still regenerates"
+git -C "$INSTALL" checkout -q -- claude/global/personal-rules.md
+
+# ── 12. update with a failing generate.sh: the failure is visible ─────────
+printf '#!/usr/bin/env bash\necho "generate boom"\nexit 7\n' > "$INSTALL/generate.sh"
+run "$H1" bash "$ROOT/update.sh"
+want_rc 7
+want_out "generate boom"
+want_out "generate.sh failed (exit 7)"
+want_no_out "Wrappers regenerated"
+finish refuse "update: failing generate.sh (exit 7 with its output)"
+git -C "$INSTALL" checkout -q -- generate.sh
+
+# ── 13. divergence: local commit + upstream commit, update without --force ─
+echo "mine" > "$INSTALL/smoke-local-note.txt"
+git -C "$INSTALL" add smoke-local-note.txt
+git -C "$INSTALL" "${GIT_ID[@]}" commit -q -m "smoke: local commit"
+LOCAL="$(head_of "$INSTALL")"
+upstream_commit 3
+run "$H1" bash "$ROOT/update.sh"
+want_rc 1
+want_out "Fast-forward failed"
+want_out "./update.sh --force"
+want_out "git: fatal: Not possible to fast-forward"
+want_no_out "hint:"
+want "own message precedes git's fatal line" \
+    test "$(grep -nF 'Fast-forward failed' <<<"$OUT" | head -1 | cut -d: -f1)" -lt "$(grep -nF 'fatal:' <<<"$OUT" | head -1 | cut -d: -f1)"
+want "HEAD unchanged" test "$(head_of "$INSTALL")" = "$LOCAL"
+finish refuse "update: diverged, no --force (exit 1 with hint)"
+
+# ── 14. divergence: install.sh re-run gives the same refusal ──────────────
+run "$H1" bash "$ROOT/install.sh"
+want_rc 1
+want_out "Fast-forward failed"
+want_out "./update.sh --force"
+want_no_out "Need to specify how to reconcile"
+want_no_out "hint:"
+want_no_out "Configuring for"
+want "HEAD unchanged" test "$(head_of "$INSTALL")" = "$LOCAL"
+finish refuse "install: re-run over a diverged clone (exit 1 with hint)"
+
+# ── 15. divergence: update --force resets to origin ───────────────────────
+run "$H1" bash "$ROOT/update.sh" --force
+want_rc 0
+want_out "--force: discarding local changes"
+want_out "Wrappers regenerated"
+want "HEAD is origin/master" test "$(head_of "$INSTALL")" = "$(head_of "$AUTHOR")"
+want "local commit's file is gone" test ! -e "$INSTALL/smoke-local-note.txt"
+finish accept "update: diverged, --force (reset to origin)"
+
+# ── matrix ────────────────────────────────────────────────────────────────
+total=$((refused_total + accepted_total))
+passed=$((refused + accepted))
+echo ""
+echo "smoke: $passed/$total cases passed — refusals that had to fire: $refused/$refused_total, paths that had to succeed: $accepted/$accepted_total"
+if [ "${#failures[@]}" -gt 0 ]; then
+    for f in "${failures[@]}"; do echo "::error::smoke case failed: $f"; done
+    exit 1
+fi

--- a/update.sh
+++ b/update.sh
@@ -3,9 +3,22 @@
 # Companion to install.sh: install wires the tool once; update pulls new content.
 #
 # Usage:
-#   ./update.sh           # fast-forward pull + regenerate Cursor rules
+#   ./update.sh           # fast-forward pull + regenerate all tool wrappers
 #   ./update.sh --force   # discard local changes, hard-reset to origin
 #   ./update.sh --help
+#
+# The wrappers are regenerated only when the generator's INPUTS are clean in the index:
+# `git status --porcelain --untracked-files=no -- VERSION skills/` must be empty. A dirty VERSION
+# would otherwise be written into every tracked plugins/*/.claude-plugin/plugin.json. The pull
+# still happens either way, and the script still exits 0: the README tells users to edit
+# claude/global/personal-rules.md in this clone, and that edit must never block an update.
+#
+# WHAT THE GUARD DOES NOT COVER: untracked files (a new skills/<name>/ that was never `git add`ed
+# is not seen, and the generator will happily emit wrappers for it), and edits anywhere outside
+# VERSION and skills/ (they do not feed the generator, so they are not checked). A regeneration
+# that ran is proof that those two paths were clean in the index, nothing more.
+# There is no interactive prompt on purpose: the README runs this script via `curl | bash`, where
+# stdin is the script itself.
 set -euo pipefail
 
 INSTALL_DIR="$HOME/ai-skills"
@@ -17,8 +30,9 @@ while [[ $# -gt 0 ]]; do
         --help|-h)
             echo "Usage: update.sh [--force]"
             echo ""
-            echo "Pulls the latest ai-skills into ~/ai-skills and regenerates Cursor rules."
-            echo "  (no flag)   fast-forward pull; aborts if local changes diverge"
+            echo "Pulls the latest ai-skills into ~/ai-skills and regenerates all tool wrappers."
+            echo "  (no flag)   fast-forward pull; aborts if local commits diverge from origin;"
+            echo "              skips the wrapper regeneration while VERSION or skills/ are modified"
             echo "  --force     discard local changes and hard-reset to origin"
             echo ""
             echo "After updating, restart your AI tool — global rules load at session start."
@@ -44,19 +58,39 @@ if [ "$FORCE" -eq 1 ]; then
     echo "  ⚠️  --force: discarding local changes, resetting to $UPSTREAM"
     git -C "$INSTALL_DIR" reset --hard "$UPSTREAM" --quiet
 else
-    if ! git -C "$INSTALL_DIR" pull --ff-only --quiet; then
+    # advice.diverging=false drops git's nine `hint:` lines; the `fatal:` line is kept as an
+    # indented detail because on a network failure it is the only useful information.
+    if ! PULL_ERR="$(git -C "$INSTALL_DIR" -c advice.diverging=false pull --ff-only --quiet 2>&1)"; then
         echo "  ❌ Fast-forward failed — local changes diverge from origin."
-        echo "     Re-run with --force to discard them: ./update.sh --force"
+        echo "     Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force"
+        [ -z "$PULL_ERR" ] || printf '     git: %s\n' "$PULL_ERR"
         exit 1
     fi
 fi
 
 AFTER=$(git -C "$INSTALL_DIR" rev-parse HEAD)
 
-# Regenerate tool wrappers from the canonical skills/ content (best-effort)
+# Regenerate tool wrappers from the canonical skills/ content — only over clean inputs (see header).
 if [ -f "$INSTALL_DIR/generate.sh" ]; then
-    echo "🔧 Regenerating tool wrappers..."
-    bash "$INSTALL_DIR/generate.sh" >/dev/null && echo "  ✅ Wrappers regenerated."
+    DIRTY_INPUTS="$(git -C "$INSTALL_DIR" status --porcelain --untracked-files=no -- VERSION skills/)"
+    if [ -n "$DIRTY_INPUTS" ]; then
+        echo "⏭️  Skipping wrapper regeneration: the generator's inputs have uncommitted changes:"
+        printf '     %s\n' "$DIRTY_INPUTS"
+        echo "     Clean them with: git -C ~/ai-skills checkout -- VERSION skills/"
+        echo "     (or discard every local change with: cd ~/ai-skills && ./update.sh --force)"
+    else
+        echo "🔧 Regenerating tool wrappers..."
+        # Not `generate.sh && echo`: under set -e a failure on the left of && is swallowed and the
+        # script carries on as if the wrappers were regenerated.
+        if GEN_OUT="$(bash "$INSTALL_DIR/generate.sh" 2>&1)"; then
+            echo "  ✅ Wrappers regenerated."
+        else
+            GEN_RC=$?
+            printf '%s\n' "$GEN_OUT"
+            echo "  ❌ generate.sh failed (exit $GEN_RC). The pull succeeded; the wrappers were not regenerated."
+            exit "$GEN_RC"
+        fi
+    fi
 fi
 
 echo ""


### PR DESCRIPTION
Closes #113

`update.sh` regenerava os wrappers sobre qualquer árvore: uma linha a mais em `VERSION`, sem commit, acabava gravada em dez `plugins/*/.claude-plugin/plugin.json`; uma falha do `generate.sh` ficava muda atrás do `&&`; `install.sh --tool` morria com `$2: unbound variable`, `--tool bogus` clonava antes de falhar e o re-run usava `git pull` sem `--ff-only`. Nenhum step do CI executava os dois scripts.

## O que muda

- **`update.sh`** regenera só quando `git status --porcelain --untracked-files=no -- VERSION skills/` está vazio; caso contrário lista os arquivos, imprime o comando que limpa, pula a regeneração e **sai 0** (o pull acontece de qualquer jeito — o README manda editar `personal-rules.md` no clone, e isso não pode bloquear o update). `bash generate.sh` sai do `&&`: falha vira exit ≠ 0 com a saída do gerador. O `pull --ff-only` imprime a mensagem própria e a dica `--force`, com o `fatal:` do git como detalhe indentado (`advice.diverging=false`).
- **`install.sh`** valida `--tool` logo após o parse, antes de `git` e do clone; `${2:-}` vazio é erro de uso com a lista suportada; o re-run faz `pull --ff-only` com a mesma mensagem de `update.sh`. `AI_SKILLS_REPO_URL` sobrepõe a URL do clone (é o que o teste usa).
- **`scripts/smoke-install-scripts.sh`** (novo) + step em `ci.yml`: bare local do HEAD, `HOME` temporário, transportes https/ssh desligados por invocação (`protocol.<name>.allow=never`), 17 casos, matriz em contagens, exit 1 se qualquer caso regredir.
- **Texto:** `README.md:141`, `update.sh` cabeçalho e `--help` dizem "all tool wrappers". Cada script declara no cabeçalho o que a guarda não cobre.

Nenhuma skill é tocada; a composição do catálogo fica idêntica (35 skills).

## Simulação — saída observada

```
bash scripts/smoke-install-scripts.sh
-> smoke: 17/17 cases passed — refusals that had to fire: 6/6, paths that had to succeed: 11/11
```

| Expectativa | Casos | Resultado |
|---|---|---|
| Tinha de recusar e recusou | **6/6** | `--tool bogus` ×2, `--tool` sem valor, `generate.sh` falhando (exit 7 com a saída), divergência sem `--force` (update e install) |
| Tinha de passar e passou | **11/11** | install padrão, re-run idempotente, `--legacy`, `--tool codex`, `--tool all`, update limpo, `VERSION` sujo, `skills/` sujo (edição rastreada), `skills/` com deleção em stage, edição fora das entradas regenera, `--force` |
| Controle negativo: scripts antigos sob o mesmo teste | **10/15 reprovados, 0/6 recusas** | o `install.sh` antigo chegou a clonar do GitHub — daí o bloqueio de transporte no `run` do teste |
| Controle por mutação: pathspec da guarda sem `skills/` | **2/17 reprovados** | casos 10b/10c `FAIL`, `smoke: 15/17`, exit 1 (com o teste de 15 casos a mutação passava `15/15`) |
| Escape declarado ficou mudo | 1/1 | arquivo não rastreado em `skills/` não pula a regeneração — está no cabeçalho de `update.sh` |

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Wrappers em sincronia | `bash generate.sh && git status --porcelain` | `Generated 10 category plugins in plugins/`, árvore limpa |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | `13/13 defect classes detected` |
| Locale | `check-identifier-locale.py --selftest`, `locale-rite.py --selftest` | OK |
| Segredos | `python3 scripts/scan-secrets.py` | `no credentials found` |
| Higiene do repo | `validate-repo-hygiene.py` + `--selftest` | `0 findings`, `2/2` |
| Teste de fumaça | `bash scripts/smoke-install-scripts.sh` | `17/17`, exit 0 |
| Rito | `bash scripts/validate-rite.sh` | `rite gate OK` |
| Evidência do rito / spec-rite | `validate-rite-evidence.py --selftest`, `validate-spec-rite.py --selftest` | `7/7`, `3/3` |
| OpenSpec estrito | `openspec validate harden-distribution-scripts --strict` | `Change 'harden-distribution-scripts' is valid` |
| Validador do vendor | `claude plugin validate . --strict` | `Validation passed` |

## Rito

Spec-rite: harden-distribution-scripts

Capability `skills-catalog` (ADDED requirement *"Distribution scripts refuse what they cannot honor, and CI exercises them"*, 7 cenários).

## Known gaps

- A dica impressa pela guarda (`git checkout -- VERSION skills/`) restaura do índice, então não desfaz um `git rm` em stage — a guarda recusa certo, só a dica é incompleta nesse estado (tasks.md S.3). Follow-up.
- Arquivo não rastreado em `skills/` não é visto pela guarda (`--untracked-files=no`) — declarado no cabeçalho de `update.sh`.
- Guarda de semver em `generate.sh` fica com a issue que reescreve o bloco dos `plugin.json` (fora de escopo na #113).
- O banner `current: v$(cat VERSION)` imprime a `VERSION` suja com a linha extra; cosmético, o script diz logo abaixo que o arquivo está sujo.