### PR TITLE
👷 ci(release): descreve o ruleset master-protect e a exigência de PR adiada

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,18 @@ jobs:
         # nothing left to release.
         # The commit released may therefore be newer than the one Validate examined in THIS run.
         # Each of those commits passed Validate on its own pull request; master takes no direct push
-        # by convention (PR-only) other than the [skip ci] release commit. No branch protection rule
-        # exists as of 2026-09-04 (`gh api repos/solvelab/ai-skills/branches/master/protection` -> 404);
-        # whether to add one is issue #120's decision.
+        # by convention (PR-only) other than the [skip ci] release commit.
+        # What GitHub enforces, since 2026-09-05, is the repository ruleset "master-protect"
+        # (id 22339892, active on refs/heads/master) with exactly two rules: `deletion` and
+        # `non_fast_forward` — master cannot be deleted or force-pushed
+        # (`gh api repos/solvelab/ai-skills/rulesets/22339892` -> rules [deletion, non_fast_forward],
+        # bypass_actors []). Classic branch protection stays absent (`.../branches/master/protection`
+        # -> 404). Neither rule blocks a normal fast-forward push, so a direct push to master is still
+        # POSSIBLE and only convention prevents it; the PR-only premise above is convention, not a
+        # rule. "Require a pull request" is deliberately left out: this job pushes the release commit
+        # with GITHUB_TOKEN, that token cannot be a bypass actor of a ruleset, and the rule would
+        # reject the release push. Enforcing it waits on a PAT or GitHub App with bypass for this
+        # job — the open decision is issue #120, which records the 2026-09-05 choice.
         uses: actions/checkout@v5
         with:
           ref: master


### PR DESCRIPTION
Closes #120

O comentário do job `Semantic Release` afirmava que nenhuma proteção existia em `master` (`.../branches/master/protection` → 404) e que a decisão estava aberta. A decisão foi tomada e registrada na issue #120 (comentário de 2026-09-05): ruleset `master-protect` (id 22339892) ativo em `refs/heads/master` com as regras `deletion` e `non_fast_forward`; exigir PR fica adiado porque o job publica com `GITHUB_TOKEN`, que não entra na lista de bypass de um ruleset, e a regra rejeitaria o push do release.

## O que muda

- Só o bloco de comentário do checkout do job `release` em `.github/workflows/ci.yml` (linhas 216-227). O texto passa a dizer o que o GitHub impõe (deleção e force-push bloqueados), o que continua sendo convenção (PR-only — as duas regras não bloqueiam push fast-forward normal) e onde mora a decisão pendente (issue #120).
- Nenhum input do step muda: `ref: master`, `fetch-depth: 0`, `token: GITHUB_TOKEN` seguem iguais. Nenhuma skill é tocada.

## Simulação — saída observada

| Expectativa | Casos | Resultado |
|---|---|---|
| Gates do CI ficam verdes com o body de dispensa | **20/20** | `gates.sh` → 20 linhas `PASS`, `dirty-after: 0` |
| YAML continua válido e o checkout continua igual | **1/1** | `yaml.safe_load` → `{'ref': 'master', 'fetch-depth': 0, 'token': '${{ secrets.GITHUB_TOKEN }}'}` |
| Único hunk é o comentário | **1/1** | `git diff master --unified=0` → `@@ -219,3 +219,12 @@` |
| Push do release sob o ruleset | **0/1** | não exercitável antes do merge — nenhuma run de `master` desde a criação do ruleset (última: 33912506567, 2026-09-04T19:42Z; ruleset: 2026-09-05T15:17Z) |

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Ruleset real | `gh api repos/solvelab/ai-skills/rulesets/22339892` | `master-protect`, `active`, rules `[deletion, non_fast_forward]`, `bypass_actors []`, include `refs/heads/master` |
| Proteção clássica | `gh api repos/solvelab/ai-skills/branches/master/protection` | `404 Branch not protected` |
| Decisão na issue | `gh api repos/solvelab/ai-skills/issues/120/comments` | comentário 5552753435, 2026-09-05T15:16:29Z |
| Wrappers em sincronia | `bash generate.sh && git status --porcelain` | sem diff gerado |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35 findings: 0` |
| Segredos | `python3 scripts/scan-secrets.py` | `no credentials found` |
| Higiene do repo | `validate-repo-hygiene.py` + `--selftest` | `0 findings`, `4/4` |
| Rito | `bash scripts/validate-rite.sh` | `rite gate OK` |
| Spec-rite | `validate-spec-rite.py --selftest` | `6/6 defect classes detected` |
| Validador do vendor | `claude plugin validate . --strict` | `Validation passed` |

## Rito

Spec-rite: none — configuração do GitHub fora da árvore; o único arquivo tocado é um comentário do ci.yml que passa a descrever o estado real da proteção de master

## Known gaps

- **Critério 2 da issue fica em aberto.** Ele é uma caixa só com duas metades: a metade "a API mostra a regra" está provada (ruleset 22339892 visível); a metade "a run de release seguinte publica normalmente (log do job)" **não foi medida** — nenhuma run de `master` aconteceu desde a criação do ruleset. A caixa só deve ser marcada depois que a primeira run de `Semantic Release` após este merge publicar, com a URL do log como evidência. Só o critério 1 (decisão registrada) é marcado neste PR.
- A frase do comentário "nenhuma das duas regras bloqueia push fast-forward normal" vem da semântica dos tipos `deletion` e `non_fast_forward`, não de uma run observada. O tripwire de `fix-release-race` cobre só "behind the remote", não "push rejected" (seção Riscos da issue #120) — a primeira release é o teste.