### PR TITLE
✨ feat(ci): mede o metadata.version por skill com gate diff-based e dispensa escrita

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,18 @@ jobs:
       - name: Spec-rite self-test (the gate is itself gated)
         run: python3 scripts/validate-spec-rite.py --selftest
 
+      - name: Skill version gate (an edited skill moves its metadata.version, or the body waives it)
+        # README.md promises that a skill's metadata.version moves when the skill changes; until
+        # issue #119 nothing measured it (49 of 165 edited (commit, skill) pairs left it alone). This
+        # reads the diff against the base per skills/<name>/ and reads the waiver line
+        # `Skill-version: none — <reason>` from GITHUB_EVENT_PATH, exactly as the spec-rite gate
+        # does and for the same reason: an `env:` block would print the body into the log. It skips
+        # itself on push events and says so.
+        run: python3 scripts/validate-skill-version.py
+
+      - name: Skill version self-test (the gate is itself gated)
+        run: python3 scripts/validate-skill-version.py --selftest
+
       - name: Claude plugin validation (vendor validator, blocking)
         # Was `continue-on-error: true` AND `|| true` — disabled twice over, so it never failed a
         # build. Measured on 2026-08-26 with claude 2.1.246: `plugin validate . --strict` passes on

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Each release automatically: bumps `VERSION`, propagates it to `.claude-plugin/pl
 | Claude Code plugin | **Version-pinned** — updates only when `plugin.json` version is bumped by a release |
 | `npx skills` / `install.sh` / `update.sh` | Latest `master` |
 
-Each skill also carries its own `metadata.version` in its `SKILL.md` frontmatter — bump it when that skill's behavior changes. Repo version = the collection; skill version = the individual contract. The CI/CD pipeline (`.github/workflows/ci.yml`) validates every pull request and every push to `master` (wrapper sync, version coherence, frontmatter) and cuts releases on `master`.
+Each skill also carries its own `metadata.version` in its `SKILL.md` frontmatter — bump it when that skill changes. Repo version = the collection; skill version = the individual contract. The bump is measured, not trusted: [`scripts/validate-skill-version.py`](scripts/validate-skill-version.py) diffs every pull request against its base and fails when anything under `skills/<name>/` changed without that skill's version moving up, unless the PR body carries one line `Skill-version: none — <reason>` covering the whole diff. The CI/CD pipeline (`.github/workflows/ci.yml`) validates every pull request and every push to `master` (wrapper sync, version coherence, frontmatter) and cuts releases on `master`.
 
 ---
 
@@ -861,7 +861,7 @@ license: MIT
 
 - `name` must match the directory name (CI enforces this).
 - Put supporting material in `skills/<skill-name>/references/` and point to it with **relative paths** (`references/examples.md`) — never absolute paths, so the skill stays portable.
-- Bump `metadata.version` whenever the skill's behavior changes.
+- Bump `metadata.version` whenever the skill changes. CI measures it (`scripts/validate-skill-version.py`): a pull request that edits `skills/<name>/` without raising that skill's version fails unless its body carries `Skill-version: none — <reason>`.
 
 ### 2. Generate the tool wrappers
 

--- a/README.md
+++ b/README.md
@@ -878,7 +878,9 @@ pull request — `master` takes no direct push (PR-only, by convention). CI read
 body: `scripts/validate-spec-rite.py` passes when the checkout carries an active change under
 `openspec/changes/<id>/` (the one `/opsx:propose` scaffolded above, committed with the skill) or the
 diff archives one, and otherwise only when the body carries a written waiver
-`Spec-rite: none — <reason>` — a PR with neither fails with S1. Write the body from a file:
+`Spec-rite: none — <reason>` — a PR with neither fails with S1. When the diff edits a skill,
+`scripts/validate-skill-version.py` also asks for the bump of that skill's `metadata.version`, or a
+PR-wide `Skill-version: none — <reason>` line. Write the body from a file:
 `gh pr create --fill` takes title and body from the commit message, so a `-m`-only commit opens a
 PR with an empty body. The release runs after the merge and does the rest (version bump, changelog,
 tag, GitHub Release):
@@ -886,7 +888,7 @@ tag, GitHub Release):
 ```bash
 git commit -m "skill: add my-skill"   # skill:/feat: → minor release once merged into master
 git push -u origin backlog/<n>-my-skill
