### PR TITLE
🐛 fix(hooks): ignora .claude/ no repo, alinha o README e fecha o contrato de argv do locale-rite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 # release 2.6.0 via an ordinary `git add -A`.
 __pycache__/
 *.py[cod]
+
+# Local tool output. `openspec init --tools claude` writes six helper skills and six /opsx commands
+# into .claude/; they are not part of the catalog, and a clean clone has no global excludes file to
+# keep `git add -A` from committing them — the same path __pycache__ took above.
+.claude/

--- a/README.md
+++ b/README.md
@@ -397,11 +397,15 @@ ai-skills/
 |--------|---------|
 | `skills/` | **Canonical skills** — self-contained `SKILL.md` per skill, open Agent Skills standard. Edit here. |
 | `.claude-plugin/` | Claude Code plugin + marketplace manifests |
+| `plugins/` | Per-domain plugins (`ai-skills-<group>`), 10 of the 11 marketplace entries — each carries its own `.claude-plugin/plugin.json` and a generated `skills/` copy of the group |
+| `openspec/` | Spec-driven rite: `specs/` (current truth), `changes/` (active + `archive/`), `schemas/skills-rite/` (the forked schema) |
+| `research/` | Measurements behind a skill (e.g. `svg-animation`) — the numbers a skill's rule was derived from |
 | `claude/global/` | Portable global rules for Claude Code, `@`-included from `~/.claude/CLAUDE.md` |
 | `claude/skills/` | Generated wrappers for legacy `~/.claude/CLAUDE.md` installs |
 | `codex/skills/` | Generated OpenAI Codex wrappers using `@./path` file includes |
 | `cursor/rules/` | Generated Cursor .mdc rules with content inlined |
 | `copilot/instructions/` | Generated GitHub Copilot wrappers with markdown link references |
+| `scripts/` | CI gates and release plumbing: `validate-skills.py` (+ selftest), `validate-repo-hygiene.py`, `validate-rite.sh` (+ `validate-rite-evidence.py`, `validate-spec-rite.py`), `scan-secrets.py`, `set-version.sh` |
 
 ---
 
@@ -765,11 +769,27 @@ Every check above iterates over *active changes*, which means a pull request tha
 pass them all vacuously: the loop found nothing, `fail` stayed 0, and the gate printed `rite gate OK`.
 That is how PR #80 and PR #84 shipped blocking CI gates with no proposal and had to be registered
 retroactively by PR #88. [`scripts/validate-spec-rite.py`](scripts/validate-spec-rite.py) reads the
-**diff** instead: a pull request touching anything outside `openspec/` (beyond the paths the release
-automation writes) must carry an active change, a change archived in the same diff, or a waiver line
-`Spec-rite: none — <reason>` in its body. The waiver is authored by whoever opened the PR, including
-from a fork, so it is matched as text and never executed. The checkout runs at `fetch-depth: 0`
-because a gate with no base revision cannot measure, and a gate that cannot measure must not approve.
+**diff** instead, and since #127 it checks **relevance, not existence**. Its three rules, quoted from
+the script's docstring:
+
+```
+S1 a diff outside openspec/ carries a change, an archive, or a written waiver
+S2 the waiver names a reason
+S3 the change it carries is ITS change: the diff touches openspec/changes/<id>/ of an active
+   change, or the pull request body names one on a `Spec-rite: <id>` line. Until issue #117
+   (2026-09-04) the mere existence of any active change registered any diff, and the selftest
+   pinned that as a silent case.
+```
+
+So a pull request touching anything outside `openspec/` (beyond the paths the release automation
+writes) passes in exactly four ways: the diff touches `openspec/changes/<id>/` of an active change (a
+tick in its `tasks.md` counts), or the PR body names an active change on a `Spec-rite: <id>` line, or
+the diff archives a change (`openspec/changes/archive/`), or the body carries the written waiver
+`Spec-rite: none — <reason>`. An active change that the diff neither touches nor names no longer
+registers it — that is the S3 finding. The waiver and the `Spec-rite:` line are authored by whoever
+opened the PR, including from a fork, so they are matched as text and never executed. The checkout
+runs at `fetch-depth: 0` because a gate with no base revision cannot measure, and a gate that cannot
+measure must not approve.
 
 A second gate checks the **content** of the skills themselves.
 [`scripts/validate-skills.py`](scripts/validate-skills.py) runs nine checks over every
