### PR TITLE
📝 docs(readme): corrige a deriva do README e do comentário do ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,8 +148,10 @@ jobs:
         # flight, so it publishes what is due for every commit up to the tip, and the next run finds
         # nothing left to release.
         # The commit released may therefore be newer than the one Validate examined in THIS run.
-        # Each of those commits passed Validate on its own pull request; master is protected and
-        # takes no direct push other than the [skip ci] release commit.
+        # Each of those commits passed Validate on its own pull request; master takes no direct push
+        # by convention (PR-only) other than the [skip ci] release commit. No branch protection rule
+        # exists as of 2026-09-04 (`gh api repos/solvelab/ai-skills/branches/master/protection` -> 404);
+        # whether to add one is issue #120's decision.
         uses: actions/checkout@v5
         with:
           ref: master

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ for every project on the machine.
 Plugin updates are **version-pinned**: you only receive changes when a new release is tagged (see
 [Releases & Versioning](#-releases--versioning)).
 
-> **Pick ONE method per machine.** Plugin skills are namespaced (`ai-skills:fivem-lua`) and don't
+> **Pick ONE method per machine.** Plugin skills are namespaced by plugin — `ai-skills-<group>:<skill>`,
+> e.g. `ai-skills-fivem:fivem-lua`; `ai-skills:fivem-lua` only under the full bundle — and don't
 > conflict with the symlink install (Option C) — but running both duplicates every skill in
 > discovery. On a machine using symlinks, disable a project's auto-install locally with
 > `.claude/settings.local.json` setting the same plugin keys to `false`.
@@ -170,14 +171,14 @@ Releases are **fully automated** by [semantic-release](https://github.com/semant
 | `BREAKING CHANGE:` footer or `!` | major |
 | `docs:`, `chore:` | none |
 
-Each release automatically: bumps `VERSION`, propagates it to `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (via `scripts/set-version.sh`), regenerates all wrappers, updates `CHANGELOG.md` from the commit messages, commits (`chore(release): vX.Y.Z [skip ci]`), tags `vX.Y.Z`, and publishes a GitHub Release with the notes.
+Each release automatically: bumps `VERSION`, propagates it to `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` (via `scripts/set-version.sh`), regenerates all wrappers, updates `CHANGELOG.md` from the commit messages, commits (`chore(release): X.Y.Z [skip ci]`), tags `vX.Y.Z`, and publishes a GitHub Release with the notes.
 
 | Channel | What you get |
 |---------|--------------|
 | Claude Code plugin | **Version-pinned** — updates only when `plugin.json` version is bumped by a release |
 | `npx skills` / `install.sh` / `update.sh` | Latest `master` |
 
-Each skill also carries its own `metadata.version` in its `SKILL.md` frontmatter — bump it when that skill's behavior changes. Repo version = the collection; skill version = the individual contract. The CI/CD pipeline (`.github/workflows/ci.yml`) validates every push/PR (wrapper sync, version coherence, frontmatter) and cuts releases on `master`.
+Each skill also carries its own `metadata.version` in its `SKILL.md` frontmatter — bump it when that skill's behavior changes. Repo version = the collection; skill version = the individual contract. The CI/CD pipeline (`.github/workflows/ci.yml`) validates every pull request and every push to `master` (wrapper sync, version coherence, frontmatter) and cuts releases on `master`.
 
 ---
 
@@ -346,6 +347,12 @@ ai-skills/
 ├── .claude-plugin/
 │   ├── plugin.json                           # Claude Code plugin manifest (version-pinned)
 │   └── marketplace.json                      # Claude Code marketplace catalog
+├── plugins/                                  # Per-domain plugins (10 of the 11 marketplace entries)
+│   └── <group>/                              # backend, devops, docs, fivem, frontend, game, nui, testing, tooling, workflow
+│       ├── .claude-plugin/plugin.json        # ai-skills-<group> manifest
+│       └── skills/                           # Generated: copies of the group's skills
+├── openspec/                                 # Spec-driven rite: specs/, changes/, schemas/skills-rite/
+├── research/                                 # Measurements behind a skill (e.g. svg-animation)
 ├── claude/
 │   ├── global/personal-rules.md              # Maintainer's portable Claude Code rules (example)
 │   └── skills/                               # Generated: thin wrappers for legacy CLAUDE.md installs
@@ -359,7 +366,12 @@ ai-skills/
 ├── generate.sh                               # Regenerates all tool wrappers from skills/
 ├── install.sh                                # One-line installer with --tool flag
 ├── update.sh                                 # Sync + regenerate
-├── scripts/set-version.sh                    # Version propagation (called by semantic-release)
+├── scripts/
+│   ├── set-version.sh                        # Version propagation (called by semantic-release)
+│   ├── validate-skills.py                    # Skill content checks (C1–C9) + selftest-validate-skills.py
+│   ├── validate-repo-hygiene.py              # Compiled artifacts, published counts
+│   ├── validate-rite.sh                      # OpenSpec rite gate (+ validate-rite-evidence.py, validate-spec-rite.py)
+│   └── scan-secrets.py                       # Credential scan (working tree gates, history reports)
 ├── .releaserc.json                           # semantic-release config (auto-versioning from commits)
 └── README.md
 ```
@@ -739,12 +751,13 @@ from a fork, so it is matched as text and never executed. The checkout runs at `
 because a gate with no base revision cannot measure, and a gate that cannot measure must not approve.
 
 A second gate checks the **content** of the skills themselves.
-[`scripts/validate-skills.py`](scripts/validate-skills.py) runs eight checks over every
+[`scripts/validate-skills.py`](scripts/validate-skills.py) runs nine checks over every
 `skills/*/SKILL.md` and its references — referenced paths exist (C1), cross-skill references name a
 real skill (C2), code blocks parse (C3, bash/yaml/json/lua/python), the description states no policy
 the body contradicts (C4), versioned external APIs are pinned (C5), fence tags match their content
-(C6), no generated wrapper is orphaned from a canonical source (C7), and no meta section sits in a
-`SKILL.md` body where it cannot affect routing (C8). The list is the script's own docstring — run
+(C6), no generated wrapper is orphaned from a canonical source (C7), no meta section sits in a
+`SKILL.md` body where it cannot affect routing (C8), and code examples use English identifiers
+(C9). The list is the script's own docstring — run
 `grep -E '^  C[0-9]' scripts/validate-skills.py` rather than trusting this paragraph. It reports any
 check skipped for want of a tool rather than counting it as a pass.
 
@@ -772,7 +785,7 @@ as operational detail, never as a build failure.
 
 ```bash
 python3 scripts/validate-skills.py           # 0 findings expected
-python3 scripts/selftest-validate-skills.py  # 12/12 defect classes detected
+python3 scripts/selftest-validate-skills.py  # 13/13 defect classes detected
 python3 scripts/scan-secrets.py              # gate: no credentials in the working tree
 python3 scripts/scan-secrets.py --history    # audit: what the published history still contains
 ```
@@ -783,6 +796,10 @@ python3 scripts/scan-secrets.py --history    # audit: what the published history
 npm install -g @fission-ai/openspec   # CLI (>= 1.6.0)
 openspec init --tools claude          # generates the /opsx commands into .claude/ (git-ignored, per machine)
 ```
+
+> `openspec init` also writes six helper skills (`openspec-propose`, `openspec-apply-change`, …) into
+> `.claude/skills/`. They are git-ignored and not part of the catalog, so `npx skills add ./ --list`
+> in a maintainer checkout finds 41 skills against the 35 that `git archive HEAD` ships.
 
 ### Board integration
 
@@ -833,11 +850,13 @@ This emits the Claude/Codex/Cursor/Copilot wrappers automatically. Commit them t
 
 ### 3. Release
 
-Commit with a [Conventional Commit](https://www.conventionalcommits.org) message and push — the release pipeline does the rest (version bump, changelog, tag, GitHub Release):
+Commit with a [Conventional Commit](https://www.conventionalcommits.org) message on a branch and open a
+pull request — `master` takes no direct push (PR-only, by convention). The release runs after the
+merge and does the rest (version bump, changelog, tag, GitHub Release):
 
 ```bash
-git commit -m "skill: add my-skill"   # skill:/feat: → minor release on push to master
-git push origin master
+git commit -m "skill: add my-skill"   # skill:/feat: → minor release once merged into master
+git push -u origin backlog/<n>-my-skill && gh pr create --fill
 ```
 
 ### 4. Key guidelines for writing skills

--- a/README.md
+++ b/README.md
@@ -853,12 +853,18 @@ This emits the Claude/Codex/Cursor/Copilot wrappers automatically. Commit them t
 ### 3. Release
 
 Commit with a [Conventional Commit](https://www.conventionalcommits.org) message on a branch and open a
-pull request — `master` takes no direct push (PR-only, by convention). The release runs after the
-merge and does the rest (version bump, changelog, tag, GitHub Release):
+pull request — `master` takes no direct push (PR-only, by convention). CI reads that pull request:
+`scripts/validate-spec-rite.py` looks in the diff for the OpenSpec change (`openspec/changes/<id>/`,
+committed together with the skill per the rite above) and, when the diff carries none, in the PR
+body for a written waiver `Spec-rite: none — <reason>` — a PR with neither fails with S1. Write the
+body from a file: `gh pr create --fill` takes title and body from the commit message, so a `-m`-only
+commit opens a PR with an empty body. The release runs after the merge and does the rest (version
+bump, changelog, tag, GitHub Release):
 
 ```bash
 git commit -m "skill: add my-skill"   # skill:/feat: → minor release once merged into master
-git push -u origin backlog/<n>-my-skill && gh pr create --fill
+git push -u origin backlog/<n>-my-skill
+gh pr create --title "skill: add my-skill" --body-file pr.md   # pr.md names the change (`Spec-rite: <id>`)
 ```
 
 ### 4. Key guidelines for writing skills

--- a/README.md
+++ b/README.md
@@ -853,18 +853,19 @@ This emits the Claude/Codex/Cursor/Copilot wrappers automatically. Commit them t
 ### 3. Release
 
 Commit with a [Conventional Commit](https://www.conventionalcommits.org) message on a branch and open a
-pull request — `master` takes no direct push (PR-only, by convention). CI reads that pull request:
-`scripts/validate-spec-rite.py` looks in the diff for the OpenSpec change (`openspec/changes/<id>/`,
-committed together with the skill per the rite above) and, when the diff carries none, in the PR
-body for a written waiver `Spec-rite: none — <reason>` — a PR with neither fails with S1. Write the
-body from a file: `gh pr create --fill` takes title and body from the commit message, so a `-m`-only
-commit opens a PR with an empty body. The release runs after the merge and does the rest (version
-bump, changelog, tag, GitHub Release):
+pull request — `master` takes no direct push (PR-only, by convention). CI reads the pull request
+body: `scripts/validate-spec-rite.py` passes when the checkout carries an active change under
+`openspec/changes/<id>/` (the one `/opsx:propose` scaffolded above, committed with the skill) or the
+diff archives one, and otherwise only when the body carries a written waiver
+`Spec-rite: none — <reason>` — a PR with neither fails with S1. Write the body from a file:
+`gh pr create --fill` takes title and body from the commit message, so a `-m`-only commit opens a
+PR with an empty body. The release runs after the merge and does the rest (version bump, changelog,
+tag, GitHub Release):
 
 ```bash
 git commit -m "skill: add my-skill"   # skill:/feat: → minor release once merged into master
 git push -u origin backlog/<n>-my-skill
-gh pr create --title "skill: add my-skill" --body-file pr.md   # pr.md names the change (`Spec-rite: <id>`)
+gh pr create --title "skill: add my-skill" --body-file pr.md   # pr.md: `Spec-rite: <id>`, or `Spec-rite: none — <reason>`
 ```
 
 ### 4. Key guidelines for writing skills

--- a/README.md
+++ b/README.md
@@ -794,12 +794,14 @@ python3 scripts/scan-secrets.py --history    # audit: what the published history
 
 ```bash
 npm install -g @fission-ai/openspec   # CLI (>= 1.6.0)
-openspec init --tools claude          # generates the /opsx commands into .claude/ (git-ignored, per machine)
+openspec init --tools claude          # generates the /opsx commands into .claude/ (not tracked; ignore it per machine)
 ```
 
 > `openspec init` also writes six helper skills (`openspec-propose`, `openspec-apply-change`, …) into
-> `.claude/skills/`. They are git-ignored and not part of the catalog, so `npx skills add ./ --list`
-> in a maintainer checkout finds 41 skills against the 35 that `git archive HEAD` ships.
+> `.claude/skills/`. They are not part of the catalog and the repo `.gitignore` does not exclude
+> `.claude/` — ignore it in your global excludes file (`core.excludesFile`) so `git add -A` never
+> commits them. That is why `npx skills add ./ --list` in a maintainer checkout finds 41 skills
+> against the 35 that `git archive HEAD` ships.
 
 ### Board integration
 


### PR DESCRIPTION
Closes #116

O documento de entrada do repositório mandava `git push origin master` (README `:839-840`), um
fluxo que o rito backlog-first proíbe, e trazia números e formatos que o próprio repositório
contradiz. O comentário do job `Semantic Release` (`ci.yml:151-152`) sustentava o `ref: master`
numa proteção de branch que não existe.

Lido em `d2918ed` (`master` em 2026-09-04). Nenhuma skill, gate ou script é tocado — só prosa e um
comentário.

## O que muda

| Linha (antes) | Dizia | Agora | Artefato que prova |
|---|---|---|---|
| README `:90` | `ai-skills:fivem-lua` | `ai-skills-<group>:<skill>`, ex. `ai-skills-fivem:fivem-lua` (**inferido**, ver Known gaps) | `.claude-plugin/marketplace.json:37-38` — `ai-skills-fivem` → `./plugins/fivem`, que contém `fivem-lua`; plugin `caveman` instalado expõe `caveman:<skill>` |
| README `:173` | `chore(release): vX.Y.Z [skip ci]` | `chore(release): X.Y.Z [skip ci]` | `.releaserc.json` `message`; `git log -1 --format=%s v2.16.0` → `chore(release): 2.16.0 [skip ci]` |
| README `:180` | "validates every push/PR" | "every pull request and every push to `master`" | `ci.yml:7-12` |
| README `:329-365` | árvore sem `plugins/`, `openspec/`, `research/`, `scripts/validate-*` | árvore com os quatro | `git ls-files plugins \| wc -l` → 148; `ls openspec research scripts` |
| README `:742-747` | "eight checks", C1–C8 | "nine checks", C1–C9 | `grep -cE '^  C[0-9]' scripts/validate-skills.py` → 9 |
| README `:775` | `12/12 defect classes detected` | `13/13` | `python3 scripts/selftest-validate-skills.py` → `13/13 defect classes detected` |
| README `:784` | `(git-ignored, per machine)` | nota: `openspec init` grava 6 skills auxiliares em `.claude/skills/`; o `.gitignore` do repo **não** exclui `.claude/` — ignorar via `core.excludesFile` por máquina; 41 no checkout de mantenedor contra 35 no archive | `cat .gitignore` → só `__pycache__/` e `*.py[cod]`; `git check-ignore -v` → `~/.config/git/ignore:1:**/.claude/`; com `-c core.excludesfile=/dev/null` → rc=1 (não ignorado); `npx skills add ./ --list` → 41 vs 35 |
| README `:834-841` | `git push origin master` | branch + PR; `gh pr create --title … --body-file pr.md` com `Spec-rite: <id>` ou `Spec-rite: none — <reason>`; o release roda após o merge | `scripts/validate-spec-rite.py` `evaluate()` (`:171-196`) lê change ativa no checkout ou archive no diff e, sem elas, a dispensa no corpo; `gh pr create --help` → `-f, --fill  Use commit info for title and body` (commit só com `-m` → corpo vazio → S1) |
| `ci.yml:151-152` | "master is protected and takes no direct push" | PR-only por convenção; nenhuma regra de proteção em 2026-09-04; decisão na #120 | `gh api repos/solvelab/ai-skills/branches/master/protection` → 404 `Branch not protected` |

## Simulação — saída observada

Mudança só de documentação; o artefato exercitado é o próprio job `Validate`, replicado passo a
passo sobre a branch commitada, e o gate de spec-rite alimentado com o corpo deste PR via
`GITHUB_EVENT_PATH`. O modo de falha que o README passa a avisar (`gh pr create --fill` com commit
só de `-m`) foi replicado como controle negativo.

| Expectativa | Casos | Resultado |
|---|---|---|
| Afirmação falsa corrigida com prova | **9/9** | cada linha da tabela acima, com o comando que a contradizia |
| Gate tinha de recusar sem dispensa e recusou | **1/1** | corpo vazio → `::error::S1 unregistered change … no waiver`, `spec-rite gate: 1 findings`, rc=1 |
| Gate tinha de passar com a dispensa e passou | **1/1** | com payload → `spec-rite gate: 0 findings (base origin/master, 2 changed path(s), 0 active change(s))`, `rite gate OK` |
| Steps do CI tinham de ficar verdes | **16/16** | tabela abaixo |
| Escape conhecido | **1/1** | `claude plugin details ai-skills-fivem@ai-skills` → `not found` (plugin não instalado); forma do namespace inferida |

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Wrappers em sincronia | `bash generate.sh && git status --porcelain` | `Generated 10 category plugins in plugins/`; árvore limpa |
| Coerência de versão | loop do `ci.yml` | `PASS version` |
| Frontmatter | loop do `ci.yml` | 35 skills, `fail=0` |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | `13/13 defect classes detected` |
| Locale de identificadores | `check-identifier-locale.py --selftest` | `selftest OK: 7 content tiers fire, 16 clean cases stay silent […]` |
| Hook de locale | `claude/global/hooks/locale-rite.py --selftest` | `selftest OK: 12 decisions plus the output shape` |
| Segredos | `python3 scripts/scan-secrets.py` | `no credentials found` |
| Higiene do repo | `validate-repo-hygiene.py` + `--selftest` | `repo hygiene: 0 findings`; `2/2 defect classes detected` |
| Rito | `bash scripts/validate-rite.sh` (com a dispensa no payload) | `rite gate OK` |
| Evidência do rito | `validate-rite-evidence.py --selftest` | `7/7 defect classes detected` |
| Spec-rite | `validate-spec-rite.py --selftest` | `3/3 defect classes detected, 6/6 false-positive cases stayed silent, 6/6 reader cases correct` |
| YAML do workflow | `yaml.safe_load` do `ci.yml` | checkout do release: `{'ref': 'master', 'fetch-depth': 0, …}` |
| Validador do vendor | `claude plugin validate . --strict` | `✔ Validation passed` |

## Rito

Spec-rite: none — só documentação; nenhum requisito muda, nenhum gate, script ou skill é tocado, e cada linha corrigida cita o artefato que a contradizia

## Known gaps

- O critério *"`claude plugin details ai-skills-fivem@ai-skills` confirma o namespace"* está
  **manual**: o comando responde `Plugin "ai-skills-fivem@ai-skills" not found` porque o plugin não
  está instalado nesta máquina, e `details` não aceita `--plugin-dir`. A forma
  `ai-skills-<group>:<skill>` em `:90-91` é **inferida** do plugin `caveman` instalado, cujas skills
  aparecem como `caveman:<skill>`. Confirmar com `/plugin install ai-skills-fivem@ai-skills` e
  ajustar a linha se a forma diferir.
- Follow-up: **decidir se `.claude/` entra no `.gitignore` do repositório.** Hoje só o
  `~/.config/git/ignore` (`**/.claude/`) esconde as seis skills que `openspec init` grava; com
  `-c core.excludesfile=/dev/null` o git as lista como untracked, e um `git add -A` num clone limpo
  as commitaria — o mesmo caminho pelo qual `__pycache__` entrou na 2.6.0. O `.gitignore` não foi
  tocado aqui (fora do escopo da #116); a nota em `:797-802` diz que o ignore é por máquina.
- A tabela *Folder | Purpose* logo abaixo da árvore não ganhou linhas para `plugins/`, `openspec/`,
  `research/` e `scripts/` — está fora do trecho desta issue (a linha `:381` pertence a outro item).
  Follow-up depois dos itens paralelos.
- Ativar proteção de branch continua fora de escopo: é a decisão da #120.