-gh pr create --title "skill: add my-skill" --body-file pr.md   # pr.md: `Spec-rite: <id>`, or `Spec-rite: none — <reason>`
+gh pr create --title "skill: add my-skill" --body-file pr.md   # pr.md: `Spec-rite: <id>` (or the waiver); `Skill-version: none — <reason>` only when a skill edit carries no bump
 ```
 
 ### 4. Key guidelines for writing skills

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.8.0
+  version: 1.8.1
   category: process
 license: MIT
 compatibility: >-

--- a/openspec/changes/add-skill-version-gate/.openspec.yaml
+++ b/openspec/changes/add-skill-version-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/add-skill-version-gate/design.md
+++ b/openspec/changes/add-skill-version-gate/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`scripts/validate-spec-rite.py` (338 linhas em `bfc400d`) é o único gate deste repositório que lê o
+**diff** e o **corpo do PR**: `resolve_base()` tenta `SPEC_RITE_BASE`, `GITHUB_BASE_REF`,
+`origin/master`, `origin/main`; `changed_paths()` roda `git diff --name-only <base>...HEAD`;
+`read_pr_body()` lê `pull_request.body` do arquivo em `GITHUB_EVENT_PATH` (nunca via `env:`, que o
+Actions imprime no log — run 32648727841), com `PR_BODY` como override; `WAIVER` é ancorado no começo
+da linha, casado como texto, com `MIN_REASON = 8`; `evaluate()` é função pura das entradas, e é o
+que `--selftest` exercita com `DEFECTS` e `SILENT`; `main()` imprime um skip em evento que não é
+`pull_request` e falha com `S0` quando não há base em CI.
+
+`metadata.version` hoje: presença e formato verificados pelo step *Skill frontmatter checks*
+(`grep -qE '^  version: [0-9]+\.[0-9]+\.[0-9]+'` sobre o bloco de frontmatter). Nenhum script lê o
+valor. `generate.sh` copia o `SKILL.md` inteiro para `claude/skills/<x>/` e `plugins/<grupo>/skills/<x>/`,
+então a linha aparece também nas árvores geradas.
+
+Dois pontos do histórico servem de fixture real, medidos em `bfc400d` (2026-09-05):
+
+- `cf767ee` (issue #76): 20 caminhos em `skills/`, 13 skills; 12 com `version` idêntica na base e
+  no HEAD; `code-locale` sem `SKILL.md` na base (skill nova).
+- PR #122, squash `e13c16a` sobre `d2918ed`: 6 skills, todas com `version` maior no HEAD
+  (`1.2.1→1.3.0`, `1.0.1→1.1.0`, `1.4.0→1.5.0`, `1.2.0→1.3.0`, `1.7.0→1.8.0`, `1.0.0→1.1.0`).
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Um PR que altera qualquer coisa sob `skills/<x>/` sem mover `metadata.version` de `<x>` e sem a
+  linha de dispensa reprova, nomeando a skill, a versão na base, a versão no HEAD e as duas saídas.
+- `--selftest` com um defeito injetado por regra e os casos que têm de ficar mudos, no CI.
+- A dispensa é PR-wide, para que uma varredura catálogo-inteiro custe uma linha.
+- O gate diz o que não cobre, no próprio docstring.
+
+**Non-Goals**
+
+- Bumps retroativos nas 20 skills medidas (fora de escopo pela issue).
+- Decidir **quanto** bumpar (major/minor/patch) — o gate exige movimento para cima, não magnitude.
+- Ler `metadata.version` em algum consumidor (`install.sh`, wrappers): o campo continua informativo
+  para máquinas; o que muda é que a promessa ao humano passa a ser medida.
+- Tocar `scripts/validate-spec-rite.py`: o novo gate importa dele apenas `MIN_REASON`, para que as
+  duas dispensas exijam o mesmo tamanho de motivo por construção, não por cópia.
+- Tocar qualquer outro step de `ci.yml`.
+
+## Decisions
+
+### D1 — Gate separado, no mesmo idioma, não uma regra a mais no spec-rite
+
+`validate-spec-rite.py` responde "existe uma change ligada a este diff?"; a pergunta aqui é "cada
+skill editada moveu sua versão?". São inputs diferentes (o segundo lê o conteúdo de dois blobs por
+skill) e saídas diferentes (achados por skill). Misturar as duas no mesmo `evaluate()` tornaria o
+selftest de cada uma dependente da outra. O novo script copia a **forma** — as mesmas funções de
+plumbing com os mesmos nomes, o mesmo leitor do corpo, o mesmo skip, o mesmo `annotate` — para que
+quem já leu um leia o outro sem custo.
+
+### D2 — "Conteúdo mudou" é qualquer caminho sob `skills/<x>/`, exceto a linha `  version:`
+
+Para cada skill com caminho alterado no diff `<merge-base>...HEAD`: se algum caminho alterado não é o
+`SKILL.md`, o conteúdo mudou. Se só o `SKILL.md` mudou, os dois blobs são comparados com todas as
+linhas `  version:` removidas; iguais → só a versão mudou → a skill não entra na regra do bump
+(mas entra na regra de regressão, D4). Rename e whitespace disparam o gate — aceito na issue: é
+exatamente o que a dispensa escrita resolve.
+
+Alternativa rejeitada: contar só linhas do corpo do `SKILL.md`, ignorando `references/`. O commit
+`bb6b391` moveu 139 arquivos para `references/` "sem perder linha"; pelo critério do README seria
+"sem mudança de comportamento". Mas um `references/*.md` é conteúdo que o agente lê; excluí-lo cria a
+classe de PR que edita doutrina sem tocar o `SKILL.md` e passa mudo. O custo (uma linha de
+dispensa em varreduras estruturais) foi aceito na decisão.
+
+### D3 — Árvores geradas nunca contam; skill nova passa; skill removida passa
+
+`claude/`, `codex/`, `cursor/`, `copilot/` e `plugins/` são saída de `generate.sh` e já têm o seu
+gate (*Wrappers in sync*). Um diff confinado a elas não é uma edição de skill. Skill sem `SKILL.md`
+na base não tem versão anterior contra a qual "subir" — passa. Skill sem `SKILL.md` no HEAD foi
+removida — não há versão a mover, e a remoção é regulada por `skills-catalog`, não por este gate.
+
+### D4 — Versão que desce é achado sempre; a dispensa cobre só o bump ausente
+
+`Skill-version: none — <motivo>` diz "esta edição não merece bump". Não existe motivo legítimo para
+`1.8.0 → 1.7.0`; um número que anda para trás é erro de edição, e a dispensa não o cobre. Regra
+separada (`V2`), com mensagem própria, para que o achado nomeie a regressão e não peça uma linha de
+dispensa que não resolveria nada.
+
+### D5 — A dispensa é PR-wide, com o mesmo `MIN_REASON` do spec-rite
+
+Uma linha por skill transformaria uma varredura de 12 skills em 12 linhas de boilerplate — o risco
+que a issue nomeou. Uma linha cobre o PR todo; o motivo tem de ter pelo menos `MIN_REASON`
+caracteres, importado de `validate-spec-rite.py` (não copiado) para que os dois gates nunca exijam
+tamanhos diferentes. Uma linha `Skill-version: none` sem motivo é achado (`V3`), com a mesma
+separação que o spec-rite faz entre "motivo curto" e "sem motivo".
+
+### D6 — Skip em evento que não é `pull_request`, impresso, como o spec-rite
+
+Em `push` para `master` não há corpo de PR a ler e o diff contra a própria base é vazio; o gate
+imprime `skill-version gate: skipped (event push, not pull_request)` e sai 0. Em CI sem base
+resolvível, falha com `V0` — um gate que não consegue medir não aprova. Fora de CI sem base, imprime
+o skip e sai 0, como o irmão.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| A linha `Spec-rite:` / `Skill-version:` no corpo do PR | `execute-backlog` (`references/spec-rite.md`, *In the PR body*) | link — a seção ganha um parágrafo com a segunda linha; o README aponta para o script, não restata o protocolo |
+| Um check declara dentro de si o que não cobre | `skills-authoring` (*Authoring rules are machine-enforced*) + `verify-before-claiming` | already canonical — o novo script traz o seu KNOWN LIMIT no docstring |
+| Um gate carrega selftest com um defeito injetado por regra | `skills-authoring` (*Authoring rules are machine-enforced*) | already canonical — `--selftest` com `DEFECTS`/`SILENT` |
+| Bump de `metadata.version` a cada mudança de skill | `README.md` (contrato ao contribuidor) + requisito novo em `skills-authoring` | move — a regra deixa de ser só prosa do README e ganha um requisito e um gate; o README passa a nomear o gate |
+| Prova observada, não esperada, antes de declarar entrega | `verify-before-claiming` | already canonical — grupo de simulação de `tasks.md` |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — nomes de função, labels de selftest, nome do step em inglês |
+
+## Risks / Trade-offs
+
+- **A dispensa vira boilerplate.** → `MIN_REASON` compartilhado com o spec-rite; e a linha é uma por
+  PR, não por skill, então uma varredura honesta custa uma frase.
+- **Rename/whitespace/typo dispara o gate.** → Aceito na issue; a linha de dispensa é a saída, e o
+  achado a nomeia.
+- **O gate reprova o próprio PR desta change** (edita `skills/execute-backlog/references/spec-rite.md`).
+  → `execute-backlog` sobe `1.8.0 → 1.8.1` no mesmo PR; o gate fica mudo por bump, não por dispensa.
+- **`git show <base>:skills/<x>/SKILL.md` em skill com muitos caminhos alterados custa um processo por
+  skill.** → 35 skills no catálogo; pior caso ~70 `git show`, medido em segundos no CI. Sem cache por
+  desenho: simplicidade sobre velocidade num gate que roda uma vez por PR.
+- **Semver com pré-release (`1.2.3-beta`).** → O gate compara a tupla `(major, minor, patch)`; o
+  step de frontmatter só exige esse prefixo. Um bump só de pré-release conta como "não moveu" —
+  declarado no KNOWN LIMIT; nenhuma skill do catálogo usa pré-release hoje.
+
+## Open Questions
+
+Nenhuma. O que poderia virar achismo — quais skills `cf767ee` e o PR #122 tocaram e com que
+versões, o que `generate.sh` copia, o que o step de frontmatter verifica — foi medido e está em
+`tasks.md` com comando e saída.

--- a/openspec/changes/add-skill-version-gate/design.md
+++ b/openspec/changes/add-skill-version-gate/design.md
@@ -52,6 +52,16 @@ selftest de cada uma dependente da outra. O novo script copia a **forma** — as
 plumbing com os mesmos nomes, o mesmo leitor do corpo, o mesmo skip, o mesmo `annotate` — para que
 quem já leu um leia o outro sem custo.
 
+Uma divergência deliberada, apontada na revisão do PR: `changed_paths()` aqui roda `git diff
+--name-only -z` e separa por NUL, e não por linha como o irmão. Sem `-z`, o git envolve em aspas e
+escapa em octal qualquer caminho com byte não-ASCII, de controle ou aspas (`core.quotePath`, padrão
+`true` num checkout limpo e nos runners ubuntu); `"skills/x/caf\303\251.md"` não começa com `skills/`,
+`skills_in()` descarta o caminho e a skill some da medição — o gate aprovou exatamente esse fixture.
+No irmão a mesma entrada continua sendo ofensora (a regra é "existe caminho fora de `openspec/`"), por
+isso ele falha fechado por acidente e não precisa da flag para decidir certo; aqui a regra é por skill
+e a flag é o que a mantém fechada. O selftest comita um caminho assim num repositório descartável com
+`core.quotePath=true` forçado e exige o nome de volta intacto.
+
 ### D2 — "Conteúdo mudou" é qualquer caminho sob `skills/<x>/`, exceto a linha `  version:`
 
 Para cada skill com caminho alterado no diff `<merge-base>...HEAD`: se algum caminho alterado não é o

--- a/openspec/changes/add-skill-version-gate/proposal.md
+++ b/openspec/changes/add-skill-version-gate/proposal.md
@@ -1,0 +1,70 @@
+# Change: Medir o `metadata.version` por skill com um gate e uma dispensa escrita
+
+## Why
+
+`README.md:194` (e de novo em `:864`) promete um contrato por skill: "Each skill also carries its
+own `metadata.version` … bump it when that skill's behavior changes. Repo version = the collection;
+skill version = the individual contract." Nada mede a segunda metade da frase. O step *Skill
+frontmatter checks* de `.github/workflows/ci.yml` verifica presença e formato semver do campo; o
+requisito *Uniform frontmatter metadata* de `openspec/specs/skills-authoring/spec.md` exige o campo,
+não o bump.
+
+Medido na issue #119 (`git log` por skill, sem `chore(release)`): 20 skills cujo último commit de
+conteúdo não mexeu em `metadata.version`; no histórico inteiro, 49 de 165 pares (commit, skill) com
+edição de conteúdo ficaram sem bump, 42 deles vindos de 4 varreduras catálogo-inteiro. Um só commit,
+`cf767ee`, tocou 13 skills e bumpou zero (a décima terceira, `code-locale`, nasceu ali). Regra
+escrita e não medida é o estado que a doutrina deste repositório rejeita — a mesma assimetria que
+levou o spec-rite a exigir dispensa por linha escrita com motivo (issue #117).
+
+A decisão registrada na issue em 2026-09-05 é a **Opção A**: gate com dispensa escrita. A Opção B
+(rebaixar o campo a informativo) apagaria a promessa em vez de honrá-la.
+
+## What Changes
+
+- `scripts/validate-skill-version.py`, novo, no molde de `scripts/validate-spec-rite.py`: mesma
+  resolução de base (`GITHUB_BASE_REF`, `origin/master`, `origin/main`), mesmo leitor do corpo do PR
+  (`GITHUB_EVENT_PATH`, com `PR_BODY` como override deliberado), mesmo `--selftest` com `DEFECTS` e
+  `SILENT`, mesmo skip impresso em evento que não é `pull_request`. Regra: para cada `skills/<x>/`
+  com qualquer caminho alterado contra a base — ignorando um diff cuja única mudança na skill é a
+  linha `  version:` — o `metadata.version` do `SKILL.md` em HEAD tem de ser semver-maior que na
+  base, **ou** o corpo do PR carrega uma linha `Skill-version: none — <motivo>` (motivo com o mesmo
+  tamanho mínimo da dispensa do spec-rite). Skill nova (sem `SKILL.md` na base) passa. Árvores
+  geradas (`claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/`) nunca contam. Versão que **desce**
+  é achado sempre, dispensa ou não.
+- Dois steps novos em `ci.yml`, logo depois de *Spec-rite self-test*: o gate e o seu `--selftest`.
+- `README.md`: as duas frases que enunciam a regra passam a dizer que o bump é medido pelo gate e
+  nomeiam a linha de dispensa.
+- `skills/execute-backlog/references/spec-rite.md`, seção *In the PR body*: a linha `Skill-version`
+  ao lado da linha `Spec-rite`, em um parágrafo curto. `metadata.version` de `execute-backlog` sobe
+  um patch, e os wrappers são regenerados.
+- Delta em `skills-authoring`: requisito novo *A skill's version moves with its content*.
+
+Não é **BREAKING** para consumidores do catálogo: nenhum skill entra, sai ou muda de nome, e nenhum
+consumidor lê `metadata.version` (`generate.sh`, `install.sh`, `update.sh`, `set-version.sh` e o
+`marketplace.json` usam só o `VERSION` do repositório). É mais restritivo para quem abre PR neste
+repositório: editar `skills/<x>/` sem bump e sem a linha passa a reprovar.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Nenhum skill novo entra no catálogo.
+
+### Modified Capabilities
+
+- `skills-authoring`: ganha o requisito *A skill's version moves with its content* — a regra do
+  README passa a ser medida por um gate diff-based, com dispensa escrita PR-wide, isenção para skill
+  nova e para diff só em árvore gerada, e skip declarado fora de `pull_request`. *Uniform
+  frontmatter metadata* não muda: ele exige o campo; o requisito novo exige o movimento.
+
+## Impact
+
+- `scripts/validate-skill-version.py` (novo); `.github/workflows/ci.yml` (dois steps).
+- `README.md:194` e `:864`.
+- `skills/execute-backlog/SKILL.md` (só `metadata.version`, 1.8.0 → 1.8.1) e
+  `skills/execute-backlog/references/spec-rite.md` (um parágrafo); espelhos regenerados por
+  `./generate.sh` em `claude/skills/execute-backlog/` e `plugins/workflow/skills/execute-backlog/`.
+- Nenhuma outra skill é tocada; a composição do catálogo (35 skills, descoberta via `npx`) fica
+  idêntica.
+- Quem abre PR neste repositório: ~1 em 5 PRs de skill carrega uma linha `Skill-version: none —
+  <motivo>` (custo aceito na decisão da issue); uma varredura catálogo-inteiro carrega uma linha só.

--- a/openspec/changes/add-skill-version-gate/specs/skills-authoring/spec.md
+++ b/openspec/changes/add-skill-version-gate/specs/skills-authoring/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: A skill's version moves with its content
+
+A pull request that changes any path under `skills/<name>/` — the `SKILL.md` body, a file under
+`references/`, anything the skill owns — SHALL raise that skill's `metadata.version` above the value
+on the base revision, or SHALL carry one pull-request-wide line `Skill-version: none — <reason>` in
+its body, with a reason at least as long as the spec-rite waiver requires. The rule SHALL be measured
+by a script wired into CI that diffs the branch against its base, so that the promise `README.md`
+makes to contributors — "bump it when that skill's behavior changes" — is enforced and not merely
+stated.
+
+The gate SHALL read the diff, not the working tree: a skill whose only change is the `  version:`
+line itself is not a content change; a skill with no `SKILL.md` on the base is new and has nothing to
+move from; a diff confined to the generated trees (`claude/`, `codex/`, `cursor/`, `copilot/`,
+`plugins/`) is not a skill edit. A version that moves **backwards** SHALL be a finding regardless of
+any waiver, because no reason makes a lower number correct.
+
+The waiver is authored by whoever opened the pull request and SHALL be matched as text at the start
+of a line, never executed or interpolated, and read from the event payload the runner writes rather
+than through a step's environment, the same way the spec-rite waiver is read.
+
+The gate SHALL carry a self-test that injects one defect per rule and asserts detection, and SHALL
+state in its own header what it does not cover: it proves the number moved, not that the movement
+was the right magnitude or that the waiver's reason is honest.
+
+#### Scenario: An edited skill without a bump fails
+
+- **WHEN** a pull request changes `skills/backlog/SKILL.md` and `metadata.version` reads `1.5.0` on
+  both the base and the head, and the body carries no `Skill-version:` line
+- **THEN** the CI validate job fails naming the skill, the base version, the head version, and the
+  two exits — bump the version above `1.5.0`, or add `Skill-version: none — <reason>` to the body
+
+#### Scenario: A pull-request-wide waiver covers every edited skill
+
+- **WHEN** a pull request edits twelve skills without moving any `metadata.version` and its body
+  carries one line `Skill-version: none — cross-reference line added to each skill, no rule changed`
+- **THEN** the gate stays silent for all twelve, because the waiver is read once for the whole diff
+
+#### Scenario: A waiver without a usable reason fails
+
+- **WHEN** the body carries `Skill-version: none` alone, or with a reason shorter than the shared
+  minimum
+- **THEN** the gate fails naming the missing reason, not the missing bump
+
+#### Scenario: A new skill passes
+
+- **WHEN** a pull request adds `skills/new-skill/SKILL.md` and no `SKILL.md` exists for it on the base
+- **THEN** the gate stays silent for that skill, because there is no previous version to move from
+
+#### Scenario: A wrapper-only diff passes
+
+- **WHEN** a pull request changes only files under `claude/skills/<name>/` or
+  `plugins/<group>/skills/<name>/` and nothing under `skills/<name>/`
+- **THEN** the gate stays silent, because generated trees are never counted as skill edits
+
+#### Scenario: A version that moves backwards fails even with a waiver
+
+- **WHEN** a pull request changes `skills/x/SKILL.md` and `metadata.version` goes from `1.8.0` to
+  `1.7.0`, with or without a `Skill-version: none — <reason>` line in the body
+- **THEN** the gate fails naming the regression
+
+#### Scenario: The gate skips on push events and says so
+
+- **WHEN** the CI job runs on an event that is not `pull_request` (a push to `master`)
+- **THEN** the gate prints that it skipped and why, and exits successfully, because there is no
+  pull request body to read and no base to diff against

--- a/openspec/changes/add-skill-version-gate/tasks.md
+++ b/openspec/changes/add-skill-version-gate/tasks.md
@@ -16,20 +16,89 @@
 
 ## 2. O gate `scripts/validate-skill-version.py` (D1–D6)
 
-- [ ] 2.1 `resolve_base`, `changed_paths`, `read_pr_body` e o skip fora de `pull_request` no idioma
+- [x] 2.1 `resolve_base`, `changed_paths`, `read_pr_body` e o skip fora de `pull_request` no idioma
       exato de `validate-spec-rite.py`; `MIN_REASON` importado do irmão
-- [ ] 2.2 `collect()` lê o diff por skill: caminhos sob `skills/<x>/`, versão na base e no HEAD, e
+
+      ```
+      grep -n "def resolve_base\|def read_pr_body\|def changed_paths\|MIN_REASON = \|not pull_request" scripts/validate-skill-version.py
+      -> 94:MIN_REASON = _sibling_min_reason()
+      -> 113:def resolve_base(root: Path) -> str | None:
+      -> 129:def read_pr_body() -> str:
+      -> 155:def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
+      -> [...] print(f"  skill-version gate: skipped (event {event}, not pull_request)")
+      python3 scripts/validate-skill-version.py --selftest | grep MIN_REASON
+      -> HELPER  MIN_REASON agrees with the spec-rite gate
+      ```
+
+- [x] 2.2 `collect()` lê o diff por skill: caminhos sob `skills/<x>/`, versão na base e no HEAD, e
       se o conteúdo mudou além da linha `  version:`; árvores geradas ignoradas
-- [ ] 2.3 `evaluate()` pura: `V1` skill editada sem bump e sem dispensa; `V2` versão que desce;
+
+      `collect(root, base, head)` em `:214`; medido contra o histórico real em S.1 (13 skills em
+      `cf767ee`, `code-locale` com `base_version=None`; 6 em `e13c16a`). Helpers no selftest:
+
+      ```
+      python3 scripts/validate-skill-version.py --selftest | grep HELPER
+      -> HELPER  version parsed from frontmatter
+      -> HELPER  version-only edit compares equal
+      -> HELPER  body edit compares different
+      -> HELPER  semver orders numerically, not lexically
+      -> HELPER  generated trees are dropped
+      -> HELPER  references group under their skill
+      ```
+
+- [x] 2.3 `evaluate()` pura: `V1` skill editada sem bump e sem dispensa; `V2` versão que desce;
       `V3` dispensa sem motivo utilizável; skill nova e wrapper-only mudos
-- [ ] 2.4 `--selftest`: editada sem bump → achado; com bump → mudo; com dispensa → mudo; skill nova →
+
+      `evaluate(skills, pr_body)` em `:249`, sem I/O; `V2` avaliado antes e independente da dispensa
+      (`:251-259`). Saída de um achado, observada:
+
+      ```
+      evaluate([SkillDiff('backlog', ('skills/backlog/SKILL.md',), '1.5.0', '1.5.0', True)], '')
+      -> V1 unbumped skill — skills/backlog/ changed 1 path(s) — skills/backlog/SKILL.md — with metadata.version 1.5.0 on the base and 1.5.0 on HEAD. Either raise `  version:` in skills/backlog/SKILL.md above 1.5.0, or add one line `Skill-version: none — <reason>` to the pull request body (it covers every skill in this diff)
+      evaluate([... '1.8.0', '1.7.0' ...], 'Skill-version: none — typo fix in one sentence')
+      -> V2 version moved backwards — skills/backlog/SKILL.md metadata.version went from 1.8.0 (base) to 1.7.0 (HEAD). [...] A `Skill-version: none` line does not cover this
+      ```
+
+- [x] 2.4 `--selftest`: editada sem bump → achado; com bump → mudo; com dispensa → mudo; skill nova →
       mudo; wrapper-only → mudo; versão que desce → achado; dispensa sem motivo → achado
-- [ ] 2.5 Docstring lista as regras e o KNOWN LIMIT
+
+      ```
+      python3 scripts/validate-skill-version.py --selftest
+      -> CAUGHT  V1 unbumped skill: ''
+      -> CAUGHT  V1 unbumped skill: 'see the Skill-version: none — reason line elsewhere'
+      -> CAUGHT  V2 version moved backwards: 'Skill-version: none — typo fix in one sentence'
+      -> CAUGHT  V3 waiver reason: 'Skill-version: none — x'
+      -> CAUGHT  V3 waiver reason: 'Skill-version: none'
+      -> SILENT  edited with a bump
+      -> SILENT  edited with a waiver
+      -> SILENT  twelve skills, one waiver
+      -> SILENT  new skill
+      -> SILENT  version-only edit
+      -> SILENT  wrapper-only diff
+      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 8/8 helper cases correct
+      -> exit=0
+      ```
+
+- [x] 2.5 Docstring lista as regras e o KNOWN LIMIT
+
+      ```
+      grep -n "^  V[123] \|^KNOWN LIMIT" scripts/validate-skill-version.py
+      -> 13:  V1 a skill with changed content has a metadata.version on HEAD that is semver-greater than on the
+      -> 16:  V2 a metadata.version never moves backwards — a lower number is an editing error, and no reason
+      -> 18:  V3 the waiver names a usable reason (the same minimum length as the spec-rite waiver, imported
+      -> 28:KNOWN LIMIT: this proves that the number MOVED, not that it moved by the right amount (a patch bump
+      ```
 
 ## 3. CI e documentação
 
-- [ ] 3.1 `ci.yml`: steps *Skill version gate* e *Skill version self-test* logo depois de *Spec-rite
+- [x] 3.1 `ci.yml`: steps *Skill version gate* e *Skill version self-test* logo depois de *Spec-rite
       self-test*
+
+      ```
+      python3 -c "import yaml; d=yaml.safe_load(open('.github/workflows/ci.yml')); n=[s['name'] for s in d['jobs']['validate']['steps']]; i=n.index('Spec-rite self-test (the gate is itself gated)'); print(len(n), n[i:i+4])"
+      -> 22 ['Spec-rite self-test (the gate is itself gated)', 'Skill version gate (an edited skill moves its metadata.version, or the body waives it)', 'Skill version self-test (the gate is itself gated)', 'Claude plugin validation (vendor validator, blocking)']
+      -> run: python3 scripts/validate-skill-version.py | python3 scripts/validate-skill-version.py --selftest
+      ```
 - [ ] 3.2 `README.md`: as duas frases da regra dizem que o bump é medido pelo gate e nomeiam a linha
       `Skill-version: none — <motivo>`
 - [ ] 3.3 `skills/execute-backlog/references/spec-rite.md`, *In the PR body*: parágrafo com a linha

--- a/openspec/changes/add-skill-version-gate/tasks.md
+++ b/openspec/changes/add-skill-version-gate/tasks.md
@@ -7,12 +7,98 @@
        E.3  names the gap, or states explicitly that there is none
        E.4  lists a follow-up, or states explicitly that there is none -->
 
-- [ ] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
-- [ ] E.2 Ferramentas e comportamentos probados contra a versão instalada; comando e fragmento da
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `bfc400d` (topo de `master`, 2026-09-05):
+
+      - `scripts/validate-spec-rite.py` — 338 linhas; `resolve_base()` (`SPEC_RITE_BASE`,
+        `GITHUB_BASE_REF`, `origin/master`, `origin/main`), `read_pr_body()` com `PR_BODY` acima de
+        `GITHUB_EVENT_PATH`, `changed_paths()` com `git diff --name-only <base>...HEAD`, `WAIVER` e
+        `WAIVER_NO_REASON` ancorados no começo da linha, `MIN_REASON = 8`, `evaluate()` pura,
+        `DEFECTS`/`SILENT`, skip impresso fora de `pull_request`, `S0` sem base em CI.
+      - `.github/workflows/ci.yml` — 20 steps em `jobs.validate`; step *Skill frontmatter checks*
+        com `grep -qE '^  version: [0-9]+\.[0-9]+\.[0-9]+'` sobre o bloco de frontmatter; step
+        *Spec-rite self-test* em `:184-185`, seguido de *Claude plugin validation*.
+      - `README.md:194` e `:864` — as duas frases da regra do bump (a issue cita `:180`/`:824`;
+        o arquivo cresceu). `README.md:876-889` descreve o spec-rite no corpo do PR — não está entre os
+        dois lugares deste item (ver E.4).
+      - `skills/execute-backlog/SKILL.md` — `metadata.version: 1.8.0`;
+        `skills/execute-backlog/references/spec-rite.md:78-88` — seção *In the PR body*.
+      - `generate.sh:1-31` — copia o `SKILL.md` inteiro para `claude/skills/<x>/` e
+        `plugins/<grupo>/skills/<x>/`; a linha `  version:` aparece portanto nas árvores geradas.
+      - `openspec/specs/skills-authoring/spec.md` — *Uniform frontmatter metadata* exige o campo,
+        não o movimento; *Authoring rules are machine-enforced* pede selftest com um defeito por regra.
+      - `openspec/changes/archive/2026-09-04-close-ci-gate-holes/{proposal,design,tasks}.md` e
+        `specs/**` — modelo de estilo.
+      - `openspec/schemas/skills-rite/templates/{proposal,design,tasks,spec}.md` e `schema.yaml`.
+      - `scripts/validate-rite.sh` e `scripts/validate-rite-evidence.py:1-60,157-200` — a forma que
+        cada caixa marcada deve ter.
+      - Histórico: `cf767ee` (issue #76) e `e13c16a` (squash do PR #122 sobre `d2918ed`) via
+        `git show --stat` — os dois pontos usados como fixture em S.1.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada; comando e fragmento da
       saída registrados
-- [ ] E.3 O que não pôde ser probado, escrito como questão aberta — nunca como fato
-- [ ] E.4 Checagem de escopo: a change faz só o que a proposta pediu; melhorias adjacentes ficam
-      listadas como follow-up
+
+      ```
+      openspec --version                                          -> 1.6.0
+      python3 --version                                           -> Python 3.14.5
+      ls skills | wc -l                                           -> 35
+      openspec new change add-skill-version-gate --schema skills-rite
+      -> Created change 'add-skill-version-gate' at openspec/changes/add-skill-version-gate/
+      openspec validate add-skill-version-gate --strict           -> Change 'add-skill-version-gate' is valid
+      ```
+
+      Versões por skill nos dois pontos do histórico (script de probe com `git diff --name-only` +
+      `git show <rev>:skills/<x>/SKILL.md | grep '^  version:'`):
+
+      ```
+      cf767ee^..cf767ee: 20 skill paths, 13 skills
+      -> api-resilience-testing: base=['  version: 1.2.1'] head=['  version: 1.2.1']
+      -> backlog: base=['  version: 1.3.0'] head=['  version: 1.3.0']
+      -> code-locale: base=[] head=['  version: 1.0.0']
+      -> execute-backlog: base=['  version: 1.5.0'] head=['  version: 1.5.0']
+      -> [...] 12 skills com base == head, 1 sem SKILL.md na base
+      d2918ed..e13c16a: 6 skill paths, 6 skills
+      -> api-resilience-testing: base=['  version: 1.2.1'] head=['  version: 1.3.0']
+      -> execute-backlog: base=['  version: 1.7.0'] head=['  version: 1.8.0']
+      -> [...] 6 de 6 com head > base
+      ```
+
+      ```
+      grep -rln "version: 1.8.0" claude codex cursor copilot plugins | grep execute-backlog
+      -> claude/skills/execute-backlog/SKILL.md
+      -> plugins/workflow/skills/execute-backlog/SKILL.md
+      python3 -c "import importlib.util; ..." (módulo carregado por spec_from_file_location sem registrar em sys.modules)
+      -> AttributeError: 'NoneType' object has no attribute '__dict__'   (dataclasses.py:814, Python 3.14.5)
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      - O comportamento do gate **na run real do GitHub Actions** (payload `GITHUB_EVENT_PATH` escrito
+        pelo runner, `GITHUB_BASE_REF` real, `fetch-depth: 0`) não é medível localmente; foi
+        reproduzido com payload fabricado e ambiente `GITHUB_ACTIONS=true` num clone descartável
+        (S.1). A prova final é a run do PR desta change.
+      - `V0 base revision` (checkout raso em CI) não foi exercitado end-to-end: exigiria um clone com
+        `--depth 1` sem `origin/master`; a regra é cópia literal do `S0` do irmão, que também só a
+        declara.
+      - Semver com pré-release: nenhuma skill do catálogo usa (`grep -E '^  version: .*-' skills/*/SKILL.md`
+        -> vazio), então o comportamento "sufixo mudou, tupla igual → não moveu" é lido do código, não
+        observado num caso real; declarado no KNOWN LIMIT.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz o que a issue #119 e a decisão da Opção A pediram e nada além. Notados pelo caminho
+      e **não** feitos, como follow-up:
+
+      - `README.md:876-889` (seção *3. Release*) descreve o que o CI lê no corpo do PR e cita só a
+        linha `Spec-rite`; não é um dos dois lugares da regra do bump que este item possui. Adicionar
+        ali a linha `Skill-version` é follow-up.
+      - Bumps retroativos nas 20 skills medidas na issue — fora de escopo pela própria issue.
+      - `validate-spec-rite.py` importado por `spec_from_file_location` sem `sys.modules` funciona
+        porque não tem `@dataclass`; este gate registra o módulo antes do `exec_module`. Fazer o
+        mesmo no irmão é higiene, não deste item.
+      - `gates.sh` (runner local do orquestrador, fora do repositório) não roda o gate novo; foi rodado
+        à parte em S.1.
 
 ## 2. O gate `scripts/validate-skill-version.py` (D1–D6)
 
@@ -99,10 +185,28 @@
       -> 22 ['Spec-rite self-test (the gate is itself gated)', 'Skill version gate (an edited skill moves its metadata.version, or the body waives it)', 'Skill version self-test (the gate is itself gated)', 'Claude plugin validation (vendor validator, blocking)']
       -> run: python3 scripts/validate-skill-version.py | python3 scripts/validate-skill-version.py --selftest
       ```
