### PR TITLE
👷 ci(gates): fecha os buracos dos gates do CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,22 +25,47 @@ jobs:
   validate:
     name: Validate
     runs-on: ubuntu-latest
+    # Least privilege. A job-level permissions block replaces the workflow-level one entirely, so
+    # every scope not listed here is `none`. No step in this job writes to the repository or reads
+    # GITHUB_TOKEN (each of them read on issue #117); the workflow-level `contents: write` exists
+    # for the release job and used to be inherited here.
+    permissions:
+      contents: read
+    # Measured 57s (run 33463864134) to 5m38s (run 33843366162). Without a ceiling a hung `npx`
+    # holds the serialized master queue for the 360-minute default.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         # fetch-depth: 0 — the spec-rite gate diffs this branch against its base. The default
         # depth of 1 leaves no base revision, and a gate that cannot measure must not approve.
+        # persist-credentials: false — the token is needed for the fetch and for nothing after it.
+        # The default (`persist-credentials: true` in the run log) leaves it in .git/config for
+        # every later step, including the third-party tools this job runs through npx.
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Wrappers in sync with skills/
+        # `git diff --exit-code` compares the index with the working tree and never sees an
+        # untracked file: a new skills/<name>/references/*.md whose mirror under plugins/ was never
+        # added passed this step (issue #117, measured 2026-09-04). `git status --porcelain` sees
+        # both, and `--untracked-files=all` names the file rather than its directory.
         run: |
           bash generate.sh
+          fail=0
+          untracked="$(git status --porcelain --untracked-files=all | grep '^??' || true)"
+          if [ -n "$untracked" ]; then
+            echo "::error::generate.sh produced files that are not tracked. Add them and commit:"
+            echo "$untracked"
+            fail=1
+          fi
           if ! git diff --exit-code --quiet; then
             echo "::error::Generated wrappers are out of sync. Run ./generate.sh and commit the result."
             git diff --stat
-            exit 1
+            fail=1
           fi
+          exit $fail
 
       - name: Version coherence (VERSION == plugin.json == marketplace.json)
         run: |
@@ -54,22 +79,28 @@ jobs:
           echo "Version $VERSION coherent across manifests."
 
       - name: Skill frontmatter checks
+        # Every grep reads the FRONTMATTER BLOCK — the text between the two `---` delimiters,
+        # extracted with the same awk generate.sh:29-31 uses — never the whole file. A `name:`
+        # inside a ```yaml block in the body satisfied a whole-file grep (issue #117). The
+        # first-line check stays on the file itself: it is what guarantees the awk has a block to
+        # start from.
         run: |
           CATEGORIES="backend testing fivem game devops docs git process nui frontend tooling"
           fail=0
           for f in skills/*/SKILL.md; do
             dir="$(basename "$(dirname "$f")")"
             head -1 "$f" | grep -q '^---$' || { echo "::error file=$f::Missing frontmatter"; fail=1; }
-            grep -q '^name:' "$f" || { echo "::error file=$f::Missing name"; fail=1; }
-            grep -q '^description:' "$f" || { echo "::error file=$f::Missing description"; fail=1; }
-            grep -q '^description: >-' "$f" || { echo "::error file=$f::description must be a folded block scalar ('description: >-')"; fail=1; }
-            name="$(grep -m1 '^name:' "$f" | sed 's/^name: *//')"
+            fm="$(awk 'NR==1 && $0=="---"{inFM=1; print; next} inFM && $0=="---"{print; exit} inFM{print}' "$f")"
+            grep -q '^name:' <<<"$fm" || { echo "::error file=$f::Missing name"; fail=1; }
+            grep -q '^description:' <<<"$fm" || { echo "::error file=$f::Missing description"; fail=1; }
+            grep -q '^description: >-' <<<"$fm" || { echo "::error file=$f::description must be a folded block scalar ('description: >-')"; fail=1; }
+            name="$(grep -m1 '^name:' <<<"$fm" | sed 's/^name: *//')"
             [ "$name" = "$dir" ] || { echo "::error file=$f::name '$name' != directory '$dir'"; fail=1; }
-            grep -qE '^  version: [0-9]+\.[0-9]+\.[0-9]+' "$f" || { echo "::error file=$f::Missing metadata.version (semver)"; fail=1; }
-            grep -qx '  author: solvelab' "$f" || { echo "::error file=$f::metadata.author must be exactly 'solvelab'"; fail=1; }
-            grep -qx 'license: MIT' "$f" || { echo "::error file=$f::license must be exactly 'MIT'"; fail=1; }
-            grep -q '^compatibility:' "$f" || { echo "::error file=$f::Missing compatibility"; fail=1; }
-            cat="$(grep -m1 '^  category:' "$f" | sed 's/^  category: *//')"
+            grep -qE '^  version: [0-9]+\.[0-9]+\.[0-9]+' <<<"$fm" || { echo "::error file=$f::Missing metadata.version (semver)"; fail=1; }
+            grep -qx '  author: solvelab' <<<"$fm" || { echo "::error file=$f::metadata.author must be exactly 'solvelab'"; fail=1; }
+            grep -qx 'license: MIT' <<<"$fm" || { echo "::error file=$f::license must be exactly 'MIT'"; fail=1; }
+            grep -q '^compatibility:' <<<"$fm" || { echo "::error file=$f::Missing compatibility"; fail=1; }
+            cat="$(grep -m1 '^  category:' <<<"$fm" | sed 's/^  category: *//')"
             if [ -z "$cat" ]; then
               echo "::error file=$f::Missing metadata.category"; fail=1
             else
@@ -95,6 +126,9 @@ jobs:
 
       - name: Secret scan (working tree)
         run: python3 scripts/scan-secrets.py
+
+      - name: Secret scan self-test (the gate is itself gated)
+        run: python3 scripts/scan-secrets.py --selftest
 
       - name: Repo hygiene (compiled artifacts, published counts)
         run: python3 scripts/validate-repo-hygiene.py
@@ -134,9 +168,8 @@ jobs:
     needs: [validate]
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
-    outputs:
-      new_release: ${{ steps.check_release.outputs.new_release }}
-      version: ${{ steps.check_release.outputs.version }}
+    # Measured 29s (run 33843366162); the ceiling exists for a hung npm install, not for the work.
+    timeout-minutes: 15
     steps:
       - name: Checkout
         # ref: master — NOT the triggering commit. On a push event checkout defaults to github.sha,
@@ -211,21 +244,4 @@ jobs:
           if grep -qF 'is behind the remote one' semantic-release.log; then
             echo "::error::semantic-release refused to publish: the checked-out branch is behind the remote one. The release job must run against the tip of master (see the 'ref: master' comment on this job's checkout step). Nothing was published by this run."
             exit 1
-          fi
-
-      - name: Check if new release was created
-        id: check_release
-        run: |
-          git fetch --tags --force 2>/dev/null || true
-          CURRENT=$(git tag --list 'v*' --sort=-v:refname | head -n 1)
-          PREV="${{ steps.prev_tag.outputs.prev_tag }}"
-
-          if [ "$CURRENT" != "$PREV" ] && [ -n "$CURRENT" ]; then
-            echo "new_release=true" >> $GITHUB_OUTPUT
-            echo "version=$CURRENT" >> $GITHUB_OUTPUT
-            echo "New release detected: $CURRENT (was: $PREV)"
-          else
-            echo "new_release=false" >> $GITHUB_OUTPUT
-            echo "version=$CURRENT" >> $GITHUB_OUTPUT
-            echo "No new release (current: $CURRENT)"
           fi

--- a/openspec/changes/close-ci-gate-holes/.openspec.yaml
+++ b/openspec/changes/close-ci-gate-holes/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-04