@@ -819,10 +839,9 @@ openspec init --tools claude          # generates the /opsx commands into .claud
 ```
 
 > `openspec init` also writes six helper skills (`openspec-propose`, `openspec-apply-change`, …) into
-> `.claude/skills/`. They are not part of the catalog and the repo `.gitignore` does not exclude
-> `.claude/` — ignore it in your global excludes file (`core.excludesFile`) so `git add -A` never
-> commits them. That is why `npx skills add ./ --list` in a maintainer checkout finds 41 skills
-> against the 35 that `git archive HEAD` ships.
+> `.claude/skills/`. They are not part of the catalog; the repo `.gitignore` excludes `.claude/` so
+> `git add -A` never commits them. That is why `npx skills add ./ --list` in a maintainer checkout
+> finds 41 skills against the 35 that `git archive HEAD` ships.
 
 ### Board integration
 

--- a/claude/global/hooks/locale-rite.py
+++ b/claude/global/hooks/locale-rite.py
@@ -15,8 +15,12 @@ WHY `hookSpecificOutput.additionalContext` AND NOT PLAIN STDOUT
     For PostToolUse, plain stdout goes to the debug log and the model never sees it. The events that
     turn stdout into context are UserPromptSubmit, UserPromptExpansion and SessionStart — which is
     why the repo's other two rite hooks can print and this one cannot. Probed against the installed
-    version rather than recalled: `claude --version` -> `2.1.246 (Claude Code)`, and the binary reads
+    binary rather than recalled. First measured on 2.1.246 (2026-08-26): the bundle reads
     `let {additionalContext:a,...l}=e.hookSpecificOutput` with the cap `additionalContext:8000`.
+    Re-measured 2026-09-05 on `readlink -f $(which claude)` ->
+    ~/.local/share/claude/versions/2.1.261 (`claude --version` -> `2.1.261 (Claude Code)`; a
+    single ELF, so the grep needs `-a`): `grep -a -o -E 'additionalContext:[0-9]+'` prints
+    `additionalContext:8000` exactly once, and the same on the 2.1.260 bundle beside it.
     Docs: code.claude.com/docs/en/hooks (read 2026-08-26).
 
 WHAT THIS HOOK DELIBERATELY DOES NOT DO
@@ -31,7 +35,7 @@ Wiring (~/.claude/settings.json):
 
     "hooks": {
       "PostToolUse": [
-        {"matcher": "Write|Edit",
+        {"matcher": "Write|Edit|MultiEdit|NotebookEdit",
          "hooks": [{"type": "command",
                     "command": "python3 ~/ai-skills/claude/global/hooks/locale-rite.py",
                     "timeout": 10}]}
@@ -42,20 +46,25 @@ Like personal-rules.md, this is the maintainer's config — edit the matcher and
 your own process instead of adopting it blindly.
 
 Modes: (default) read one payload from stdin   |   --selftest assert the decisions against synthetic payloads.
+Any other argument prints usage to stderr and exits 2 — the same contract as backlog-rite.py and
+verify-rite.py since #115, so a misspelt flag cannot fall through to the stdin path and exit 0.
 """
 
 import importlib.util
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
-# The check lives in the skill that owns the doctrine. Two directories up from claude/global/hooks/
-# is the repository root; the path is resolved, never guessed, and a miss exits silently.
+# The check lives in the skill that owns the doctrine. parents[3] of this file is the repository
+# root — three directories up from claude/global/hooks/ (hooks -> global -> claude -> root); the path
+# is resolved, never guessed, and a miss exits silently.
 CHECK_PATH = Path(__file__).resolve().parents[3] / "skills/code-locale/references/check-identifier-locale.py"
 
 # The harness truncates a longer value; truncating here keeps the tail we choose rather than the
-# tail it chooses. Measured cap: `additionalContext:8000` in claude 2.1.246.
+# tail it chooses. Measured cap: `additionalContext:8000` in claude 2.1.246, 2.1.260 and 2.1.261
+# (see the docstring for the probe).
 CONTEXT_CAP = 8000
 
 WRITE_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit"}
@@ -233,17 +242,33 @@ def selftest() -> int:
     print(f"  {'OK     ' if shape_ok else 'FAILED '} output shape is the field the harness reads")
     if not shape_ok:
         failed.append("output shape")
+    # The argv contract can only be measured through the real entry point: a misspelt flag must
+    # print usage and exit 2, never read stdin and exit 0 (the silent no-op #115 closed in the
+    # sibling hooks).
+    run = subprocess.run([sys.executable, __file__, "--bogus"], stdin=subprocess.DEVNULL,
+                         capture_output=True, text=True)
+    argv_ok = run.returncode == 2 and "usage:" in run.stderr and run.stdout == ""
+    print(f"  {'OK     ' if argv_ok else 'FAILED '} unknown flag prints usage and exits 2")
+    if not argv_ok:
+        failed.append("unknown flag")
     print()
     if failed:
         print("selftest FAILED: " + "; ".join(failed))
         return 1
-    print(f"selftest OK: {len(cases)} decisions plus the output shape")
+    print(f"selftest OK: {len(cases)} decisions, the output shape, plus the argv contract")
     return 0
 
 
 def main() -> int:
-    if "--selftest" in sys.argv[1:]:
+    args = sys.argv[1:]
+    if args == ["--selftest"]:
         return selftest()
+    if args:
+        # An unknown argument must not fall through to the stdin path: a misspelt flag in a CI
+        # step would then read empty stdin and exit 0 — the silent no-op the selftest mode exists
+        # to make impossible.
+        print(f"usage: {sys.argv[0]} [--selftest]", file=sys.stderr)
+        return 2
     try:
         payload = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError):


### PR DESCRIPTION
Closes #130

Follow-ups da auditoria (#122–#128) que ficaram fora dos itens por pertencerem a outro dono de arquivo na hora, ou por serem higiene fora do escopo: o `.gitignore` não ignorava `.claude/`, o README ficou atrás da árvore (#126) e do gate de relevância (#127), e o `locale-rite.py` era o único dos três hooks que aceitava uma flag desconhecida em silêncio.

## O que muda

- **`.gitignore`**: `.claude/` com comentário. `openspec init --tools claude` escreve seis skills auxiliares e seis comandos ali; nesta máquina só ficavam de fora pelo excludes global (`~/.config/git/ignore`). Num clone limpo um `git add -A` os commitaria — o mesmo caminho pelo qual `__pycache__` chegou à release 2.6.0.
- **README, tabela *Folder | Purpose***: linhas para `plugins/`, `openspec/`, `research/` e `scripts/`, batendo com a árvore acima dela.
- **README, seção do rito**: deixa de dizer que o PR "must carry an active change". Desde o #127 `scripts/validate-spec-rite.py` checa relevância, não existência — as três regras (S1, S2, S3) entram citadas do docstring do script (diff vazio contra a fonte), e o parágrafo nomeia os quatro jeitos de passar: o diff toca `openspec/changes/<id>/` de uma change ativa, ou o corpo nomeia uma em `Spec-rite: <id>`, ou arquiva, ou traz a dispensa escrita.
- **README, nota de setup por máquina**: deixa de mandar ignorar `.claude/` no excludes global — o `.gitignore` do repo passou a fazer isso.
- **`claude/global/hooks/locale-rite.py`**: `main()` lê `sys.argv[1:]` explicitamente como `backlog-rite.py` e `verify-rite.py` fazem desde o #115 — só `--selftest`; qualquer outro argumento imprime `usage` no stderr e sai 2, em vez de cair no caminho de stdin e sair 0 sem saída. O selftest ganha o caso pela entrada real (`subprocess`), e foi visto **falhar** contra o `main()` antigo. Deriva de documentação corrigida: o snippet de wiring lista os quatro tools de `WRITE_TOOLS` (`Write|Edit|MultiEdit|NotebookEdit`), o comentário do `CHECK_PATH` diz três níveis acima como `parents[3]` faz, e o teto `additionalContext:8000` foi re-medido em 2026-09-05 no binário instalado (`readlink -f $(which claude)` → `versions/2.1.261`, ELF único, `grep -a` → uma ocorrência; idem no 2.1.260 ao lado) além do 2.1.246 original.

Comportamento do hook para payloads válidos não muda.

## Simulação — saída observada

Entrada real (`python3 claude/global/hooks/locale-rite.py` via stdin/argv), antes e depois:

| Expectativa | Casos | Resultado |
|---|---|---|
| Tinha de disparar e disparou | **3/3** | payload `Write` com caminho em português → mesmo JSON antes e depois (`systemMessage: code-locale: 1 non-English name in the last write`); `--bogus` → `usage: [...] [--selftest]`, exit 2 (antes: exit 0, sem saída); `--selftest --bogus` → usage, exit 2 |
| Tinha de ficar mudo e ficou | **3/3** | payload limpo (`orders/shipping_cost.py`) → exit 0 sem saída; stdin vazio → exit 0 sem saída; `--selftest` sozinho segue rodando o selftest |
| Escape conhecido | **0** | nenhum observado; o teto de 8000 é lido do binário, não exercitado numa sessão viva |

O caso novo do selftest, rodado contra uma cópia com o `main()` antigo: `selftest FAILED: unknown flag`.

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| `.claude/` ignorado pelo repo | `git -c core.excludesfile=/dev/null check-ignore -v .claude/x` | `.gitignore:11:.claude/` (antes: rc=1) |
| Citação = docstring | `diff <(bloco S1–S3 do script) <(bloco do README)` | vazio |
| Docstring × código | matcher vs `WRITE_TOOLS`; comentário vs `parents[3]` | `match: True`; `parents[3] comment: True` |
| Wrappers em sincronia | `bash generate.sh && git status` | 0 linhas |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | `15/15 defect classes detected` |
| Locale de identificadores | `check-identifier-locale.py --selftest` | OK |
| Hook de locale | `locale-rite.py --selftest` | `selftest OK: 12 decisions, the output shape, plus the argv contract` |
| Hooks irmãos | `backlog-rite.py --selftest`, `verify-rite.py --selftest` | `16 decisions [...]`, `12 decisions [...]` OK |
| Segredos | `python3 scripts/scan-secrets.py` (+ `--selftest`) | `no credentials found`; `12/12 patterns fire` |
| Higiene do repo | `validate-repo-hygiene.py` (+ `--selftest`) | `0 findings`; `4/4` |
| Rito | `bash scripts/validate-rite.sh` (corpo com a dispensa) | `rite gate OK` |
| Evidência do rito | `validate-rite-evidence.py --selftest` | `7/7 defect classes detected` |
| Spec-rite | `validate-spec-rite.py` neste diff | `0 findings (base origin/master, 3 changed path(s), 0 active change(s))`; sem a dispensa: `S1 unregistered change` |
| Spec-rite self-test | `validate-spec-rite.py --selftest` | `6/6 defect classes detected, 10/10 false-positive cases stayed silent` |
| Smoke dos instaladores | `bash scripts/smoke-install-scripts.sh` | `17/17 cases passed` |
| Validador do vendor | `claude plugin validate . --strict` (2.1.261) | `✔ Validation passed` |

## Rito

Spec-rite: none — higiene e documentação; a única mudança de código (parse de argv do locale-rite) espelha o contrato que os hooks irmãos já têm desde #115 e não altera nenhum requisito

## Known gaps

- O item pedia a re-medição no claude 2.1.260; o instalado hoje é o 2.1.261. Os dois bundles foram medidos (`additionalContext:8000`, uma ocorrência cada) e o docstring registra ambos — mas o teto continua lido do binário, não exercitado por um hook numa sessão viva.
- O caso novo do selftest roda o próprio arquivo por `subprocess` (única forma de medir o contrato de argv pela entrada real). Os hooks irmãos têm o mesmo contrato e não têm esse caso — fora dos arquivos deste item.
- Além das duas seções listadas no item, a nota *Per-machine setup* do README foi ajustada porque o `.gitignore` novo a tornava falsa; a frase dos 41 × 35 skills foi mantida.