-- [ ] 3.2 `README.md`: as duas frases da regra dizem que o bump é medido pelo gate e nomeiam a linha
+- [x] 3.2 `README.md`: as duas frases da regra dizem que o bump é medido pelo gate e nomeiam a linha
       `Skill-version: none — <motivo>`
-- [ ] 3.3 `skills/execute-backlog/references/spec-rite.md`, *In the PR body*: parágrafo com a linha
+
+      ```
+      grep -n "validate-skill-version" README.md
+      -> 194:Each skill also carries its own `metadata.version` [...] The bump is measured, not trusted: [`scripts/validate-skill-version.py`](scripts/validate-skill-version.py) diffs every pull request against its base [...] `Skill-version: none — <reason>` covering the whole diff. [...]
+      -> 864:- Bump `metadata.version` whenever the skill changes. CI measures it (`scripts/validate-skill-version.py`): [...] unless its body carries `Skill-version: none — <reason>`.
+      ```
+
+- [x] 3.3 `skills/execute-backlog/references/spec-rite.md`, *In the PR body*: parágrafo com a linha
       `Skill-version`; `metadata.version` de `execute-backlog` 1.8.0 → 1.8.1; `bash generate.sh`
+
+      ```
+      grep -n "Skill-version" skills/execute-backlog/references/spec-rite.md
+      -> 92:skill without moving its version: `Skill-version: none — <the reason these edits deserve no bump>`.
+      grep -n "^  version:" skills/execute-backlog/SKILL.md claude/skills/execute-backlog/SKILL.md plugins/workflow/skills/execute-backlog/SKILL.md
+      -> skills/execute-backlog/SKILL.md:17:  version: 1.8.1
+      -> claude/skills/execute-backlog/SKILL.md:17:  version: 1.8.1
+      -> plugins/workflow/skills/execute-backlog/SKILL.md:17:  version: 1.8.1
+      bash generate.sh -> Generated 10 category plugins in plugins/ (descriptions derived from the tree)
+      git status --porcelain (depois do commit 1f9b27b) -> (vazio)
+      ```
 
 ## 4. Simulation & Field Proof (MANDATORY)
 
