### PR TITLE
✨ feat(hooks): dá selftest e gate de CI aos hooks backlog-rite e verify-rite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Locale write-gate hook self-test (the shipped hook is itself gated)
         run: python3 claude/global/hooks/locale-rite.py --selftest
 
+      - name: Backlog rite hook self-test (the shipped hook is itself gated)
+        run: python3 claude/global/hooks/backlog-rite.py --selftest
+
+      - name: Grounding rite hook self-test (the shipped hook is itself gated)
+        run: python3 claude/global/hooks/verify-rite.py --selftest
+
       - name: Secret scan (working tree)
         run: python3 scripts/scan-secrets.py
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,11 @@ workflow, so the reminder does not teach a step that does not exist there.
 
 It stays silent for prompts already inside the rite (`/backlog`, `/execute-backlog`, any slash
 command), for explicit waivers ("sem backlog", "skip the rite"), and for anything that does not look
-like a code change. It persists nothing and needs no credentials.
+like a code change. It persists nothing and needs no credentials. A diagnostic question that
+contains a change word — `erro`, `bug`, `falha`/`fail` ("por que o teste falha?") — does fire, on
+purpose: the matcher is deliberately generous because a false positive costs one paragraph of context
+while a false negative costs traceability, the reminder itself says diagnosis is free, and the hook's
+`--selftest` fixes that case as one that fires so a well-meant "fix" cannot revert it unread.
 
 ### The grounding rite (anti-achismo)
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ It stays silent for prompts already inside the rite (`/backlog`, `/execute-backl
 command), for explicit waivers ("sem backlog", "skip the rite"), and for anything that does not look
 like a code change. It persists nothing and needs no credentials. A diagnostic question that
 contains a change word — `erro`, `bug`, `falha`/`fail` ("por que o teste falha?") — does fire, on
-purpose: the matcher is deliberately generous because a false positive costs one paragraph of context
+purpose: the matcher is deliberately generous because a false positive costs one line of context
 while a false negative costs traceability, the reminder itself says diagnosis is free, and the hook's
 `--selftest` fixes that case as one that fires so a well-meant "fix" cannot revert it unread.
 

--- a/claude/global/hooks/backlog-rite.py
+++ b/claude/global/hooks/backlog-rite.py
@@ -15,6 +15,16 @@ Why a hook and not only a rule in personal-rules.md: the harness runs this on ev
 prompt, so enforcement does not depend on the assistant noticing a rule already in
 context. It informs — it never blocks a tool call, and the user can always waive.
 
+ACCEPTED FALSE POSITIVE: a diagnostic question that contains a change word — "por que o
+teste falha?", "why does the build fail?", "como corrijo esse bug?" — fires. The matcher is
+deliberately generous: a false positive costs one paragraph of context, a false negative
+costs traceability, and the injected text itself says diagnosis is free. Decided in
+openspec/changes/archive/2026-08-07-add-backlog-first-rite/design.md:32 and :78; fixed
+below as a self-test case that FIRES, so a well-meant "fix" breaks the test and reads the
+reason first. A question-shape exclusion was measured and rejected: it silences real
+requests ("por que não implementa o endpoint de login?") and does not remove the class it
+aims at ("como corrijo esse bug?" still fires).
+
 Wiring (~/.claude/settings.json):
 
     "hooks": {
@@ -27,12 +37,22 @@ Wiring (~/.claude/settings.json):
 
 Like personal-rules.md, this is the maintainer's config — edit the signal list and the
 reminder to match your own process instead of adopting it blindly.
+
+Modes: (default) read one payload from stdin   |   --selftest assert the decisions against synthetic payloads.
+
+WHAT THE SELFTEST DOES NOT COVER: the harness's real payload is not reproduced — only the
+two fields this hook reads (`prompt`, `cwd`) are fed to `evaluate()`. That the harness still
+sends those fields under those names is a premise of the pinned docs
+(code.claude.com/docs/en/hooks), not something the selftest measures. The `openspec/`
+fixture lives in a temporary directory, so the selftest never reads the real cwd.
 """
 
+import io
 import json
 import os
 import re
 import sys
+import tempfile
 
 # Verbs and nouns that signal "code is about to change" (pt-BR + English).
 CHANGE_SIGNALS = re.compile(
@@ -44,7 +64,7 @@ CHANGE_SIGNALS = re.compile(
     r"remov\w*|delet\w*|apaga\w*|drop|"
     r"ajusta\w*|altera\w*|muda\w*|troca\w*|atualiza\w*|change|update|"
     r"migra\w*|migrate|renomeia\w*|rename|"
-    r"fix|bug|erro|error|falha|quebr\w*|broken|"
+    r"fix|bug|erro|error|falha|fail\w*|quebr\w*|broken|"
     r"feature|funcionalidade|endpoint|"
     r"melhora\w*|otimiza\w*|improve|optimi[sz]e"
     r")\b",
@@ -86,22 +106,117 @@ def has_spec_rite(payload: dict) -> bool:
     return os.path.isdir(os.path.join(cwd, SPEC_RITE_DIR))
 
 
-def main() -> int:
+def read_payload(stream) -> "dict | None":
+    """One JSON object from the stream, or None for anything the hook must ignore.
+
+    A payload that is not an object (`[]`, `"x"`, `null`, empty stdin) is not a hook event this
+    script can read, and a hook that crashes on it costs the turn it was meant to inform.
+    """
     try:
-        payload = json.load(sys.stdin)
+        payload = json.load(stream)
     except (json.JSONDecodeError, ValueError):
-        return 0
+        return None
+    return payload if isinstance(payload, dict) else None
 
+
+def evaluate(payload: dict) -> "str | None":
+    """The whole decision, isolated from stdin and stdout so the selftest can drive it."""
     prompt = payload.get("prompt") or ""
-    if not prompt or SKIP.search(prompt):
+    if not isinstance(prompt, str) or not prompt or SKIP.search(prompt):
+        return None
+    if not CHANGE_SIGNALS.search(prompt):
+        return None
+    reminder = REMINDER
+    if has_spec_rite(payload):
+        reminder += SPEC_RITE
+    return reminder
+
+
+def selftest() -> int:
+    failed = []
+    with tempfile.TemporaryDirectory() as td:
+        with_rite = os.path.join(td, "with-rite")
+        without_rite = os.path.join(td, "without-rite")
+        os.makedirs(os.path.join(with_rite, SPEC_RITE_DIR))
+        os.makedirs(without_rite)
+
+        # (name, should_fire, payload, spec_sentence) — spec_sentence is None when the case does
+        # not care whether the SPEC_RITE sentence is appended, True/False when it must/must not be.
+        cases = [
+            ("change request fires", True,
+             {"prompt": "implementa o endpoint de login", "cwd": without_rite}, False),
+            ("english change request fires", True,
+             {"prompt": "add a retry to the http client", "cwd": without_rite}, False),
+            ("cwd with openspec/ appends the spec sentence", True,
+             {"prompt": "implementa o endpoint de login", "cwd": with_rite}, True),
+            ("cwd without openspec/ omits the spec sentence", True,
+             {"prompt": "implementa o endpoint de login", "cwd": without_rite}, False),
+            # ACCEPTED TRADE-OFF, not a defect: a diagnostic question containing a change word
+            # fires. openspec/changes/archive/2026-08-07-add-backlog-first-rite/design.md:32
+            # ("the matcher is deliberately generous") and :78 ("accepted deliberately: the
+            # injected text says diagnosis is free"). Turning this case to False reverts a
+            # recorded decision — read the design first.
+            ("diagnostic question containing 'falha' fires (accepted trade-off)", True,
+             {"prompt": "por que o teste falha?", "cwd": without_rite}, False),
+            ("english 'fail' mirrors 'falha'", True,
+             {"prompt": "why does the build fail?", "cwd": without_rite}, False),
+            ("slash command is silent", False,
+             {"prompt": "/backlog nova ideia", "cwd": with_rite}, None),
+            ("waiver 'sem backlog' is silent", False,
+             {"prompt": "faz isso sem backlog, corrige o typo", "cwd": with_rite}, None),
+            ("neutral question is silent", False,
+             {"prompt": "o que é um hook?", "cwd": with_rite}, None),
+            ("empty prompt is silent", False, {"prompt": "", "cwd": with_rite}, None),
+            ("payload without prompt is silent", False, {"cwd": with_rite}, None),
+            ("prompt that is not a string is silent", False, {"prompt": 42, "cwd": with_rite}, None),
+        ]
+        for name, should_fire, payload, spec_sentence in cases:
+            got = evaluate(payload)
+            ok = bool(got) == should_fire
+            if ok and got and spec_sentence is not None:
+                ok = (SPEC_RITE in got) == spec_sentence
+            print(f"  {'OK     ' if ok else 'FAILED '} {name}")
+            if not ok:
+                failed.append(name)
+
+        # The harness reads plain stdout for UserPromptSubmit: what fires must be the reminder text.
+        fired = evaluate(cases[0][2])
+        shape_ok = isinstance(fired, str) and fired.startswith("DEVELOPMENT RITE")
+        print(f"  {'OK     ' if shape_ok else 'FAILED '} output shape is the reminder the harness reads")
+        if not shape_ok:
+            failed.append("output shape")
+
+    # Malformed payloads are ignored, never raised on (issue #115: `[]`, `"x"`, empty stdin).
+    malformed = [("json array", "[]"), ("json string", '"x"'), ("empty stdin", ""),
+                 ("json null", "null"), ("json number", "42"), ("not json", "{not json")]
+    for name, raw in malformed:
+        ok = read_payload(io.StringIO(raw)) is None
+        print(f"  {'OK     ' if ok else 'FAILED '} malformed payload is ignored: {name}")
+        if not ok:
+            failed.append(f"malformed: {name}")
+    well_formed = read_payload(io.StringIO('{"prompt": "x"}'))
+    ok = well_formed == {"prompt": "x"}
+    print(f"  {'OK     ' if ok else 'FAILED '} well-formed payload is read")
+    if not ok:
+        failed.append("well-formed payload")
+
+    print()
+    if failed:
+        print("selftest FAILED: " + "; ".join(failed))
+        return 1
+    print(f"selftest OK: {len(cases)} decisions, {len(malformed)} malformed payloads, plus the output shape")
+    return 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv[1:]:
+        return selftest()
+    payload = read_payload(sys.stdin)
+    if payload is None:
         return 0
-
-    if CHANGE_SIGNALS.search(prompt):
-        reminder = REMINDER
-        if has_spec_rite(payload):
-            reminder += SPEC_RITE
-        print(reminder)
-
+    result = evaluate(payload)
+    if result:
+        print(result)
     return 0
 
 

--- a/claude/global/hooks/backlog-rite.py
+++ b/claude/global/hooks/backlog-rite.py
@@ -17,7 +17,7 @@ context. It informs — it never blocks a tool call, and the user can always wai
 
 ACCEPTED FALSE POSITIVE: a diagnostic question that contains a change word — "por que o
 teste falha?", "why does the build fail?", "como corrijo esse bug?" — fires. The matcher is
-deliberately generous: a false positive costs one paragraph of context, a false negative
+deliberately generous: a false positive costs one line of context, a false negative
 costs traceability, and the injected text itself says diagnosis is free. Decided in
 openspec/changes/archive/2026-08-07-add-backlog-first-rite/design.md:32 and :78; fixed
 below as a self-test case that FIRES, so a well-meant "fix" breaks the test and reads the
@@ -64,7 +64,9 @@ CHANGE_SIGNALS = re.compile(
     r"remov\w*|delet\w*|apaga\w*|drop|"
     r"ajusta\w*|altera\w*|muda\w*|troca\w*|atualiza\w*|change|update|"
     r"migra\w*|migrate|renomeia\w*|rename|"
-    r"fix|bug|erro|error|falha|fail\w*|quebr\w*|broken|"
+    # `fail(s|ed|ing)?` is the verb's four forms and nothing else: `fail\w*` was measured firing
+    # on failover / failsafe / failure, concept nouns that are questions, not change requests.
+    r"fix|bug|erro|error|falha|fail(s|ed|ing)?|quebr\w*|broken|"
     r"feature|funcionalidade|endpoint|"
     r"melhora\w*|otimiza\w*|improve|optimi[sz]e"
     r")\b",
@@ -162,8 +164,14 @@ def selftest() -> int:
             # recorded decision — read the design first.
             ("diagnostic question containing 'falha' fires (accepted trade-off)", True,
              {"prompt": "por que o teste falha?", "cwd": without_rite}, False),
-            ("english 'fail' mirrors 'falha'", True,
+            ("english 'fail' (verb forms fail/fails/failed/failing) fires", True,
              {"prompt": "why does the build fail?", "cwd": without_rite}, False),
+            ("english 'failing' fires", True,
+             {"prompt": "the tests are failing", "cwd": without_rite}, False),
+            # Fixes the narrowing: a concept noun that merely starts with "fail" is not a change
+            # request. Widening to `fail\w*` must break this case, not silently fire here.
+            ("english noun 'failover' is silent", False,
+             {"prompt": "what is a failover cluster?", "cwd": without_rite}, None),
             # The prompt carries a change word on purpose: silence can then only come from the
             # slash-command SKIP rule. "/backlog nova ideia" has no signal and stays silent even
             # with that rule deleted — it never exercised the decision it was named for.

--- a/claude/global/hooks/backlog-rite.py
+++ b/claude/global/hooks/backlog-rite.py
@@ -102,7 +102,11 @@ SPEC_RITE_DIR = "openspec"
 
 
 def has_spec_rite(payload: dict) -> bool:
-    cwd = payload.get("cwd") or os.getcwd()
+    # A `cwd` that is missing, empty or not a string falls back to the process cwd: the field is
+    # read from untrusted JSON, and os.path.join on a non-string would cost the turn.
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = os.getcwd()
     return os.path.isdir(os.path.join(cwd, SPEC_RITE_DIR))
 
 
@@ -172,6 +176,11 @@ def selftest() -> int:
             ("empty prompt is silent", False, {"prompt": "", "cwd": with_rite}, None),
             ("payload without prompt is silent", False, {"cwd": with_rite}, None),
             ("prompt that is not a string is silent", False, {"prompt": 42, "cwd": with_rite}, None),
+            # The fallback for a malformed cwd is os.getcwd(), so this case cannot assert the spec
+            # sentence either way without reading the real cwd (TR1): it asserts only "no crash,
+            # still fires".
+            ("cwd that is not a string falls back and still fires", True,
+             {"prompt": "implementa o endpoint", "cwd": 42}, None),
         ]
         for name, should_fire, payload, spec_sentence in cases:
             got = evaluate(payload)
@@ -212,8 +221,15 @@ def selftest() -> int:
 
 
 def main() -> int:
-    if "--selftest" in sys.argv[1:]:
+    args = sys.argv[1:]
+    if args == ["--selftest"]:
         return selftest()
+    if args:
+        # An unknown argument must not fall through to the stdin path: a misspelt flag in a CI
+        # step would then read empty stdin and exit 0 — the silent no-op the selftest mode exists
+        # to make impossible.
+        print(f"usage: {sys.argv[0]} [--selftest]", file=sys.stderr)
+        return 2
     payload = read_payload(sys.stdin)
     if payload is None:
         return 0

--- a/claude/global/hooks/backlog-rite.py
+++ b/claude/global/hooks/backlog-rite.py
@@ -160,8 +160,11 @@ def selftest() -> int:
              {"prompt": "por que o teste falha?", "cwd": without_rite}, False),
             ("english 'fail' mirrors 'falha'", True,
              {"prompt": "why does the build fail?", "cwd": without_rite}, False),
-            ("slash command is silent", False,
-             {"prompt": "/backlog nova ideia", "cwd": with_rite}, None),
+            # The prompt carries a change word on purpose: silence can then only come from the
+            # slash-command SKIP rule. "/backlog nova ideia" has no signal and stays silent even
+            # with that rule deleted — it never exercised the decision it was named for.
+            ("slash command carrying a change word is silent", False,
+             {"prompt": "/execute-backlog 12 implementa o endpoint", "cwd": with_rite}, None),
             ("waiver 'sem backlog' is silent", False,
              {"prompt": "faz isso sem backlog, corrige o typo", "cwd": with_rite}, None),
             ("neutral question is silent", False,

--- a/claude/global/hooks/backlog-rite.py
+++ b/claude/global/hooks/backlog-rite.py
@@ -44,9 +44,13 @@ WHAT THE SELFTEST DOES NOT COVER: the harness's real payload is not reproduced â
 two fields this hook reads (`prompt`, `cwd`) are fed to `evaluate()`. That the harness still
 sends those fields under those names is a premise of the pinned docs
 (code.claude.com/docs/en/hooks), not something the selftest measures. The `openspec/`
-fixture lives in a temporary directory, so the selftest never reads the real cwd.
+fixture lives in a temporary directory and every case passes it as `cwd`; the two cases that
+exercise the os.getcwd() fallback move the process cwd into that fixture for the duration of the
+call and restore it afterwards, so the selftest never stats the real cwd and its result does not
+depend on where it runs.
 """
 
+import contextlib
 import io
 import json
 import os
@@ -138,6 +142,20 @@ def evaluate(payload: dict) -> "str | None":
     return reminder
 
 
+@contextlib.contextmanager
+def process_cwd(path: "str | None"):
+    """Run the block with the process cwd moved to `path` (no-op for None), always restoring it."""
+    if path is None:
+        yield
+        return
+    previous = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
 def selftest() -> int:
     failed = []
     with tempfile.TemporaryDirectory() as td:
@@ -184,14 +202,18 @@ def selftest() -> int:
             ("empty prompt is silent", False, {"prompt": "", "cwd": with_rite}, None),
             ("payload without prompt is silent", False, {"cwd": with_rite}, None),
             ("prompt that is not a string is silent", False, {"prompt": 42, "cwd": with_rite}, None),
-            # The fallback for a malformed cwd is os.getcwd(), so this case cannot assert the spec
-            # sentence either way without reading the real cwd (TR1): it asserts only "no crash,
-            # still fires".
-            ("cwd that is not a string falls back and still fires", True,
-             {"prompt": "implementa o endpoint", "cwd": 42}, None),
+            # The fallback for a malformed cwd is os.getcwd(). A fifth field moves the process cwd
+            # into the named fixture for the call (restored right after), so the fallback is measured
+            # against both fixtures instead of the real cwd (TR1) â€” and a fallback that ignored the
+            # process cwd, or always omitted the sentence, would fail one of the two.
+            ("cwd that is not a string falls back to the process cwd (with openspec/)", True,
+             {"prompt": "implementa o endpoint", "cwd": 42}, True, with_rite),
+            ("cwd that is not a string falls back to the process cwd (without openspec/)", True,
+             {"prompt": "implementa o endpoint", "cwd": 42}, False, without_rite),
         ]
-        for name, should_fire, payload, spec_sentence in cases:
-            got = evaluate(payload)
+        for name, should_fire, payload, spec_sentence, *rest in cases:
+            with process_cwd(rest[0] if rest else None):
+                got = evaluate(payload)
             ok = bool(got) == should_fire
             if ok and got and spec_sentence is not None:
                 ok = (SPEC_RITE in got) == spec_sentence

--- a/claude/global/hooks/verify-rite.py
+++ b/claude/global/hooks/verify-rite.py
@@ -42,8 +42,17 @@ Wiring (~/.claude/settings.json) — alongside the backlog rite, in the same arr
 
 Like personal-rules.md, this is the maintainer's config — edit the signal list and the reminder to
 match your own process instead of adopting it blindly.
+
+Modes: (default) read one payload from stdin   |   --selftest assert the decisions against synthetic payloads.
+
+WHAT THE SELFTEST DOES NOT COVER: the harness's real payload is not reproduced — only the one
+field this hook reads (`prompt`) is fed to `evaluate()`. That the harness still sends it under that
+name is a premise of the pinned docs (code.claude.com/docs/en/hooks), not something the selftest
+measures. The KNOWN LIMIT above is not measurable by any selftest: no case here can assert that a
+guess was caught before it was written, because the hook itself cannot see that moment.
 """
 
+import io
 import json
 import re
 import sys
@@ -100,19 +109,95 @@ REMINDER = (
 )
 
 
-def main() -> int:
+def read_payload(stream) -> "dict | None":
+    """One JSON object from the stream, or None for anything the hook must ignore.
+
+    A payload that is not an object (`[]`, `"x"`, `null`, empty stdin) is not a hook event this
+    script can read, and a hook that crashes on it costs the turn it was meant to inform.
+    """
     try:
-        payload = json.load(sys.stdin)
+        payload = json.load(stream)
     except (json.JSONDecodeError, ValueError):
-        return 0
+        return None
+    return payload if isinstance(payload, dict) else None
 
+
+def evaluate(payload: dict) -> "str | None":
+    """The whole decision, isolated from stdin and stdout so the selftest can drive it."""
     prompt = payload.get("prompt") or ""
-    if not prompt or SKIP.search(prompt):
+    if not isinstance(prompt, str) or not prompt or SKIP.search(prompt):
+        return None
+    if not GUESS_SIGNALS.search(prompt):
+        return None
+    return REMINDER
+
+
+def selftest() -> int:
+    failed = []
+    cases = [
+        ("portuguese caught guess fires", True, {"prompt": "isso é achismo"}),
+        ("english demand for a source fires", True, {"prompt": "where did you see that"}),
+        ("'essa flag não existe' fires", True, {"prompt": "essa flag não existe, lê a doc"}),
+        ("'that's not what I asked' fires", True, {"prompt": "that's not what I asked for"}),
+        # Deliberately the opposite of backlog-rite.py: a correction typed inside a slash command
+        # still deserves the reminder (see the comment above SKIP). A future "harmonisation" of
+        # the two hooks must break this case, not silently erase the difference.
+        ("correction inside a slash command still fires", True,
+         {"prompt": "/backlog você inventou essa flag"}),
+        ("waiver 'pode chutar' is silent", False, {"prompt": "pode chutar, de onde tirou isso?"}),
+        ("waiver 'from memory is fine' is silent", False,
+         {"prompt": "from memory is fine, where did you see that?"}),
+        ("implementation request is silent", False, {"prompt": "implementa o endpoint"}),
+        ("neutral question is silent", False, {"prompt": "o que é um hook?"}),
+        ("empty prompt is silent", False, {"prompt": ""}),
+        ("payload without prompt is silent", False, {}),
+        ("prompt that is not a string is silent", False, {"prompt": 42}),
+    ]
+    for name, should_fire, payload in cases:
+        got = evaluate(payload)
+        ok = bool(got) == should_fire
+        print(f"  {'OK     ' if ok else 'FAILED '} {name}")
+        if not ok:
+            failed.append(name)
+
+    # The harness reads plain stdout for UserPromptSubmit: what fires must be the reminder text.
+    fired = evaluate(cases[0][2])
+    shape_ok = isinstance(fired, str) and fired.startswith("GROUNDING RITE")
+    print(f"  {'OK     ' if shape_ok else 'FAILED '} output shape is the reminder the harness reads")
+    if not shape_ok:
+        failed.append("output shape")
+
+    # Malformed payloads are ignored, never raised on (issue #115: `[]`, `"x"`, empty stdin).
+    malformed = [("json array", "[]"), ("json string", '"x"'), ("empty stdin", ""),
+                 ("json null", "null"), ("json number", "42"), ("not json", "{not json")]
+    for name, raw in malformed:
+        ok = read_payload(io.StringIO(raw)) is None
+        print(f"  {'OK     ' if ok else 'FAILED '} malformed payload is ignored: {name}")
+        if not ok:
+            failed.append(f"malformed: {name}")
+    well_formed = read_payload(io.StringIO('{"prompt": "x"}'))
+    ok = well_formed == {"prompt": "x"}
+    print(f"  {'OK     ' if ok else 'FAILED '} well-formed payload is read")
+    if not ok:
+        failed.append("well-formed payload")
+
+    print()
+    if failed:
+        print("selftest FAILED: " + "; ".join(failed))
+        return 1
+    print(f"selftest OK: {len(cases)} decisions, {len(malformed)} malformed payloads, plus the output shape")
+    return 0
+
+
+def main() -> int:
+    if "--selftest" in sys.argv[1:]:
+        return selftest()
+    payload = read_payload(sys.stdin)
+    if payload is None:
         return 0
-
-    if GUESS_SIGNALS.search(prompt):
-        print(REMINDER)
-
+    result = evaluate(payload)
+    if result:
+        print(result)
     return 0
 
 

--- a/claude/global/hooks/verify-rite.py
+++ b/claude/global/hooks/verify-rite.py
@@ -190,8 +190,15 @@ def selftest() -> int:
 
 
 def main() -> int:
-    if "--selftest" in sys.argv[1:]:
+    args = sys.argv[1:]
+    if args == ["--selftest"]:
         return selftest()
+    if args:
+        # An unknown argument must not fall through to the stdin path: a misspelt flag in a CI
+        # step would then read empty stdin and exit 0 — the silent no-op the selftest mode exists
+        # to make impossible.
+        print(f"usage: {sys.argv[0]} [--selftest]", file=sys.stderr)
+        return 2
     payload = read_payload(sys.stdin)
     if payload is None:
         return 0

--- a/openspec/changes/add-hook-selftests/.openspec.yaml
+++ b/openspec/changes/add-hook-selftests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-04

--- a/openspec/changes/add-hook-selftests/design.md
+++ b/openspec/changes/add-hook-selftests/design.md
@@ -70,8 +70,8 @@ Um `prompt` que existe mas não é string (`{"prompt": 42}`) é tratado como aus
 O mesmo vale para o outro campo que o backlog-rite lê: `{"cwd": 42}` (ou lista, ou objeto) estourava
 em `os.path.join` com `TypeError` e exit 1 — medido na revisão, depois da guarda do `prompt` ter
 entrado sozinha. `has_spec_rite()` passa a aceitar só string não-vazia e cai em `os.getcwd()` no
-resto. O caso do selftest afirma apenas "não estoura e dispara": com o fallback no cwd real, afirmar
-a frase do spec-rite leria o cwd de quem roda o teste, o que TR1 proíbe.
+resto. Os dois casos do selftest que cobrem esse fallback não leem o cwd de quem roda o teste (TR1):
+movem o cwd do processo para uma das fixtures durante a chamada e o restauram em seguida — ver D4.
 
 ### D3 — `--selftest` é lido de `sys.argv[1:]`, nunca de stdin
 
@@ -89,8 +89,21 @@ sai 2. O `locale-rite.py` carrega a fraqueza herdada e fica como follow-up, fora
 ### D4 — A fixture de `openspec/` vive em `tempfile.TemporaryDirectory()`
 
 `has_spec_rite()` lê `payload["cwd"]` com fallback em `os.getcwd()`. O selftest cria dois diretórios
-temporários — um com `openspec/` dentro, outro sem — e passa cada um como `cwd`. Nunca lê o cwd real,
-então o resultado é o mesmo rodando do repositório, de `/tmp` ou do runner do CI (TR1 da issue).
+temporários — um com `openspec/` dentro, outro sem — e passa cada um como `cwd`. Os dois casos que
+exercitam o fallback (`cwd: 42`) não podem passar a fixture pelo payload, então movem o cwd do
+processo para ela com `os.chdir` num `try/finally` que restaura o anterior, e afirmam a frase do
+spec-rite nos dois sentidos: presente com a fixture que tem `openspec/`, ausente com a outra. Um
+fallback que ignorasse o cwd do processo, ou que sempre omitisse a frase, derruba um dos dois. A
+revisão mediu a forma anterior desse caso (um só, sem `chdir`, `spec_sentence=None`) fazendo
+`os.path.isdir(<cwd real>/openspec)` — o que a issue, este D4 e o docstring diziam não acontecer.
+
+Alternativa rejeitada: um parâmetro `default_cwd` em `has_spec_rite()` só para o teste. Deixaria a
+linha `os.getcwd()` real sem cobertura — o selftest provaria o parâmetro, não o fallback.
+
+Assim o selftest nunca faz `stat` no cwd real, e o resultado é o mesmo rodando do repositório, de
+`/tmp` ou do runner do CI (TR1 da issue). O que ele ainda lê do cwd real é só o **caminho** — a
+string devolvida por `os.getcwd()` para restaurar depois, e a que `tempfile` consulta ao escolher o
+diretório temporário — nunca o que existe dentro dele.
 
 ### D5 — O falso positivo aceito é um caso que **dispara**, com a decisão citada no comentário
 

--- a/openspec/changes/add-hook-selftests/design.md
+++ b/openspec/changes/add-hook-selftests/design.md
@@ -1,0 +1,139 @@
+## Context
+
+Os três hooks de `claude/global/hooks/` compartilham o contrato "informa, nunca bloqueia, não
+persiste nada", mas não a estrutura interna. Lidos em `d2918ed`:
+
+- `locale-rite.py` (260 linhas): `evaluate(payload, check)` em 155-173, `selftest()` em 176-241 com
+  lista de `(nome, deve_reportar, payload)`, uma linha `OK`/`FAILED` por caso, asserção da forma da
+  saída em 226-235, linha de resumo em 240; `main()` em 244-256 lê `--selftest` de `sys.argv[1:]`
+  (245) e guarda `isinstance(payload, dict)` (251). Step de CI em `ci.yml:93-94`.
+- `backlog-rite.py` (109 linhas): `main()` em 89-105 faz tudo — `json.load`, `.get("prompt")`,
+  `SKIP`, `CHANGE_SIGNALS`, `has_spec_rite`, `print`. Sem `argv`, sem guarda de tipo.
+- `verify-rite.py` (120 linhas): `main()` em 103-116, mesma forma. Sem `argv`, sem guarda de tipo.
+
+O `CHANGE_SIGNALS` do backlog-rite (linhas 38-52) é bilíngue por linha: cada verbo em pt-BR tem um
+par em inglês. A linha 47 é a exceção: `fix|bug|erro|error|falha|quebr\w*|broken` — `falha` sem par
+inglês. Medido por stdin: "por que o teste falha?" dispara e "why does the build fail?" fica mudo.
+
+O falso positivo em perguntas de diagnóstico está registrado como decisão:
+`openspec/changes/archive/2026-08-07-add-backlog-first-rite/design.md:31-32` ("A false positive
+costs one line of context; a false negative costs traceability. The matcher is deliberately
+generous.") e `:78-80` ("A generous matcher fires on pure questions containing 'erro'/'bug' →
+accepted deliberately: the injected text says diagnosis is free").
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- `python3 <hook> --selftest` sai 0 com uma linha por caso e uma linha de resumo; qualquer regressão
+  numa decisão fixada sai 1 e o CI fica vermelho.
+- Payload que não é objeto JSON (`[]`, `"x"`, stdin vazio): saída vazia, exit 0, sem traceback.
+- Comportamento para payloads válidos idêntico ao atual, exceto `fail\w*` no lado inglês.
+- O falso positivo aceito fica **fixado como caso que dispara**, com a decisão citada ao lado.
+
+**Non-Goals:**
+
+- Exclusão por forma de pergunta (`por que`, `why`, `?`). Reverte a decisão de 2026-08-07 e foi
+  medida: silencia "por que não implementa o endpoint de login?" (pedido real) e não remove a classe
+  que mira ("como corrijo esse bug?" continua disparando).
+- Um selftest central em `scripts/`. O padrão da casa — `check-identifier-locale.py`,
+  `locale-rite.py`, `validate-*.py` — é selftest no próprio arquivo, e o step de CI aponta para ele.
+- Reproduzir o payload completo do harness. O selftest alimenta só os campos que o hook lê
+  (`prompt`, `cwd`); isso fica declarado no docstring de cada hook (TR2 da issue).
+- Wiring dos hooks em `~/.claude/settings.json` de qualquer máquina.
+
+## Decisions
+
+### D1 — A decisão vira `evaluate(payload) -> str | None`, e `main()` só faz I/O
+
+Mesma divisão do `locale-rite.py:155`. A função recebe o dicionário já decodificado e devolve o texto
+do lembrete ou `None`; `main()` lê stdin, guarda o tipo, chama `evaluate` e imprime. O selftest
+chama `evaluate` diretamente — sem subprocess, sem tocar stdin/stdout — e por isso é hermético e
+rápido.
+
+Alternativa rejeitada: selftest por `subprocess.run([sys.executable, __file__], input=...)`. Cobre
+`main()` de ponta a ponta, mas custa um processo por caso e não é o formato que o `locale-rite.py`
+já estabeleceu. A cobertura de `main()` fica na simulação por stdin (`tasks.md`, grupo 3), que é o
+caminho real do harness.
+
+### D2 — A leitura do payload vira `read_payload(stream) -> dict | None`
+
+O `isinstance(payload, dict)` do `locale-rite.py:251` fica dentro de `main()`, fora do alcance do
+selftest. Aqui a leitura é extraída para uma função que recebe o stream, para que o selftest possa
+alimentar `io.StringIO("[]")`, `io.StringIO('"x"')` e `io.StringIO("")` e afirmar `None` sem
+subprocess. É o único ponto em que a forma diverge do `locale-rite.py`, e diverge para cobrir FR2
+(payload malformado) no CI, não só na simulação.
+
+Um `prompt` que existe mas não é string (`{"prompt": 42}`) é tratado como ausente pelo mesmo motivo:
+`SKIP.search(42)` estouraria em `TypeError`, e o contrato do hook é nunca derrubar o turno.
+
+### D3 — `--selftest` é lido de `sys.argv[1:]`, nunca de stdin
+
+Hoje `python3 backlog-rite.py --selftest` lê stdin, encontra vazio, sai 0 e não imprime nada. Um step
+de CI escrito assim seria verde para sempre. O parse explícito é o que torna o step honesto, e o
+selftest imprime uma linha por caso mais uma de resumo pelo mesmo motivo: um step que passa sem
+nenhuma saída é indistinguível do no-op de hoje, e um leitor do log do CI precisa ver os casos.
+
+### D4 — A fixture de `openspec/` vive em `tempfile.TemporaryDirectory()`
+
+`has_spec_rite()` lê `payload["cwd"]` com fallback em `os.getcwd()`. O selftest cria dois diretórios
+temporários — um com `openspec/` dentro, outro sem — e passa cada um como `cwd`. Nunca lê o cwd real,
+então o resultado é o mesmo rodando do repositório, de `/tmp` ou do runner do CI (TR1 da issue).
+
+### D5 — O falso positivo aceito é um caso que **dispara**, com a decisão citada no comentário
+
+"por que o teste falha?" entra na lista com `should_fire=True` e um comentário apontando para
+`2026-08-07-add-backlog-first-rite/design.md:32` e `:78`. O selftest passa a ser onde a decisão fica
+visível: quem tentar "corrigir" o falso positivo vê o caso quebrar e lê o porquê antes de mexer.
+
+### D6 — `fail\w*` entra no lado inglês da linha 47
+
+`falha` casa "falha", "falhou", "falhando" pelo `\b...\b` com a alternância; o par inglês precisa
+de `\w*` para casar "fail", "fails", "failed", "failing". Isso amplia o matcher em inglês na exata
+medida em que o português já é amplo — coerente com a assimetria escolhida (falso positivo barato,
+falso negativo caro). O selftest fixa "why does the build fail?" como caso que dispara.
+
+### D7 — O verify-rite fixa que slash command **não** silencia
+
+`verify-rite.py:78-79` diz por quê: "a correction typed inside a slash command still deserves the
+reminder". É o oposto do backlog-rite, e um caso do selftest de cada hook fixa cada lado, para que
+uma "harmonização" futura não apague a diferença sem ler o comentário.
+
+### D8 — Dois steps em `ci.yml`, um por hook, ao lado do step do `locale-rite`
+
+Um step por script segue o padrão das linhas 87-94 e 113-117: cada gate tem o próprio nome na lista
+de checks do pull request, então uma regressão nomeia o hook sem abrir o log.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Um check embarcado carrega selftest e declara o que não cobre | `skills-catalog` (spec do repositório, *A shipped enforcement script declares what escapes it*) | already canonical — o delta estende a mesma cláusula aos dois hooks; nada é reescrito |
+| Prova observada pelo caminho real antes de declarar entrega | `verify-before-claiming` | already canonical — citado no grupo de simulação de `tasks.md` |
+| Rito backlog-first e o falso positivo aceito do matcher | `backlog` / `execute-backlog` (doutrina) + `2026-08-07-add-backlog-first-rite/design.md` (decisão) | already canonical — o selftest e o README **citam** a decisão, não a reescrevem |
+| Rito anti-achismo e o limite conhecido do verify-rite | `verify-before-claiming` | already canonical — o docstring do hook já aponta para a skill |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — `evaluate`, `read_payload`, `selftest`, ids de step |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **Refatorar `main()` muda a saída sem ninguém notar** → a asserção de forma do selftest afirma que
+  o que dispara é uma string que começa pelo cabeçalho do lembrete (`DEVELOPMENT RITE` /
+  `GROUNDING RITE`) e, no backlog-rite, que a frase do spec-rite está presente só com `openspec/`
+  no cwd. A simulação por stdin (grupo 3) compara os 8 prompts antes e depois.
+- **`fail\w*` dispara em mais prompts em inglês** → aceito e registrado (D6); é a simetria com o
+  lado português que já existe.
+- **O selftest não reproduz o payload real do harness** → declarado no docstring de cada hook: só
+  `prompt` e `cwd` são alimentados, que são os únicos campos lidos. O que um payload real prova e o
+  selftest não é se o harness ainda manda esses campos com esses nomes — isso fica com a simulação
+  e com a doc pinada (`code.claude.com/docs/en/hooks`).
+- **Um payload malformado que não seja `[]`, `"x"` ou vazio** (por exemplo `null`, `42`) → `null` e
+  `42` não são `dict` e caem na mesma guarda; fixados como casos do selftest junto com os três da
+  issue.
+
+## Open Questions
+
+Nenhuma. As três lacunas que poderiam virar achismo — se `--selftest` hoje é ignorado, se um payload
+`[]` estoura, e se "why does the build fail?" fica mudo — foram medidas por stdin antes de escrever,
+e estão em `tasks.md` com comando e saída.

--- a/openspec/changes/add-hook-selftests/design.md
+++ b/openspec/changes/add-hook-selftests/design.md
@@ -28,7 +28,7 @@ accepted deliberately: the injected text says diagnosis is free").
 - `python3 <hook> --selftest` sai 0 com uma linha por caso e uma linha de resumo; qualquer regressão
   numa decisão fixada sai 1 e o CI fica vermelho.
 - Payload que não é objeto JSON (`[]`, `"x"`, stdin vazio): saída vazia, exit 0, sem traceback.
-- Comportamento para payloads válidos idêntico ao atual, exceto `fail\w*` no lado inglês.
+- Comportamento para payloads válidos idêntico ao atual, exceto `fail(s|ed|ing)?` no lado inglês.
 - O falso positivo aceito fica **fixado como caso que dispara**, com a decisão citada ao lado.
 
 **Non-Goals:**
@@ -67,12 +67,24 @@ subprocess. É o único ponto em que a forma diverge do `locale-rite.py`, e dive
 Um `prompt` que existe mas não é string (`{"prompt": 42}`) é tratado como ausente pelo mesmo motivo:
 `SKIP.search(42)` estouraria em `TypeError`, e o contrato do hook é nunca derrubar o turno.
 
+O mesmo vale para o outro campo que o backlog-rite lê: `{"cwd": 42}` (ou lista, ou objeto) estourava
+em `os.path.join` com `TypeError` e exit 1 — medido na revisão, depois da guarda do `prompt` ter
+entrado sozinha. `has_spec_rite()` passa a aceitar só string não-vazia e cai em `os.getcwd()` no
+resto. O caso do selftest afirma apenas "não estoura e dispara": com o fallback no cwd real, afirmar
+a frase do spec-rite leria o cwd de quem roda o teste, o que TR1 proíbe.
+
 ### D3 — `--selftest` é lido de `sys.argv[1:]`, nunca de stdin
 
 Hoje `python3 backlog-rite.py --selftest` lê stdin, encontra vazio, sai 0 e não imprime nada. Um step
 de CI escrito assim seria verde para sempre. O parse explícito é o que torna o step honesto, e o
 selftest imprime uma linha por caso mais uma de resumo pelo mesmo motivo: um step que passa sem
 nenhuma saída é indistinguível do no-op de hoje, e um leitor do log do CI precisa ver os casos.
+
+Ler `--selftest` por pertinência (`"--selftest" in sys.argv[1:]`, a forma do `locale-rite.py:245`)
+não fecha a porta: `--self-test` grafado errado num step cai no caminho do stdin, lê vazio e sai 0 —
+o mesmo no-op verde, medido na revisão. Por isso `argv` é comparado por igualdade: exatamente
+`["--selftest"]` roda o selftest, vazio lê stdin, qualquer outra coisa imprime o usage em stderr e
+sai 2. O `locale-rite.py` carrega a fraqueza herdada e fica como follow-up, fora desta change.
 
 ### D4 — A fixture de `openspec/` vive em `tempfile.TemporaryDirectory()`
 
@@ -86,12 +98,29 @@ então o resultado é o mesmo rodando do repositório, de `/tmp` ou do runner do
 `2026-08-07-add-backlog-first-rite/design.md:32` e `:78`. O selftest passa a ser onde a decisão fica
 visível: quem tentar "corrigir" o falso positivo vê o caso quebrar e lê o porquê antes de mexer.
 
-### D6 — `fail\w*` entra no lado inglês da linha 47
+### D6 — `fail(s|ed|ing)?` entra no lado inglês da linha 47, medido e não `fail\w*`
 
-`falha` casa "falha", "falhou", "falhando" pelo `\b...\b` com a alternância; o par inglês precisa
-de `\w*` para casar "fail", "fails", "failed", "failing". Isso amplia o matcher em inglês na exata
-medida em que o português já é amplo — coerente com a assimetria escolhida (falso positivo barato,
-falso negativo caro). O selftest fixa "why does the build fail?" como caso que dispara.
+A issue pediu `fail\w*` "para simetria com `falha`". Probado contra o regex antes de decidir
+(`CHANGE_SIGNALS.search`, via `importlib` no próprio hook):
+
+| Lado | Expressão | Casa | Não casa |
+|---|---|---|---|
+| pt-BR (já existia) | `\bfalha\b` | "o teste falha" | "falhou", "falhando", "falhas", "falhar", "falharam" |
+| inglês, forma pedida | `fail\w*` | fail, fails, failed, failing, **failure, failover, failsafe** | — |
+| inglês, forma adotada | `fail(s|ed|ing)?` | fail, fails, failed, failing | failure, failover, failsafe |
+
+Duas alternativas fechavam a assimetria: estreitar o inglês ou alargar o português para `falh\w*`.
+Fica o estreitamento, por dois motivos. FR3 da issue exige comportamento idêntico para todo payload
+válido exceto o sinal `fail`, e alargar `falha` mudaria prompts em português ("o teste falhou
+ontem" passaria a disparar) — fora do que a issue autorizou. E os três substantivos que `\w*`
+arrasta (failure, failover, failsafe) são conceito, não pedido: "what is a failover cluster?"
+disparando é custo de contexto sem contrapartida de rastreabilidade.
+
+O lado inglês continua mais amplo que o português (quatro formas do verbo contra a palavra nua) —
+de propósito e agora medido, coerente com a assimetria escolhida (falso positivo barato, falso
+negativo caro). O selftest fixa os dois lados da decisão: "why does the build fail?" e "the tests
+are failing" disparam; "what is a failover cluster?" fica mudo, e restaurar `fail\w*` deixa esse
+caso vermelho.
 
 ### D7 — O verify-rite fixa que slash command **não** silencia
 
@@ -122,8 +151,9 @@ Nenhuma skill do catálogo é editada por esta change, então não há doutrina 
   o que dispara é uma string que começa pelo cabeçalho do lembrete (`DEVELOPMENT RITE` /
   `GROUNDING RITE`) e, no backlog-rite, que a frase do spec-rite está presente só com `openspec/`
   no cwd. A simulação por stdin (grupo 3) compara os 8 prompts antes e depois.
-- **`fail\w*` dispara em mais prompts em inglês** → aceito e registrado (D6); é a simetria com o
-  lado português que já existe.
+- **`fail(s|ed|ing)?` dispara em mais prompts em inglês** → aceito e registrado (D6) com o conjunto
+  medido: três prompts do corpus passam a disparar (fail / failing / failed) e os de substantivo
+  (failover, failure, failsafe) ficam mudos; o lado português não muda.
 - **O selftest não reproduz o payload real do harness** → declarado no docstring de cada hook: só
   `prompt` e `cwd` são alimentados, que são os únicos campos lidos. O que um payload real prova e o
   selftest não é se o harness ainda manda esses campos com esses nomes — isso fica com a simulação

--- a/openspec/changes/add-hook-selftests/proposal.md
+++ b/openspec/changes/add-hook-selftests/proposal.md
@@ -37,12 +37,15 @@ avisasse.
 
 - `backlog-rite.py` e `verify-rite.py` ganham o mesmo formato do `locale-rite.py`: a decisão vira
   uma função pura `evaluate(payload) -> str | None`; `--selftest` é lido explicitamente de
-  `sys.argv[1:]`; um payload que não é objeto JSON é ignorado (saída vazia, exit 0).
+  `sys.argv[1:]` e qualquer outro argumento imprime o usage e sai 2; um payload que não é objeto
+  JSON, ou cujo `cwd` não é string, é ignorado (saída vazia ou fallback, exit 0, sem traceback).
 - Cada selftest fixa os casos que o design de cada hook já assume — inclusive o falso positivo
   aceito do backlog-rite, gravado como caso que **dispara**, e o fato de o verify-rite **não**
   silenciar em slash command (`verify-rite.py:78-79`).
-- O lado inglês do sinal em `backlog-rite.py:47` ganha `fail\w*`, simétrico ao `falha` que já
-  existe: "por que o teste falha?" dispara hoje e "why does the build fail?" fica mudo.
+- O lado inglês do sinal em `backlog-rite.py:47` ganha `fail(s|ed|ing)?` — as quatro formas do
+  verbo — como par do `falha` que já existe: "por que o teste falha?" dispara hoje e "why does the
+  build fail?" fica mudo. (`fail\w*`, a forma pedida na issue, foi medida casando failover /
+  failsafe / failure e estreitada; design D6.)
 - Dois steps novos em `ci.yml`, logo após o step do `locale-rite`, rodam os dois selftests.
 - `README.md` ganha uma frase, junto à lista do que silencia o hook, dizendo que perguntas contendo
   `erro`/`bug`/`falha` disparam e por quê.

--- a/openspec/changes/add-hook-selftests/proposal.md
+++ b/openspec/changes/add-hook-selftests/proposal.md
@@ -1,0 +1,76 @@
+# Change: Dar selftest e gate de CI aos hooks backlog-rite e verify-rite
+
+## Why
+
+Três hooks vivem em `claude/global/hooks/`. `locale-rite.py` carrega `--selftest` — uma função
+`evaluate()` isolada de stdin/stdout, uma lista de casos que devem disparar e ficar mudos, uma
+asserção da forma da saída — e um step próprio em `.github/workflows/ci.yml:93-94`.
+`backlog-rite.py` e `verify-rite.py` não têm nem um nem outro. Pior: `--selftest` hoje é aceito em
+silêncio por ambos, porque nenhum dos dois lê `sys.argv`, então um step de CI escrito antes do modo
+existir seria um no-op verde.
+
+Medido em `d2918ed` (2026-09-04):
+
+```
+python3 claude/global/hooks/backlog-rite.py --selftest </dev/null; echo rc=$?
+-> rc=0            (sem saída: o flag é ignorado e o hook leu stdin vazio)
+```
+
+Os dois hooks também estouram com traceback e exit 1 num payload JSON que não é objeto —
+`backlog-rite.py:95` e `verify-rite.py:109` chamam `.get()` no que quer que `json.load` devolva:
+
+```
+echo '[]' | python3 claude/global/hooks/backlog-rite.py
+-> AttributeError: 'list' object has no attribute 'get'
+-> rc=1
+```
+
+`locale-rite.py:251` guarda esse caso com `isinstance(payload, dict)` e o selftest cobre.
+
+Qualquer edição na lista de sinais — que o README convida o leitor a fazer — só é medida à mão. Um
+falso positivo já conhecido e **aceito** (perguntas de diagnóstico contendo `erro`/`bug`/`falha`
+disparam: `openspec/changes/archive/2026-08-07-add-backlog-first-rite/design.md:32` e `:78`) não
+está fixado em lugar nenhum, então uma "correção" bem-intencionada poderia revertê-lo sem que nada
+avisasse.
+
+## What Changes
+
+- `backlog-rite.py` e `verify-rite.py` ganham o mesmo formato do `locale-rite.py`: a decisão vira
+  uma função pura `evaluate(payload) -> str | None`; `--selftest` é lido explicitamente de
+  `sys.argv[1:]`; um payload que não é objeto JSON é ignorado (saída vazia, exit 0).
+- Cada selftest fixa os casos que o design de cada hook já assume — inclusive o falso positivo
+  aceito do backlog-rite, gravado como caso que **dispara**, e o fato de o verify-rite **não**
+  silenciar em slash command (`verify-rite.py:78-79`).
+- O lado inglês do sinal em `backlog-rite.py:47` ganha `fail\w*`, simétrico ao `falha` que já
+  existe: "por que o teste falha?" dispara hoje e "why does the build fail?" fica mudo.
+- Dois steps novos em `ci.yml`, logo após o step do `locale-rite`, rodam os dois selftests.
+- `README.md` ganha uma frase, junto à lista do que silencia o hook, dizendo que perguntas contendo
+  `erro`/`bug`/`falha` disparam e por quê.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: os requisitos *The development rite is enforced outside the model's discretion*
+  e *The grounding rite is carried into context on correction* ganham a cláusula de que o artefato
+  embarcado carrega um selftest exercitado pelo CI do repositório e ignora um payload que não é
+  objeto, com o cenário correspondente. Hoje a cláusula de selftest existe para scripts de autoria
+  (`skills-authoring/spec.md:259-263`) e para checks embarcados em skill
+  (`skills-catalog/spec.md:579-585`), mas não para os hooks — lacuna de convenção da casa, não
+  promessa quebrada: 5 dos 6 gates do CI são auto-testados.
+
+## Impact
+
+- `claude/global/hooks/backlog-rite.py`, `claude/global/hooks/verify-rite.py` — refatoração de
+  `main()` mais o modo `--selftest`; comportamento para payloads válidos idêntico ao atual, exceto o
+  sinal `fail` em inglês.
+- `.github/workflows/ci.yml` — dois steps de `Validate`.
+- `README.md` — uma frase na seção do hook de backlog.
+- Nenhuma skill do catálogo muda: nenhum `SKILL.md` é tocado e a composição do catálogo (contagem,
+  descoberta via `npx`) fica idêntica. Quem já tem os hooks wired em `~/.claude/settings.json` não
+  precisa mudar nada: a linha de comando é a mesma.
+
+Fora de escopo, por decisão registrada na issue #115: exclusão por forma de pergunta (reverte a
+decisão de 2026-08-07 e foi medida silenciando pedidos reais), um `scripts/selftest-hooks.py`
+central (o padrão da casa é selftest no próprio arquivo) e o wiring dos hooks na máquina do
+mantenedor.

--- a/openspec/changes/add-hook-selftests/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-hook-selftests/specs/skills-catalog/spec.md
@@ -1,0 +1,117 @@
+## MODIFIED Requirements
+
+### Requirement: The development rite is enforced outside the model's discretion
+
+The catalog SHALL state, in its portable global rules, that every code change starts as a backlog
+item, and SHALL ship an enforcement artifact that fires without depending on the assistant noticing
+the rule. The artifact SHALL inform rather than block: it never denies a tool call, and the user can
+always waive the rite explicitly. Diagnosing, reading and answering SHALL remain unrestricted — the
+rite applies only when code is going to change.
+
+In a repository that runs a spec-driven workflow, the rite SHALL NOT end at the backlog item. The
+spec artifact SHALL be named by the same enforcement artifact that names the backlog step, and the
+naming SHALL be conditional on that workflow being present, so that the reminder stays silent where
+it does not apply. A repository whose spec policy is unstated SHALL be treated as requiring the
+artifact, so that the absence of a decision is not read as permission to skip it.
+
+The decision to ship without a spec artifact SHALL be a written one. A judgment made silently by the
+assistant, or by a contributor in conversation, SHALL NOT satisfy the rite: the waiver SHALL exist as
+a reviewable line in the pull request, and the gate SHALL be what reads it.
+
+The enforcement artifact SHALL carry a self-test, exercised by the repository's own CI, that fixes
+the decisions its design already assumes — what fires, what stays silent, and where the spec
+sentence is appended — so that an edit to its signal list is measured rather than trusted. A
+deliberately accepted false positive SHALL be fixed in that self-test as a case that fires, with the
+recorded decision cited beside it, so that a well-meant correction cannot revert it unread. A
+payload that is not a JSON object SHALL be ignored: the artifact exits zero with no output and no
+traceback, because a hook that crashes on malformed input costs the turn it was meant to inform.
+
+#### Scenario: A code-change request carries the rite into context
+
+- **WHEN** a prompt asks for an implementation, fix, refactor or removal
+- **THEN** the shipped `UserPromptSubmit` hook injects the rite reminder naming `/backlog` as the
+  entry point and `/execute-backlog` as the second step
+- **AND** the reminder states that diagnosis is free and that an approved plan is not a waiver
+
+#### Scenario: The reminder names the spec rite only where it exists
+
+- **WHEN** the prompt matches a code-change signal and the working directory carries the
+  spec-driven workflow's directory
+- **THEN** the reminder also names the spec artifact as a step that precedes the first edit outside
+  that directory
+- **AND** the same prompt in a working directory without that workflow produces the reminder without
+  the spec sentence, so the added line never fires where it has no meaning
+
+#### Scenario: The reminder is silent inside its own rite
+
+- **WHEN** the prompt is already a rite command (`/backlog`, `/execute-backlog`), another slash
+  command, or contains an explicit waiver
+- **THEN** the hook produces no output, so the reminder never fires against the flow it enforces
+
+#### Scenario: Plan approval is not a bypass
+
+- **WHEN** an assistant finishes planning and the plan is approved
+- **THEN** the rule as stated in the global rules requires the work to become a backlog item before
+  the first edit, because approving a plan approves the plan and not the skipping of the rite
+
+#### Scenario: The enforcement artifact persists nothing
+
+- **WHEN** the shipped hook runs
+- **THEN** it reads the prompt payload, matches, prints and exits, writing no state outside the
+  repository and requiring no credentials
+
+#### Scenario: The shipped hook carries a self-test and a malformed payload is ignored
+
+- **WHEN** the hook is run with `--selftest`
+- **THEN** it prints one OK/FAILED line per fixed decision plus a summary line and exits non-zero
+  when any decision regressed, and the repository's CI runs that mode as a blocking step
+- **AND** the case list includes a diagnostic question containing a change word as a case that
+  fires, citing the decision that accepted the false positive
+- **AND** when the payload on stdin is a JSON array, a JSON string or empty, the hook exits zero
+  with no output and no traceback
+
+### Requirement: The grounding rite is carried into context on correction
+
+The catalog SHALL ship an enforcement artifact that re-injects the anti-guessing doctrine when a
+prompt indicates a guess was caught or research is being demanded, in both of the catalog's working
+languages. The artifact SHALL inform rather than block: it never denies a tool call, it persists
+nothing, it needs no credentials, and an explicit waiver silences it.
+
+The artifact SHALL state which moment it does **not** cover, and the documentation SHALL name the
+layer that enforces evidence when the artifact is not wired, so that a reader does not mistake a
+per-session convenience for a gate.
+
+The artifact SHALL carry a self-test, exercised by the repository's own CI, that fixes the decisions
+its design already assumes — a caught guess fires in each working language, a waiver silences, a
+correction typed inside a slash command still fires, an implementation request stays silent — so
+that an edit to its signal list is measured rather than trusted. A payload that is not a JSON object
+SHALL be ignored: the artifact exits zero with no output and no traceback.
+
+#### Scenario: A caught guess carries the doctrine into the turn
+
+- **WHEN** a prompt says the assistant invented something, demands a source, asks where a fact came
+  from, states that a flag or option does not exist, or says the work was out of scope
+- **THEN** the hook injects the research ladder, the labelling rule, the not-found rule and the scope
+  rule into that turn's context
+
+#### Scenario: The reminder is silent when the user waives it
+
+- **WHEN** the prompt explicitly permits an unverified answer
+- **THEN** the hook produces no output, because the rite is the user's to waive
+
+#### Scenario: The uncovered moment is declared, not implied
+
+- **WHEN** the artifact is documented
+- **THEN** the documentation states that it fires on corrections rather than on the guess itself,
+  that no prompt regex can observe the moment a model is about to guess, and that the artifact does
+  not run in CI or for a contributor who has not wired it
+
+#### Scenario: The shipped hook carries a self-test and a malformed payload is ignored
+
+- **WHEN** the hook is run with `--selftest`
+- **THEN** it prints one OK/FAILED line per fixed decision plus a summary line and exits non-zero
+  when any decision regressed, and the repository's CI runs that mode as a blocking step
+- **AND** the case list fixes that a correction typed inside a slash command still fires, which is
+  the opposite of the backlog hook's rule and is deliberate
+- **AND** when the payload on stdin is a JSON array, a JSON string or empty, the hook exits zero
+  with no output and no traceback

--- a/openspec/changes/add-hook-selftests/tasks.md
+++ b/openspec/changes/add-hook-selftests/tasks.md
@@ -157,8 +157,8 @@
 - [x] 2.3 `backlog-rite.py --selftest`: casos que disparam, casos mudos, payloads malformados via
       `read_payload`, asserção de forma, uma linha OK/FAILED por caso, resumo, exit code (D4, D5)
 
-      Saída em `c86a9ce` (15 decisões: as 12 originais mais o cwd não-string, "failing" e
-      "failover"), linhas de decisão completas, bloco dos malformados elidido:
+      Saída depois da rodada 2 da revisão (16 decisões: as 12 originais, "failing", "failover" e os
+      dois casos do fallback de `cwd`), linhas de decisão completas, bloco dos malformados elidido:
 
       ```
       python3 claude/global/hooks/backlog-rite.py --selftest; echo "rc=$?"
@@ -176,15 +176,34 @@
       ->   OK      empty prompt is silent
       ->   OK      payload without prompt is silent
       ->   OK      prompt that is not a string is silent
-      ->   OK      cwd that is not a string falls back and still fires
+      ->   OK      cwd that is not a string falls back to the process cwd (with openspec/)
+      ->   OK      cwd that is not a string falls back to the process cwd (without openspec/)
       ->   OK      output shape is the reminder the harness reads
       ->   OK      malformed payload is ignored: json array
       ->   [...]                       (json string, empty stdin, json null, json number, not json)
       ->   OK      well-formed payload is read
       ->
-      -> selftest OK: 15 decisions, 6 malformed payloads, plus the output shape
+      -> selftest OK: 16 decisions, 6 malformed payloads, plus the output shape
       -> rc=0
       ```
+
+      Hermético de verdade (TR1), medido com `os.path.isdir` e `os.getcwd` instrumentados no módulo
+      carregado por `importlib`, rodando `selftest()` do repositório. Antes desta rodada, o caso
+      único `cwd: 42` (`spec_sentence=None`) fazia `isdir('<repo>/openspec')`; depois, nenhum
+      `isdir` cai no cwd real, o `getcwd()` que o fallback vê é a fixture, e o cwd é restaurado:
+
+      ```
+      antes  -> rc 0 isdir on real cwd: ['<worktree>/openspec'] getcwd calls: 2
+      depois -> rc 0 | isdir calls on real cwd: [] | isdir calls total: 10
+      -> getcwd returned: ['REAL', 'REAL', 'fixture:with-rite', 'REAL', 'fixture:without-rite']
+      -> cwd restored after selftest: True
+      cd /tmp && python3 <worktree>/claude/global/hooks/backlog-rite.py --selftest | tail -1; echo "rc=$?"
+      -> selftest OK: 16 decisions, 6 malformed payloads, plus the output shape
+      -> rc=0
+      ```
+
+      (Os `REAL` são só o caminho: `previous = os.getcwd()` antes de cada `chdir`, e a consulta que
+      `tempfile` faz ao escolher o diretório temporário — nada é lido dentro dele.)
 
       O selftest fica vermelho quando uma decisão regride — provado em cópias, cada uma com um
       defeito injetado:
@@ -205,9 +224,16 @@
       -> noslash rc=1
       ```
 
-      Sem a guarda de `cwd` (cópia com o `payload.get("cwd") or os.getcwd()` de `7804e62`), o caso
-      novo não imprime FAILED: estoura com `TypeError: expected str, bytes or os.PathLike object,
-      not int` e rc=1 — vermelho do mesmo jeito, mas por traceback, não por asserção.
+      Sem a guarda de `cwd` (cópia com o `payload.get("cwd") or os.getcwd()` de `7804e62`), os casos
+      do fallback não imprimem FAILED: estouram com `TypeError: expected str, bytes or os.PathLike
+      object, not int` e rc=1 — vermelho do mesmo jeito, mas por traceback, não por asserção. Com um
+      fallback que ignora o cwd do processo (cópia com `cwd = "/"` no lugar de `os.getcwd()`):
+
+      ```
+      python3 $SCR/backlog-rite-nofallback.py --selftest | grep FAILED; echo "nofallback rc=$?"
+      ->   FAILED  cwd that is not a string falls back to the process cwd (with openspec/)
+      -> nofallback rc=1
+      ```
 
 - [x] 2.4 `verify-rite.py`: mesma extração — `evaluate`, `read_payload`, `--selftest` explícito,
       docstring com o limite do selftest (D1-D3). Commit `7804e62`.
@@ -351,8 +377,9 @@
       | backlog-rite (stdin) | payload malformado mudo, exit 0 | 4/4 | `[]`, `"x"`, vazio, `null` (antes: 2/4 estouravam) |
       | backlog-rite (stdin) | `cwd` não-string não estoura | 2/2 | `42`, `["/tmp"]` (antes: 2/2 estouravam) |
       | os dois hooks (argv) | argumento desconhecido sai 2 com usage | 4/4 | `--self-test`, `--selftest extra` × 2 hooks (antes: 4/4 saíam 0) |
-      | backlog-rite `--selftest` | decisões OK | 15/15 + forma da saída + 6/6 malformados | rc=0 |
-      | backlog-rite `--selftest` (cópias com defeito injetado) | tinha de ficar vermelho e ficou | 4/4 | sem `fail`, `fail\w*` de volta, slash SKIP apagado, sem guarda de cwd — rc=1 cada |
+      | backlog-rite `--selftest` | decisões OK | 16/16 + forma da saída + 6/6 malformados | rc=0 |
+      | backlog-rite `--selftest` (cópias com defeito injetado) | tinha de ficar vermelho e ficou | 5/5 | sem `fail`, `fail\w*` de volta, slash SKIP apagado, sem guarda de cwd, fallback que ignora o cwd — rc=1 cada |
+| backlog-rite `--selftest` (hermético, TR1) | nenhum `isdir` no cwd real; cwd restaurado; mesmo resultado de `/tmp` | 3/3 | instrumentado por `importlib` (2.3) |
       | verify-rite (stdin, 5 prompts) | tinha de disparar e disparou | 3/3 | inclui slash command com correção |
       | verify-rite (stdin, 5 prompts) | tinha de ficar mudo e ficou | 2/2 | dispensa, pedido de implementação |
       | verify-rite (stdin) | payload malformado mudo, exit 0 | 4/4 | `[]`, `"x"`, vazio, `null` (antes: 2/4 estouravam) |
@@ -373,6 +400,10 @@
       - O caso "slash command is silent" original usava "/backlog nova ideia", sem palavra de mudança,
         e ficava verde com a regra de slash command apagada; o prompt agora carrega um sinal
         (`0ebe63e`), e a cópia sem a regra fica vermelha.
+      - O caso `cwd: 42` da rodada 1 afirmava só "não estoura e dispara" e, medido com `isdir`
+        instrumentado, lia `<repo>/openspec` pelo fallback — o docstring, D4 e TR1 diziam o
+        contrário. Virou dois casos que movem o cwd do processo para cada fixture (`try/finally`) e
+        afirmam a frase do spec-rite nos dois sentidos (2.3, D4).
 
       Um escape conhecido e mantido de propósito: "por que não implementa o endpoint de login?" é
       um pedido real com forma de pergunta, e dispara — por isso a exclusão por forma de pergunta

--- a/openspec/changes/add-hook-selftests/tasks.md
+++ b/openspec/changes/add-hook-selftests/tasks.md
@@ -107,7 +107,14 @@
       - Um `prompt` presente mas não-string (`{"prompt": 42}`) estouraria em `SKIP.search` com
         `TypeError`; tratado como ausente por D2 do design, porque cai na mesma classe "payload
         malformado não derruba o turno" de FR2. Registrado aqui por ser um caso a mais do que a
-        issue enumerou.
+        issue enumerou. A revisão achou o irmão dele — `{"cwd": 42}` estourava em `os.path.join` —
+        e a guarda entrou pelo mesmo motivo (D2, commit `9c04572`).
+      - Argumento desconhecido (`--self-test`) caía no caminho do stdin e saía 0 sem saída, o no-op
+        verde de D3; os dois hooks passam a rejeitar com usage em stderr e exit 2 (D3, `9c04572`).
+        O `locale-rite.py:245` carrega a mesma leitura por pertinência e fica como follow-up.
+      - `fail\w*`, a forma pedida na issue, foi medida casando failover / failsafe / failure e
+        estreitada para `fail(s|ed|ing)?` (D6, `c86a9ce`); a issue previa "exceto o sinal `fail`",
+        e é só isso que muda.
       - `README.md:258-260` e não `:255-257` como a issue cita: a frase é a mesma, deslocada três
         linhas por uma edição posterior ao grooming.
 
@@ -116,43 +123,91 @@
 - [x] 2.1 `backlog-rite.py`: decisão extraída para `evaluate(payload) -> str | None`; leitura de
       stdin em `read_payload(stream) -> dict | None` com guarda `isinstance(payload, dict)`;
       `--selftest` lido de `sys.argv[1:]`; docstring declara o que o selftest não cobre (D1-D3).
-      Commit `7804e62`.
-- [x] 2.2 `backlog-rite.py`: `fail\w*` no lado inglês da linha 47, ao lado de `falha` (D6)
+      Commit `7804e62`. Depois da revisão, `9c04572`: `cwd` que não é string cai em `os.getcwd()`
+      em vez de estourar, e argumento que não seja exatamente `--selftest` sai 2 com usage:
 
       ```
-      git diff -U0 origin/master...HEAD -- claude/global/hooks/backlog-rite.py | grep -E '^[-+].*falha\|'
+      printf '{"prompt": "implementa o endpoint", "cwd": 42}' | python3 claude/global/hooks/backlog-rite.py | cut -c1-40; echo "rc=$?"
+      -> DEVELOPMENT RITE (backlog-first): this
+      -> rc=0                        (antes de 9c04572: TypeError ... not int, rc=1)
+      python3 claude/global/hooks/backlog-rite.py --self-test </dev/null; echo "rc=$?"
+      -> usage: claude/global/hooks/backlog-rite.py [--selftest]
+      -> rc=2                        (antes: rc=0, nenhuma saída)
+      python3 claude/global/hooks/backlog-rite.py --selftest extra </dev/null; echo "rc=$?"
+      -> usage: claude/global/hooks/backlog-rite.py [--selftest]
+      -> rc=2                        (antes: rodava o selftest e ignorava o resto)
+      ```
+- [x] 2.2 `backlog-rite.py`: `fail(s|ed|ing)?` no lado inglês da linha 47, ao lado de `falha` (D6;
+      `7804e62` entrou com `fail\w*`, `c86a9ce` estreitou depois de medir failover/failsafe/failure)
+
+      ```
+      git diff -U0 d2918ed...HEAD -- claude/global/hooks/backlog-rite.py | grep -E '^[-+].*falha\|'
       -> -    r"fix|bug|erro|error|falha|quebr\w*|broken|"
-      -> +    r"fix|bug|erro|error|falha|fail\w*|quebr\w*|broken|"
+      -> +    r"fix|bug|erro|error|falha|fail(s|ed|ing)?|quebr\w*|broken|"
+      ```
+
+      Conjuntos medidos (`CHANGE_SIGNALS.search` importado do hook), que D6 registra em tabela:
+
+      ```
+      \bfalha\b        : 'o teste falha' True | 'o teste falhou' False | 'está falhando' False | 'falhas no deploy' False
+      fail\w*          : fail/fails/failed/failing True | 'the failure domain' True | 'a failover cluster' True | 'a failsafe' True
+      fail(s|ed|ing)?  : fail/fails/failed/failing True | 'the failure domain' False | 'a failover cluster' False | 'a failsafe' False
       ```
 
 - [x] 2.3 `backlog-rite.py --selftest`: casos que disparam, casos mudos, payloads malformados via
       `read_payload`, asserção de forma, uma linha OK/FAILED por caso, resumo, exit code (D4, D5)
 
+      Saída em `c86a9ce` (15 decisões: as 12 originais mais o cwd não-string, "failing" e
+      "failover"), linhas de decisão completas, bloco dos malformados elidido:
+
       ```
       python3 claude/global/hooks/backlog-rite.py --selftest; echo "rc=$?"
       ->   OK      change request fires
+      ->   OK      english change request fires
       ->   OK      cwd with openspec/ appends the spec sentence
       ->   OK      cwd without openspec/ omits the spec sentence
       ->   OK      diagnostic question containing 'falha' fires (accepted trade-off)
-      ->   OK      english 'fail' mirrors 'falha'
-      ->   OK      slash command is silent
+      ->   OK      english 'fail' (verb forms fail/fails/failed/failing) fires
+      ->   OK      english 'failing' fires
+      ->   OK      english noun 'failover' is silent
+      ->   OK      slash command carrying a change word is silent
       ->   OK      waiver 'sem backlog' is silent
       ->   OK      neutral question is silent
+      ->   OK      empty prompt is silent
+      ->   OK      payload without prompt is silent
+      ->   OK      prompt that is not a string is silent
+      ->   OK      cwd that is not a string falls back and still fires
+      ->   OK      output shape is the reminder the harness reads
       ->   OK      malformed payload is ignored: json array
-      ->   [...]
-      -> selftest OK: 12 decisions, 6 malformed payloads, plus the output shape
+      ->   [...]                       (json string, empty stdin, json null, json number, not json)
+      ->   OK      well-formed payload is read
+      ->
+      -> selftest OK: 15 decisions, 6 malformed payloads, plus the output shape
       -> rc=0
       ```
 
-      O selftest fica vermelho quando uma decisão regride — provado numa cópia sem `fail\w*`:
+      O selftest fica vermelho quando uma decisão regride — provado em cópias, cada uma com um
+      defeito injetado:
 
       ```
-      sed 's/|fail\\w\*//' claude/global/hooks/backlog-rite.py > $SCR/backlog-rite-broken.py
-      python3 $SCR/backlog-rite-broken.py --selftest; echo "broken rc=$?"
-      ->   FAILED  english 'fail' mirrors 'falha'
-      -> selftest FAILED: english 'fail' mirrors 'falha'
-      -> broken rc=1
+      sed 's/|fail(s|ed|ing)?//' claude/global/hooks/backlog-rite.py > $SCR/backlog-rite-nofail.py
+      python3 $SCR/backlog-rite-nofail.py --selftest | grep FAILED; echo "nofail rc=$?"
+      ->   FAILED  english 'fail' (verb forms fail/fails/failed/failing) fires
+      ->   FAILED  english 'failing' fires
+      -> nofail rc=1
+      sed 's/fail(s|ed|ing)?/fail\\w*/' claude/global/hooks/backlog-rite.py > $SCR/backlog-rite-wide.py
+      python3 $SCR/backlog-rite-wide.py --selftest | grep FAILED; echo "wide rc=$?"
+      ->   FAILED  english noun 'failover' is silent
+      -> wide rc=1
+      sed 's#r"(^\\s\*/\[a-z-\]+"#r"(^\\s*/NEVER"#' claude/global/hooks/backlog-rite.py > $SCR/backlog-rite-noslash.py
+      python3 $SCR/backlog-rite-noslash.py --selftest | grep FAILED; echo "noslash rc=$?"
+      ->   FAILED  slash command carrying a change word is silent
+      -> noslash rc=1
       ```
+
+      Sem a guarda de `cwd` (cópia com o `payload.get("cwd") or os.getcwd()` de `7804e62`), o caso
+      novo não imprime FAILED: estoura com `TypeError: expected str, bytes or os.PathLike object,
+      not int` e rc=1 — vermelho do mesmo jeito, mas por traceback, não por asserção.
 
 - [x] 2.4 `verify-rite.py`: mesma extração — `evaluate`, `read_payload`, `--selftest` explícito,
       docstring com o limite do selftest (D1-D3). Commit `7804e62`.
@@ -164,12 +219,23 @@
       python3 claude/global/hooks/verify-rite.py --selftest; echo "rc=$?"
       ->   OK      portuguese caught guess fires
       ->   OK      english demand for a source fires
+      ->   [...]                       ('essa flag não existe', 'that's not what I asked')
       ->   OK      correction inside a slash command still fires
       ->   OK      waiver 'pode chutar' is silent
+      ->   [...]                       (waiver 'from memory is fine')
       ->   OK      implementation request is silent
-      ->   [...]
+      ->   [...]                       (neutral question, empty prompt, no prompt, prompt not a string,
+      ->                                output shape, 6 malformed payloads, well-formed payload)
       -> selftest OK: 12 decisions, 6 malformed payloads, plus the output shape
       -> rc=0
+      ```
+
+      Argumento desconhecido (`9c04572`):
+
+      ```
+      python3 claude/global/hooks/verify-rite.py --self-test </dev/null; echo "rc=$?"
+      -> usage: claude/global/hooks/verify-rite.py [--selftest]
+      -> rc=2                        (antes: rc=0, nenhuma saída)
       ```
 
       Vermelho quando a regra do slash command é "harmonizada" com o backlog-rite — cópia com
@@ -195,15 +261,20 @@
 
 - [x] 2.7 `README.md:258-264`, junto à frase "It stays silent for prompts already inside the
       rite…": uma frase dizendo que perguntas de diagnóstico contendo `erro`/`bug`/`falha`/`fail`
-      disparam e por quê, citando o custo assimétrico e o selftest que fixa o caso. Commit `0381b1f`.
+      disparam e por quê, citando o custo assimétrico e o selftest que fixa o caso. Commit `0381b1f`;
+      `7cf89c7` troca "one paragraph of context" por "one line of context", a palavra da decisão
+      citada (`2026-08-07-add-backlog-first-rite/design.md:31-32`) — o docstring do hook idem, em
+      `c86a9ce`.
 
 ## 3. Simulation & Field Proof (MANDATORY)
 
 - [x] S.1 O artefato foi exercitado pelo caminho real — stdin do harness — com a saída observada
 
       Entrada: `printf '{"prompt": <json>, "cwd": "<repo>"}' | python3 claude/global/hooks/backlog-rite.py`,
-      um processo por prompt, `chars` = tamanho da saída, `spec` = ocorrências da frase do spec-rite.
-      Os 8 prompts, **antes** (`d2918ed`) e **depois** (`7804e62`):
+      um processo por prompt. Unidade única em todo este grupo: `chars` = caracteres da saída
+      capturada em shell (`out=$(...)`; `${#out}`), sem o newline final — `wc -c` daria 3 bytes a
+      mais (743/503) pelos acentos e pelo newline. `spec` = ocorrências da frase do spec-rite.
+      Os 8 prompts, **antes** (`d2918ed`) e **depois** (`c86a9ce`, mesmos números que em `7804e62`):
 
       ```
       implementa o endpoint de login               -> antes rc=0 chars=740 spec=1 | depois rc=0 chars=740 spec=1
@@ -221,7 +292,29 @@
 
       ```
       printf '{"prompt": "implementa o endpoint", "cwd": "/tmp"}' | python3 claude/global/hooks/backlog-rite.py | grep -c 'spec-driven rite'
-      -> 0            (503 chars: só o REMINDER)
+      -> 0            (500 chars: só o REMINDER)
+      ```
+
+      O lado inglês de `fail`, corpus da revisão, `cwd=/tmp`, **antes** (`d2918ed`) e **depois**
+      (`c86a9ce`) — é o alargamento que D6 registra, e o que ficou de fora dele:
+
+      ```
+      why does the build fail?               -> antes rc=0 chars=0   | depois rc=0 chars=500
+      the tests are failing                  -> antes rc=0 chars=0   | depois rc=0 chars=500
+      the build failed again                 -> antes rc=0 chars=0   | depois rc=0 chars=500
+      what is a failover cluster?            -> antes rc=0 chars=0   | depois rc=0 chars=0
+      explain the failure domain concept     -> antes rc=0 chars=0   | depois rc=0 chars=0
+      o que é um failsafe?                   -> antes rc=0 chars=0   | depois rc=0 chars=0
+      o teste falhou ontem                   -> antes rc=0 chars=0   | depois rc=0 chars=0
+      o deploy está falhando                 -> antes rc=0 chars=0   | depois rc=0 chars=0
+      ```
+
+      (Em `7804e62`, com `fail\w*`, os três de substantivo davam 500 — medido na revisão; é o que
+      `c86a9ce` desfaz.) Slash command com sinal e `cwd` não-string, pelo mesmo caminho:
+
+      ```
+      /execute-backlog 12 implementa o endpoint   (cwd=<repo>)  -> rc=0 chars=0
+      implementa o endpoint                       (cwd=42)      -> rc=0 chars=740 rodando do repo, 500 rodando de /tmp (fallback: os.getcwd())
       ```
 
       `verify-rite.py` pelo mesmo caminho (`{"prompt": <json>}`), antes e depois idênticos:
@@ -253,9 +346,13 @@
       |---|---|---|---|
       | backlog-rite (stdin, 8 prompts) | tinha de disparar e disparou | 5/5 | inclui o falso positivo aceito e "why does the build fail?" (novo) |
       | backlog-rite (stdin, 8 prompts) | tinha de ficar mudo e ficou | 3/3 | slash command, "sem backlog", pergunta neutra |
+      | backlog-rite (stdin, corpus `fail`) | tinha de passar a disparar e passou | 3/3 | fail / failing / failed |
+      | backlog-rite (stdin, corpus `fail`) | tinha de continuar mudo e continuou | 5/5 | failover, failure, failsafe, falhou, falhando |
       | backlog-rite (stdin) | payload malformado mudo, exit 0 | 4/4 | `[]`, `"x"`, vazio, `null` (antes: 2/4 estouravam) |
-      | backlog-rite `--selftest` | decisões OK | 12/12 + forma da saída + 6/6 malformados | rc=0 |
-      | backlog-rite `--selftest` (cópia sem `fail\w*`) | tinha de ficar vermelho e ficou | 1/1 | rc=1 |
+      | backlog-rite (stdin) | `cwd` não-string não estoura | 2/2 | `42`, `["/tmp"]` (antes: 2/2 estouravam) |
+      | os dois hooks (argv) | argumento desconhecido sai 2 com usage | 4/4 | `--self-test`, `--selftest extra` × 2 hooks (antes: 4/4 saíam 0) |
+      | backlog-rite `--selftest` | decisões OK | 15/15 + forma da saída + 6/6 malformados | rc=0 |
+      | backlog-rite `--selftest` (cópias com defeito injetado) | tinha de ficar vermelho e ficou | 4/4 | sem `fail`, `fail\w*` de volta, slash SKIP apagado, sem guarda de cwd — rc=1 cada |
       | verify-rite (stdin, 5 prompts) | tinha de disparar e disparou | 3/3 | inclui slash command com correção |
       | verify-rite (stdin, 5 prompts) | tinha de ficar mudo e ficou | 2/2 | dispensa, pedido de implementação |
       | verify-rite (stdin) | payload malformado mudo, exit 0 | 4/4 | `[]`, `"x"`, vazio, `null` (antes: 2/4 estouravam) |
@@ -265,8 +362,17 @@
 
 - [x] S.3 O que escapou ou se comportou diferente do esperado
 
-      Nada se comportou diferente do previsto na issue: os 8 prompts dão o mesmo resultado antes e
-      depois, exceto "why does the build fail?", que passa a disparar.
+      Os 8 prompts dão o mesmo resultado antes e depois, exceto "why does the build fail?", que passa
+      a disparar — como a issue previu. Duas coisas se comportaram diferente do escrito:
+
+      - A forma pedida na issue, `fail\w*`, foi medida em `7804e62` disparando em "what is a failover
+        cluster?", "explain the failure domain concept" e "o que é um failsafe?" (0 -> 500 chars cada,
+        `cwd=/tmp`) — e o D6 original dizia que `\bfalha\b` casa "falhou"/"falhando", o que a mesma
+        medição desmentiu. O sinal ficou `fail(s|ed|ing)?` (`c86a9ce`): fail / failing / failed
+        disparam (0 -> 500), os substantivos e o português conjugado continuam em 0.
+      - O caso "slash command is silent" original usava "/backlog nova ideia", sem palavra de mudança,
+        e ficava verde com a regra de slash command apagada; o prompt agora carrega um sinal
+        (`0ebe63e`), e a cópia sem a regra fica vermelha.
 
       Um escape conhecido e mantido de propósito: "por que não implementa o endpoint de login?" é
       um pedido real com forma de pergunta, e dispara — por isso a exclusão por forma de pergunta
@@ -280,8 +386,9 @@
 ## 4. Quality Gates (MANDATORY)
 
 - [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: esta change não toca
-      nenhuma skill. O loop do CI foi rodado mesmo assim:
-      `bash $SCR/frontmatter-loop.sh` -> `frontmatter checks: fail=0 (35 files)`
+      nenhuma skill. O step `Skill frontmatter checks` de `.github/workflows/ci.yml:56` foi extraído
+      (`yaml.safe_load` do workflow, corpo do `run:` para um arquivo) e rodado verbatim: nenhuma linha
+      `::error`, `rc=0` (o step só imprime em falha)
 - [x] Q.2 Conteúdo de skill tocado em inglês — **não se aplica** pelo mesmo motivo; o delta de spec,
       os docstrings dos hooks, os nomes dos casos do selftest e a frase do README estão em inglês,
       como o catálogo exige; proposal/design/tasks em português, como as changes da casa

--- a/openspec/changes/add-hook-selftests/tasks.md
+++ b/openspec/changes/add-hook-selftests/tasks.md
@@ -113,45 +113,197 @@
 
 ## 2. Selftest e guarda de payload nos dois hooks
 
-- [ ] 2.1 `backlog-rite.py`: decisão extraída para `evaluate(payload) -> str | None`; leitura de
+- [x] 2.1 `backlog-rite.py`: decisão extraída para `evaluate(payload) -> str | None`; leitura de
       stdin em `read_payload(stream) -> dict | None` com guarda `isinstance(payload, dict)`;
-      `--selftest` lido de `sys.argv[1:]`; docstring declara o que o selftest não cobre (D1-D3)
-- [ ] 2.2 `backlog-rite.py`: `fail\w*` no lado inglês da linha 47, ao lado de `falha` (D6)
-- [ ] 2.3 `backlog-rite.py --selftest`: casos que disparam (pedido de mudança pt/en, cwd com
-      `openspec/` em `tempfile` acrescenta `SPEC_RITE`, cwd sem ele não acrescenta, "por que o teste
-      falha?" com a decisão de 2026-08-07 citada, "why does the build fail?"), casos mudos (slash
-      command, "sem backlog", pergunta neutra, prompt vazio/ausente/não-string), payloads
-      malformados (`[]`, `"x"`, vazio, `null`, `42`) via `read_payload`, asserção de forma da
-      saída, uma linha OK/FAILED por caso, linha de resumo, exit code (D4, D5)
-- [ ] 2.4 `verify-rite.py`: mesma extração — `evaluate`, `read_payload`, `--selftest` explícito,
-      docstring com o limite do selftest (D1-D3)
-- [ ] 2.5 `verify-rite.py --selftest`: casos que disparam ("isso é achismo", "where did you see
-      that", "essa flag não existe", "that's not what I asked", slash command com correção —
-      `verify-rite.py:78-79`), casos mudos (dispensa "pode chutar", "implementa o endpoint", prompt
-      vazio/ausente), payloads malformados via `read_payload`, forma da saída, resumo, exit code (D7)
-- [ ] 2.6 `.github/workflows/ci.yml`: dois steps novos logo após `Locale write-gate hook self-test`,
-      um por hook, mesmo padrão de nome dos gates auto-testados (D8)
-- [ ] 2.7 `README.md`, junto à frase "It stays silent for prompts already inside the rite…": uma
-      frase dizendo que perguntas de diagnóstico contendo `erro`/`bug`/`falha` disparam e por quê
+      `--selftest` lido de `sys.argv[1:]`; docstring declara o que o selftest não cobre (D1-D3).
+      Commit `7804e62`.
+- [x] 2.2 `backlog-rite.py`: `fail\w*` no lado inglês da linha 47, ao lado de `falha` (D6)
+
+      ```
+      git diff -U0 origin/master...HEAD -- claude/global/hooks/backlog-rite.py | grep -E '^[-+].*falha\|'
+      -> -    r"fix|bug|erro|error|falha|quebr\w*|broken|"
+      -> +    r"fix|bug|erro|error|falha|fail\w*|quebr\w*|broken|"
+      ```
+
+- [x] 2.3 `backlog-rite.py --selftest`: casos que disparam, casos mudos, payloads malformados via
+      `read_payload`, asserção de forma, uma linha OK/FAILED por caso, resumo, exit code (D4, D5)
+
+      ```
+      python3 claude/global/hooks/backlog-rite.py --selftest; echo "rc=$?"
+      ->   OK      change request fires
+      ->   OK      cwd with openspec/ appends the spec sentence
+      ->   OK      cwd without openspec/ omits the spec sentence
+      ->   OK      diagnostic question containing 'falha' fires (accepted trade-off)
+      ->   OK      english 'fail' mirrors 'falha'
+      ->   OK      slash command is silent
+      ->   OK      waiver 'sem backlog' is silent
+      ->   OK      neutral question is silent
+      ->   OK      malformed payload is ignored: json array
+      ->   [...]
+      -> selftest OK: 12 decisions, 6 malformed payloads, plus the output shape
+      -> rc=0
+      ```
+
+      O selftest fica vermelho quando uma decisão regride — provado numa cópia sem `fail\w*`:
+
+      ```
+      sed 's/|fail\\w\*//' claude/global/hooks/backlog-rite.py > $SCR/backlog-rite-broken.py
+      python3 $SCR/backlog-rite-broken.py --selftest; echo "broken rc=$?"
+      ->   FAILED  english 'fail' mirrors 'falha'
+      -> selftest FAILED: english 'fail' mirrors 'falha'
+      -> broken rc=1
+      ```
+
+- [x] 2.4 `verify-rite.py`: mesma extração — `evaluate`, `read_payload`, `--selftest` explícito,
+      docstring com o limite do selftest (D1-D3). Commit `7804e62`.
+- [x] 2.5 `verify-rite.py --selftest`: casos que disparam (inclusive slash command com correção,
+      `verify-rite.py:78-79`), casos mudos, payloads malformados, forma da saída, resumo, exit code
+      (D7)
+
+      ```
+      python3 claude/global/hooks/verify-rite.py --selftest; echo "rc=$?"
+      ->   OK      portuguese caught guess fires
+      ->   OK      english demand for a source fires
+      ->   OK      correction inside a slash command still fires
+      ->   OK      waiver 'pode chutar' is silent
+      ->   OK      implementation request is silent
+      ->   [...]
+      -> selftest OK: 12 decisions, 6 malformed payloads, plus the output shape
+      -> rc=0
+      ```
+
+      Vermelho quando a regra do slash command é "harmonizada" com o backlog-rite — cópia com
+      `^\s*/[a-z-]+` acrescentado ao `SKIP`:
+
+      ```
+      python3 $SCR/verify-rite-broken.py --selftest; echo "broken rc=$?"
+      ->   FAILED  correction inside a slash command still fires
+      -> selftest FAILED: correction inside a slash command still fires
+      -> broken rc=1
+      ```
+
+- [x] 2.6 `.github/workflows/ci.yml`: dois steps novos logo após `Locale write-gate hook self-test`,
+      um por hook, mesmo padrão de nome dos gates auto-testados (D8). Commit `bb683b7`:
+
+      ```
+      git diff origin/master...HEAD -- .github/workflows/ci.yml
+      -> +      - name: Backlog rite hook self-test (the shipped hook is itself gated)
+      -> +        run: python3 claude/global/hooks/backlog-rite.py --selftest
+      -> +      - name: Grounding rite hook self-test (the shipped hook is itself gated)
+      -> +        run: python3 claude/global/hooks/verify-rite.py --selftest
+      ```
+
+- [x] 2.7 `README.md:258-264`, junto à frase "It stays silent for prompts already inside the
+      rite…": uma frase dizendo que perguntas de diagnóstico contendo `erro`/`bug`/`falha`/`fail`
+      disparam e por quê, citando o custo assimétrico e o selftest que fixa o caso. Commit `0381b1f`.
 
 ## 3. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 O artefato foi exercitado pelo caminho real — stdin do harness — com a saída observada
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado
+- [x] S.1 O artefato foi exercitado pelo caminho real — stdin do harness — com a saída observada
+
+      Entrada: `printf '{"prompt": <json>, "cwd": "<repo>"}' | python3 claude/global/hooks/backlog-rite.py`,
+      um processo por prompt, `chars` = tamanho da saída, `spec` = ocorrências da frase do spec-rite.
+      Os 8 prompts, **antes** (`d2918ed`) e **depois** (`7804e62`):
+
+      ```
+      implementa o endpoint de login               -> antes rc=0 chars=740 spec=1 | depois rc=0 chars=740 spec=1
+      /backlog nova ideia                          -> antes rc=0 chars=0   spec=0 | depois rc=0 chars=0   spec=0
+      faz isso sem backlog, corrige o typo         -> antes rc=0 chars=0   spec=0 | depois rc=0 chars=0   spec=0
+      o que é um hook?                             -> antes rc=0 chars=0   spec=0 | depois rc=0 chars=0   spec=0
+      por que o teste falha?                       -> antes rc=0 chars=740 spec=1 | depois rc=0 chars=740 spec=1
+      why does the build fail?                     -> antes rc=0 chars=0   spec=0 | depois rc=0 chars=740 spec=1
+      por que não implementa o endpoint de login?  -> antes rc=0 chars=740 spec=1 | depois rc=0 chars=740 spec=1
+      como corrijo esse bug?                       -> antes rc=0 chars=740 spec=1 | depois rc=0 chars=740 spec=1
+      ```
+
+      Só "why does the build fail?" mudou, como a issue previu. A frase do spec-rite some quando o
+      `cwd` não tem `openspec/`:
+
+      ```
+      printf '{"prompt": "implementa o endpoint", "cwd": "/tmp"}' | python3 claude/global/hooks/backlog-rite.py | grep -c 'spec-driven rite'
+      -> 0            (503 chars: só o REMINDER)
+      ```
+
+      `verify-rite.py` pelo mesmo caminho (`{"prompt": <json>}`), antes e depois idênticos:
+
+      ```
+      isso é achismo                      -> rc=0 chars=883
+      where did you see that              -> rc=0 chars=883
+      pode chutar, de onde tirou isso?    -> rc=0 chars=0
+      /backlog você inventou essa flag    -> rc=0 chars=883
+      implementa o endpoint               -> rc=0 chars=0
+      ```
+
+      Payloads malformados, **antes** (traceback, E.2) e **depois**:
+
+      ```
+      echo '[]'  | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"   -> rc=0  (sem saída)
+      echo '"x"' | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"   -> rc=0  (sem saída)
+      printf ''  | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"   -> rc=0  (sem saída)
+      echo null  | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"   -> rc=0  (sem saída)
+      echo '[]'  | python3 claude/global/hooks/verify-rite.py;  echo "rc=$?"   -> rc=0  (sem saída)
+      echo '"x"' | python3 claude/global/hooks/verify-rite.py;  echo "rc=$?"   -> rc=0  (sem saída)
+      printf ''  | python3 claude/global/hooks/verify-rite.py;  echo "rc=$?"   -> rc=0  (sem saída)
+      echo null  | python3 claude/global/hooks/verify-rite.py;  echo "rc=$?"   -> rc=0  (sem saída)
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Artefato | Expectativa | Casos | Resultado |
+      |---|---|---|---|
+      | backlog-rite (stdin, 8 prompts) | tinha de disparar e disparou | 5/5 | inclui o falso positivo aceito e "why does the build fail?" (novo) |
+      | backlog-rite (stdin, 8 prompts) | tinha de ficar mudo e ficou | 3/3 | slash command, "sem backlog", pergunta neutra |
+      | backlog-rite (stdin) | payload malformado mudo, exit 0 | 4/4 | `[]`, `"x"`, vazio, `null` (antes: 2/4 estouravam) |
+      | backlog-rite `--selftest` | decisões OK | 12/12 + forma da saída + 6/6 malformados | rc=0 |
+      | backlog-rite `--selftest` (cópia sem `fail\w*`) | tinha de ficar vermelho e ficou | 1/1 | rc=1 |
+      | verify-rite (stdin, 5 prompts) | tinha de disparar e disparou | 3/3 | inclui slash command com correção |
+      | verify-rite (stdin, 5 prompts) | tinha de ficar mudo e ficou | 2/2 | dispensa, pedido de implementação |
+      | verify-rite (stdin) | payload malformado mudo, exit 0 | 4/4 | `[]`, `"x"`, vazio, `null` (antes: 2/4 estouravam) |
+      | verify-rite `--selftest` | decisões OK | 12/12 + forma da saída + 6/6 malformados | rc=0 |
+      | verify-rite `--selftest` (cópia que silencia slash command) | tinha de ficar vermelho e ficou | 1/1 | rc=1 |
+      | escape conhecido | ficou mudo | 1/1 | ver S.3 |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Nada se comportou diferente do previsto na issue: os 8 prompts dão o mesmo resultado antes e
+      depois, exceto "why does the build fail?", que passa a disparar.
+
+      Um escape conhecido e mantido de propósito: "por que não implementa o endpoint de login?" é
+      um pedido real com forma de pergunta, e dispara — por isso a exclusão por forma de pergunta
+      não entra (design, Non-Goals). O que continua fora do alcance de qualquer selftest é o
+      KNOWN LIMIT do `verify-rite.py`: ele dispara na correção, nunca no achismo em si; isso está
+      declarado no docstring, não medido aqui.
+
+      O que a simulação **não** prova: que o harness real ainda envie `prompt` e `cwd` com esses
+      nomes — a entrada aqui foi construída à mão a partir da doc pinada (E.3).
 
 ## 4. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado
-- [ ] Q.2 Conteúdo de skill tocado em inglês
-- [ ] Q.3 Gatilhos de descrição testáveis
-- [ ] Q.4 Sem doutrina duplicada
-- [ ] Q.5 Identificadores em inglês no que a change introduz
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: esta change não toca
+      nenhuma skill. O loop do CI foi rodado mesmo assim:
+      `bash $SCR/frontmatter-loop.sh` -> `frontmatter checks: fail=0 (35 files)`
+- [x] Q.2 Conteúdo de skill tocado em inglês — **não se aplica** pelo mesmo motivo; o delta de spec,
+      os docstrings dos hooks, os nomes dos casos do selftest e a frase do README estão em inglês,
+      como o catálogo exige; proposal/design/tasks em português, como as changes da casa
+- [x] Q.3 Gatilhos de descrição testáveis — **não se aplica**: nenhuma descrição de skill muda
+- [x] Q.4 Sem doutrina duplicada: o selftest e o README **citam** a decisão de 2026-08-07 em vez de
+      reescrevê-la; o docstring do verify-rite continua apontando para `verify-before-claiming`;
+      ver a tabela de Canonical Home em `design.md`
+- [x] Q.5 Identificadores em inglês no que a change introduz — `evaluate`, `read_payload`,
+      `selftest`, `with_rite`, `without_rite`, `spec_sentence`, ids de step — conforme o glossário
+      da issue #115 e `code-locale`:
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py claude/global/hooks/backlog-rite.py claude/global/hooks/verify-rite.py
+      -> findings: 0
+      ```
 
 ## 5. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-hook-selftests --strict` verde
-- [ ] V.2 Descoberta do catálogo intacta: contagem de skills inalterada, sem órfão ou renomeado
-- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+- [x] V.1 `openspec validate add-hook-selftests --strict` -> `Change 'add-hook-selftests' is valid`
+- [x] V.2 Descoberta do catálogo intacta: `npx skills add . --list` -> `Found 35 skills`;
+      `ls -d skills/*/ | wc -l` -> `35`; sem órfão ou renomeado
+- [x] V.3 README / docs atualizados: `README.md:258-264` ganha a frase do falso positivo aceito
+      (2.7); a composição do catálogo não muda
 - [ ] V.4 `openspec archive add-hook-selftests --yes` depois que todos os grupos acima estiverem
       `[x]` — PR separado, como o repositório já faz

--- a/openspec/changes/add-hook-selftests/tasks.md
+++ b/openspec/changes/add-hook-selftests/tasks.md
@@ -1,0 +1,157 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `d2918ed` (`docs(openspec): arquiva as duas changes de svg-animation`), topo de
+      `master` em 2026-09-04:
+
+      - `claude/global/hooks/backlog-rite.py` — 109 linhas; `CHANGE_SIGNALS` em 38-52 com a linha 47
+        `fix|bug|erro|error|falha|quebr\w*|broken|` (sem par inglês para `falha`); `SKIP` em 55-60
+        silencia slash command e dispensas; `has_spec_rite()` em 84-86 lê `payload["cwd"]` com
+        fallback `os.getcwd()`; `main()` em 89-105 chama `payload.get("prompt")` na linha 95 sem
+        guarda de tipo e sem ler `sys.argv`.
+      - `claude/global/hooks/verify-rite.py` — 120 linhas; `GUESS_SIGNALS` em 54-76; `SKIP` em 80-86
+        com o comentário de 78-79 ("this does NOT skip slash commands"); `main()` em 103-116 chama
+        `payload.get("prompt")` na linha 109 sem guarda e sem `argv`.
+      - `claude/global/hooks/locale-rite.py` — 260 linhas; o modelo: `evaluate()` em 155-173,
+        `selftest()` em 176-241, `"--selftest" in sys.argv[1:]` em 245, `isinstance(payload, dict)`
+        em 251.
+      - `.github/workflows/ci.yml` — step `Locale write-gate hook self-test` em 93-94; os outros
+        gates auto-testados em 87-91 e 113-117.
+      - `README.md` — seção do hook de backlog em 225-260; a frase "It stays silent for prompts
+        already inside the rite…" em 258-260 (a issue cita 255-257: drift de três linhas desde o
+        grooming, mesma frase).
+      - `openspec/changes/archive/2026-08-07-add-backlog-first-rite/design.md:31-32` e `:78-80` —
+        a decisão do matcher generoso e do falso positivo aceito.
+      - `openspec/specs/skills-catalog/spec.md:188-239` (*The development rite is enforced outside
+        the model's discretion*) e `:457-486` (*The grounding rite is carried into context on
+        correction*) — os dois requisitos que o delta modifica; `:579-585` (*A shipped enforcement
+        script declares what escapes it*) e `openspec/specs/skills-authoring/spec.md:259-263` — as
+        cláusulas de selftest que hoje só cobrem scripts de skill e de autoria.
+      - `openspec/changes/archive/2026-08-30-fix-release-race/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md` — modelo de estilo da casa.
+      - `openspec/schemas/skills-rite/templates/{proposal,design,tasks,spec}.md`,
+        `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py`,
+        `scripts/validate-spec-rite.py` — o que os gates exigem de cada grupo.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      ```
+      python3 --version
+      -> Python 3.14.5
+      openspec --version
+      -> 1.6.0
+      openspec list
+      -> No active changes found.
+      ```
+
+      `--selftest` é hoje um no-op silencioso (o hook lê stdin vazio e sai 0):
+
+      ```
+      python3 claude/global/hooks/backlog-rite.py --selftest </dev/null; echo "selftest-before rc=$?"
+      -> selftest-before rc=0        (nenhuma outra linha)
+      ```
+
+      Payload que não é objeto estoura nos dois hooks:
+
+      ```
+      echo '[]' | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"
+      ->   File ".../backlog-rite.py", line 95, in main
+      ->     prompt = payload.get("prompt") or ""
+      -> AttributeError: 'list' object has no attribute 'get'
+      -> rc=1
+      echo '"x"' | python3 claude/global/hooks/verify-rite.py; echo "rc=$?"
+      ->   File ".../verify-rite.py", line 109, in main
+      -> AttributeError: 'str' object has no attribute 'get'
+      -> rc=1
+      printf '' | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"
+      -> rc=0                        (JSONDecodeError já é capturado)
+      ```
+
+      Assimetria `falha`/`fail`, medida pelo stdin real (payload `{"prompt": …, "cwd": <repo>}`):
+
+      ```
+      por que o teste falha?      -> rc=0 chars=740 spec=1   (dispara, com a frase do spec-rite)
+      why does the build fail?    -> rc=0 chars=0   spec=0   (mudo)
+      ```
+
+      Scaffold da change com o schema do repositório:
+
+      ```
+      openspec new change add-hook-selftests --schema skills-rite
+      -> Created change 'add-hook-selftests' at openspec/changes/add-hook-selftests/
+      -> Schema: skills-rite
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      Um item. A lista exata dos 8 prompts da simulação de 2026-09-04 não está gravada no
+      `findings.md` que a originou (o arquivo registra só o resultado: "backlog-rite dispara em
+      'por que o teste falha?'"). Os 8 prompts usados aqui foram reconstruídos a partir dos exemplos
+      citados na issue #115 (os quatro de diagnóstico/pedido) e das três classes que o `SKIP`
+      silencia mais uma pergunta neutra; a lista está escrita por extenso em S.1, para que a
+      comparação antes/depois seja reproduzível mesmo que não coincida byte a byte com a original.
+
+      O payload real do harness não foi capturado nesta sessão: o selftest alimenta só `prompt` e
+      `cwd`, os únicos campos que os hooks leem, e isso fica declarado no docstring de cada hook
+      (TR2). Que o harness ainda envie esses campos com esses nomes é uma premissa da doc pinada
+      (`code.claude.com/docs/en/hooks`), não algo medido aqui.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a issue #115 pediu. Notados pelo caminho e **não** feitos, ficam como
+      follow-up:
+
+      - `verify-rite.py` não está wired em `~/.claude/settings.json` desta máquina, enquanto o
+        README mostra os dois hooks — configuração pessoal, fora da issue por decisão dela.
+      - Um `prompt` presente mas não-string (`{"prompt": 42}`) estouraria em `SKIP.search` com
+        `TypeError`; tratado como ausente por D2 do design, porque cai na mesma classe "payload
+        malformado não derruba o turno" de FR2. Registrado aqui por ser um caso a mais do que a
+        issue enumerou.
+      - `README.md:258-260` e não `:255-257` como a issue cita: a frase é a mesma, deslocada três
+        linhas por uma edição posterior ao grooming.
+
+## 2. Selftest e guarda de payload nos dois hooks
+
+- [ ] 2.1 `backlog-rite.py`: decisão extraída para `evaluate(payload) -> str | None`; leitura de
+      stdin em `read_payload(stream) -> dict | None` com guarda `isinstance(payload, dict)`;
+      `--selftest` lido de `sys.argv[1:]`; docstring declara o que o selftest não cobre (D1-D3)
+- [ ] 2.2 `backlog-rite.py`: `fail\w*` no lado inglês da linha 47, ao lado de `falha` (D6)
+- [ ] 2.3 `backlog-rite.py --selftest`: casos que disparam (pedido de mudança pt/en, cwd com
+      `openspec/` em `tempfile` acrescenta `SPEC_RITE`, cwd sem ele não acrescenta, "por que o teste
+      falha?" com a decisão de 2026-08-07 citada, "why does the build fail?"), casos mudos (slash
+      command, "sem backlog", pergunta neutra, prompt vazio/ausente/não-string), payloads
+      malformados (`[]`, `"x"`, vazio, `null`, `42`) via `read_payload`, asserção de forma da
+      saída, uma linha OK/FAILED por caso, linha de resumo, exit code (D4, D5)
+- [ ] 2.4 `verify-rite.py`: mesma extração — `evaluate`, `read_payload`, `--selftest` explícito,
+      docstring com o limite do selftest (D1-D3)
+- [ ] 2.5 `verify-rite.py --selftest`: casos que disparam ("isso é achismo", "where did you see
+      that", "essa flag não existe", "that's not what I asked", slash command com correção —
+      `verify-rite.py:78-79`), casos mudos (dispensa "pode chutar", "implementa o endpoint", prompt
+      vazio/ausente), payloads malformados via `read_payload`, forma da saída, resumo, exit code (D7)
+- [ ] 2.6 `.github/workflows/ci.yml`: dois steps novos logo após `Locale write-gate hook self-test`,
+      um por hook, mesmo padrão de nome dos gates auto-testados (D8)
+- [ ] 2.7 `README.md`, junto à frase "It stays silent for prompts already inside the rite…": uma
+      frase dizendo que perguntas de diagnóstico contendo `erro`/`bug`/`falha` disparam e por quê
+
+## 3. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 O artefato foi exercitado pelo caminho real — stdin do harness — com a saída observada
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+## 4. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado
+- [ ] Q.2 Conteúdo de skill tocado em inglês
+- [ ] Q.3 Gatilhos de descrição testáveis
+- [ ] Q.4 Sem doutrina duplicada
+- [ ] Q.5 Identificadores em inglês no que a change introduz
+
+## 5. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-hook-selftests --strict` verde
+- [ ] V.2 Descoberta do catálogo intacta: contagem de skills inalterada, sem órfão ou renomeado
+- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+- [ ] V.4 `openspec archive add-hook-selftests --yes` depois que todos os grupos acima estiverem
+      `[x]` — PR separado, como o repositório já faz


### PR DESCRIPTION
Closes #115

Spec-rite: add-hook-selftests

`backlog-rite.py` e `verify-rite.py` não tinham rede de regressão: `--selftest` era aceito em silêncio (nenhum parse de `argv`, então um step de CI seria um no-op verde), e um payload JSON que não é objeto derrubava os dois com traceback e exit 1.

Medido em `d2918ed`, pelo stdin real:

```
python3 claude/global/hooks/backlog-rite.py --selftest </dev/null; echo "rc=$?"
-> selftest-before rc=0        (nenhuma outra linha)
echo '[]' | python3 claude/global/hooks/backlog-rite.py; echo "rc=$?"
-> AttributeError: 'list' object has no attribute 'get'
-> rc=1
```

## O que muda

- **Os dois hooks ganham `evaluate(payload) -> str | None` e `read_payload(stream) -> dict | None`**, no formato do `locale-rite.py`; `main()` só faz I/O. `--selftest` é lido de `sys.argv[1:]` por igualdade: qualquer outro argumento imprime usage em stderr e sai 2 (o `--self-test` grafado errado deixa de ser um no-op verde).
- **Payload que não é objeto (`[]`, `"x"`, vazio, `null`, `42`) e `prompt`/`cwd` que não são string**: ignorados, exit 0, sem traceback.
- **`fail(s|ed|ing)?` no lado inglês de `falha`** — a issue pediu `fail\w*`, medido casando failover / failsafe / failure (conceito, não pedido); ficam as quatro formas do verbo. Só "why does the build fail?" muda entre os 8 prompts da simulação.
- **O falso positivo aceito fica fixado como caso que dispara** ("por que o teste falha?"), com a decisão de 2026-08-07 citada ao lado; o README ganha a frase que explica o porquê.
- **Dois steps em `ci.yml`**, um por hook, ao lado do step do `locale-rite`.
- **Selftest hermético de verdade (TR1)**: a revisão mediu o caso `cwd: 42` fazendo `isdir('<repo>/openspec')` pelo fallback em `os.getcwd()`. Viraram dois casos que movem o cwd do processo para cada fixture (`try/finally`) e afirmam a frase do spec-rite nos dois sentidos; nenhum `isdir` cai no cwd real e o resultado é o mesmo rodando de `/tmp`.

Nenhuma skill é tocada; a composição do catálogo fica idêntica (35 skills).

## Simulação — saída observada

| Expectativa | Casos | Resultado |
|---|---|---|
| backlog-rite (stdin, 8 prompts): tinha de disparar e disparou | 5/5 | inclui o falso positivo aceito e "why does the build fail?" (novo) |
| backlog-rite (stdin, 8 prompts): tinha de ficar mudo e ficou | 3/3 | slash command, "sem backlog", pergunta neutra |
| corpus `fail`: passa a disparar / continua mudo | 3/3 · 5/5 | fail, failing, failed · failover, failure, failsafe, falhou, falhando |
| payload malformado mudo, exit 0 (os dois hooks) | 8/8 | `[]`, `"x"`, vazio, `null` (antes: 4/8 estouravam) |
| `backlog-rite --selftest` | 16/16 + forma + 6/6 malformados | rc=0, do repo e de `/tmp` |
| `backlog-rite --selftest` com defeito injetado | 5/5 vermelhos | sem `fail`, `fail\w*`, slash SKIP apagado, sem guarda de cwd, fallback que ignora o cwd |
| `verify-rite --selftest` | 12/12 + forma + 6/6 malformados | rc=0; cópia que silencia slash command fica vermelha |
| hermético (TR1), `isdir`/`getcwd` instrumentados | 3/3 | nenhum `isdir` no cwd real; cwd restaurado; mesmo resultado de `/tmp` |

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Selftests | `python3 claude/global/hooks/{backlog,verify}-rite.py --selftest` | `16 decisions` / `12 decisions`, rc=0 |
| Change | `openspec validate add-hook-selftests --strict` | `Change 'add-hook-selftests' is valid` |
| Rito | `scripts/validate-rite.sh` | `rite gate OK` |
| Locale | `check-identifier-locale.py` nos dois hooks | `findings: 0` |
| Catálogo | `npx skills add . --list` | `Found 35 skills` |

Detalhes, comandos e saídas em `openspec/changes/add-hook-selftests/tasks.md`; decisões (D1-D8) em `design.md`.