--- a/openspec/changes/close-ci-gate-holes/design.md
+++ b/openspec/changes/close-ci-gate-holes/design.md
@@ -1,0 +1,183 @@
+## Context
+
+O `.github/workflows/ci.yml` (231 linhas em `d2918ed`) tem dois jobs. `validate` (linhas 25-131)
+roda em todo evento e encadeia treze steps; `release` (133-231) roda só em `push` para `master`. As
+permissões são declaradas uma vez, no nível do workflow (linhas 14-17: `contents: write`,
+`issues: write`, `pull-requests: write`), e os dois jobs as herdam. Nenhum job declara
+`timeout-minutes`.
+
+Os quatro scripts que este change toca declaram cada um, no cabeçalho, o que não cobrem — a
+convenção do repositório. Os buracos medidos na issue #117 estão todos **fora** dessas declarações:
+são coisas que o gate diz medir e não mede.
+
+O que foi lido para decidir, no commit `d2918ed` (2026-09-04):
+
+- `generate.sh:29-31` — a função `frontmatter()` extrai o bloco entre os dois `---` com
+  `awk 'NR==1 && $0=="---"{inFM=1; print; next} inFM && $0=="---"{print; exit} inFM{print}'`.
+  Os greps do CI não a usam; varrem o arquivo inteiro.
+- `scripts/validate-spec-rite.py:171-196` — `evaluate()` retorna sem achado quando `changes` (a lista
+  de diretórios ativos) não está vazia. A lista vem de `active_changes()`, que lê o filesystem, não o
+  diff. `SILENT[2]` (`:210`) fixa esse comportamento como correto.
+- `scripts/scan-secrets.py:55-64` — `find()` descarta o match quando `PLACEHOLDER` casa no token
+  **ou** nos 40 caracteres anteriores. `PLACEHOLDER` inclui `test` e `<`.
+- `scripts/validate-rite-evidence.py:157-161` e `:197-200` — E.3, E.4 e S.3 passam com `NEGATIVE`
+  **ou** `len(body) > 120`. O KNOWN LIMIT (`:36-51`) tem seis itens; nenhum menciona o comprimento.
+- `scripts/validate-rite.sh:78-82` — usa `openspec` do PATH quando existe; no CI cai em
+  `npx -y @fission-ai/openspec@latest`. `npm view @fission-ai/openspec version` -> `1.12.0`; a versão
+  instalada e probada localmente é `1.6.0`.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Cada um dos sete buracos fecha, ou fica escrito como limite conhecido **dentro do check**.
+- Todo gate Python alterado mantém ou ganha `--selftest` verde, com um defeito injetado por regra.
+- O job `Validate` roda com o mínimo de privilégio e versões pinadas.
+- O fluxo de arquivar não quebra: um PR que só toca `openspec/changes/archive/` continua passando.
+
+**Non-Goals**
+
+- Proteção de branch e Dependabot (issues de decisão, fora deste item).
+- Pinar actions por SHA (mudança de política de manutenção; follow-up).
+- Tornar o spec-rite capaz de julgar se a change é honesta — continua provando relevância por caminho
+  e por nome, não por conteúdo.
+- Tocar qualquer outro step de `ci.yml` (itens paralelos adicionam steps depois de outros selftests).
+- Atualizar `README.md`: o parágrafo que descreve o spec-rite (linhas 731-739) fica um passo atrás
+  do script; registrado como follow-up em `tasks.md` E.4.
+
+## Decisions
+
+### D1 — O step de wrappers lê `git status --porcelain`, não só `git diff`
+
+`git diff --exit-code` compara índice com árvore de trabalho e nunca vê arquivo `??`. Depois de
+`bash generate.sh`, o step passa a falhar quando `git status --porcelain` devolve qualquer linha, e
+imprime as linhas `??` separadamente, com o nome de cada arquivo, antes do `git diff --stat` dos
+rastreados. Uma única checagem cobriria os dois casos, mas a mensagem do caso antigo ("out of sync,
+run ./generate.sh") continua correta e vale manter distinta da nova ("generated file untracked, add
+it").
+
+Alternativa rejeitada: `git add -A && git diff --cached --exit-code`. Funciona, mas muda o índice do
+runner e esconde a distinção entre "modificado" e "novo" que a mensagem quer nomear.
+
+### D2 — Relevância do spec-rite por caminho ou por nome, nunca por existência
+
+`evaluate()` ganha uma regra: com `offenders` não vazio e sem arquivo em `archive/`, o diff está
+registrado só se **(a)** algum caminho começa com `openspec/changes/<id>/` para `<id>` ativo, ou
+**(b)** o corpo do PR carrega uma linha `Spec-rite: <id>` com `<id>` ativo. A linha é lida com o
+mesmo cuidado da dispensa: âncora no começo da linha, casada como texto, nunca interpolada.
+
+Quando existem changes ativas mas nenhuma satisfaz (a) ou (b), o achado é novo — `S3 unrelated
+change` — e nomeia as changes ativas encontradas e as duas formas de ligar o diff a uma delas. `S1`
+continua sendo o caso "nenhuma change existe". A separação importa para o selftest: `SILENT[2]`
+("active change present") passa a ser um `DEFECT`, e os casos mudos ganham "change tocada no diff" e
+"change nomeada no corpo".
+
+Por que (a) basta: o PR que só marca caixas em `tasks.md` toca `openspec/changes/<id>/tasks.md`, e
+portanto registra-se sozinho — é exatamente o PR legítimo que o risco da issue temia reprovar.
+
+Por que (b) existe: um PR de correção pequena, aberto contra uma change já em andamento em outro
+branch, não toca o diretório dela. A linha `Spec-rite: <id>` já é a que `execute-backlog` manda
+escrever no corpo (`skills/execute-backlog/references/spec-rite.md:83`); o gate só passa a lê-la.
+
+`archived_in_diff` fica intocado: TR2 da issue exige que o PR de archive continue passando, e ele
+toca só `openspec/`, então nem chega à regra nova.
+
+KNOWN LIMIT atualizado: relevância é por caminho e por nome, não por conteúdo. Um tick qualquer em
+`tasks.md` de uma change ativa liga qualquer diff a ela; a revisão continua sendo quem julga.
+
+### D3 — `PLACEHOLDER` só no token; selftest gera as credenciais em runtime
+
+`find()` passa a testar `PLACEHOLDER` só em `m.group(0)`. A janela de 40 caracteres anteriores foi
+medida no tree atual antes de remover: zero matches dependem só dela (`tasks.md` E.2), então a
+mudança não cria falso positivo no repositório de hoje.
+
+O selftest injeta uma amostra por padrão em `PATTERNS`, mais uma precedida de `test_token = ` e uma
+entre `<` e `>`, e afirma que a classe é detectada; e injeta casos que devem ficar mudos (token com
+`xxx`, senha `<password>` numa connection string, IP privado reportado sem gatar). As amostras são
+**montadas** em runtime (`"ghp_" + fill(36)`), nunca literais: o próprio `scan-secrets.py` está no
+tree que o scan do CI lê, e um token literal no arquivo reprovaria o build por design.
+
+Padrões novos: `github_pat_[A-Za-z0-9_]{22,}` (PAT fine-grained) e `sk-[A-Za-z0-9_\-]{20,}` (chaves
+`sk-…`, `sk-proj-…`, `sk-ant-…`). Ambos probados contra o tree atual sem match (`tasks.md` E.2).
+
+### D4 — Greps de frontmatter sobre o bloco extraído com o `awk` de `generate.sh`
+
+O step extrai o bloco uma vez por arquivo, com o **mesmo** `awk` de `generate.sh:29-31` (copiado
+literalmente, para que os dois leiam a mesma coisa), e todos os greps rodam sobre esse texto via
+here-string. O check de primeira linha (`head -1 | grep '^---$'`) fica como está: é ele que garante
+que o `awk` tem por onde começar.
+
+Alternativa rejeitada: chamar `source generate.sh` para reutilizar a função. `generate.sh` tem
+`set -euo pipefail` e efeitos colaterais no topo; importar só a função exigiria refatorar um arquivo
+fora deste item.
+
+### D5 — Privilégio mínimo no job, não no workflow
+
+`permissions: contents: read` vai no job `validate`, não no nível do workflow: o job `release`
+precisa de `contents: write` (tag, commit de release) e o bloco do workflow continua servindo a ele.
+Um bloco de permissões no job substitui o do workflow por inteiro — todo escopo não listado vira
+`none` — então `Validate` fica só com leitura. Nenhum step de `Validate` escreve no repositório ou
+usa `GITHUB_TOKEN` (lidos um a um em `tasks.md` E.1). `persist-credentials: false` remove o token do
+`.git/config` depois do fetch; o fetch em si ainda usa o token, o que é tudo de que o checkout precisa.
+
+`openspec` pinado em `1.6.0` porque é a versão probada aqui (`openspec --version` -> `1.6.0`) e a que
+o cabeçalho de `validate-rite.sh` já cita. O comentário de bump repete a regra do step do
+`claude-code`: sobe deliberadamente, depois de rodar local.
+
+### D6 — Timeout nos dois jobs; `outputs` e `check_release` removidos
+
+`timeout-minutes: 15` nos dois jobs. Medido: `Validate` levou 57s (run 33463864134) e 5m38s (run
+33843366162); `Semantic Release` 29s. O teto é generoso o bastante para uma run lenta de `npx` e
+curto o bastante para não segurar a fila de `master` (serializada por `concurrency`) por horas.
+
+`outputs.new_release`/`outputs.version` e o step `check_release` são removidos, não ligados a um
+consumidor: `grep -rn "check_release\|new_release\|needs: \[release\]"` fora de `ci.yml` devolve
+vazio, o semantic-release já imprime `Published release X` no log, e o step escrevia
+`new_release=false` tanto para "nada a publicar" quanto para "não consegui publicar" — a
+ambiguidade que a change `fix-release-race` (E.4) já tinha notado. O step `Get previous tag`
+(`prev_tag`), cujo único leitor era `check_release`, **não** está na lista de steps deste item e fica
+como está; registrado como follow-up.
+
+### D7 — O escape dos 120 caracteres é declarado e coberto, não fechado
+
+Fechar o escape exigiria decidir o que é "nomear um gap" por regex, o que é o mesmo problema que o
+KNOWN LIMIT 1 já rejeitou: CI só prova forma. A decisão é declarar o escape como KNOWN LIMIT 7 e
+adicionar ao selftest uma lista `ESCAPES` com um caso explícito — E.3 com 130 caracteres de
+enchimento sem gap nomeado — cujo resultado esperado é **silêncio**. O selftest passa a imprimir
+`n/n known escapes stayed silent`, o mesmo formato que `S.2` já pede.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Um check declara dentro de si o que não cobre | `skills-catalog` (spec do repositório) + `verify-before-claiming` | already canonical — os quatro scripts só estendem o próprio KNOWN LIMIT |
+| Um gate carrega selftest com um defeito injetado por regra | `skills-authoring` (*Authoring rules are machine-enforced*) | already canonical — `scan-secrets.py` passa a cumprir a regra; nenhum texto é copiado |
+| A linha `Spec-rite: <id>` no corpo do PR | `execute-backlog` (`references/spec-rite.md`) | already canonical — o gate passa a ler a linha que a skill já manda escrever; a skill não muda |
+| Prova observada, não esperada, antes de declarar entrega | `verify-before-claiming` | already canonical — citado no grupo de simulação de `tasks.md` |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — ids de step, nomes de função e labels de selftest em inglês |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **`contents: read` pode quebrar um step de `Validate` que escreva.** → Nenhum escreve hoje (E.1
+  lista os treze); confirmado na run do PR, registrada em `tasks.md` S.1 quando existir.
+- **A relevância do spec-rite pode reprovar um PR legítimo.** → Os dois PRs legítimos previsíveis
+  passam por desenho: "só tick de tasks" toca a change (D2-a); "correção pequena contra change em
+  andamento" nomeia a change (D2-b). O PR de archive nem chega à regra.
+- **`git status --porcelain` no CI pode ver lixo que não é de `generate.sh`.** → O step é o primeiro
+  depois do checkout, e `.gitignore` já cobre `__pycache__`/`*.py[cod]`. Se um step futuro deixar
+  arquivo antes dele, a mensagem nomeia o arquivo, o que é o comportamento desejado.
+- **`PLACEHOLDER` só no token pode criar falso positivo em docs que escrevem `example` antes de um
+  token real-shaped.** → Medido zero no tree atual; e um token real-shaped em docs é exatamente o que
+  o cenário *An example credential is written so it cannot be mistaken for one* proíbe.
+- **`sk-` é prefixo curto.** → Exige 20+ caracteres de classe estreita depois do hífen e `\b` antes;
+  probado sem match no tree atual.
+- **`timeout-minutes: 15` pode matar uma run legítima muito lenta.** → 15 min é 2,7x a pior run
+  medida; uma run acima disso é sinal de `npx` travado, que hoje segura a fila até o default de 360 min.
+
+## Open Questions
+
+Nenhuma. Os pontos que poderiam virar achismo — o valor de `persist-credentials` no log, a versão
+publicada do `openspec`, a existência de consumidor dos `outputs`, o efeito da janela de 40
+caracteres no tree atual — foram medidos e estão em `tasks.md` com comando e saída.

--- a/openspec/changes/close-ci-gate-holes/proposal.md
+++ b/openspec/changes/close-ci-gate-holes/proposal.md
@@ -1,0 +1,77 @@
+# Change: Fechar os buracos medidos nos gates do CI
+
+## Why
+
+A auditoria de 2026-09-04 (issue #117) reproduziu, em cópia do repositório, sete formas de um pull
+request passar verde no `.github/workflows/ci.yml` sem ter feito o que o gate diz medir:
+
+1. **Wrappers in sync** usa `git diff --exit-code`, que ignora arquivo não rastreado. Um
+   `references/*.md` novo commitado gera um arquivo `??` em `plugins/` e o step passa.
+2. **Spec-rite** (`scripts/validate-spec-rite.py:176`) aprova qualquer diff desde que **alguma**
+   change ativa exista, mesmo sem relação; o selftest fixa isso como caso mudo (`:210`).
+3. **scan-secrets** não tem `--selftest`; o filtro `PLACEHOLDER` é aplicado aos 40 caracteres
+   anteriores ao token (`:59-60`), então `test_token = ghp_…` e `<ghp_…>` ficam mudos; não cobre
+   `github_pat_` nem `sk-`.
+4. **Frontmatter greps** varrem o arquivo inteiro: `name:` dentro de um bloco ```yaml satisfaz o check.
+5. **Permissões e pins**: o job `Validate` herda `contents: write` do workflow e o checkout persiste o
+   token (`persist-credentials: true` no log da run 33463864134); `openspec` roda `@latest`
+   (`scripts/validate-rite.sh:81`) enquanto o `claude-code` é pinado.
+6. **Higiene**: nenhum `timeout-minutes` (Validate variou de 57s a 5m38s entre as runs 33463864134 e
+   33843366162); `outputs`/step `check_release` não têm consumidor.
+7. **validate-rite-evidence.py** (`:159`, `:198`): E.3/E.4/S.3 aceitam qualquer texto acima de 120
+   caracteres, e o limite não está declarado no KNOWN LIMIT.
+
+Cada uma está fora das declarações de "o que não cobre" que este repositório exige de cada check
+(`openspec/specs/skills-catalog/spec.md`, cenário *The uncovered part is declared, not implied*).
+
+## What Changes
+
+- O step de wrappers falha também quando `git status --porcelain` não está vazio depois de
+  `generate.sh`, nomeando os arquivos não rastreados.
+- `validate-spec-rite.py` exige **relevância**: o diff toca `openspec/changes/<id>/` de uma change
+  ativa, ou o corpo do PR nomeia `Spec-rite: <id>` de uma change ativa, ou o diff arquiva uma change,
+  ou carrega a dispensa escrita. O selftest ganha "change ativa não relacionada" como achado.
+- `scan-secrets.py` ganha `--selftest` (uma credencial injetada por padrão, inclusive uma precedida de
+  `test` e uma de `<`), aplica `PLACEHOLDER` só ao token casado, cobre `github_pat_` e `sk-`, e o
+  selftest entra no CI logo depois do scan.
+- Os greps de frontmatter passam a olhar só o bloco entre os dois `---`, extraído com o mesmo `awk`
+  de `generate.sh:29-31`.
+- O job `Validate` roda com `permissions: contents: read`, checkout com `persist-credentials: false`;
+  `@fission-ai/openspec@1.6.0` pinado em `validate-rite.sh` com comentário de bump.
+- `timeout-minutes` nos dois jobs; `outputs` e `check_release` do job de release removidos por não
+  terem consumidor.
+- `validate-rite-evidence.py` declara o escape dos 120 caracteres no KNOWN LIMIT e o cobre com caso
+  de selftest explícito (esperado mudo).
+
+Nenhuma dessas mudanças é **BREAKING** para consumidores do catálogo: nenhum skill entra, sai ou
+muda de nome. É mais restritiva para quem abre PR neste repositório: um diff fora de `openspec/` com
+uma change ativa alheia e sem linha `Spec-rite:` passa a reprovar.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Nenhum skill novo entra no catálogo.
+
+### Modified Capabilities
+
+- `skills-catalog`: *The repository itself is gated, not only its skills* ganha três classes que
+  escapavam — arquivo gerado não rastreado, change ativa sem relação com o diff, campo de frontmatter
+  fora do bloco de frontmatter — e passa a exigir privilégio mínimo, versões pinadas e timeout no job
+  que gata. *The rite gates evidence before it gates quality* passa a exigir que o escape de
+  comprimento das caixas de gap seja declarado no próprio script e coberto por caso de selftest.
+- `skills-authoring`: *The catalog carries no credentials* ganha o selftest do scanner, o escopo do
+  filtro de placeholder (só o token casado) e as duas classes novas de token.
+
+## Impact
+
+- `.github/workflows/ci.yml` — bloco de permissões do job `Validate`, checkout, steps *Wrappers in
+  sync* e *Skill frontmatter checks*, um step novo de selftest do scanner, `timeout-minutes` nos dois
+  jobs, `outputs` e step `check_release` removidos.
+- `scripts/validate-rite.sh` — pin do `openspec`.
+- `scripts/validate-spec-rite.py`, `scripts/scan-secrets.py`, `scripts/validate-rite-evidence.py`.
+- Nenhum `SKILL.md` é tocado; a composição do catálogo (35 skills, descoberta via `npx`) fica
+  idêntica. Espelhos gerados por `./generate.sh` não mudam.
+- Quem abre PR neste repositório: uma change ativa alheia deixa de servir de registro. O PR que só
+  marca caixas em `tasks.md` toca o diretório da change e continua passando; o PR que só arquiva
+  continua passando via `archived_in_diff`.

--- a/openspec/changes/close-ci-gate-holes/specs/skills-authoring/spec.md
+++ b/openspec/changes/close-ci-gate-holes/specs/skills-authoring/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: The catalog carries no credentials
+
+The repository SHALL be scanned for credentials by a script wired into CI. The gate SHALL run against
+the **working tree**, which can be kept clean; a separate on-demand mode SHALL report findings in the
+full git history without gating, because a secret already published cannot be removed by a later
+commit and a gate that can never pass is one contributors learn to ignore.
+
+Findings that are operational detail rather than credentials — private (RFC1918) addresses, internal
+hostnames — SHALL be reported distinctly and SHALL NOT fail the build.
+
+The scanner SHALL carry a self-test, wired into CI beside the scan, that injects one credential per
+pattern it claims to detect and asserts each class is reported, including a credential preceded by a
+word the placeholder filter recognises and one wrapped in angle brackets, because the filter that
+silences documentation placeholders SHALL apply to the matched token only and never to the text
+around it. The self-test SHALL build its samples at run time rather than carry them as literals, so
+the scanner's own source does not fail the scan. The pattern set SHALL cover fine-grained GitHub
+tokens (`github_pat_`) and `sk-`-prefixed API keys in addition to the classic classes.
+
+#### Scenario: A credential added to the tree fails the build
+
+- **WHEN** a change introduces an API key, token, private key, JWT or a connection string carrying a
+  password into any tracked text file
+- **THEN** the CI secret scan fails and names the file and the matched class
+
+#### Scenario: An example credential is written so it cannot be mistaken for one
+
+- **WHEN** documentation needs to show a connection string or a secret-shaped value
+- **THEN** it uses an unmistakable placeholder, so the scanner does not have to guess and a reader
+  cannot copy something that looks real
+
+#### Scenario: History is reported, not gated
+
+- **WHEN** the history contains a finding that a later commit already removed from the tree
+- **THEN** the audit mode reports it with its class, and the build is not failed by it
+
+#### Scenario: A credential after a placeholder word is still a credential
+
+- **WHEN** a real-shaped token is written after the word `test` (`test_token = ghp_…`) or between
+  angle brackets (`<ghp_…>`)
+- **THEN** the scanner reports it, because the placeholder filter is applied to the token and not to
+  the forty characters before it
+
+#### Scenario: A scanner pattern that cannot fire is caught
+
+- **WHEN** a change to the scanner silently stops one of its patterns from matching its sample
+- **THEN** `--selftest` fails naming the pattern, because a clean tree and a pattern that cannot fire
+  are otherwise indistinguishable

--- a/openspec/changes/close-ci-gate-holes/specs/skills-catalog/spec.md
+++ b/openspec/changes/close-ci-gate-holes/specs/skills-catalog/spec.md
@@ -1,0 +1,225 @@
+## MODIFIED Requirements
+
+### Requirement: The repository itself is gated, not only its skills
+
+The catalog SHALL carry a gate whose subject is the whole repository rather than a subtree, wired
+into CI, covering at minimum two classes that have escaped every other gate: a compiled artifact
+that is tracked, and a published count of the catalog's contents that disagrees with the contents.
+Tracked-file discovery SHALL read the index rather than the filesystem, so that an ignored artifact
+present in a working directory is not a finding and one forced into the index is.
+
+The gate SHALL carry a self-test that injects one known defect per check and asserts detection, and
+each check SHALL state inside itself what it does not cover.
+
+The repository's other whole-repository checks SHALL measure what they claim to measure, and three
+classes that were measured escaping them SHALL be covered:
+
+- The check that keeps the generated wrapper trees in sync with `skills/` SHALL fail on a generated
+  file that is **untracked** after regeneration, naming the file, and not only on a tracked file
+  whose content changed — a diff against the index never sees an untracked file.
+- The check that a pull request registers its change SHALL require **relevance**, not existence: the
+  diff touches the directory of an active change, or the pull request body names an active change
+  on a `Spec-rite: <id>` line, or the diff archives a change, or the body carries the written
+  waiver. The mere presence of an unrelated active change SHALL NOT register a diff. The line
+  naming a change SHALL be matched as text, anchored to the start of a line, and never executed.
+- The frontmatter checks on `skills/*/SKILL.md` SHALL read only the frontmatter block — the text
+  between the two `---` delimiters, extracted the same way the wrapper generator extracts it — so a
+  field that appears only inside a code block in the body does not satisfy a check on the
+  frontmatter.
+
+The job that runs these gates SHALL hold the least privilege the gates need: read-only repository
+contents, no credential persisted past the checkout, a declared timeout, and every third-party tool
+it runs pinned to a version that was probed, with the bump rule stated beside the pin. A job output
+that no consumer reads SHALL be removed or wired to one.
+
+#### Scenario: A compiled artifact forced into the index fails the build
+
+- **WHEN** a file matching the repository's bytecode ignore rules is nonetheless tracked
+- **THEN** the hygiene gate fails and names the file and the command that untracks it
+
+#### Scenario: An ignored artifact in the working directory is not a finding
+
+- **WHEN** a developer runs a Python file and leaves a `__pycache__` beside it
+- **THEN** the gate is silent, because the artifact is not in the index
+
+#### Scenario: A published count that disagrees with the tree fails the build
+
+- **WHEN** a document publishes a count of the catalog's skills that differs from the number of skill
+  directories
+- **THEN** the gate fails and names the file, the line, the claimed number and the real one
+
+#### Scenario: A check that cannot fire is caught
+
+- **WHEN** a change to the gate silently stops one of its checks from detecting its defect class
+- **THEN** the self-test fails, because a clean repository and a check that cannot fire are otherwise
+  indistinguishable
+
+#### Scenario: The uncovered part is declared, not implied
+
+- **WHEN** a check enforces its rule only over a named pattern or a named file list
+- **THEN** the pattern, the file list and what escapes them are stated in the check itself, so a
+  passing run is not read as full coverage
+
+#### Scenario: An untracked generated file fails the wrapper-sync check
+
+- **WHEN** a commit adds a file under `skills/<name>/` whose regenerated mirror under `plugins/` is
+  not tracked
+- **THEN** the wrapper-sync step fails and names the untracked file, instead of passing because the
+  diff against the index is empty
+
+#### Scenario: An unrelated active change does not register a diff
+
+- **WHEN** a pull request's diff touches a path outside the workflow's own directory, an active
+  change exists whose directory the diff does not touch, and the body names no active change and
+  carries no waiver
+- **THEN** the spec-rite gate fails, naming the active changes it found and the two ways of linking
+  the diff to one of them
+
+#### Scenario: A pull request that touches or names its change passes
+
+- **WHEN** the diff touches `openspec/changes/<id>/` of an active change, or the body carries
+  `Spec-rite: <id>` naming an active change
+- **THEN** the spec-rite gate passes, so a pull request that only ticks a task list, or a small fix
+  opened against a change in progress elsewhere, is not rejected
+
+#### Scenario: An archive-only pull request still passes
+
+- **WHEN** a pull request only moves a change into `openspec/changes/archive/` and syncs the specs
+- **THEN** the spec-rite gate passes, whether or not another change is active
+
+#### Scenario: A frontmatter field inside a code block does not count
+
+- **WHEN** a `SKILL.md` carries no `name:` in its frontmatter but a fenced `yaml` block in its body
+  contains `name: <dir>`
+- **THEN** the frontmatter check fails with `Missing name`, because only the block between the two
+  `---` delimiters is read
+
+#### Scenario: The validate job holds no writable token
+
+- **WHEN** the validate job runs on a pull request
+- **THEN** its permissions grant read-only repository contents, the checkout does not persist the
+  token, the job carries a timeout, and the spec-driven CLI it runs is pinned to a probed version
+
+### Requirement: The rite gates evidence before it gates quality
+
+The repository's spec-driven rite SHALL require every active change to open its task list with a
+group recording what was probed: local paths opened rather than recalled, external tools, flags,
+config keys, API names and versions checked against the installed version, and anything that could
+not be probed written down as an open question rather than stated as fact. The group SHALL be the
+first task group, and its presence and position SHALL be enforced by the same script that enforces
+the other mandatory groups, because the OpenSpec CLI validates delta-spec format only.
+
+Recorded evidence SHALL be a command together with a fragment of its raw output, never a conclusion,
+so that a reviewer can re-run it. That rule SHALL be enforced in **shape**: a ticked box in the
+evidence group SHALL be checked against the form its kind owes — a path opened together with the
+commit or date it was read at; a probe together with a fragment of its output; a gap named or
+explicitly declared absent — with a file-specific error naming the box and what is missing. The
+rules SHALL be per box kind rather than uniform, because the kinds do not share a shape and a
+uniform rule rejects boxes that are correct as written.
+
+The gate SHALL cover the **absence** of a change and not only the shape of one that is present. A
+gate whose checks are written as a loop over active changes passes vacuously when there are none,
+which reads as approval of a pull request that recorded nothing. Therefore a pull request whose diff
+touches paths outside the workflow's own directory SHALL be required to carry one of: an active
+change, a change archived within the same diff, or a waiver line in the pull request body naming a
+reason. Paths written by the release automation alone SHALL be exempt, and the check SHALL run only
+where a base revision to compare against exists. Where it runs in continuous integration and no base
+revision can be resolved, it SHALL fail rather than skip, because a gate that cannot measure must not
+approve — an unresolvable base there is a misconfigured checkout, not an exemption.
+
+The waiver SHALL be treated as untrusted input: it is authored by whoever opened the pull request,
+including from a fork, and SHALL be matched as text and never executed or interpolated into a
+command.
+
+The same care SHALL apply to what the gate makes appear. A gate SHALL NOT publish the content it
+reads into a channel whose audience differs from that content's own: it reads the pull request body
+from the payload the runner already writes, rather than having it handed over through a mechanism the
+continuous-integration system echoes into the build log. Where the gate is nonetheless given the
+content explicitly — for local runs, or as a fallback — that path SHALL be the deliberate override
+and not the default. Failure to read the payload SHALL degrade to an empty body rather than an
+error, so that the decision stays with the rules that already exist instead of the build failing for
+a reason unrelated to the rite.
+
+Every enforcing script SHALL state that it verifies presence, position and shape, and **not the
+truth of the contents**: a box padded to satisfy the shape passes, and no script can tell an
+invented output from a real one. A script that also verifies that a change exists SHALL state that
+existence is not honesty — a change scaffolded to satisfy the gate passes it.
+
+Where a shape rule accepts a box on a proxy — a length threshold standing in for "names something"
+— the proxy and what it lets through SHALL be declared in the script's own known limits, and the
+self-test SHALL carry an explicit case for it whose expected result is silence, so that the escape
+is measured on every run rather than remembered.
+
+The mandatory groups that are **not** gated on shape SHALL have their evidence density reported
+without affecting the exit code, so that a group whose boxes carry no probe is visible to a reviewer
+without reading the diff.
+
+#### Scenario: A change without recorded evidence fails the build
+
+- **WHEN** an active change's task list lacks the evidence group, or carries it somewhere other than
+  the first task group
+- **THEN** the rite gate script fails with a file-specific error naming the missing or misplaced
+  group, and the build does not pass
+
+#### Scenario: A pull request that records nothing fails the build
+
+- **WHEN** a pull request's diff touches a path outside the workflow's own directory and carries
+  neither an active change, nor a change archived in the same diff, nor a waiver line
+- **THEN** the rite gate fails, naming the offending path, rather than passing because the loop over
+  active changes found nothing to check
+
+#### Scenario: A gate that cannot measure does not approve
+
+- **WHEN** the check runs in continuous integration and no base revision can be resolved
+- **THEN** it fails naming the missing fetch depth, rather than passing because it had nothing to
+  compare against
+
+#### Scenario: The waiver is a written line, not a judgment
+
+- **WHEN** the same diff is accompanied by a waiver line in the pull request body naming a reason
+- **THEN** the gate passes and the reason is visible to the reviewer in the pull request itself
+- **AND** the line is matched as text, never executed, because its author is whoever opened the pull
+  request
+
+#### Scenario: The gate does not publish what it reads
+
+- **WHEN** the gate needs the pull request body to look for a waiver
+- **THEN** it reads it from the event payload the runner already wrote, so no step hands the body
+  over through a mechanism that prints it into the build log
+- **AND** an explicit hand-over remains available as an override for running the gate outside
+  continuous integration, taking precedence when it is set
+- **AND** a payload that is missing, unreadable or without the key yields an empty body, leaving the
+  existing rules to decide, rather than failing the build
+
+#### Scenario: A ticked box that states a conclusion fails the build
+
+- **WHEN** a ticked box in the evidence group records a conclusion instead of the form its kind owes
+- **THEN** the gate fails, naming the box and the missing element
+- **AND** the same box rewritten with a command and a fragment of its output passes
+
+#### Scenario: The gate declares what it cannot check
+
+- **WHEN** the gate passes
+- **THEN** the enforcing scripts state that shape is not truth — a box padded to satisfy the rule is
+  indistinguishable from an earned one — so that a green run is not read as verified evidence
+- **AND** they state that the existence of a change is not the honesty of one
+
+#### Scenario: A declared escape is measured, not remembered
+
+- **WHEN** a gap box (E.3, E.4 or S.3) is ticked with more than the length threshold of text that
+  names no gap and declares none absent
+- **THEN** the gate stays silent, the script's known limits name that threshold as the reason, and
+  the self-test reports the case under its known escapes with the observed silence
+
+#### Scenario: A group that is reported rather than gated is not implied to be gated
+
+- **WHEN** a mandatory group carries items that are judgments rather than executions
+- **THEN** its evidence density is printed as a labelled report that never changes the exit code,
+  and the check states that the group is reported and not gated, rather than demanding a command
+  where none belongs
+
+#### Scenario: A gate introduced mid-flight does not exempt existing work
+
+- **WHEN** a new mandatory group is added while a change is already open
+- **THEN** the open change is backfilled with the group in the same change that introduces the gate,
+  rather than being added to an exemption list

--- a/openspec/changes/close-ci-gate-holes/tasks.md
+++ b/openspec/changes/close-ci-gate-holes/tasks.md
@@ -148,74 +148,385 @@
 
 ## 2. Wrappers in sync vê arquivo não rastreado (D1)
 
-- [ ] 2.1 O step falha quando `git status --porcelain` devolve qualquer linha depois de
+- [x] 2.1 O step falha quando `git status --porcelain` devolve qualquer linha depois de
       `bash generate.sh`, com `::error::` nomeando os arquivos `??` separadamente dos modificados
-- [ ] 2.2 O caso antigo (arquivo rastreado modificado) continua falhando com a mensagem antiga
+
+      Medido em cópia independente do worktree (`42591ee`, 2026-09-04): shell do step extraído
+      literalmente de `ci.yml` (`yaml.safe_load` -> `jobs.validate.steps[1].run`) e rodado com
+      `bash -e`, como o runner faz. Detalhe em S.1.
+
+      ```
+      bash -e step-new-wrappers-in-sync-with-skills.sh   # após commitar skills/backlog/references/zz.md
+      -> ::error::generate.sh produced files that are not tracked. Add them and commit:
+      -> ?? plugins/workflow/skills/backlog/references/zz.md
+      -> exit=1
+      ```
+
+- [x] 2.2 O caso antigo (arquivo rastreado modificado) continua falhando com a mensagem antiga
+
+      ```
+      echo "stale line" >> plugins/workflow/skills/backlog/SKILL.md && git commit -qam "probe: stale wrapper"
+      bash -e step-new-wrappers-in-sync-with-skills.sh
+      -> ::error::Generated wrappers are out of sync. Run ./generate.sh and commit the result.
+      ->  plugins/workflow/skills/backlog/SKILL.md | 1 -
+      -> exit=1
+      ```
 
 ## 3. Spec-rite exige relevância (D2)
 
-- [ ] 3.1 `NAMED_CHANGE` lê `Spec-rite: <id>` ancorado no começo da linha, sem casar `none`
-- [ ] 3.2 `evaluate()` registra o diff só por caminho tocado, nome no corpo, archive no diff ou
+- [x] 3.1 `NAMED_CHANGE` lê `Spec-rite: <id>` ancorado no começo da linha, sem casar `none`
+
+      ```
+      python3 -c "...; print(m.named_changes('Spec-rite: none — reason'))"          -> []
+      python3 -c "...; print(m.named_changes('see Spec-rite: close-ci-gate-holes mid-line'))"  -> []
+      python3 -c "...; print(m.named_changes('- Spec-rite: close-ci-gate-holes'))"   -> ['close-ci-gate-holes']
+      ```
+
+- [x] 3.2 `evaluate()` registra o diff só por caminho tocado, nome no corpo, archive no diff ou
       dispensa; caso contrário emite `S3 unrelated change` nomeando as changes ativas
-- [ ] 3.3 Selftest: "active change present" sai de `SILENT` e entra em `DEFECTS`; `SILENT` ganha
+
+      `evaluate()` importado de `scripts/validate-spec-rite.py` em `42591ee` e chamado com entradas
+      sintéticas (`annotate = False`); o mesmo primeiro caso contra a versão de `d2918ed`:
+
+      ```
+      evaluate(['skills/backlog/SKILL.md'], ['close-ci-gate-holes'], '')
+      -> findings=['S3 unrelated change: this diff touches 1 path(s) outside openspec/ — skills/backlog/SKILL.md — and 1 active change(s) exist (close-ci-gate-holes), but the diff touches none of their directories and the pull request body names none of them. [...]']
+      evaluate(mesmo diff, mesma change, 'Closes #117\n\nSpec-rite: close-ci-gate-holes\n')
+      -> findings=[]
+      evaluate(['openspec/changes/archive/2026-09-04-x/tasks.md', 'README.md'], ['close-ci-gate-holes'], '')
+      -> findings=[]
+      evaluate(['scripts/x.py', 'openspec/changes/close-ci-gate-holes/tasks.md'], ['close-ci-gate-holes'], '')
+      -> findings=[]
+      evaluate(['skills/backlog/SKILL.md'], ['close-ci-gate-holes'], 'Spec-rite: fix-release-race')
+      -> findings=['S3 unrelated change: [...]; the body names fix-release-race, which is not an active change. [...]']
+      master (d2918ed) evaluate(['skills/backlog/SKILL.md'], ['close-ci-gate-holes'], '')
+      -> []                                              (o buraco 2, reproduzido na versão antiga)
+      ```
+
+- [x] 3.3 Selftest: "active change present" sai de `SILENT` e entra em `DEFECTS`; `SILENT` ganha
       "active change touched in the diff", "active change named in the body" e "archive with an
       unrelated active change"; um id nomeado que não está ativo é achado
-- [ ] 3.4 Docstring: regra `S3` listada ao lado de `S1`/`S2`; KNOWN LIMIT diz que relevância é por
+
+      ```
+      python3 scripts/validate-spec-rite.py --selftest
+      -> CAUGHT  S3 unrelated change: ''
+      -> CAUGHT  S3 unrelated change: 'Spec-rite: some-archived-change'
+      -> CAUGHT  S3 unrelated change: 'see the Spec-rite: add-spec-rite-gate line elsewhere'
+      -> SILENT  active change touched in the diff
+      -> SILENT  active change named in the body
+      -> SILENT  archived with an unrelated active change
+      -> 6/6 defect classes detected, 10/10 false-positive cases stayed silent, 6/6 reader cases correct
+      -> exit=0
+      ```
+
+- [x] 3.4 Docstring: regra `S3` listada ao lado de `S1`/`S2`; KNOWN LIMIT diz que relevância é por
       caminho e por nome, não por conteúdo
+
+      ```
+      grep -n "S3 \|KNOWN LIMIT" scripts/validate-spec-rite.py
+      -> 18:  S3 the change it carries is ITS change: the diff touches openspec/changes/<id>/ of an active
+      -> 23:KNOWN LIMIT: this proves that a change EXISTS and is LINKED to the diff — by path or by name, never
+      ```
 
 ## 4. Secret scan ganha selftest e fecha o filtro (D3)
 
-- [ ] 4.1 `PLACEHOLDER` aplicado só a `m.group(0)`; a janela de 40 caracteres anteriores sai
-- [ ] 4.2 Padrões `github_pat_` e `sk-` em `PATTERNS`
-- [ ] 4.3 `--selftest`: uma amostra montada em runtime por padrão, mais `test_token = <token>` e
+- [x] 4.1 `PLACEHOLDER` aplicado só a `m.group(0)`; a janela de 40 caracteres anteriores sai
+
+      `find()` de `d2918ed` e de `42591ee` chamados sobre o mesmo corpo (tokens montados em runtime):
+
+      ```
+      test_token = <ghp_…36>      master=[]  new=['GitHub token']
+      <ghp_…36> entre < >         master=[]  new=['GitHub token']
+      ghp_ + 'x'*36               master=[]  new=[]          (placeholder no próprio token: mudo)
+      postgres://app:<password>@  master=[]  new=[]
+      ```
+
+- [x] 4.2 Padrões `github_pat_` e `sk-` em `PATTERNS`
+
+      ```
+      github_pat_ + 30 chars      master=[]  new=['GitHub fine-grained token']
+      sk- + 24 chars              master=[]  new=['sk- API key']
+      PATTERNS master: 10 new: 12 added: ['GitHub fine-grained token', 'sk- API key']
+      ```
+
+- [x] 4.3 `--selftest`: uma amostra montada em runtime por padrão, mais `test_token = <token>` e
       `<token>`; casos mudos (`xxx`, `<password>`, IP privado sem gatar); saída `n/n`
-- [ ] 4.4 Docstring declara o modo e o que o selftest não prova (não lê o tree, não julga
+
+      ```
+      python3 scripts/scan-secrets.py --selftest
+      -> CAUGHT  token after the word test
+      -> CAUGHT  token between angle brackets
+      -> SILENT  token that is itself a placeholder
+      -> SILENT  connection string with a <password> placeholder
+      -> REPORTED  private IPv4 is reported, never a credential
+      -> 12/12 patterns fire on their sample, 3/3 context cases caught, 3/3 placeholder cases stayed silent
+      -> exit=0
+      ```
+
+- [x] 4.4 Docstring declara o modo e o que o selftest não prova (não lê o tree, não julga
       placeholders que a documentação inventar)
-- [ ] 4.5 `ci.yml`: step *Secret scan self-test (the gate is itself gated)* logo depois de *Secret
+
+      ```
+      grep -n "selftest\|MATCHED TOKEN ONLY\|KNOWN LIMIT" scripts/scan-secrets.py | head -3
+      -> 13:  --selftest    inject one credential per pattern and assert each class is reported. Gates
+      -> 22:The placeholder filter applies to the MATCHED TOKEN ONLY. It used to also read the forty
+      -> 26:KNOWN LIMIT: the selftest proves each pattern fires on its own sample and stays silent on the
+      ```
+
+- [x] 4.5 `ci.yml`: step *Secret scan self-test (the gate is itself gated)* logo depois de *Secret
       scan (working tree)*
+
+      ```
+      python3 -c "import yaml; print([s['name'] for s in yaml.safe_load(open('.github/workflows/ci.yml'))['jobs']['validate']['steps']])"
+      -> [..., 'Secret scan (working tree)', 'Secret scan self-test (the gate is itself gated)', 'Repo hygiene (compiled artifacts, published counts)', ...]
+      bash -e step-new-secret-scan-self-test.sh   (run: do step, literal)
+      -> 12/12 patterns fire on their sample, 3/3 context cases caught, 3/3 placeholder cases stayed silent   exit=0
+      ```
 
 ## 5. Frontmatter greps escopados ao bloco (D4)
 
-- [ ] 5.1 O step extrai o bloco com o `awk` literal de `generate.sh:29-31` uma vez por arquivo e todos
+- [x] 5.1 O step extrai o bloco com o `awk` literal de `generate.sh:29-31` uma vez por arquivo e todos
       os greps rodam sobre ele; o check de primeira linha fica
+
+      Fixture `skills/fm-probe/SKILL.md` na cópia: frontmatter completo **sem** `name:`, corpo com um
+      bloco ```yaml contendo `name: fm-probe`. Shell dos dois steps extraído literalmente:
+
+      ```
+      bash -e step-master-skill-frontmatter-checks.sh   (d2918ed)
+      -> exit=0, 0 linhas ::error, nenhuma linha nomeia fm-probe        (buraco 4 reproduzido)
+      bash -e step-new-skill-frontmatter-checks.sh      (42591ee)
+      -> ::error file=skills/fm-probe/SKILL.md::Missing name
+      -> ::error file=skills/fm-probe/SKILL.md::name '' != directory 'fm-probe'
+      -> exit=1
+      bash -e step-new-skill-frontmatter-checks.sh      (worktree, 35 skills reais)
+      -> exit=0
+      ```
 
 ## 6. Privilégio mínimo e pins (D5)
 
-- [ ] 6.1 `permissions: contents: read` no job `validate`; bloco do workflow intocado (serve o release)
-- [ ] 6.2 `persist-credentials: false` no checkout do `validate`, com o motivo no comentário
-- [ ] 6.3 `scripts/validate-rite.sh`: `npx -y @fission-ai/openspec@1.6.0` com comentário de bump
+- [x] 6.1 `permissions: contents: read` no job `validate`; bloco do workflow intocado (serve o release)
+
+      ```
+      python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); print(d['permissions'], d['jobs']['validate']['permissions'])"
+      -> {'contents': 'write', 'issues': 'write', 'pull-requests': 'write'} {'contents': 'read'}
+      ```
+
+      O efeito na run real (nenhum step de `Validate` precisando de escrita) só se mede na run do PR;
+      ver E.3 e S.3.
+
+- [x] 6.2 `persist-credentials: false` no checkout do `validate`, com o motivo no comentário
+
+      ```
+      python3 -c "...; print(d['jobs']['validate']['steps'][0]['with'])"
+      -> {'fetch-depth': 0, 'persist-credentials': False}
+      grep -n "persist-credentials" .github/workflows/ci.yml
+      -> 41:        # persist-credentials: false — the token is needed for the fetch and for nothing after it.
+      -> 47:          persist-credentials: false
+      ```
+
+- [x] 6.3 `scripts/validate-rite.sh`: `npx -y @fission-ai/openspec@1.6.0` com comentário de bump
+
+      ```
+      grep -n "openspec@" scripts/validate-rite.sh
+      -> 81:# `npx -y @fission-ai/openspec@<new> validate --all --strict` locally, then change the version here
+      -> 87:  npx -y @fission-ai/openspec@1.6.0 validate --all --strict || fail=1
+      npx -y @fission-ai/openspec@1.6.0 --version   -> 1.6.0   exit=0
+      ```
 
 ## 7. Higiene do workflow (D6)
 
-- [ ] 7.1 `timeout-minutes: 15` nos dois jobs, com as medições no comentário
-- [ ] 7.2 `outputs` do job `release` e step `check_release` removidos, com o motivo no commit
+- [x] 7.1 `timeout-minutes: 15` nos dois jobs, com as medições no comentário
+
+      ```
+      python3 -c "...; print(d['jobs']['validate']['timeout-minutes'], d['jobs']['release']['timeout-minutes'])"
+      -> 15 15
+      grep -n "timeout-minutes\|Measured" .github/workflows/ci.yml
+      -> 34:    # Measured 57s (run 33463864134) to 5m38s (run 33843366162). Without a ceiling a hung `npx`
+      -> 36:    timeout-minutes: 15
+      -> 171:    # Measured 29s (run 33843366162); the ceiling exists for a hung npm install, not for the work.
+      -> 172:    timeout-minutes: 15
+      ```
+
+- [x] 7.2 `outputs` do job `release` e step `check_release` removidos, com o motivo no commit
+
+      ```
+      python3 -c "...; print(d['jobs']['release'].get('outputs'), [s.get('id') for s in d['jobs']['release']['steps']])"
+      -> None [None, 'prev_tag', None, None, None, None, None]        (em d2918ed: outputs com 2 chaves e id 'check_release' no fim)
+      grep -c "check_release\|new_release\|outputs:" .github/workflows/ci.yml   -> 0
+      git log -1 --format=%b 42591ee | grep -c "check_release"                -> 1
+      ```
 
 ## 8. Escape dos 120 caracteres declarado e coberto (D7)
 
-- [ ] 8.1 KNOWN LIMIT 7 em `validate-rite-evidence.py` nomeia o limite e o que ele deixa passar
-- [ ] 8.2 `ESCAPES` no selftest com o caso E.3 de 130 caracteres sem gap; resultado esperado mudo;
+- [x] 8.1 KNOWN LIMIT 7 em `validate-rite-evidence.py` nomeia o limite e o que ele deixa passar
+
+      ```
+      sed -n 52,56p scripts/validate-rite-evidence.py
+      ->   7. E.3, E.4 and S.3 accept any body longer than 120 characters as "names a gap / a follow-up /
+      ->      an escape", with no negative word required. [...] What it lets through: 121 characters of padding that name nothing.
+      ```
+
+- [x] 8.2 `ESCAPES` no selftest com o caso E.3 de 130 caracteres sem gap; resultado esperado mudo;
       saída `n/n known escapes stayed silent`
+
+      ```
+      python3 scripts/validate-rite-evidence.py --selftest
+      -> ESCAPED R1 evidence shape: E.3 padded past 120 characters names no gap   (silent, as KNOWN LIMIT 7 declares)
+      -> 7/7 defect classes detected, 1/1 known escapes stayed silent
+      -> exit=0
+      ```
 
 ## 9. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 Cada gate exercitado pelo caminho real (o step do CI ou o script como o CI o invoca), com
+- [x] S.1 Cada gate exercitado pelo caminho real (o step do CI ou o script como o CI o invoca), com
       a saída observada registrada
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+      Tudo em `42591ee` (2026-09-04). Os steps de `ci.yml` foram extraídos com `yaml.safe_load`
+      (`jobs.validate.steps[*].run`, das duas versões: `d2918ed` e `42591ee`) para arquivos
+      `step-<versão>-<nome>.sh` e rodados com `bash -e`, o shell padrão de um `run:` no runner.
+      As reproduções que sujam a árvore rodaram numa **cópia** independente do worktree (`cp -r`
+      seguido de troca do ponteiro `.git` por um clone do mesmo HEAD, porque o `.git` de um worktree
+      é um ponteiro para o índice do worktree real); o worktree ficou limpo o tempo todo
+      (`git status --porcelain | wc -l -> 0` antes e depois).
+
+      Buraco 1 — wrappers (cópia):
+
+      ```
+      bash generate.sh; git status --porcelain --untracked-files=all | wc -l      -> 0   (baseline)
+      printf '# zz probe\n' > skills/backlog/references/zz.md; git add; git commit -qm "probe: add reference"
+      bash -e step-master-wrappers-in-sync-with-skills.sh   (d2918ed)
+      -> Generated 10 category plugins in plugins/
+      -> exit=0                                            (o buraco: passou)
+      git status --porcelain --untracked-files=all
+      -> ?? plugins/workflow/skills/backlog/references/zz.md
+      bash -e step-new-wrappers-in-sync-with-skills.sh      (42591ee)
+      -> ::error::generate.sh produced files that are not tracked. Add them and commit:
+      -> ?? plugins/workflow/skills/backlog/references/zz.md
+      -> exit=1
+      ```
+
+      Skill nova inteira (`skills/zz-probe/SKILL.md` commitada) continua falhando nas duas versões,
+      e a nova nomeia os cinco arquivos gerados:
+
+      ```
+      bash -e step-master-wrappers-in-sync-with-skills.sh -> exit=1  ::error::Generated wrappers are out of sync. [...]
+      bash -e step-new-wrappers-in-sync-with-skills.sh    -> exit=1  5 linhas `??` (claude/, codex/, copilot/, cursor/, plugins/tooling/) + as duas ::error::
+      ```
+
+      Buraco 2 — spec-rite: `evaluate()` com diff de `skills/` e change ativa alheia -> achado `S3`;
+      com `Spec-rite: close-ci-gate-holes` no corpo -> mudo; diff só de archive -> mudo (saídas em
+      3.2). Pelo caminho do CI, no worktree, com o payload que o runner escreve:
+
+      ```
+      printf '{"pull_request":{"body":"Closes #117\n\nSpec-rite: close-ci-gate-holes\n"}}' > event.json
+      GITHUB_EVENT_PATH=event.json bash scripts/validate-rite.sh
+      -> rite evidence gate: 0 findings
+      -> spec-rite gate: 0 findings (base origin/master, 11 changed path(s), 1 active change(s))
+      -> Totals: 3 passed, 0 failed (3 items)
+      -> rite gate OK
+      PR_BODY="" python3 scripts/validate-spec-rite.py        (sem a linha: registra-se por caminho, D2-a)
+      -> spec-rite gate: 0 findings (base origin/master, 11 changed path(s), 1 active change(s))
+      ```
+
+      Buraco 3 — scan-secrets: `find()` das duas versões sobre `test_token = ghp_…` (4.1) e o
+      selftest pelo step literal (4.5). Scan real do tree pelo step literal:
+
+      ```
+      bash -e step-new-secret-scan.sh   -> no credentials found   exit=0
+      ```
+
+      Buraco 4 — frontmatter: fixture com `name:` só em bloco de código (5.1): `d2918ed` exit=0 sem
+      nenhum `::error`; `42591ee` exit=1 com `Missing name`.
+
+      Buracos 5 e 6 — YAML de `ci.yml` parseado com `yaml.safe_load` nas duas versões:
+
+      ```
+      d2918ed: validate.permissions=None validate.timeout-minutes=None release.timeout-minutes=None
+               release.outputs={'new_release': '${{ steps.check_release.outputs.new_release }}', 'version': ...}
+               validate checkout with={'fetch-depth': 0}
+      42591ee: validate.permissions={'contents': 'read'} validate.timeout-minutes=15 release.timeout-minutes=15
+               release.outputs=None  validate checkout with={'fetch-depth': 0, 'persist-credentials': False}
+      ```
+
+      Buraco 7 — evidence gate: selftest pelo step literal, com o escape declarado:
+
+      ```
+      bash -e step-new-rite-evidence-self-test.sh
+      -> ESCAPED R1 evidence shape: E.3 padded past 120 characters names no gap   (silent, as KNOWN LIMIT 7 declares)
+      -> 7/7 defect classes detected, 1/1 known escapes stayed silent   exit=0
+      ```
+
+      Os steps de `Validate` que este item toca, todos literais, no worktree:
+
+      ```
+      step-new-wrappers-in-sync-with-skills  exit=0 :: Generated 10 category plugins in plugins/
+      step-new-version-coherence             exit=0 :: Version 2.16.0 coherent across manifests.
+      step-new-skill-frontmatter-checks      exit=0
+      step-new-secret-scan                   exit=0 :: no credentials found
+      step-new-secret-scan-self-test         exit=0 :: 12/12 patterns fire on their sample, 3/3 context cases caught, 3/3 placeholder cases stayed silent
+      step-new-rite-evidence-self-test       exit=0 :: 7/7 defect classes detected, 1/1 known escapes stayed silent
+      step-new-spec-rite-self-test           exit=0 :: 6/6 defect classes detected, 10/10 false-positive cases stayed silent, 6/6 reader cases correct
+      git status --porcelain --untracked-files=all | wc -l   -> 0
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | Tinha de disparar e disparou | 9/9 | wrappers: ref nova (1), skill nova (1), wrapper stale (1); spec-rite `S3`: change alheia (1), id não ativo (1); scan-secrets: `test_token =` (1), `< >` (1); frontmatter: fixture (1); evidence: 7/7 do selftest contados como 1 |
+      | Tinha de ficar mudo e ficou | 8/8 | wrappers: tree limpo (1); spec-rite: nomeada no corpo (1), archive+README (1), tick em tasks.md (1), branch real por caminho (1); scan-secrets: `ghp_xxx…` (1), `<password>` (1); frontmatter: 35 skills reais (1) |
+      | Versão antiga passou onde a nova falha | 4/4 | wrappers ref nova, spec-rite change alheia, scan-secrets após `test`, frontmatter em bloco de código — cada um com `exit=0`/`[]` em `d2918ed` |
+      | Escape conhecido ficou mudo | 1/1 | E.3 com 130 caracteres sem gap (`ESCAPED … silent`) |
+      | Selftests do CI | 3/3 | spec-rite 6/6+10/10+6/6; scan-secrets 12/12+3/3+3/3; evidence 7/7+1/1 |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      - `permissions: contents: read` e `persist-credentials: false` **não** foram exercitados pelo
+        caminho real: o efeito só existe no runner do GitHub. Localmente o que se prova é o YAML
+        (6.1, 6.2) e a leitura dos steps (E.1: nenhum escreve). A prova é a run do PR desta change:
+        `Validate` verde com `persist-credentials: false` no log do checkout. Até ela, é gap.
+      - `timeout-minutes` idem: só o YAML é provável localmente.
+      - O `awk` do step de frontmatter rodou aqui com o awk do WSL, não com o do `ubuntu-latest`
+        (E.3); o mesmo programa já roda em `generate.sh` no mesmo runner.
+      - A fixture do buraco 4 dispara **dois** achados na versão nova (`Missing name` e
+        `name '' != directory`), não um: o segundo grep lê o mesmo bloco vazio. Esperado era um;
+        o segundo é redundante mas correto, e fica.
+      - Escape declarado e medido: E.3/E.4/S.3 com mais de 120 caracteres sem gap nomeado passam
+        (KNOWN LIMIT 7, `1/1 known escapes stayed silent`). A relevância do spec-rite é por caminho
+        e por nome: um tick qualquer em `tasks.md` de uma change ativa registra qualquer diff (KNOWN
+        LIMIT do script). Nenhum dos dois é fechado por esta change, por desenho (D2, D7).
 
 ## 10. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica: nenhuma skill é tocada
-- [ ] Q.2 Conteúdo de skill tocado em inglês — não se aplica; os deltas de spec estão em inglês
-- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição muda
-- [ ] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md`
-- [ ] Q.5 Identificadores em inglês no que a change introduz — ids de step, nomes de função,
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica: nenhuma skill é tocada
+      (`git diff --name-only origin/master...HEAD | grep -c '^skills/'` -> 0)
+- [x] Q.2 Conteúdo de skill tocado em inglês — não se aplica; os deltas de spec estão em inglês
+- [x] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição muda
+- [x] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md` (cinco linhas, todas
+      *already canonical*; nenhuma skill editada)
+- [x] Q.5 Identificadores em inglês no que a change introduz — ids de step, nomes de função,
       labels de selftest, chaves de YAML (`code-locale`)
+
+      ```
+      git diff origin/master...HEAD -- .github scripts | python3 skills/code-locale/references/check-identifier-locale.py --diff -
+      -> findings: 0   exit=0
+      ```
 
 ## 11. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate close-ci-gate-holes --strict` verde
-- [ ] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 35 skills
-- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
+- [x] V.1 `openspec validate close-ci-gate-holes --strict` verde
+
+      ```
+      openspec validate close-ci-gate-holes --strict   -> Change 'close-ci-gate-holes' is valid   (openspec 1.6.0)
+      ```
+
+- [x] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 35 skills
+
+      ```
+      python3 scripts/validate-skills.py   -> skills checked: 35   findings: 0
+      ls skills | wc -l                    -> 35
+      ```
+
+- [x] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
       não muda; o parágrafo do spec-rite no README é follow-up (E.4)
 - [ ] V.4 `openspec archive close-ci-gate-holes --yes` em PR separado, depois do merge

--- a/openspec/changes/close-ci-gate-holes/tasks.md
+++ b/openspec/changes/close-ci-gate-holes/tasks.md
@@ -1,0 +1,221 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `d2918ed` (topo de `master`, 2026-09-04):
+
+      - `.github/workflows/ci.yml` — 231 linhas; `permissions` do workflow em 14-17
+        (`contents: write`, `issues: write`, `pull-requests: write`); job `validate` em 25-131 com
+        treze steps, nenhum escreve no repositório nem lê `GITHUB_TOKEN` (Checkout, Wrappers,
+        Version coherence, Frontmatter, Content checks, Validator self-test, Locale detector
+        self-test, Locale hook self-test, Secret scan, Repo hygiene, Hygiene self-test, OpenSpec
+        rite gate, Evidence self-test, Spec-rite self-test, Plugin validation); step *Wrappers in
+        sync* em 38-45 usa `git diff --exit-code --quiet`; *Skill frontmatter checks* em 62-84 com
+        `grep -q '^name:' "$f"` sobre o arquivo inteiro; job `release` em 133-231, `outputs` em
+        139-141, step `check_release` em 216-231; nenhum `timeout-minutes` em nenhum job.
+      - `generate.sh:29-31` — função `frontmatter()`:
+        `awk 'NR==1 && $0=="---"{inFM=1; print; next} inFM && $0=="---"{print; exit} inFM{print}'`.
+      - `scripts/validate-spec-rite.py` — 338 linhas; `evaluate()` em 171-196 retorna sem achado
+        quando `changes` não está vazio (`:176`); `SILENT[2]` = `("active change present", ...)` em
+        `:210`; `WAIVER` em 64-67 ancorado no começo da linha; KNOWN LIMIT em 19-23.
+      - `scripts/scan-secrets.py` — 132 linhas; `PATTERNS` em 26-43 (sem `github_pat_` nem `sk-`);
+        `PLACEHOLDER` em 48-49 inclui `test` e `<`; `find()` em 55-64 aplica o filtro em
+        `m.group(0)` e em `body[m.start()-40:m.start()]` (`:59-60`); `main()` não trata `--selftest`.
+      - `scripts/validate-rite-evidence.py` — 360 linhas; `_shape_ok()` E.3/E.4 em 157-161 com
+        `len(body) > 120`; `_simulation_shape_ok()` S.3 em 197-200 com o mesmo limite; KNOWN LIMIT
+        1-6 em 36-51, nenhum cita o comprimento; `DEFECTS` em 318-324.
+      - `scripts/validate-rite.sh` — 88 linhas; `openspec` do PATH ou
+        `npx -y @fission-ai/openspec@latest` em 78-82.
+      - `.gitignore` — `__pycache__/` e `*.py[cod]`; `.releaserc.json` — assets do
+        `@semantic-release/git`, nenhum plugin lê output de job.
+      - `openspec/specs/skills-catalog/spec.md:345-486` (*The rite gates evidence before it gates
+        quality*) e `:487-524` (*The repository itself is gated, not only its skills*);
+        `openspec/specs/skills-authoring/spec.md` (*The catalog carries no credentials*).
+      - `openspec/changes/archive/2026-08-30-fix-release-race/{proposal,design,tasks}.md` — modelo
+        de estilo; E.4 dele já registra `check_release` como ambíguo.
+      - `skills/execute-backlog/references/spec-rite.md:83-84` — as duas formas da linha
+        `Spec-rite:` que o corpo do PR carrega.
+      - `README.md:731-739` — parágrafo que descreve o spec-rite (fica um passo atrás; ver E.4).
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      Cada buraco reproduzido antes de escrever, em `d2918ed` (2026-09-04):
+
+      ```
+      python3 -c "...; m.evaluate(['skills/backlog/SKILL.md'], ['unrelated-change'], ''); print(m.findings)"
+      -> unrelated active change, no Spec-rite line -> []
+      ```
+
+      ```
+      python3 -c "...; m.find('test_token = ghp_' + <36 chars>, 'x', h); print(h)"
+      -> after test -> {}
+      -> after < -> {}
+      -> github_pat_ -> {}
+      -> sk- -> {}
+      python3 scripts/scan-secrets.py --selftest
+      -> scanned 635 files (working tree)   (flag ignorada: o script não tem esse modo)
+      ```
+
+      ```
+      python3 -c "...; pad='Checked everything carefully and thoroughly, '*4; print(len(pad), m._shape_ok('E.3', pad), m._shape_ok('E.4', pad), m._simulation_shape_ok('S.3', pad))"
+      -> 180 (True, '') (True, '') (True, '')
+      ```
+
+      ```
+      grep -q '^name:' <fixture SKILL.md sem name no frontmatter, com ```yaml name: fm-probe no corpo>
+      -> whole-file grep: name FOUND (hole 4 reproduced)
+      awk '<frontmatter() de generate.sh:29-31>' <fixture> | grep -q '^name:'
+      -> frontmatter-scoped: Missing name
+      ```
+
+      ```
+      gh run view --job 99719547987 -R solvelab/ai-skills --log | grep -iE "persist-credentials|fetch-depth"
+      -> Validate  fetch-depth: 0
+      -> Validate  persist-credentials: true
+      ```
+
+      ```
+      gh run view 33463864134 --json jobs --jq '.jobs[] | "\(.name) \(.startedAt) \(.completedAt)"'
+      -> Validate 2026-09-01T02:47:44Z 2026-09-01T02:48:41Z      (57s)
+      gh run view 33843366162 --json jobs --jq ...
+      -> Validate 2026-09-04T06:11:49Z 2026-09-04T06:17:27Z      (5m38s)
+      -> Semantic Release 2026-09-04T06:17:31Z 2026-09-04T06:18:00Z   (29s)
+      ```
+
+      ```
+      grep -rn "check_release\|new_release\|needs.release\|needs: \[release\]" .github .releaserc.json README.md scripts | grep -v "workflows/ci.yml"
+      -> (vazio) grep exit=1
+      ```
+
+      ```
+      grep -n "timeout-minutes\|persist-credentials\|permissions:\|contents:" .github/workflows/ci.yml
+      -> 14:permissions:
+      -> 15:  contents: write
+      ```
+
+      Medidas que sustentam as decisões do design:
+
+      ```
+      python3 - <<'EOF'   # quantos matches do tree atual só a janela de 40 chars silencia
+      ... if not PLACEHOLDER.search(token) and PLACEHOLDER.search(before): suppressed[name]+=1
+      EOF
+      -> {}
+      ```
+
+      ```
+      grep -rnE "sk-[A-Za-z0-9_-]{20,}|github_pat_[A-Za-z0-9_]{20,}" --include='*.md' --include='*.py' ... .
+      -> (vazio) exit=0
+      ```
+
+      ```
+      openspec --version                                  -> 1.6.0
+      npx -y @fission-ai/openspec@1.6.0 --version         -> 1.6.0
+      npm view @fission-ai/openspec version               -> 1.12.0   (o @latest de hoje)
+      python3 --version                                   -> Python 3.14.5
+      ls skills | wc -l                                   -> 35
+      openspec new change close-ci-gate-holes --schema skills-rite
+      -> Created change 'close-ci-gate-holes' at openspec/changes/close-ci-gate-holes/  (só .openspec.yaml; artefatos escritos a partir de openspec/schemas/skills-rite/templates/)
+      openspec validate close-ci-gate-holes --strict      -> Change 'close-ci-gate-holes' is valid
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      - O efeito de `permissions: contents: read` + `persist-credentials: false` **na run real do
+        CI** não pode ser medido localmente: é medido na run do PR desta change, e o resultado entra
+        em S.1 quando existir. Até lá, a afirmação "nenhum step de Validate escreve" é leitura dos
+        treze steps (E.1), não observação de run.
+      - O `awk` do GitHub runner (`ubuntu-latest`, mawk ou gawk) não foi probado; o mesmo programa
+        `awk` já roda em `generate.sh` no mesmo runner a cada build, então a sintaxe está coberta pelo
+        step anterior.
+      - A janela de 40 caracteres foi medida como irrelevante **no tree de hoje**; um tree futuro
+        pode ter um match que só ela silenciava, e aí o scan reprova nomeando o arquivo — que é o
+        comportamento desejado, não um gap.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz o que a issue #117 pediu e nada além. Notados pelo caminho e **não** feitos, como
+      follow-up:
+
+      - `README.md:731-739` descreve o spec-rite como "carry an active change" — depois desta change
+        a regra é relevância (tocar ou nomear a change). `README.md` não está entre os arquivos deste
+        item; corrigir o parágrafo é follow-up.
+      - O step `Get previous tag` (`prev_tag`) do job de release fica sem leitor depois da remoção de
+        `check_release`; não está na lista de steps deste item e fica como está.
+      - Pinar actions por SHA (`actions/checkout@v5` etc.) — fora de escopo pela issue.
+      - O `openspec` do PATH local continua sendo o que roda em `validate-rite.sh` quando existe; o
+        pin só governa o caminho `npx` (o do CI). Alinhar os dois exigiria exigir versão exata do
+        binário local, decisão de manutenção fora deste item.
+
+## 2. Wrappers in sync vê arquivo não rastreado (D1)
+
+- [ ] 2.1 O step falha quando `git status --porcelain` devolve qualquer linha depois de
+      `bash generate.sh`, com `::error::` nomeando os arquivos `??` separadamente dos modificados
+- [ ] 2.2 O caso antigo (arquivo rastreado modificado) continua falhando com a mensagem antiga
+
+## 3. Spec-rite exige relevância (D2)
+
+- [ ] 3.1 `NAMED_CHANGE` lê `Spec-rite: <id>` ancorado no começo da linha, sem casar `none`
+- [ ] 3.2 `evaluate()` registra o diff só por caminho tocado, nome no corpo, archive no diff ou
+      dispensa; caso contrário emite `S3 unrelated change` nomeando as changes ativas
+- [ ] 3.3 Selftest: "active change present" sai de `SILENT` e entra em `DEFECTS`; `SILENT` ganha
+      "active change touched in the diff", "active change named in the body" e "archive with an
+      unrelated active change"; um id nomeado que não está ativo é achado
+- [ ] 3.4 Docstring: regra `S3` listada ao lado de `S1`/`S2`; KNOWN LIMIT diz que relevância é por
+      caminho e por nome, não por conteúdo
+
+## 4. Secret scan ganha selftest e fecha o filtro (D3)
+
+- [ ] 4.1 `PLACEHOLDER` aplicado só a `m.group(0)`; a janela de 40 caracteres anteriores sai
+- [ ] 4.2 Padrões `github_pat_` e `sk-` em `PATTERNS`
+- [ ] 4.3 `--selftest`: uma amostra montada em runtime por padrão, mais `test_token = <token>` e
+      `<token>`; casos mudos (`xxx`, `<password>`, IP privado sem gatar); saída `n/n`
+- [ ] 4.4 Docstring declara o modo e o que o selftest não prova (não lê o tree, não julga
+      placeholders que a documentação inventar)
+- [ ] 4.5 `ci.yml`: step *Secret scan self-test (the gate is itself gated)* logo depois de *Secret
+      scan (working tree)*
+
+## 5. Frontmatter greps escopados ao bloco (D4)
+
+- [ ] 5.1 O step extrai o bloco com o `awk` literal de `generate.sh:29-31` uma vez por arquivo e todos
+      os greps rodam sobre ele; o check de primeira linha fica
+
+## 6. Privilégio mínimo e pins (D5)
+
+- [ ] 6.1 `permissions: contents: read` no job `validate`; bloco do workflow intocado (serve o release)
+- [ ] 6.2 `persist-credentials: false` no checkout do `validate`, com o motivo no comentário
+- [ ] 6.3 `scripts/validate-rite.sh`: `npx -y @fission-ai/openspec@1.6.0` com comentário de bump
+
+## 7. Higiene do workflow (D6)
+
+- [ ] 7.1 `timeout-minutes: 15` nos dois jobs, com as medições no comentário
+- [ ] 7.2 `outputs` do job `release` e step `check_release` removidos, com o motivo no commit
+
+## 8. Escape dos 120 caracteres declarado e coberto (D7)
+
+- [ ] 8.1 KNOWN LIMIT 7 em `validate-rite-evidence.py` nomeia o limite e o que ele deixa passar
+- [ ] 8.2 `ESCAPES` no selftest com o caso E.3 de 130 caracteres sem gap; resultado esperado mudo;
+      saída `n/n known escapes stayed silent`
+
+## 9. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 Cada gate exercitado pelo caminho real (o step do CI ou o script como o CI o invoca), com
+      a saída observada registrada
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+## 10. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica: nenhuma skill é tocada
+- [ ] Q.2 Conteúdo de skill tocado em inglês — não se aplica; os deltas de spec estão em inglês
+- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição muda
+- [ ] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md`
+- [ ] Q.5 Identificadores em inglês no que a change introduz — ids de step, nomes de função,
+      labels de selftest, chaves de YAML (`code-locale`)
+
+## 11. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate close-ci-gate-holes --strict` verde
+- [ ] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 35 skills
+- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
+      não muda; o parágrafo do spec-rite no README é follow-up (E.4)
+- [ ] V.4 `openspec archive close-ci-gate-holes --yes` em PR separado, depois do merge

--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,6 +1,6 @@
 """Scan the repository for credentials.
 
-Two modes, deliberately different, because they answer different questions:
+Three modes, deliberately different, because they answer different questions:
 
   (default)     scan the WORKING TREE. Gates CI: exits 1 on any credential class.
                 This is the part that can be kept clean, so this is the part that gates.
@@ -10,15 +10,32 @@ Two modes, deliberately different, because they answer different questions:
                 knowing — but it cannot be fixed by a later commit, and a gate that can
                 never go green is a gate everyone learns to ignore.
 
+  --selftest    inject one credential per pattern and assert each class is reported. Gates
+                CI beside the scan: a clean tree and a pattern that cannot fire are otherwise
+                indistinguishable. Samples are BUILT at run time, never written as literals —
+                this file is in the tree the default mode scans, and a literal token here would
+                fail the build by design.
+
 Private (RFC1918) addresses are reported as operational detail, not as a credential class:
 worth removing from a public repo, not a breach, and never a reason to fail a build.
 
-Usage:  python3 scripts/scan-secrets.py [--history]
+The placeholder filter applies to the MATCHED TOKEN ONLY. It used to also read the forty
+characters before the match, which silenced `test_token = ghp_…` and `<ghp_…>` — a real key
+after the word `test` or after `<` passed the gate (issue #117, measured 2026-09-04).
+
+KNOWN LIMIT: the selftest proves each pattern fires on its own sample and stays silent on the
+placeholder shapes listed below; it does not read the tree, and it cannot judge a placeholder the
+documentation invents that the filter does not know. A token that itself contains a placeholder
+word (`ghp_test…`) is silenced on purpose and is not a class this scanner claims. The pattern set
+is what it is: a credential format not listed in PATTERNS passes.
+
+Usage:  python3 scripts/scan-secrets.py [--history | --selftest]
 """
 from __future__ import annotations
 
 import collections
 import re
+import string
 import subprocess
 import sys
 from pathlib import Path
@@ -26,6 +43,8 @@ from pathlib import Path
 PATTERNS = {
     "AWS access key":     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     "GitHub token":       re.compile(r"\bgh[pousr]_[A-Za-z0-9]{36,}\b"),
+    "GitHub fine-grained token": re.compile(r"\bgithub_pat_[A-Za-z0-9_]{22,}\b"),
+    "sk- API key":        re.compile(r"\bsk-[A-Za-z0-9_\-]{20,}\b"),
     "Slack token":        re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),
     "Google API key":     re.compile(r"\bAIza[0-9A-Za-z_\-]{35}\b"),
     "private key block":  re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
@@ -45,6 +64,7 @@ PATTERNS = {
 # A credential class fails the build. Everything else is reported.
 NOT_A_CREDENTIAL = {"private IPv4"}
 
+# Applied to the matched token only — never to the text around it (see the module docstring).
 PLACEHOLDER = re.compile(
     r"(?i)your|example|changeme|xxx|placeholder|<|\.\.\.|dummy|sample|test|fake|redact|REPLACE_ME")
 
@@ -56,8 +76,7 @@ def find(body: str, where: str, hits: dict) -> None:
     for name, rx in PATTERNS.items():
         for m in rx.finditer(body):
             frag = m.group(0)[:60]
-            before = body[max(0, m.start() - 40):m.start()]
-            if PLACEHOLDER.search(m.group(0)) or PLACEHOLDER.search(before):
+            if PLACEHOLDER.search(m.group(0)):
                 continue
             if name == "public IPv4" and any(int(o) > 255 for o in frag.split(".") if o.isdigit()):
                 continue                                   # a version string, not an address
@@ -97,7 +116,97 @@ def scan_history(hits: dict) -> int:
     return len(paths)
 
 
+# ── selftest ──────────────────────────────────────────────────────────────
+# One sample per pattern, assembled from pieces so that no line of this file matches a pattern.
+# `fill(n)` yields n characters of a fixed alphabet that contains no placeholder word.
+_ALPHABET = string.ascii_letters + string.digits
+
+
+def _fill(n: int) -> str:
+    return (_ALPHABET * (n // len(_ALPHABET) + 1))[:n]
+
+
+def _samples() -> dict[str, str]:
+    return {
+        "AWS access key":            "AKIA" + _fill(16).upper(),
+        "GitHub token":              "ghp_" + _fill(36),
+        "GitHub fine-grained token": "github_pat_" + _fill(30),
+        "sk- API key":               "sk-" + _fill(24),
+        "Slack token":               "xoxb-" + _fill(14),
+        "Google API key":            "AIza" + _fill(35),
+        "private key block":         "-----BEGIN " + "RSA PRIVATE" + " KEY-----",
+        "JWT":                       "eyJ" + _fill(12) + "." + _fill(12) + "." + _fill(12),
+        "generic assigned secret":   "password = " + '"' + _fill(16) + '"',
+        "connection string w/ creds": "postgres://app:" + _fill(10) + "@db.internal/app",
+        "public IPv4":               ".".join(["203", "0", "113", "7"]),
+        "private IPv4":              ".".join(["10", "0", "0", "1"]),
+    }
+
+
+def _classes(body: str) -> set[str]:
+    hits: dict = collections.defaultdict(list)
+    find(body, "<selftest>", hits)
+    return set(hits)
+
+
+def selftest() -> int:
+    samples = _samples()
+    fired = 0
+    for name in PATTERNS:
+        if name not in samples:
+            print(f"  MISSED  {name}: no sample in the selftest   <-- add one")
+            continue
+        if name in _classes(samples[name]):
+            print(f"  CAUGHT  {name}")
+            fired += 1
+        else:
+            print(f"  MISSED  {name}   <-- the pattern cannot fire")
+
+    # The two shapes the old before-window silenced: a placeholder word BEFORE the token, and the
+    # token wrapped in angle brackets. Both are real credentials and must be reported.
+    context_cases = [
+        ("token after the word test", "test_token = " + samples["GitHub token"], "GitHub token"),
+        ("token between angle brackets", "<" + samples["GitHub token"] + ">", "GitHub token"),
+        ("key after the word example", "example: " + samples["sk- API key"], "sk- API key"),
+    ]
+    context_ok = 0
+    for label, body, expected in context_cases:
+        if expected in _classes(body):
+            print(f"  CAUGHT  {label}")
+            context_ok += 1
+        else:
+            print(f"  MISSED  {label}   <-- silenced by the text around the token")
+
+    # Placeholder shapes the scanner must stay silent on, and the class that is reported but
+    # never fails the build.
+    silent_cases = [
+        ("token that is itself a placeholder", "ghp_" + "x" * 36),
+        ("connection string with a <password> placeholder", "postgres://app:<password>@db/app"),
+        ("assigned secret set to a placeholder", "api_key = " + '"' + "REPLACE_ME_WITH_YOURS" + '"'),
+    ]
+    quiet = 0
+    for label, body in silent_cases:
+        got = _classes(body)
+        if got:
+            print(f"  FALSE POSITIVE  {label}   <-- {sorted(got)}")
+        else:
+            print(f"  SILENT  {label}")
+            quiet += 1
+
+    reported_only = _classes(samples["private IPv4"]) == {"private IPv4"}
+    print(f"  {'REPORTED' if reported_only else 'GATED'}  private IPv4 is reported, never a credential")
+
+    print(f"\n{fired}/{len(PATTERNS)} patterns fire on their sample, "
+          f"{context_ok}/{len(context_cases)} context cases caught, "
+          f"{quiet}/{len(silent_cases)} placeholder cases stayed silent")
+    return 0 if (fired == len(PATTERNS) and context_ok == len(context_cases)
+                 and quiet == len(silent_cases) and reported_only) else 1
+
+
+# ── main ──────────────────────────────────────────────────────────────────
 def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
     history = "--history" in sys.argv
     hits: dict = collections.defaultdict(list)
     n = scan_history(hits) if history else scan_worktree(hits)

--- a/scripts/validate-rite-evidence.py
+++ b/scripts/validate-rite-evidence.py
@@ -49,6 +49,12 @@ KNOWN LIMIT — what this gate does NOT do. A passing run is not proof the evide
   5. Only active changes are read; `openspec/changes/archive/` is history and is never re-litigated.
   6. It fires on nothing in the current corpus — every historical E box passes. That is calibration
      (no false positives on genuine boxes), not proof it works; `--selftest` is what proves that.
+  7. E.3, E.4 and S.3 accept any body longer than 120 characters as "names a gap / a follow-up /
+     an escape", with no negative word required. The length is a proxy for "says something", chosen
+     because a genuine gap statement is rarely short and a regex for "names a gap" would be limit 1
+     again. What it lets through: 121 characters of padding that name nothing. Measured on issue
+     #117 (2026-09-04) and kept, declared here and exercised by the ESCAPES case of `--selftest`,
+     whose expected result is silence.
 
 Exit 1 on any finding. Run from the repo root.
 Modes: (default) check active changes   |   --selftest inject one defect per rule and assert detection.
@@ -324,26 +330,60 @@ DEFECTS = (("R1 evidence shape: E.1", _break_e1),
            ("R2 simulation shape: S.3", _break_s3))
 
 
+# KNOWN LIMIT 7, kept measurable: 125 characters that name no gap and declare none absent. The
+# expected result is SILENCE — the case documents what escapes, it does not pretend to catch it.
+_PADDING = ("Reviewed the surrounding code paths and the documentation at length before "
+            "deciding that this looked fine to me overall today")
+
+
+def _pad_e3(tmp: Path) -> None:
+    p = _seed(tmp)
+    p.write_text(p.read_text(encoding="utf-8").replace(
+        "- [x] E.3 Nothing could not be probed: none outstanding",
+        f"- [x] E.3 {_PADDING}"), encoding="utf-8")
+
+
+ESCAPES = (("R1 evidence shape: E.3 padded past 120 characters names no gap", _pad_e3),)
+
+
+def _run_injected(inject) -> list[str]:
+    global findings
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td) / "repo"
+        shutil.copytree(ROOT, tmp, ignore=shutil.ignore_patterns(".git", "__pycache__"))
+        inject(tmp)
+        findings = []
+        for run in CHECKS:
+            run(tmp)
+        return findings
+
+
 def selftest() -> int:
-    global findings, annotate
+    global annotate
     annotate = False        # injected paths do not exist; see the note on `annotate`
+    assert len(_PADDING) > 120, "the ESCAPES case must exceed the length proxy it documents"
     caught = 0
     for label, inject in DEFECTS:
         check, box = label.split(": ")
-        with tempfile.TemporaryDirectory() as td:
-            tmp = Path(td) / "repo"
-            shutil.copytree(ROOT, tmp, ignore=shutil.ignore_patterns(".git", "__pycache__"))
-            inject(tmp)
-            findings = []
-            for run in CHECKS:
-                run(tmp)
-            if any(f.startswith(check) and box in f for f in findings):
-                print(f"  CAUGHT  {label}")
-                caught += 1
-            else:
-                print(f"  MISSED  {label}   <-- the rule cannot fire")
-    print(f"\n{caught}/{len(DEFECTS)} defect classes detected")
-    return 0 if caught == len(DEFECTS) else 1
+        found = _run_injected(inject)
+        if any(f.startswith(check) and box in f for f in found):
+            print(f"  CAUGHT  {label}")
+            caught += 1
+        else:
+            print(f"  MISSED  {label}   <-- the rule cannot fire")
+
+    silent = 0
+    for label, inject in ESCAPES:
+        found = _run_injected(inject)
+        if found:
+            print(f"  FIRED   {label}   <-- KNOWN LIMIT 7 no longer holds; update the docstring")
+        else:
+            print(f"  ESCAPED {label}   (silent, as KNOWN LIMIT 7 declares)")
+            silent += 1
+
+    print(f"\n{caught}/{len(DEFECTS)} defect classes detected, "
+          f"{silent}/{len(ESCAPES)} known escapes stayed silent")
+    return 0 if caught == len(DEFECTS) and silent == len(ESCAPES) else 1
 
 
 def main() -> int:

--- a/scripts/validate-rite.sh
+++ b/scripts/validate-rite.sh
@@ -75,10 +75,16 @@ python3 scripts/validate-rite-evidence.py || fail=1
 # them all vacuously. This one reads the diff instead of the changes directory.
 python3 scripts/validate-spec-rite.py || fail=1
 
+# The CLI is pinned on purpose, the same rule as the claude-code pin in ci.yml: a blocking gate on
+# @latest fails this repository's builds on someone else's release schedule (1.12.0 was already
+# published when this pin was written, 2026-09-04). Bump it deliberately: run
+# `npx -y @fission-ai/openspec@<new> validate --all --strict` locally, then change the version here
+# and the `(v1.6.0)` note in the header together. A local `openspec` on PATH is used as-is, so a
+# contributor's binary can differ from CI's — that is why CI is the version of record.
 if command -v openspec >/dev/null 2>&1; then
   openspec validate --all --strict || fail=1
 else
-  npx -y @fission-ai/openspec@latest validate --all --strict || fail=1
+  npx -y @fission-ai/openspec@1.6.0 validate --all --strict || fail=1
 fi
 
 if [ "$fail" -ne 0 ]; then

--- a/scripts/validate-spec-rite.py
+++ b/scripts/validate-spec-rite.py
@@ -15,12 +15,18 @@ retroactively by PR #88.
 
   S1 a diff outside openspec/ carries a change, an archive, or a written waiver
   S2 the waiver names a reason
+  S3 the change it carries is ITS change: the diff touches openspec/changes/<id>/ of an active
+     change, or the pull request body names one on a `Spec-rite: <id>` line. Until issue #117
+     (2026-09-04) the mere existence of any active change registered any diff, and the selftest
+     pinned that as a silent case.
 
-KNOWN LIMIT: this proves that a change EXISTS, never that it is honest — a change scaffolded to
-satisfy the gate passes it, exactly as a padded evidence box passes the shape gate. Existence is a
-required, reviewable artifact; the review is what judges it. The selftest exercises the decision
-rules against synthetic inputs, not the git plumbing that feeds them: a misconfigured checkout is
-caught by the CI-only base-resolution failure below, not by the selftest.
+KNOWN LIMIT: this proves that a change EXISTS and is LINKED to the diff — by path or by name, never
+by content — not that it is honest. A change scaffolded to satisfy the gate passes it, exactly as a
+padded evidence box passes the shape gate, and a single tick in the tasks.md of any active change
+links any diff to it. Existence and relevance are required, reviewable artifacts; the review is what
+judges them. The selftest exercises the decision rules against synthetic inputs, not the git
+plumbing that feeds them: a misconfigured checkout is caught by the CI-only base-resolution failure
+below, not by the selftest.
 
 The waiver is read from the event payload the runner already writes (GITHUB_EVENT_PATH), not from
 an environment variable handed to the step: GitHub Actions prints a step's `env:` block into the
@@ -72,6 +78,16 @@ WAIVER_NO_REASON = re.compile(
     re.IGNORECASE | re.MULTILINE,
 )
 MIN_REASON = 8
+
+# The line that names the change a pull request belongs to — the form execute-backlog writes into
+# the body (skills/execute-backlog/references/spec-rite.md). Same treatment as the waiver: anchored
+# to the start of a line, matched as text, never executed. `none` is the waiver, not a change id,
+# and is filtered out after the match rather than excluded in the pattern so the two regexes stay
+# readable side by side.
+NAMED_CHANGE = re.compile(
+    r"^[ \t>*-]*Spec-rite:[ \t]*(?P<id>[A-Za-z0-9][A-Za-z0-9._-]*)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 
 findings: list[str] = []
 
@@ -168,12 +184,28 @@ def waiver_reason(pr_body: str) -> str | None:
     return m.group("reason").strip() if m else None
 
 
+def named_changes(pr_body: str) -> list[str]:
+    """Every change id the body names on a `Spec-rite: <id>` line, in order; the waiver is not one."""
+    return [m.group("id") for m in NAMED_CHANGE.finditer(pr_body or "")
+            if m.group("id").lower() != "none"]
+
+
+def touched_changes(paths: list[str], changes: list[str]) -> list[str]:
+    """The active changes whose own directory this diff touches — a tick in tasks.md counts."""
+    return sorted(c for c in changes if any(p.startswith(f"{CHANGES}/{c}/") for p in paths))
+
+
 def evaluate(paths: list[str], changes: list[str], pr_body: str) -> None:
     """The whole decision, as a pure function of its inputs — this is what --selftest exercises."""
     offenders = requires_registration(paths)
     if not offenders:
         return
-    if changes or archived_in_diff(paths):
+    if archived_in_diff(paths):
+        return
+
+    # Relevance, not existence (S3): the diff is registered by the change it touches or names.
+    named = named_changes(pr_body)
+    if touched_changes(paths, changes) or any(n in changes for n in named):
         return
 
     reason = waiver_reason(pr_body)
@@ -189,6 +221,19 @@ def evaluate(paths: list[str], changes: list[str], pr_body: str) -> None:
         return
 
     sample = ", ".join(offenders[:5]) + (f" (+{len(offenders) - 5} more)" if len(offenders) > 5 else "")
+    if changes:
+        stale = [n for n in named if n not in changes]
+        stale_note = (f"; the body names {', '.join(stale)}, which is not an active change"
+                      if stale else "")
+        add("S3 unrelated change",
+            f"this diff touches {len(offenders)} path(s) outside {EXEMPT_PREFIX} — {sample} — and "
+            f"{len(changes)} active change(s) exist ({', '.join(changes)}), but the diff touches none "
+            f"of their directories and the pull request body names none of them{stale_note}. "
+            f"Link the diff to its change: touch {CHANGES}/<id>/ (a tick in tasks.md counts) or add "
+            "a line `Spec-rite: <id>` to the pull request body — or waive it with "
+            "`Spec-rite: none — <reason>`")
+        return
+
     add("S1 unregistered change",
         f"this diff touches {len(offenders)} path(s) outside {EXEMPT_PREFIX} — {sample} — with no "
         f"active change under {CHANGES}/, no change archived in the same diff, and no waiver. "
@@ -202,14 +247,30 @@ DEFECTS = [
     ("S1 unregistered change", (["skills/backlog/SKILL.md"], [], "")),
     ("S2 waiver reason", (["skills/backlog/SKILL.md"], [], "Spec-rite: none — x")),
     ("S2 waiver reason", (["skills/backlog/SKILL.md"], [], "Spec-rite: none")),
+    # Until issue #117 this exact input was SILENT[2] "active change present": any active change
+    # registered any diff. It is the defect the relevance rule exists to catch.
+    ("S3 unrelated change", (["skills/backlog/SKILL.md"], ["add-spec-rite-gate"], "")),
+    ("S3 unrelated change", (["skills/backlog/SKILL.md"], ["add-spec-rite-gate"],
+                             "Spec-rite: some-archived-change")),
+    ("S3 unrelated change", (["skills/backlog/SKILL.md"], ["add-spec-rite-gate"],
+                             "see the Spec-rite: add-spec-rite-gate line elsewhere")),
 ]
 
 SILENT = [
     ("diff confined to openspec/", (["openspec/changes/x/tasks.md"], [], "")),
     ("release automation only", (["VERSION", "CHANGELOG.md", ".claude-plugin/plugin.json"], [], "")),
-    ("active change present", (["skills/backlog/SKILL.md"], ["add-spec-rite-gate"], "")),
+    ("active change touched in the diff",
+     (["skills/backlog/SKILL.md", f"{CHANGES}/add-spec-rite-gate/tasks.md"], ["add-spec-rite-gate"], "")),
+    ("active change named in the body",
+     (["skills/backlog/SKILL.md"], ["add-spec-rite-gate", "other-change"], "Spec-rite: add-spec-rite-gate")),
+    ("active change named in a list item",
+     (["README.md"], ["add-spec-rite-gate"], "- Spec-rite: add-spec-rite-gate")),
     ("archived in the same diff", ([f"{CHANGES}/archive/2026-01-01-x/tasks.md", "README.md"], [], "")),
+    ("archived with an unrelated active change",
+     ([f"{CHANGES}/archive/2026-01-01-x/tasks.md", "README.md"], ["other-change"], "")),
     ("waiver with a reason", (["skills/backlog/SKILL.md"], [], "Spec-rite: none — typo no README")),
+    ("waiver with a reason beside an unrelated active change",
+     (["skills/backlog/SKILL.md"], ["other-change"], "Spec-rite: none — typo no README")),
     ("waiver quoted in a list item", (["README.md"], [], "- Spec-rite: none — correcao de link quebrado")),
 ]
 


### PR DESCRIPTION
Closes #117

A auditoria de 2026-09-04 mediu sete formas de um PR passar verde no `.github/workflows/ci.yml` sem
ter feito o que o gate diz medir — todas fora das declarações de "o que não cobre" que cada check do
repositório carrega. Cada uma foi reproduzida em cópia do repositório antes de qualquer edição, com
o shell literal dos steps (extraído de `ci.yml` por `yaml.safe_load` e rodado com `bash -e`):

| # | Buraco | Reprodução em `d2918ed` (topo de `master`) |
|---|---|---|
| 1 | *Wrappers in sync* usa `git diff --exit-code`, que não vê arquivo não rastreado | `skills/backlog/references/zz.md` commitado; `generate.sh` cria `plugins/workflow/skills/backlog/references/zz.md` como `??`; step `exit=0` |
| 2 | Spec-rite aprova qualquer diff desde que **alguma** change ativa exista | `evaluate(['skills/backlog/SKILL.md'], ['close-ci-gate-holes'], '')` -> `[]`; o selftest fixava isso como caso mudo |
| 3 | `scan-secrets.py` sem `--selftest`; `PLACEHOLDER` lia os 40 caracteres anteriores | `find('test_token = ghp_…')` -> `[]`; `find('<ghp_…>')` -> `[]`; `github_pat_` e `sk-` sem padrão |
| 4 | Greps do frontmatter varrem o arquivo inteiro | `SKILL.md` sem `name` no frontmatter e com ```` ```yaml name: fm-probe ```` no corpo: step `exit=0`, zero `::error` |
| 5 | `Validate` herda `contents: write`; checkout persiste o token; `openspec` roda `@latest` | `persist-credentials: true` no log do job 99719547987; `npm view @fission-ai/openspec version` -> `1.12.0` contra `1.6.0` probado |
| 6 | Nenhum `timeout-minutes`; `outputs`/`check_release` sem consumidor | `Validate` de 57s (run 33463864134) a 5m38s (run 33843366162); `grep -rn check_release` fora de `ci.yml` -> vazio |
| 7 | E.3/E.4/S.3 do gate de evidência aceitam qualquer texto > 120 caracteres, sem declarar | `_shape_ok('E.3', 180 chars de enchimento)` -> `(True, '')`; KNOWN LIMIT com seis itens, nenhum cita comprimento |

## O que muda

- **Wrappers (1).** Depois de `bash generate.sh` o step lê `git status --porcelain --untracked-files=all`
  e falha em qualquer `??`, nomeando os arquivos separadamente do `git diff --stat` dos rastreados. A
  mensagem antiga continua para o caso antigo.
- **Spec-rite (2).** `evaluate()` ganha a regra `S3`: o diff está registrado só se toca
  `openspec/changes/<id>/` de uma change ativa **ou** o corpo do PR nomeia uma em `Spec-rite: <id>`
  (ancorado no começo da linha, casado como texto, `none` não é id). O achado nomeia as changes ativas
  e as duas formas de ligar. `archived_in_diff` intocado: o PR de archive continua passando. Selftest:
  "active change present" sai de `SILENT` e vira `DEFECT`; entram "touched in the diff", "named in the
  body", "archive with an unrelated active change" e "id nomeado que não está ativo".
- **scan-secrets (3).** `PLACEHOLDER` só no token casado; padrões `github_pat_` e `sk-`; `--selftest`
  monta uma credencial por padrão em runtime (um literal no próprio script reprovaria o scan do tree),
  mais `test_token = <token>` e `<token>`, e três formas que devem ficar mudas. Step novo no CI logo
  depois do scan. Medido antes: zero matches do tree atual dependiam da janela removida.
- **Frontmatter (4).** O step extrai o bloco entre os dois `---` com o mesmo `awk` de
  `generate.sh:29-31` e todos os greps rodam sobre ele; o check de primeira linha fica.
- **Privilégio e pins (5).** `permissions: contents: read` no job `Validate` (o bloco do workflow
  segue servindo o release), `persist-credentials: false` no checkout dele,
  `npx -y @fission-ai/openspec@1.6.0` em `validate-rite.sh` com o comentário de bump, a mesma regra
  do pin do `claude-code`.
- **Higiene (6).** `timeout-minutes: 15` nos dois jobs (2,7x a pior run medida); `outputs` e
  `check_release` removidos — nenhum consumidor, e o step escrevia `new_release=false` tanto para
  "nada a publicar" quanto para "não consegui publicar".
- **Escape dos 120 caracteres (7).** Declarado como KNOWN LIMIT 7 e coberto por uma lista `ESCAPES`
  no selftest cujo resultado esperado é silêncio, impresso como `n/n known escapes stayed silent`.
  Fechar exigiria julgar "nomeia um gap" por regex, que é o limite 1 de novo.

Nenhuma skill é tocada; a composição do catálogo fica idêntica (35 skills).

## Simulação — saída observada

Cada gate exercitado pelo caminho real: o shell literal dos steps das duas versões (`d2918ed` e
`42591ee`) numa cópia independente do worktree; os scripts como o CI os invoca. Detalhe completo em
`openspec/changes/close-ci-gate-holes/tasks.md` (grupos 2-9).

| Expectativa | Casos | Resultado |
|---|---|---|
| Tinha de disparar e disparou | **9/9** | wrappers: ref nova, skill nova, wrapper stale; spec-rite `S3`: change alheia, id não ativo; scan-secrets: após `test`, entre `< >`; frontmatter: fixture; evidence: selftest 7/7 |
| Versão de `master` passou onde a nova falha | **4/4** | buracos 1-4, cada um com `exit=0`/`[]` em `d2918ed` e `exit=1`/achado em `42591ee` |
| Tinha de ficar mudo e ficou | **8/8** | wrappers: tree limpo; spec-rite: nomeada no corpo, archive+README, tick em `tasks.md`, o diff real deste branch; scan-secrets: `ghp_xxx…`, `<password>`; frontmatter: 35 skills reais |
| Escape conhecido ficou mudo | **1/1** | E.3 com 130 caracteres sem gap — `ESCAPED … (silent, as KNOWN LIMIT 7 declares)` |
| Selftests pelo step do CI | **3/3** | spec-rite `6/6 … 10/10 … 6/6`; scan-secrets `12/12 … 3/3 … 3/3`; evidence `7/7 … 1/1` |

Fragmentos do que se viu:

```
bash -e step-master-wrappers-in-sync-with-skills.sh   -> exit=0   (?? plugins/workflow/skills/backlog/references/zz.md)
bash -e step-new-wrappers-in-sync-with-skills.sh      -> ::error::generate.sh produced files that are not tracked. Add them and commit:
                                                      -> ?? plugins/workflow/skills/backlog/references/zz.md   exit=1
evaluate(['skills/backlog/SKILL.md'], ['close-ci-gate-holes'], '')   -> ['S3 unrelated change: … 1 active change(s) exist (close-ci-gate-holes), but the diff touches none of their directories and the pull request body names none of them …']
find('test_token = ghp_…')                            master=[]  new=['GitHub token']
bash -e step-new-skill-frontmatter-checks.sh          -> ::error file=skills/fm-probe/SKILL.md::Missing name   exit=1
```

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| YAML das duas versões | `yaml.safe_load(ci.yml)` | `validate.permissions={'contents': 'read'}`, checkout `{'fetch-depth': 0, 'persist-credentials': False}`, `timeout-minutes` 15/15, `release.outputs=None`, sem `check_release` |
| Wrappers em sincronia | step literal + `git status --porcelain --untracked-files=all` | `exit=0`, 0 linhas |
| Versão coerente | step literal | `Version 2.16.0 coherent across manifests.` |
| Frontmatter | step literal (35 skills) | `exit=0` |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | `13/13 defect classes detected` |
| Locale de identificadores | `check-identifier-locale.py --selftest`; `--diff` sobre o diff do branch | selftest OK; `findings: 0` |
| Hook de locale | `claude/global/hooks/locale-rite.py --selftest` | OK |
| Segredos | `python3 scripts/scan-secrets.py` + `--selftest` | `no credentials found`; `12/12 … 3/3 … 3/3` |
| Higiene do repo | `validate-repo-hygiene.py` + `--selftest` | `0 findings`; `2/2` |
| Rito | `GITHUB_EVENT_PATH=event.json bash scripts/validate-rite.sh` | `spec-rite gate: 0 findings (base origin/master, 11 changed path(s), 1 active change(s))`, `rite gate OK` |
| Evidência do rito | `validate-rite-evidence.py --selftest` | `7/7 defect classes detected, 1/1 known escapes stayed silent` |
| Spec-rite | `validate-spec-rite.py --selftest` | `6/6 defect classes detected, 10/10 false-positive cases stayed silent, 6/6 reader cases correct` |
| Pin do openspec | `npx -y @fission-ai/openspec@1.6.0 --version` | `1.6.0` |
| OpenSpec estrito | `openspec validate close-ci-gate-holes --strict` | `Change 'close-ci-gate-holes' is valid` |
| Validador do vendor | `claude-code@2.1.246 plugin validate . --strict` | `Validation passed` |

## Rito

Spec-rite: close-ci-gate-holes

Capabilities do delta: `skills-catalog` (MODIFIED *The repository itself is gated, not only its
skills* e *The rite gates evidence before it gates quality*) e `skills-authoring` (*The catalog
carries no credentials* ganha o cenário do selftest).

## Known gaps

- `permissions: contents: read`, `persist-credentials: false` e `timeout-minutes` estão provados só
  como YAML (parseado, valores listados) e pela leitura dos treze steps de `Validate` (nenhum escreve
  nem lê `GITHUB_TOKEN`). O efeito existe só no runner: a run de CI **deste PR** é a prova —
  `Validate` verde com `persist-credentials: false` no log do checkout. Registrado em `tasks.md` S.3.
- O `awk` do step de frontmatter rodou com o awk do WSL, não com o do `ubuntu-latest`; o mesmo
  programa já roda em `generate.sh` no mesmo runner a cada build.
- Escapes declarados e mantidos por desenho: corpo E.3/E.4/S.3 acima de 120 caracteres sem gap
  nomeado passa (KNOWN LIMIT 7, medido `1/1` mudo); a relevância do spec-rite é por caminho e por
  nome, então um tick qualquer em `tasks.md` de uma change ativa registra qualquer diff (KNOWN LIMIT
  do script). A revisão continua sendo quem julga.
- A change `close-ci-gate-holes` fica **ativa**; `openspec archive close-ci-gate-holes --yes` (V.4)
  é PR separado, depois do merge.
- Follow-ups notados e não feitos (E.4 do `tasks.md`): `README.md:731-739` ainda descreve o spec-rite
  como "carry an active change"; o step `Get previous tag` do release fica sem leitor; pinar actions
  por SHA está fora de escopo pela issue.