@@ -111,25 +215,142 @@
        S.2  the case matrix as counts (n/n)
        S.3  names what escaped or misbehaved, or states explicitly that nothing did -->
 
-- [ ] S.1 O gate exercitado pelo caminho real: `evaluate()` contra o histórico (`cf767ee` tem de
+- [x] S.1 O gate exercitado pelo caminho real: `evaluate()` contra o histórico (`cf767ee` tem de
       produzir achados; o branch do PR #122 tem de ficar mudo) e o script pelo entry point com
       `GITHUB_EVENT_PATH` fabricado, com e sem a dispensa
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+      **Histórico real** — `collect(root, base, head)` + `evaluate()` importados de
+      `scripts/validate-skill-version.py` (`f787d65`, 2026-09-05), apontados para os dois commits:
+
+      ```
+      collect(W, 'cf767ee^', 'cf767ee'); evaluate(skills, '')
+      -> 13 skill(s), 13 with content, 12 finding(s)
+      -> code-locale: None -> 1.0.0 content=True paths=5          (skill nova: sem achado)
+      -> FINDING V1 unbumped skill: skills/backlog/ changed 2 path(s) — skills/backlog/SKILL.md, skills/backlog/references/issue-template.md — with metadata.version 1.3.0 on the base and 1.3.0 on HEAD. [...]
+      -> FINDING V1 unbumped skill: skills/execute-backlog/ changed 3 path(s) [...] 1.5.0 on the base and 1.5.0 on HEAD. [...]
+      -> [...] 12 achados V1, um por skill existente
+      collect(W, 'cf767ee^', 'cf767ee'); evaluate(skills, 'Closes #76\n\nSkill-version: none — cross-reference line to code-locale in nine skills; the rest is the new skill\n')
+      -> 13 skill(s), 13 with content, 0 finding(s)
+      collect(W, 'd2918ed', 'e13c16a'); evaluate(skills, '')          (PR #122)
+      -> 6 skill(s), 6 with content, 0 finding(s)
+      -> execute-backlog: 1.7.0 -> 1.8.0 content=True paths=1  [...]
+      collect(W, 'origin/master', 'HEAD'); evaluate(skills, '')        (este branch)
+      -> 1 skill(s), 1 with content, 0 finding(s)
+      -> execute-backlog: 1.8.0 -> 1.8.1 content=True paths=2
+      ```
+
+      **Entry point real** — `python3 scripts/validate-skill-version.py` como subprocesso a partir da
+      raiz, com `GITHUB_ACTIONS=true GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master` e o corpo
+      só no arquivo apontado por `GITHUB_EVENT_PATH` (`{"pull_request":{"body":...}}`), num clone
+      descartável do worktree (`git clone <worktree> scratch/e2e-clone`, branch `probe` a partir de
+      `f787d65`); o worktree ficou limpo (`git status --porcelain` -> vazio antes e depois):
+
+      ```
+      branch como commitado, corpo "Closes #119\n\nSpec-rite: add-skill-version-gate\n"
+      -> skill-version gate: 0 findings (base origin/master, 1 skill(s) changed, 1 with content changes)   exit=0
+      + linha no fim de skills/backlog/SKILL.md, commit, mesmo corpo (sem Skill-version)
+      -> ::error::V1 unbumped skill — skills/backlog/ changed 1 path(s) — skills/backlog/SKILL.md — with metadata.version 1.5.0 on the base and 1.5.0 on HEAD. [...]
+      -> skill-version gate: 1 findings (base origin/master, 2 skill(s) changed, 2 with content changes)   exit=1
+      mesmo diff, corpo com "Skill-version: none — probe: one trailing line added, no rule changed"
+      -> skill-version gate: 0 findings (base origin/master, 2 skill(s) changed, 2 with content changes)   exit=0
+      mesmo diff, corpo "Skill-version: none\n"
+      -> ::error::V3 waiver reason — the pull request body carries `Skill-version: none` with no reason — [...]   exit=1
+      mesmo diff, sem GITHUB_EVENT_PATH (corpo degrada para vazio)
+      -> ::error::V1 unbumped skill — [...]   exit=1
+      mesmo diff, GITHUB_EVENT_NAME=push
+      -> skill-version gate: skipped (event push, not pull_request)   exit=0
+      mesmo diff + `  version: 1.5.0` -> `1.5.1`, corpo vazio
+      -> skill-version gate: 0 findings (base origin/master, 2 skill(s) changed, 2 with content changes)   exit=0
+      mesmo diff + `  version:` -> `1.4.0` (abaixo da base 1.5.0), corpo "Skill-version: none — probe: pretend this is fine"
+      -> ::error::V2 version moved backwards — skills/backlog/SKILL.md metadata.version went from 1.5.0 (base) to 1.4.0 (HEAD). A version never goes down; restore it above 1.5.0. A `Skill-version: none` line d[...]   exit=1
+      branch limpo + linha só em claude/skills/backlog/SKILL.md, corpo vazio
+      -> skill-version gate: 0 findings (base origin/master, 1 skill(s) changed, 1 with content changes)   exit=0
+      branch limpo + skills/zz-probe/SKILL.md novo, corpo vazio
+      -> skill-version gate: 0 findings (base origin/master, 2 skill(s) changed, 2 with content changes)   exit=0
+      ```
+
+      No próprio worktree, sem ambiente de CI:
+
+      ```
+      python3 scripts/validate-skill-version.py
+      -> skill-version gate: 0 findings (base origin/master, 1 skill(s) changed, 1 with content changes)   exit=0
+      GITHUB_ACTIONS=true GITHUB_EVENT_NAME=push python3 scripts/validate-skill-version.py
+      -> skill-version gate: skipped (event push, not pull_request)   exit=0
+      python3 scripts/validate-skill-version.py --selftest
+      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 8/8 helper cases correct   exit=0
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | Tinha de disparar e disparou | 5/5 | histórico `cf767ee` sem dispensa (12 achados V1, contado como 1); entry point: edição sem bump sem dispensa (1), dispensa sem motivo (1), sem payload (1), versão abaixo da base com dispensa (1) |
+      | Tinha de ficar mudo e ficou | 8/8 | histórico: `cf767ee` com dispensa PR-wide (1), PR #122 com 6 bumps (1), este branch (1); entry point: branch commitado (1), bump patch (1), dispensa com motivo (1), wrapper-only (1), skill nova (1) |
+      | Skip declarado | 2/2 | `GITHUB_EVENT_NAME=push` no clone e no worktree — `skipped (event push, not pull_request)` |
+      | Selftest | 3/3 | 7/7 defeitos, 11/11 mudos, 8/8 helpers |
+      | Escape conhecido ficou mudo | 0/0 | nenhum caso de escape foi construído (pré-release não existe no catálogo; ver E.3) |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      - **Importação do gate quebrou na primeira tentativa**: carregar `validate-skill-version.py` com
+        `importlib.util.spec_from_file_location` sem registrar em `sys.modules` falha em Python 3.14.5
+        na criação do `@dataclass SkillDiff` (`dataclasses.py:814`, `AttributeError: 'NoneType' object
+        has no attribute '__dict__'`). O script passou a registrar o módulo irmão antes do
+        `exec_module`, e o comentário em `_sibling_min_reason()` avisa quem importar este arquivo do
+        mesmo jeito. Não afeta o caminho do CI (o script roda como programa).
+      - **A primeira versão do probe de "versão que desce" não desceu**: baixou `1.5.1 → 1.5.0`, que é
+        igual à base, e o gate ficou (corretamente) mudo com a dispensa presente. Corrigido para
+        `1.4.0`; o `V2` disparou. Defeito do probe, não do gate — registrado porque um caso de
+        simulação mal construído passa em silêncio.
+      - O PR #122 tocou **6** skills, não 5 como a issue estimou; todas bumpadas, resultado mudo.
+      - `README.md` cita `:180`/`:824` na issue; hoje as frases estão em `:194`/`:864`. Editadas as
+        duas, nenhuma outra.
+      - `V0 base revision` (CI sem `fetch-depth: 0`) não exercitado (E.3).
 
 ## 5. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: name == directory, description dobrada,
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: name == directory, description dobrada,
       author solvelab, version semver, category no conjunto, license MIT, compatibility presente
-- [ ] Q.2 Conteúdo de skill tocado em inglês
-- [ ] Q.3 Gatilhos de descrição testáveis, sem colisão com skill irmã
-- [ ] Q.4 Sem doutrina duplicada: cada regra transversal restada inline virou link (tabela Canonical
-      Home em `design.md`)
-- [ ] Q.5 Identificadores em inglês em todo exemplo de código tocado (`code-locale`)
+
+      Única skill tocada: `execute-backlog` (só a linha `  version:` no `SKILL.md`).
+
+      ```
+      awk '<frontmatter() de generate.sh>' skills/execute-backlog/SKILL.md | grep -E '^name:|^  version:|^  author:|^  category:|^license:|^compatibility:|^description: >-'
+      -> name: execute-backlog / description: >- / author: solvelab / version: 1.8.1 / category: process / license: MIT / compatibility: >-
+      gates.sh -> PASS frontmatter   (o shell do step, sobre as 35 skills)
+      ```
+
+- [x] Q.2 Conteúdo de skill tocado em inglês — o parágrafo novo em `references/spec-rite.md:90-97`
+      está em inglês; `validate-skills.py` -> `skills checked: 35   findings: 0`
+- [x] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma `description` muda
+- [x] Q.4 Sem doutrina duplicada: tabela Canonical Home em `design.md` (seis linhas); o README nomeia o
+      gate e a linha sem restatar o protocolo, que mora em `execute-backlog/references/spec-rite.md`
+- [x] Q.5 Identificadores em inglês no que a change introduz — nomes de função (`collect`, `moved_up`,
+      `skills_in`), `SkillDiff`, labels de selftest, nome dos steps (`code-locale`)
+
+      ```
+      git diff origin/master...HEAD -- .github scripts | python3 skills/code-locale/references/check-identifier-locale.py --diff -
+      -> findings: 0   exit=0
+      ```
 
 ## 6. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-skill-version-gate --strict` verde
-- [ ] V.2 Descoberta do catálogo intacta: 35 skills, sem órfão
-- [ ] V.3 README / docs atualizados onde a change altera o uso (regra do bump e linha de dispensa)
+- [x] V.1 `openspec validate add-skill-version-gate --strict` verde
+
+      ```
+      openspec validate add-skill-version-gate --strict -> Change 'add-skill-version-gate' is valid   (openspec 1.6.0)
+      bash scripts/validate-rite.sh -> rite evidence gate: 0 findings [...] rite gate OK
+      ```
+
+- [x] V.2 Descoberta do catálogo intacta: 35 skills, sem órfão
+
+      ```
+      ls skills | wc -l                       -> 35
+      python3 scripts/validate-skills.py      -> skills checked: 35   findings: 0   (C7: nenhum wrapper órfão)
+      python3 scripts/validate-repo-hygiene.py -> repo hygiene: 0 findings   (H2: contagens publicadas == 35)
+      ```
+
+- [x] V.3 README / docs atualizados onde a change altera o uso — `README.md:194` e `:864` (3.2),
+      `skills/execute-backlog/references/spec-rite.md` (3.3); o parágrafo *3. Release* do README fica
+      como follow-up (E.4)
 - [ ] V.4 `openspec archive add-skill-version-gate --yes` depois de todos os grupos acima `[x]`

--- a/openspec/changes/add-skill-version-gate/tasks.md
+++ b/openspec/changes/add-skill-version-gate/tasks.md
@@ -113,9 +113,9 @@
 
       ```
       grep -n "def resolve_base\|def read_pr_body\|def split_nul_paths\|def changed_paths\|MIN_REASON = \|not pull_request\|\"-z\"" scripts/validate-skill-version.py
-      -> 102:MIN_REASON = _sibling_min_reason()
-      -> 121:def resolve_base(root: Path) -> str | None:
-      -> 137:def read_pr_body() -> str:
+      -> 101:MIN_REASON = _sibling_min_reason()
+      -> 120:def resolve_base(root: Path) -> str | None:
+      -> 136:def read_pr_body() -> str:
       -> 162:def split_nul_paths(out: str) -> list[str]:
       -> 168:def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
       -> [...] "diff", "--name-only", "-z", f"{base}...{head}"],

--- a/openspec/changes/add-skill-version-gate/tasks.md
+++ b/openspec/changes/add-skill-version-gate/tasks.md
@@ -1,0 +1,66 @@
+## 1. Evidence & Sources (MANDATORY)
+
+<!-- Always the FIRST group: probe before you write. Record the COMMAND and a fragment of its
+     RAW OUTPUT, never a conclusion. Shape gated by scripts/validate-rite-evidence.py once ticked:
+       E.1  a repo-relative path AND the commit sha or date it was read at
+       E.2  at least one `command` -> a fragment of its output
+       E.3  names the gap, or states explicitly that there is none
+       E.4  lists a follow-up, or states explicitly that there is none -->
+
+- [ ] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+- [ ] E.2 Ferramentas e comportamentos probados contra a versão instalada; comando e fragmento da
+      saída registrados
+- [ ] E.3 O que não pôde ser probado, escrito como questão aberta — nunca como fato
+- [ ] E.4 Checagem de escopo: a change faz só o que a proposta pediu; melhorias adjacentes ficam
+      listadas como follow-up
+
+## 2. O gate `scripts/validate-skill-version.py` (D1–D6)
+
+- [ ] 2.1 `resolve_base`, `changed_paths`, `read_pr_body` e o skip fora de `pull_request` no idioma
+      exato de `validate-spec-rite.py`; `MIN_REASON` importado do irmão
+- [ ] 2.2 `collect()` lê o diff por skill: caminhos sob `skills/<x>/`, versão na base e no HEAD, e
+      se o conteúdo mudou além da linha `  version:`; árvores geradas ignoradas
+- [ ] 2.3 `evaluate()` pura: `V1` skill editada sem bump e sem dispensa; `V2` versão que desce;
+      `V3` dispensa sem motivo utilizável; skill nova e wrapper-only mudos
+- [ ] 2.4 `--selftest`: editada sem bump → achado; com bump → mudo; com dispensa → mudo; skill nova →
+      mudo; wrapper-only → mudo; versão que desce → achado; dispensa sem motivo → achado
+- [ ] 2.5 Docstring lista as regras e o KNOWN LIMIT
+
+## 3. CI e documentação
+
+- [ ] 3.1 `ci.yml`: steps *Skill version gate* e *Skill version self-test* logo depois de *Spec-rite
+      self-test*
+- [ ] 3.2 `README.md`: as duas frases da regra dizem que o bump é medido pelo gate e nomeiam a linha
+      `Skill-version: none — <motivo>`
+- [ ] 3.3 `skills/execute-backlog/references/spec-rite.md`, *In the PR body*: parágrafo com a linha
+      `Skill-version`; `metadata.version` de `execute-backlog` 1.8.0 → 1.8.1; `bash generate.sh`
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+<!-- Shape gated by scripts/validate-rite-evidence.py once ticked:
+       S.1  an `entry point` -> a fragment of the OBSERVED output
+       S.2  the case matrix as counts (n/n)
+       S.3  names what escaped or misbehaved, or states explicitly that nothing did -->
+
+- [ ] S.1 O gate exercitado pelo caminho real: `evaluate()` contra o histórico (`cf767ee` tem de
+      produzir achados; o branch do PR #122 tem de ficar mudo) e o script pelo entry point com
+      `GITHUB_EVENT_PATH` fabricado, com e sem a dispensa
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+## 5. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado: name == directory, description dobrada,
+      author solvelab, version semver, category no conjunto, license MIT, compatibility presente
+- [ ] Q.2 Conteúdo de skill tocado em inglês
+- [ ] Q.3 Gatilhos de descrição testáveis, sem colisão com skill irmã
+- [ ] Q.4 Sem doutrina duplicada: cada regra transversal restada inline virou link (tabela Canonical
+      Home em `design.md`)
+- [ ] Q.5 Identificadores em inglês em todo exemplo de código tocado (`code-locale`)
+
+## 6. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-skill-version-gate --strict` verde
+- [ ] V.2 Descoberta do catálogo intacta: 35 skills, sem órfão
+- [ ] V.3 README / docs atualizados onde a change altera o uso (regra do bump e linha de dispensa)
+- [ ] V.4 `openspec archive add-skill-version-gate --yes` depois de todos os grupos acima `[x]`

--- a/openspec/changes/add-skill-version-gate/tasks.md
+++ b/openspec/changes/add-skill-version-gate/tasks.md
@@ -99,18 +99,26 @@
         mesmo no irmão é higiene, não deste item.
       - `gates.sh` (runner local do orquestrador, fora do repositório) não roda o gate novo; foi rodado
         à parte em S.1.
+      - `validate-spec-rite.py` lê o diff sem `-z` e recebe caminhos com aspas e escapes octais quando
+        `core.quotePath` está ativo (padrão); como a regra dele é "existe caminho fora de `openspec/`",
+        o caminho quotado continua ofensor e o gate falha fechado — mas a mensagem nomeia o caminho
+        escapado. Trocar para `-z` lá é higiene do irmão, não deste item.
 
 ## 2. O gate `scripts/validate-skill-version.py` (D1–D6)
 
 - [x] 2.1 `resolve_base`, `changed_paths`, `read_pr_body` e o skip fora de `pull_request` no idioma
-      exato de `validate-spec-rite.py`; `MIN_REASON` importado do irmão
+      de `validate-spec-rite.py`; `MIN_REASON` importado do irmão. Única divergência (revisão do PR,
+      D1): `changed_paths` roda `git diff --name-only -z` e separa por NUL — sem a flag um caminho
+      com byte não-ASCII chega quotado (`"skills/x/caf\303\251.md"`) e `skills_in()` o descarta
 
       ```
-      grep -n "def resolve_base\|def read_pr_body\|def changed_paths\|MIN_REASON = \|not pull_request" scripts/validate-skill-version.py
-      -> 94:MIN_REASON = _sibling_min_reason()
-      -> 113:def resolve_base(root: Path) -> str | None:
-      -> 129:def read_pr_body() -> str:
-      -> 155:def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
+      grep -n "def resolve_base\|def read_pr_body\|def split_nul_paths\|def changed_paths\|MIN_REASON = \|not pull_request\|\"-z\"" scripts/validate-skill-version.py
+      -> 102:MIN_REASON = _sibling_min_reason()
+      -> 121:def resolve_base(root: Path) -> str | None:
+      -> 137:def read_pr_body() -> str:
+      -> 162:def split_nul_paths(out: str) -> list[str]:
+      -> 168:def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
+      -> [...] "diff", "--name-only", "-z", f"{base}...{head}"],
       -> [...] print(f"  skill-version gate: skipped (event {event}, not pull_request)")
       python3 scripts/validate-skill-version.py --selftest | grep MIN_REASON
       -> HELPER  MIN_REASON agrees with the spec-rite gate
@@ -130,6 +138,19 @@
       -> HELPER  semver orders numerically, not lexically
       -> HELPER  generated trees are dropped
       -> HELPER  references group under their skill
+      -> HELPER  NUL-separated names are read verbatim, quotes and newlines included
+      -> HELPER  a non-ASCII name still groups under its skill
+      -> HELPER  changed_paths() survives core.quotePath on a real repository
+      ```
+
+      O último helper é a única sonda de plumbing do selftest (`_probe_quoted_path()` em `:347`):
+      `git init` num diretório temporário, dois commits, `skills/probe/references/café.md` no segundo,
+      `core.quotePath=true` forçado. Mutação (mesmo script com `-z` removido e `splitlines()` de volta):
+
+      ```
+      sed 's/"--name-only", "-z",/"--name-only",/; s/return split_nul_paths(out)/return [l for l in out.splitlines() if l]/' [...] | python3 - --selftest
+      -> HELPER FAIL  changed_paths() survives core.quotePath on a real repository
+      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 10/11 helper cases correct
       ```
 
 - [x] 2.3 `evaluate()` pura: `V1` skill editada sem bump e sem dispensa; `V2` versão que desce;
@@ -161,7 +182,7 @@
       -> SILENT  new skill
       -> SILENT  version-only edit
       -> SILENT  wrapper-only diff
-      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 8/8 helper cases correct
+      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 11/11 helper cases correct
       -> exit=0
       ```
 
@@ -269,6 +290,25 @@
       -> skill-version gate: 0 findings (base origin/master, 2 skill(s) changed, 2 with content changes)   exit=0
       ```
 
+      **Fixture da revisão — caminho que o git quota.** Clone descartável do worktree, commit de
+      `skills/backlog/references/café.md` (conteúdo `x`) sem bump, `core.quotePath` não definido
+      (`git config --get core.quotePath` -> vazio; padrão `true`), `SKILL_VERSION_BASE=<commit anterior>`:
+
+      ```
+      git diff --name-only BASE...HEAD
+      -> "skills/backlog/references/caf\303\251.md"
+      python3 scripts/validate-skill-version.py            (script em 3c91f54, antes da correção)
+      -> skill-version gate: 0 findings (base 3c91f54[...], 0 skill(s) changed, 0 with content changes)   exit=0
+      python3 scripts/validate-skill-version.py            (script corrigido, --name-only -z)
+      -> ::error::V1 unbumped skill — skills/backlog/ changed 1 path(s) — skills/backlog/references/café.md — with metadata.version 1.5.0 on the base and 1.5.0 on HEAD. [...]
+      -> skill-version gate: 1 findings (base 3c91f54[...], 1 skill(s) changed, 1 with content changes)   exit=1
+      mesmo diff, PR_BODY="Skill-version: none — probe: quoted-path fixture"
+      -> skill-version gate: 0 findings (base 3c91f54[...], 1 skill(s) changed, 1 with content changes)   exit=0
+      mesmo diff, git config core.quotePath false (caixa que não quota)
+      -> skill-version gate: 1 findings (base 3c91f54[...], 1 skill(s) changed, 1 with content changes)
+      git ls-files skills | grep -cP '[^\x00-\x7F]'   -> 0   (nenhum caminho assim no catálogo hoje)
+      ```
+
       No próprio worktree, sem ambiente de CI:
 
       ```
@@ -277,18 +317,19 @@
       GITHUB_ACTIONS=true GITHUB_EVENT_NAME=push python3 scripts/validate-skill-version.py
       -> skill-version gate: skipped (event push, not pull_request)   exit=0
       python3 scripts/validate-skill-version.py --selftest
-      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 8/8 helper cases correct   exit=0
+      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 11/11 helper cases correct   exit=0
       ```
 
 - [x] S.2 Matriz de casos medida, em contagens
 
       | Expectativa | Casos | Resultado |
       |---|---|---|
-      | Tinha de disparar e disparou | 5/5 | histórico `cf767ee` sem dispensa (12 achados V1, contado como 1); entry point: edição sem bump sem dispensa (1), dispensa sem motivo (1), sem payload (1), versão abaixo da base com dispensa (1) |
-      | Tinha de ficar mudo e ficou | 8/8 | histórico: `cf767ee` com dispensa PR-wide (1), PR #122 com 6 bumps (1), este branch (1); entry point: branch commitado (1), bump patch (1), dispensa com motivo (1), wrapper-only (1), skill nova (1) |
+      | Tinha de disparar e disparou | 7/7 | histórico `cf767ee` sem dispensa (12 achados V1, contado como 1); entry point: edição sem bump sem dispensa (1), dispensa sem motivo (1), sem payload (1), versão abaixo da base com dispensa (1); fixture da revisão: caminho quotado sem bump, `quotePath` padrão (1) e `false` (1) |
+      | Tinha de ficar mudo e ficou | 9/9 | histórico: `cf767ee` com dispensa PR-wide (1), PR #122 com 6 bumps (1), este branch (1); entry point: branch commitado (1), bump patch (1), dispensa com motivo (1), wrapper-only (1), skill nova (1); fixture da revisão com dispensa (1) |
       | Skip declarado | 2/2 | `GITHUB_EVENT_NAME=push` no clone e no worktree — `skipped (event push, not pull_request)` |
-      | Selftest | 3/3 | 7/7 defeitos, 11/11 mudos, 8/8 helpers |
-      | Escape conhecido ficou mudo | 0/0 | nenhum caso de escape foi construído (pré-release não existe no catálogo; ver E.3) |
+      | Selftest | 3/3 | 7/7 defeitos, 11/11 mudos, 11/11 helpers |
+      | Mutação detectada | 1/1 | `-z` removido → `HELPER FAIL changed_paths() survives core.quotePath [...]`, 10/11, exit 1 |
+      | Escape conhecido ficou mudo | 1/1 | caminho quotado com o script de `3c91f54`: `0 skill(s) changed`, exit 0 — o escape que a revisão apontou, fechado nesta rodada (S.3) |
 
 - [x] S.3 O que escapou ou se comportou diferente do esperado
 
@@ -306,6 +347,15 @@
       - `README.md` cita `:180`/`:824` na issue; hoje as frases estão em `:194`/`:864`. Editadas as
         duas, nenhuma outra.
       - `V0 base revision` (CI sem `fetch-depth: 0`) não exercitado (E.3).
+      - **Escape apontado na revisão do PR, reproduzido e fechado**: com o script de `3c91f54`, um
+        caminho que o git quota (`skills/backlog/references/café.md`, `core.quotePath` padrão) saía de
+        `git diff --name-only` como `"skills/backlog/references/caf\303\251.md"`, `skills_in()` o
+        descartava e o gate aprovava com `0 skill(s) changed` — falha aberta, o oposto do irmão. A
+        simulação original não construiu esse caso porque nenhum caminho do catálogo tem byte não-ASCII
+        (`git ls-files skills | grep -cP '[^\x00-\x7F]'` -> 0; `code-locale` proíbe) — buraco na
+        medição, não regressão presente. Corrigido com `--name-only -z` + `split_nul_paths()`, três
+        helpers novos no selftest (um deles comita o caminho num repositório temporário), mutação
+        confirmada. Registrado no docstring do script e em D1.
 
 ## 5. Quality Gates (MANDATORY)
 

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.8.0
+  version: 1.8.1
   category: process
 license: MIT
 compatibility: >-

--- a/plugins/workflow/skills/execute-backlog/references/spec-rite.md
+++ b/plugins/workflow/skills/execute-backlog/references/spec-rite.md
@@ -86,6 +86,14 @@ Spec-rite: none — <the reason the work registers nothing>
 
 A waiver with no reason is worse than no waiver: it looks decided and says nothing.
 
+A repo that also gates each skill's `metadata.version` (this catalog does, with
+`scripts/validate-skill-version.py`) reads a second line from the same body when the diff edits a
+skill without moving its version: `Skill-version: none — <the reason these edits deserve no bump>`.
+One line covers every skill in the PR; the reason has the same minimum length as the `Spec-rite`
+waiver; a version that goes **down** is never waived. The default is to bump — the line exists for
+the sweep that adds one cross-reference to twelve skills, not for the PR that changes what one of
+them does.
+
 ## Archive is not part of this run
 
 `openspec archive` syncs the delta into the main specs. Doing it in the implementation PR would move

--- a/scripts/validate-skill-version.py
+++ b/scripts/validate-skill-version.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""Skill-version gate — a pull request that edits a skill moves that skill's metadata.version.
+
+README.md promises every skill a version of its own: "bump it when that skill's behavior changes.
+Repo version = the collection; skill version = the individual contract." Until issue #119 nothing
+measured the second half of that sentence. The frontmatter step in ci.yml checks that the field is
+present and looks like semver; no gate read its value. Measured on the history: 49 of 165
+(commit, skill) pairs that edited skill content left the version where it was, 42 of them from four
+catalog-wide sweeps — commit cf767ee alone touched 12 existing skills and bumped none.
+
+This gate reads the diff against the base, the way validate-spec-rite.py does, and asks per skill:
+
+  V1 a skill with changed content has a metadata.version on HEAD that is semver-greater than on the
+     base, or the pull request body carries ONE line `Skill-version: none — <reason>` covering the
+     whole diff (a catalog-wide sweep costs one line, not one per skill)
+  V2 a metadata.version never moves backwards — a lower number is an editing error, and no reason
+     makes it right, so the waiver does not cover it
+  V3 the waiver names a usable reason (the same minimum length as the spec-rite waiver, imported
+     from that script so the two can never drift apart)
+
+What counts as "changed content": any path under skills/<x>/ in the diff — the SKILL.md body, a
+references/ file, anything the skill owns — except a SKILL.md whose only difference is the
+`  version:` line itself. A skill with no SKILL.md on the base is new and has nothing to move from.
+A skill with no SKILL.md on HEAD was removed, which skills-catalog regulates, not this. The generated
+trees (claude/ codex/ cursor/ copilot/ plugins/) are never counted: they are generate.sh output with
+a gate of their own.
+
+KNOWN LIMIT: this proves that the number MOVED, not that it moved by the right amount (a patch bump
+on a breaking rewrite passes) and not that a waiver's reason is honest (any eight characters pass
+V3). Both stay with the review; the gate makes them a required, visible artifact. Semver is compared
+on the (major, minor, patch) tuple the frontmatter step already requires, so a change confined to a
+pre-release suffix reads as "did not move" — no skill in the catalog carries one. A rename or a
+whitespace-only edit is a content change here, accepted on issue #119: the written waiver is the exit,
+and the finding names it. The selftest exercises the decision rules against synthetic inputs, not the
+git plumbing that feeds them: a misconfigured checkout is caught by the CI-only base-resolution
+failure below, not by the selftest.
+
+The pull request body is read from the event payload the runner already writes (GITHUB_EVENT_PATH),
+never from a step's `env:` block, for the reason validate-spec-rite.py records: Actions prints that
+block into the build log. PR_BODY survives as the deliberate override for running this outside CI.
+
+Exit 1 on any finding. Run from the repo root.
+Modes: (default) check this diff   |   --selftest inject one defect per rule and assert detection.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILLS = "skills"
+
+# The waiver is authored by whoever opened the pull request, including from a fork. It is matched as
+# text and never executed, never interpolated into a command. Anchored to the start of a line so a
+# mention of the syntax inside a sentence does not silently waive the gate. Same shape, same
+# separators and same prefix tolerance as the spec-rite waiver, so a body that carries both lines
+# reads as two entries of one list.
+WAIVER = re.compile(
+    r"^[ \t>*-]*Skill-version:[ \t]*none[ \t]*(?:—|--|–|-)[ \t]*(?P<reason>.*\S)[ \t]*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+WAIVER_NO_REASON = re.compile(
+    r"^[ \t>*-]*Skill-version:[ \t]*none[ \t]*(?:(?:—|--|–|-)[ \t]*)?$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+VERSION_LINE = re.compile(r"^  version:[ \t]*(?P<value>\S+)[ \t]*$", re.MULTILINE)
+SEMVER = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
+
+
+def _sibling_min_reason() -> int:
+    """MIN_REASON as validate-spec-rite.py defines it — imported, not copied, so the two waivers
+    demand the same reason length by construction. The module name carries a hyphen, hence the
+    spec-from-file dance instead of a plain import."""
+    path = Path(__file__).resolve().parent / "validate-spec-rite.py"
+    spec = importlib.util.spec_from_file_location("validate_spec_rite", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # Registered before exec: a module loaded this way is otherwise absent from sys.modules, and on
+    # Python 3.14 a @dataclass in such a module fails at class creation (dataclasses resolves
+    # annotations through sys.modules[cls.__module__]). Same rule applies to whoever imports THIS
+    # file the same way — the simulation on issue #119 hit it first.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return int(module.MIN_REASON)
+
+
+MIN_REASON = _sibling_min_reason()
+
+findings: list[str] = []
+
+# GitHub turns `::error` into a red annotation on the pull request. During --selftest the findings
+# are injected on purpose, so annotating them would put bogus failures on a PR whose job passed —
+# the defect the evidence gate hit on run 31790712710.
+annotate = True
+
+
+def add(check: str, detail: str) -> None:
+    findings.append(f"{check}: {detail}")
+    if annotate:
+        print(f"::error::{check} — {detail}")
+    else:
+        print(f"    injected: {check} — {detail}")
+
+
+# ── inputs ────────────────────────────────────────────────────────────────
+def resolve_base(root: Path) -> str | None:
+    """The revision this branch is measured against, or None when there is nothing to compare to."""
+    candidates = []
+    for env in ("SKILL_VERSION_BASE", "GITHUB_BASE_REF"):
+        ref = os.environ.get(env, "").strip()
+        if ref:
+            candidates += [f"origin/{ref}", ref]
+    candidates += ["origin/master", "origin/main"]
+    for ref in candidates:
+        probe = subprocess.run(["git", "-C", str(root), "rev-parse", "--verify", "-q", f"{ref}^{{commit}}"],
+                               capture_output=True, text=True)
+        if probe.returncode == 0:
+            return ref
+    return None
+
+
+def read_pr_body() -> str:
+    """The pull request body, without routing it through anything that echoes it.
+
+    Precedence: PR_BODY when set (local runs and the end-to-end probes of this gate); otherwise
+    pull_request.body from the file at GITHUB_EVENT_PATH; otherwise empty. A payload that is
+    missing, unreadable or without the key degrades to an empty body rather than an error, so the
+    decision falls to the rules that exist instead of the build failing for an unrelated reason.
+    """
+    override = os.environ.get("PR_BODY")
+    if override is not None:
+        return override
+
+    event_path = os.environ.get("GITHUB_EVENT_PATH", "")
+    if not event_path:
+        return ""
+    try:
+        with open(event_path, encoding="utf-8") as fh:
+            payload = json.load(fh)
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError) as exc:
+        print(f"  skill-version gate: event payload unreadable ({exc.__class__.__name__}) — "
+              "continuing with an empty body")
+        return ""
+    body = (payload.get("pull_request") or {}).get("body")
+    return body if isinstance(body, str) else ""
+
+
+def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
+    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", f"{base}...{head}"],
+                         capture_output=True, text=True, check=True).stdout
+    return [line for line in out.splitlines() if line]
+
+
+def merge_base(root: Path, base: str, head: str = "HEAD") -> str:
+    """`git diff A...B` measures from the merge base; the blobs must be read from that same commit."""
+    return subprocess.run(["git", "-C", str(root), "merge-base", base, head],
+                          capture_output=True, text=True, check=True).stdout.strip()
+
+
+def blob(root: Path, rev: str, path: str) -> str | None:
+    """The file at `rev`, or None when it does not exist there."""
+    proc = subprocess.run(["git", "-C", str(root), "show", f"{rev}:{path}"],
+                          capture_output=True, text=True)
+    return proc.stdout if proc.returncode == 0 else None
+
+
+# ── the per-skill record the rules read ───────────────────────────────────
+@dataclass(frozen=True)
+class SkillDiff:
+    name: str
+    paths: tuple[str, ...]          # the changed paths under skills/<name>/
+    base_version: str | None        # None: no SKILL.md on the base (new skill)
+    head_version: str | None        # None: no SKILL.md on HEAD (removed skill)
+    content_changed: bool           # anything beyond the `  version:` line moved
+
+
+def version_of(text: str | None) -> str | None:
+    if text is None:
+        return None
+    m = VERSION_LINE.search(text)
+    return m.group("value") if m else None
+
+
+def strip_version_line(text: str) -> str:
+    return VERSION_LINE.sub("", text)
+
+
+def semver_key(value: str | None) -> tuple[int, int, int] | None:
+    if value is None:
+        return None
+    m = SEMVER.match(value)
+    if not m:
+        return None
+    return int(m.group("major")), int(m.group("minor")), int(m.group("patch"))
+
+
+def skills_in(paths: list[str]) -> dict[str, list[str]]:
+    """Changed paths grouped by skill — only the canonical tree, never the generated mirrors."""
+    per: dict[str, list[str]] = {}
+    for p in paths:
+        parts = p.split("/")
+        if len(parts) >= 3 and parts[0] == SKILLS:
+            per.setdefault(parts[1], []).append(p)
+    return per
+
+
+def collect(root: Path, base: str, head: str = "HEAD") -> list[SkillDiff]:
+    """Read the diff into one record per touched skill — this is the git plumbing evaluate() never sees.
+
+    `head` is HEAD in every real run; the parameter exists so the gate can be pointed at a historical
+    commit and measured against what actually shipped (the simulation on issue #119 did exactly that).
+    """
+    mb = merge_base(root, base, head)
+    out: list[SkillDiff] = []
+    for name, paths in sorted(skills_in(changed_paths(root, base, head)).items()):
+        skill_md = f"{SKILLS}/{name}/SKILL.md"
+        base_text = blob(root, mb, skill_md)
+        head_text = blob(root, head, skill_md)
+        if any(p != skill_md for p in paths):
+            content_changed = True
+        elif base_text is None or head_text is None:
+            content_changed = True
+        else:
+            content_changed = strip_version_line(base_text) != strip_version_line(head_text)
+        out.append(SkillDiff(name, tuple(paths), version_of(base_text), version_of(head_text),
+                             content_changed))
+    return out
+
+
+# ── rules ─────────────────────────────────────────────────────────────────
+def waiver_reason(pr_body: str) -> str | None:
+    m = WAIVER.search(pr_body or "")
+    return m.group("reason").strip() if m else None
+
+
+def moved_up(s: SkillDiff) -> bool:
+    """HEAD is semver-greater than the base. An unparseable value on either side is not a move."""
+    b, h = semver_key(s.base_version), semver_key(s.head_version)
+    return b is not None and h is not None and h > b
+
+
+def evaluate(skills: list[SkillDiff], pr_body: str) -> None:
+    """The whole decision, as a pure function of its inputs — this is what --selftest exercises."""
+    # V2 first and unconditionally: a regression is a finding whether or not the body waives the bump.
+    for s in skills:
+        b, h = semver_key(s.base_version), semver_key(s.head_version)
+        if b is not None and h is not None and h < b:
+            add("V2 version moved backwards",
+                f"{SKILLS}/{s.name}/SKILL.md metadata.version went from {s.base_version} (base) to "
+                f"{s.head_version} (HEAD). A version never goes down; restore it above "
+                f"{s.base_version}. A `Skill-version: none` line does not cover this")
+
+    # New skill (no base), removed skill (no head), and version-only edits are out of the bump rule.
+    owed = [s for s in skills
+            if s.content_changed and s.base_version is not None and s.head_version is not None
+            and not moved_up(s)]
+    if not owed:
+        return
+
+    reason = waiver_reason(pr_body)
+    if reason is not None:
+        if len(reason) < MIN_REASON:
+            add("V3 waiver reason", f"the waiver names no usable reason ({reason!r}) — write "
+                                    "`Skill-version: none — <why these skill edits deserve no bump>`")
+        return
+    if WAIVER_NO_REASON.search(pr_body or ""):
+        add("V3 waiver reason", "the pull request body carries `Skill-version: none` with no reason — "
+                                "write `Skill-version: none — <why these skill edits deserve no bump>`")
+        return
+
+    for s in owed:
+        # A regression already produced V2 above; do not also ask for a bump it cannot satisfy.
+        b, h = semver_key(s.base_version), semver_key(s.head_version)
+        if b is not None and h is not None and h < b:
+            continue
+        sample = ", ".join(s.paths[:3]) + (f" (+{len(s.paths) - 3} more)" if len(s.paths) > 3 else "")
+        add("V1 unbumped skill",
+            f"{SKILLS}/{s.name}/ changed {len(s.paths)} path(s) — {sample} — with metadata.version "
+            f"{s.base_version} on the base and {s.head_version} on HEAD. Either raise `  version:` in "
+            f"{SKILLS}/{s.name}/SKILL.md above {s.base_version}, or add one line "
+            "`Skill-version: none — <reason>` to the pull request body (it covers every skill in this diff)")
+
+
+# ── selftest ──────────────────────────────────────────────────────────────
+def _skill(name: str = "backlog", base: str | None = "1.5.0", head: str | None = "1.5.0",
+           content: bool = True, paths: tuple[str, ...] = ("skills/backlog/SKILL.md",)) -> SkillDiff:
+    return SkillDiff(name, paths, base, head, content)
+
+
+# One injected defect per rule, plus the false-positive cases the rules must stay silent on. The
+# wrapper-only case is expressed the way collect() would hand it over: no SkillDiff at all, because
+# skills_in() drops every path outside skills/.
+DEFECTS = [
+    ("V1 unbumped skill", ([_skill()], "")),
+    ("V1 unbumped skill", ([_skill(paths=("skills/backlog/references/issue-template.md",))], "")),
+    ("V1 unbumped skill", ([_skill()], "see the Skill-version: none — reason line elsewhere")),
+    ("V2 version moved backwards", ([_skill(base="1.8.0", head="1.7.0")], "")),
+    ("V2 version moved backwards", ([_skill(base="1.8.0", head="1.7.0")],
+                                    "Skill-version: none — typo fix in one sentence")),
+    ("V3 waiver reason", ([_skill()], "Skill-version: none — x")),
+    ("V3 waiver reason", ([_skill()], "Skill-version: none")),
+]
+
+SILENT = [
+    ("edited with a bump", ([_skill(head="1.5.1")], "")),
+    ("edited with a minor bump", ([_skill(head="1.6.0")], "")),
+    ("edited with a waiver", ([_skill()], "Skill-version: none — cross-reference line added")),
+    ("twelve skills, one waiver",
+     ([_skill(name=f"skill-{i}", paths=(f"skills/skill-{i}/SKILL.md",)) for i in range(12)],
+      "Closes #119\n\nSpec-rite: some-change\n- Skill-version: none — cross-reference line added to each\n")),
+    ("new skill", ([_skill(base=None, head="1.0.0")], "")),
+    ("removed skill", ([_skill(base="1.5.0", head=None)], "")),
+    ("version-only edit", ([_skill(head="1.5.1", content=False)], "")),
+    # Expressed the way collect() hands it over: skills_in() drops every path outside skills/, so a
+    # diff confined to the generated trees yields no SkillDiff at all.
+    ("wrapper-only diff", (list(skills_in(["claude/skills/backlog/SKILL.md",
+                                           "plugins/workflow/skills/backlog/SKILL.md"]).values()), "")),
+    ("no skill touched", ([], "")),
+    ("waiver quoted in a list item", ([_skill()], "- Skill-version: none — whitespace-only reflow")),
+    ("bump beside an unrelated spec-rite waiver",
+     ([_skill(head="1.5.1")], "Spec-rite: none — README only")),
+]
+
+
+def selftest_collect_helpers() -> tuple[int, int]:
+    """The parsers collect() relies on, exercised on literal text: a wrong VERSION_LINE regex would
+    make every skill read as new, and evaluate() would stay silent on everything."""
+    cases = [
+        ("version parsed from frontmatter",
+         version_of("---\nname: x\nmetadata:\n  author: solvelab\n  version: 1.8.0\n---\n") == "1.8.0"),
+        ("no version line reads as None", version_of("---\nname: x\n---\n") is None),
+        ("version-only edit compares equal",
+         strip_version_line("a\n  version: 1.0.0\nb\n") == strip_version_line("a\n  version: 1.0.1\nb\n")),
+        ("body edit compares different",
+         strip_version_line("a\n  version: 1.0.0\nb\n") != strip_version_line("a\n  version: 1.0.1\nc\n")),
+        ("semver orders numerically, not lexically", semver_key("1.10.0") > semver_key("1.9.0")),
+        ("generated trees are dropped",
+         skills_in(["claude/skills/x/SKILL.md", "plugins/g/skills/x/SKILL.md", "skills/y/SKILL.md"]) == {"y": ["skills/y/SKILL.md"]}),
+        ("references group under their skill",
+         skills_in(["skills/y/references/a.md", "skills/y/SKILL.md"]) == {"y": ["skills/y/references/a.md", "skills/y/SKILL.md"]}),
+        ("MIN_REASON agrees with the spec-rite gate", MIN_REASON == _sibling_min_reason()),
+    ]
+    ok = 0
+    for label, passed in cases:
+        print(f"  {'HELPER' if passed else 'HELPER FAIL'}  {label}")
+        ok += bool(passed)
+    return ok, len(cases)
+
+
+def selftest() -> int:
+    global findings, annotate
+    annotate = False
+    caught = 0
+    for label, (skills, body) in DEFECTS:
+        findings = []
+        evaluate(skills, body)
+        if any(f.startswith(label) for f in findings):
+            print(f"  CAUGHT  {label}: {body!r}")
+            caught += 1
+        else:
+            print(f"  MISSED  {label}: {body!r}   <-- the rule cannot fire")
+
+    quiet = 0
+    for label, (skills, body) in SILENT:
+        findings = []
+        evaluate(skills, body)
+        if findings:
+            print(f"  FALSE POSITIVE  {label}   <-- {findings[0]}")
+        else:
+            print(f"  SILENT  {label}")
+            quiet += 1
+
+    helpers_ok, helpers_total = selftest_collect_helpers()
+
+    print(f"\n{caught}/{len(DEFECTS)} defect classes detected, "
+          f"{quiet}/{len(SILENT)} false-positive cases stayed silent, "
+          f"{helpers_ok}/{helpers_total} helper cases correct")
+    return 0 if (caught == len(DEFECTS) and quiet == len(SILENT)
+                 and helpers_ok == helpers_total) else 1
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+def main() -> int:
+    if "--selftest" in sys.argv:
+        return selftest()
+
+    event = os.environ.get("GITHUB_EVENT_NAME", "")
+    in_ci = os.environ.get("GITHUB_ACTIONS", "") == "true"
+    if in_ci and event and event != "pull_request":
+        print(f"  skill-version gate: skipped (event {event}, not pull_request)")
+        return 0
+
+    base = resolve_base(ROOT)
+    if base is None:
+        # A gate that cannot measure must not approve. In CI an unresolvable base means the checkout
+        # was not given enough history (fetch-depth), which is a misconfiguration, not an exemption.
+        if in_ci:
+            add("V0 base revision", "no base revision to diff against — the checkout needs "
+                                    "`fetch-depth: 0` for this gate to measure anything")
+            return 1
+        print("  skill-version gate: skipped (no base revision to diff against)")
+        return 0
+
+    skills = collect(ROOT, base)
+    evaluate(skills, read_pr_body())
+    print(f"  skill-version gate: {len(findings)} findings "
+          f"(base {base}, {len(skills)} skill(s) changed, "
+          f"{sum(s.content_changed for s in skills)} with content changes)")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-skill-version.py
+++ b/scripts/validate-skill-version.py
@@ -33,7 +33,14 @@ pre-release suffix reads as "did not move" — no skill in the catalog carries o
 whitespace-only edit is a content change here, accepted on issue #119: the written waiver is the exit,
 and the finding names it. The selftest exercises the decision rules against synthetic inputs, not the
 git plumbing that feeds them: a misconfigured checkout is caught by the CI-only base-resolution
-failure below, not by the selftest.
+failure below, not by the selftest. The one plumbing probe it does run is the path reader, below.
+
+Paths are read with `git diff --name-only -z` and split on NUL. Without `-z`, git wraps any path that
+carries a non-ASCII, control or quote character in double quotes with octal escapes (core.quotePath,
+default true on a fresh checkout and on the ubuntu runners), `"skills/x/caf\303\251.md"` no longer
+starts with `skills/` and the skill vanishes from the measurement — the gate approved a fixture like
+that in the review of issue #119. The selftest commits such a path in a throwaway repository and
+asserts the reader hands it back verbatim, so the flag cannot be dropped silently.
 
 The pull request body is read from the event payload the runner already writes (GITHUB_EVENT_PATH),
 never from a step's `env:` block, for the reason validate-spec-rite.py records: Actions prints that
@@ -152,10 +159,18 @@ def read_pr_body() -> str:
     return body if isinstance(body, str) else ""
 
 
+def split_nul_paths(out: str) -> list[str]:
+    """`git diff --name-only -z` output -> paths, verbatim. NUL is the one byte a path cannot contain,
+    so nothing here is quoted, escaped or split on a newline inside a name."""
+    return [p for p in out.split("\0") if p]
+
+
 def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
-    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", f"{base}...{head}"],
+    # -z: raw names separated by NUL. The default line mode quotes and octal-escapes any name with a
+    # non-ASCII, control or quote character, which skills_in() would then fail to recognise.
+    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", "-z", f"{base}...{head}"],
                          capture_output=True, text=True, check=True).stdout
-    return [line for line in out.splitlines() if line]
+    return split_nul_paths(out)
 
 
 def merge_base(root: Path, base: str, head: str = "HEAD") -> str:
@@ -329,6 +344,34 @@ SILENT = [
 ]
 
 
+def _probe_quoted_path() -> bool:
+    """The one git-plumbing probe of the selftest: commit a path git would quote in line mode and
+    check changed_paths() hands it back unquoted. core.quotePath is forced on so the probe measures
+    the worst case whatever the box's config says. Same input the review of issue #119 used."""
+    import tempfile
+    name = "skills/probe/references/caf\u00e9.md"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_NOSYSTEM": "1",
+               "GIT_AUTHOR_NAME": "probe", "GIT_AUTHOR_EMAIL": "probe@localhost",
+               "GIT_COMMITTER_NAME": "probe", "GIT_COMMITTER_EMAIL": "probe@localhost"}
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", "-C", tmp, "-c", "core.quotePath=true", *args],
+                           capture_output=True, text=True, check=True, env=env)
+
+        git("init", "-q", "-b", "main")
+        (root / "skills/probe").mkdir(parents=True)
+        (root / "skills/probe/SKILL.md").write_text("---\n  version: 1.0.0\n---\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "base")
+        (root / "skills/probe/references").mkdir()
+        (root / name).write_text("x\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "edit")
+        return changed_paths(root, "HEAD^") == [name] and list(skills_in(changed_paths(root, "HEAD^"))) == ["probe"]
+
+
 def selftest_collect_helpers() -> tuple[int, int]:
     """The parsers collect() relies on, exercised on literal text: a wrong VERSION_LINE regex would
     make every skill read as new, and evaluate() would stay silent on everything."""
@@ -346,6 +389,12 @@ def selftest_collect_helpers() -> tuple[int, int]:
         ("references group under their skill",
          skills_in(["skills/y/references/a.md", "skills/y/SKILL.md"]) == {"y": ["skills/y/references/a.md", "skills/y/SKILL.md"]}),
         ("MIN_REASON agrees with the spec-rite gate", MIN_REASON == _sibling_min_reason()),
+        ("NUL-separated names are read verbatim, quotes and newlines included",
+         split_nul_paths('skills/y/SKILL.md\0skills/y/references/caf\u00e9 "x"\n.md\0')
+         == ["skills/y/SKILL.md", 'skills/y/references/caf\u00e9 "x"\n.md']),
+        ("a non-ASCII name still groups under its skill",
+         skills_in(["skills/y/references/caf\u00e9.md"]) == {"y": ["skills/y/references/caf\u00e9.md"]}),
+        ("changed_paths() survives core.quotePath on a real repository", _probe_quoted_path()),
     ]
     ok = 0
     for label, passed in cases:

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.8.0
+  version: 1.8.1
   category: process
 license: MIT
 compatibility: >-

--- a/skills/execute-backlog/references/spec-rite.md
+++ b/skills/execute-backlog/references/spec-rite.md
@@ -86,6 +86,14 @@ Spec-rite: none — <the reason the work registers nothing>
 
 A waiver with no reason is worse than no waiver: it looks decided and says nothing.
 
+A repo that also gates each skill's `metadata.version` (this catalog does, with
+`scripts/validate-skill-version.py`) reads a second line from the same body when the diff edits a
+skill without moving its version: `Skill-version: none — <the reason these edits deserve no bump>`.
+One line covers every skill in the PR; the reason has the same minimum length as the `Spec-rite`
+waiver; a version that goes **down** is never waived. The default is to bump — the line exists for
+the sweep that adds one cross-reference to twelve skills, not for the PR that changes what one of
+them does.
+
 ## Archive is not part of this run
 
 `openspec archive` syncs the delta into the main specs. Doing it in the implementation PR would move


### PR DESCRIPTION
Closes #119

O README promete a cada skill um `metadata.version` próprio — "bump it when that skill's behavior changes" — e nada media a segunda metade da frase: o step *Skill frontmatter checks* só confere que o campo existe e parece semver. Medido no histórico: 49 de 165 pares (commit, skill) que editaram conteúdo de skill deixaram a versão parada, 42 deles em quatro varreduras catálogo-inteiro (`cf767ee` sozinho tocou 12 skills existentes e não bumpou nenhuma). Decisão registrada na issue: **Opção A — gate com dispensa escrita**, no molde do `validate-spec-rite.py`.

## O que muda

- **`scripts/validate-skill-version.py`** (novo): lê o diff `<merge-base>...HEAD`, agrupa os caminhos sob `skills/<x>/` e pergunta por skill: `V1` conteúdo mudou e `metadata.version` no HEAD é semver-maior que na base, ou o corpo do PR carrega **uma** linha `Skill-version: none — <motivo>` cobrindo o diff todo; `V2` a versão nunca desce (a dispensa não cobre); `V3` a dispensa nomeia um motivo utilizável (`MIN_REASON` importado do irmão, não copiado). Skill nova, skill removida, edição só da linha `  version:` e árvores geradas (`claude/ codex/ cursor/ copilot/ plugins/`) não entram. Corpo do PR lido de `GITHUB_EVENT_PATH`, nunca de `env:`; `PR_BODY` como override local.
- **Diff lido com `-z`** (apontado na revisão): sem a flag, `git diff --name-only` quota e escapa em octal qualquer caminho com byte não-ASCII/controle/aspas (`core.quotePath`, padrão `true`), `"skills/x/caf\303\251.md"` não começa com `skills/` e a skill sumia da medição — o gate aprovava. O leitor separa por NUL e o selftest comita um caminho assim num repositório temporário com `core.quotePath=true` forçado; remover a flag derruba o selftest (mutação: 10/11 helpers).
- **`ci.yml`**: dois steps novos logo depois de *Spec-rite self-test* — o gate e o seu `--selftest`.
- **`README.md`**: as duas frases da regra do bump (`:194`, `:864`) passam a nomear o gate e a linha de dispensa.
- **`skills/execute-backlog/references/spec-rite.md`**, *In the PR body*: a linha `Skill-version` ao lado da `Spec-rite`; `execute-backlog` 1.8.0 → 1.8.1, wrappers regenerados.

Nenhuma skill nova; 35 skills, catálogo intacto.

## Simulação

| Expectativa | Casos | Resultado |
|---|---|---|
| Tinha de disparar e disparou | 7/7 | `cf767ee` sem dispensa (12 achados V1); entry point: edição sem bump, dispensa sem motivo, sem payload, versão abaixo da base com dispensa; fixture da revisão (caminho quotado) com `quotePath` padrão e `false` |
| Tinha de ficar mudo e ficou | 9/9 | `cf767ee` com dispensa PR-wide; PR #122 com 6 bumps; este branch; bump patch; dispensa com motivo; wrapper-only; skill nova; fixture da revisão com dispensa |
| Skip declarado | 2/2 | `GITHUB_EVENT_NAME=push` → `skipped (event push, not pull_request)` |
| Selftest | 3/3 | 7/7 defeitos, 11/11 mudos, 11/11 helpers |
| Mutação detectada | 1/1 | `-z` removido → `HELPER FAIL changed_paths() survives core.quotePath [...]` |
| Escape conhecido | 1/1 | caminho quotado com o script anterior: `0 skill(s) changed`, exit 0 — fechado nesta rodada |

## Evidência

| Comando | Saída observada |
|---|---|
| `collect(W, 'cf767ee^', 'cf767ee'); evaluate(skills, '')` | `13 skill(s), 13 with content, 12 finding(s)` — `code-locale: None -> 1.0.0` (nova, sem achado) |
| `collect(W, 'd2918ed', 'e13c16a'); evaluate(skills, '')` (PR #122) | `6 skill(s), 6 with content, 0 finding(s)` |
| clone, linha em `skills/backlog/SKILL.md` sem bump, payload sem `Skill-version` | `::error::V1 unbumped skill — skills/backlog/ changed 1 path(s) [...] 1.5.0 on the base and 1.5.0 on HEAD` exit=1 |
| mesmo diff, `  version:` → `1.4.0`, corpo com dispensa | `::error::V2 version moved backwards — [...] 1.5.0 (base) to 1.4.0 (HEAD). [...] A \`Skill-version: none\` line does not cover this` exit=1 |
| clone, `skills/backlog/references/café.md` sem bump, script anterior | `git diff --name-only` → `"skills/backlog/references/caf\303\251.md"`; gate → `0 skill(s) changed` exit=0 |
| mesmo diff, script corrigido | `::error::V1 unbumped skill — [...] skills/backlog/references/café.md [...]` exit=1 |
| `python3 scripts/validate-skill-version.py --selftest` | `7/7 defect classes detected, 11/11 false-positive cases stayed silent, 11/11 helper cases correct` |
| `python3 scripts/validate-skill-version.py` (este branch) | `0 findings (base origin/master, 1 skill(s) changed, 1 with content changes)` |
| `git ls-files skills \| grep -cP '[^\x00-\x7F]'` | `0` — o escape era buraco na medição, não regressão presente |
| `bash scripts/validate-rite.sh` · `openspec validate add-skill-version-gate --strict` | `rite gate OK` · `Change 'add-skill-version-gate' is valid` |

## Rito

Spec-rite: add-skill-version-gate
Skill-version: execute-backlog 1.8.0 → 1.8.1 (única skill editada; bump presente, sem dispensa)

## Known gaps

- A run real do GitHub Actions (payload escrito pelo runner, `GITHUB_BASE_REF` real, `fetch-depth: 0`) não é medível localmente; a run deste PR é a prova final.
- `V0 base revision` (checkout raso em CI) não exercitado end-to-end — cópia literal do `S0` do irmão.
- Semver com pré-release: nenhuma skill do catálogo usa; comportamento lido do código, declarado no KNOWN LIMIT.
- `validate-spec-rite.py` continua lendo o diff sem `-z`; falha fechado por direção da regra, mas nomeia o caminho escapado. Portar `-z` para lá é follow-up.
- `README.md` seção *3. Release* cita só a linha `Spec-rite`; adicionar a `Skill-version` ali é follow-up.