### PR TITLE
✨ feat(hooks): nega em PreToolUse a escrita com nome em português na camada de máquina

### DIFF
--- a/claude/global/hooks/locale-rite.py
+++ b/claude/global/hooks/locale-rite.py
@@ -5,11 +5,20 @@ Reads the hook payload on stdin and, when a Write/Edit is about to land (PreTool
 landed (PostToolUse), runs the shipped identifier-locale check against the written PATH and the
 written CONTENT. One decision, two envelopes, chosen by `hook_event_name`:
 
-    PreToolUse   a gating finding (pt-verb, pt-noun, path-pt-*) DENIES the tool call, with the findings
-                 and the three exits in the reason; an advisory finding alone (en-unknown) denies
-                 nothing, and neither does a clean write.
+    PreToolUse   a gating finding (pt-verb, pt-noun in the added content; path-pt-* in a path the write
+                 CREATES) DENIES the tool call, with the findings and the three exits in the reason; an
+                 advisory finding alone (en-unknown) denies nothing, and neither does a clean write.
+                 A file that already exists is never denied for its own name: the name is on disk
+                 already, existing names change through a deprecation window and not through a blocked
+                 edit, and a denial naming a file the model did not name has no exit but the allowlist.
     PostToolUse  advisory only, exactly as before this mode existed: findings go back to the assistant
-                 as context for the next turn, gating and advisory alike. Silent when the write is clean.
+                 as context for the next turn, gating and advisory alike — a legacy path included, so
+                 the name stays visible. Silent when the write is clean.
+
+    On both events a `# locale-ok: <reason>` that already sits in the file on the line above the
+    fragment an Edit replaces counts as if it were part of the new text (D9 of the change): the
+    denial's first exit tells the model to put the waiver there, and a hook that then cannot see it
+    produces the blind second attempt issue #137 lists as a risk.
 
 Why deny and not only inform: the rule already existed in three layers — the Code Locale section of
 personal-rules.md, the `code-locale` skill and this hook on PostToolUse — and Portuguese identifiers
@@ -219,19 +228,48 @@ def first_line_of(path: Path, anchor: str) -> int:
     return body.count("\n", 0, index) + 1 if index >= 0 else 1
 
 
-def findings_for(check, file_path: str, text: str, cwd: str, anchor: str) -> list:
+def waiver_above(check, path: Path, first_line: int) -> bool:
+    """True when the file line immediately above the located fragment carries `locale-ok: <reason>`.
+
+    `scan_text()` honours a waiver on the line above a name, but only inside the text it is given; an
+    Edit hands over `new_string` alone, so a waiver that already sits in the file — including one the
+    model just added because the denial told it to — is outside that text. `first_line` is 1 when
+    the fragment was not located (or is the whole file), and then there is no line above to read.
+    The regex is the check's own, so the two never drift apart.
+    """
+    if first_line <= 1:
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    above = first_line - 2                       # 0-based index of the line before the fragment
+    return above < len(lines) and bool(check.WAIVER_RE.search(lines[above]))
+
+
+def findings_for(check, file_path: str, text: str, cwd: str, anchor: str, pre: bool = False) -> list:
+    """Path findings plus content findings for one write.
+
+    Before the write (`pre`), the path is judged only when the write CREATES it — a file already on
+    disk is never denied for its own name, and its path findings are left out of the reason entirely
+    (D8). After the write the path is reported as it always was, so a legacy name stays visible.
+    """
     path = Path(file_path)
     if check.is_vendored(path):
         return []
     root = Path(cwd) if cwd else Path.cwd()
     allow = check.load_allowlist(root)
     english = check.load_english() if hasattr(check, "load_english") else None
-    findings = list(check.scan_path(path, allow, root, english))
+    creates = not path.exists()
+    findings = list(check.scan_path(path, allow, root, english)) if (creates or not pre) else []
     lang = check.EXT_LANG.get(path.suffix.lower())
     if lang and text:
         rel = check.project_relative(path, root)
-        findings.extend(check.scan_text(text, lang, str(rel), allow,
-                                        first_line=first_line_of(path, anchor), english=english))
+        first_line = first_line_of(path, anchor)
+        fragment = check.scan_text(text, lang, str(rel), allow, first_line=first_line, english=english)
+        if waiver_above(check, path, first_line):
+            fragment = [f for f in fragment if f.line != first_line]
+        findings.extend(fragment)
     return findings
 
 
@@ -337,7 +375,7 @@ def evaluate(payload: dict, check, mode: "str | None" = None) -> "dict | None":
     if not isinstance(anchor, str):
         anchor = ""
     try:
-        findings = findings_for(check, file_path, text, cwd, anchor)
+        findings = findings_for(check, file_path, text, cwd, anchor, pre=pre)
     except Exception:
         return None                      # a check that crashes must not crash the write
     if not findings:
@@ -486,6 +524,46 @@ def selftest() -> int:
         if not ok:
             failed.append("allowlist")
 
+    # A file that already exists is never denied for its own name (D8), and a waiver already in the
+    # file on the line above the edited fragment counts (D9). Both need a real file, built in a
+    # temporary tree; both were review findings on the first version of this mode.
+    with tempfile.TemporaryDirectory() as tmp:
+        legacy = Path(tmp) / "servico_pedido.py"
+        legacy.write_text("total = 0\n", encoding="utf-8")
+        edit = {"file_path": str(legacy), "old_string": "total = 0", "new_string": "total = 1\n"}
+        pre_edit = evaluate(pre(edit, tool_name="Edit", cwd_=tmp), check)
+        post_edit = evaluate({**pre(edit, tool_name="Edit", cwd_=tmp), "hook_event_name": POST_EVENT}, check)
+        ok = pre_edit is None and bool(post_edit) and "servico_pedido" in post_edit["hookSpecificOutput"]["additionalContext"]
+        print(f"  {'OK     ' if ok else 'FAILED '} PreToolUse allows a clean Edit on a legacy portuguese-named file; PostToolUse still reports the path")
+        if not ok:
+            failed.append("legacy path edit")
+        pt_edit = {**edit, "new_string": "usuario_count = 1\n"}
+        denied = evaluate(pre(pt_edit, tool_name="Edit", cwd_=tmp), check)
+        reason = denied["hookSpecificOutput"]["permissionDecisionReason"] if denied else ""
+        ok = "1 non-English name " in reason and "usuario_count" in reason and "path-pt-noun" not in reason
+        print(f"  {'OK     ' if ok else 'FAILED '} PreToolUse denies the identifier in that Edit and names only the identifier, not the legacy path")
+        if not ok:
+            failed.append("legacy path identifier")
+        overwrite = evaluate(pre({"file_path": str(legacy), "content": "total = 2\n"}, cwd_=tmp), check)
+        fresh = evaluate(pre({"file_path": f"{tmp}/novo_servico.py", "content": "total = 2\n"}, cwd_=tmp), check)
+        ok = overwrite is None and bool(fresh) and fresh["hookSpecificOutput"].get("permissionDecision") == "deny"
+        print(f"  {'OK     ' if ok else 'FAILED '} PreToolUse allows a clean Write over the legacy file and still denies the Write that creates a portuguese path")
+        if not ok:
+            failed.append("legacy path write")
+        two = Path(tmp) / "two.py"
+        two.write_text("a = 1\n# locale-ok: wire name from the legacy adapter\nb = 2\n", encoding="utf-8")
+        waived = {"file_path": str(two), "old_string": "b = 2", "new_string": "usuario = 2"}
+        pre_waived = evaluate(pre(waived, tool_name="Edit", cwd_=tmp), check)
+        two.write_text("a = 1\n# locale-ok: wire name from the legacy adapter\nusuario = 2\n", encoding="utf-8")
+        post_waived = evaluate({**pre(waived, tool_name="Edit", cwd_=tmp), "hook_event_name": POST_EVENT}, check)
+        two.write_text("a = 1\nb = 2\n", encoding="utf-8")
+        unwaived = evaluate(pre(waived, tool_name="Edit", cwd_=tmp), check)
+        ok = pre_waived is None and post_waived is None and bool(unwaived) \
+            and unwaived["hookSpecificOutput"].get("permissionDecision") == "deny"
+        print(f"  {'OK     ' if ok else 'FAILED '} locale-ok already in the file above old_string: PreToolUse silent, PostToolUse silent, denied without it")
+        if not ok:
+            failed.append("waiver above the fragment")
+
     # Denial envelope: the shape the 2.1.261 bundle parses, within both measured caps, each distinct
     # name once, the three exits at the end — on a write with 30 gating findings plus an advisory one.
     many = "\n".join(f"preco_{i} = {i}" for i in range(30)) + "\nzqxbrv_count = 1\n"
@@ -545,7 +623,8 @@ def selftest() -> int:
         print("selftest FAILED: " + "; ".join(failed))
         return 1
     print(f"selftest OK: {len(cases)} PostToolUse decisions, {len(pre_cases)} PreToolUse decisions, "
-          "inform mode, en-unknown, the allowlist, both envelopes, the environment and the argv contract")
+          "inform mode, en-unknown, the allowlist, the legacy path, the waiver above the fragment, "
+          "both envelopes, the environment and the argv contract")
     return 0
 
 

--- a/claude/global/hooks/locale-rite.py
+++ b/claude/global/hooks/locale-rite.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
-"""PostToolUse hook — measures the code-locale rite at the moment a file is written.
+"""PreToolUse + PostToolUse hook — enforces the code-locale rite at the moment a file is written.
 
-Reads the hook payload on stdin and, when a Write/Edit just landed, runs the shipped
-identifier-locale check against the written PATH and the written CONTENT. Findings go back to the
-assistant as context for the next turn. Silent when the write is clean.
+Reads the hook payload on stdin and, when a Write/Edit is about to land (PreToolUse) or has just
+landed (PostToolUse), runs the shipped identifier-locale check against the written PATH and the
+written CONTENT. One decision, two envelopes, chosen by `hook_event_name`:
 
-Why a hook and not only the skill and the global rule: both were already in place — the `code-locale`
-skill in the catalog and the Code Locale section of personal-rules.md — and Portuguese identifiers
-and file names kept reaching code in new sessions (issue #95). Doctrine in context is not
-measurement. This is the same argument `backlog-rite.py` states for its own rule, applied to the one
-rule whose violation is visible in the artifact itself.
+    PreToolUse   a gating finding (pt-verb, pt-noun, path-pt-*) DENIES the tool call, with the findings
+                 and the three exits in the reason; an advisory finding alone (en-unknown) denies
+                 nothing, and neither does a clean write.
+    PostToolUse  advisory only, exactly as before this mode existed: findings go back to the assistant
+                 as context for the next turn, gating and advisory alike. Silent when the write is clean.
 
-WHY `hookSpecificOutput.additionalContext` AND NOT PLAIN STDOUT
+Why deny and not only inform: the rule already existed in three layers — the Code Locale section of
+personal-rules.md, the `code-locale` skill and this hook on PostToolUse — and Portuguese identifiers
+kept reaching code in new sessions (issues #95, #137). With the hook only informing, the model reads
+the finding and moves on; nothing obliges it to rename. PreToolUse has the content in the payload, so
+this is measurement of the write itself, not a proxy for it.
+
+WHY `hookSpecificOutput.additionalContext` AND NOT PLAIN STDOUT (PostToolUse)
     For PostToolUse, plain stdout goes to the debug log and the model never sees it. The events that
     turn stdout into context are UserPromptSubmit, UserPromptExpansion and SessionStart — which is
     why the repo's other two rite hooks can print and this one cannot. Probed against the installed
@@ -23,17 +29,63 @@ WHY `hookSpecificOutput.additionalContext` AND NOT PLAIN STDOUT
     `additionalContext:8000` exactly once, and the same on the 2.1.260 bundle beside it.
     Docs: code.claude.com/docs/en/hooks (read 2026-08-26).
 
+WHY `hookSpecificOutput.permissionDecision` AND NOT `exit 2` (PreToolUse)
+    Probed 2026-09-05 on the same 2.1.261 bundle with `re.finditer` over the bytes (the machine's
+    grep is ugrep and refuses the pattern with context). The output schema for the event is
+    `c({hookEventName:C("PreToolUse"),permissionDecision:boe().optional(),permissionDecisionReason:
+    s().optional(),updatedInput:pe(s(),se()).optional(),additionalContext:s().optional()})`, and the
+    normaliser keeps the reason only when the decision is deny or ask:
+    `let o=t.permissionDecision==="deny"||t.permissionDecision==="ask"; ... d=o?X5(e,
+    "permissionDecisionReason",t.permissionDecisionReason):void 0`. `X5` applies TWO caps, read
+    from `AKr={...,additionalContext:8000,permissionDecisionReason:2000}` (characters) and
+    `RKr={...,additionalContext:200,permissionDecisionReason:20}` (lines): the reason is cut to 20
+    lines and 2000 characters, the context to 200 lines and 8000 characters — the line cap was not
+    recorded here before. An envelope whose `hookEventName` does not match the event is dropped
+    (`if(t.hookEventName!==r){Ik(e,"hookSpecificOutput_event_mismatch",!0);return}`), which is why
+    the event name comes from the payload and not from a constant. `exit 2` also denies (the bundle
+    wraps stderr as the reason), but through a cap this hook did not measure; JSON keeps one output
+    format for both events. The bundle also honours `additionalContext` on PreToolUse — the schema
+    above carries it, and the run loop yields it as `hook_additional_context` with
+    `hookEvent:"PreToolUse"` — but this hook does not use it: with both events wired, the advisory
+    would reach the model twice for one write, and PostToolUse already carries it.
+
+MODES
+    default                  PreToolUse denies on a gating finding; PostToolUse informs.
+    LOCALE_RITE_MODE=inform  PreToolUse never denies; PostToolUse informs as before. The whole
+                             session, for the rare tree where the lexicon is wrong more often than
+                             right. Any other value of the variable — empty, absent, misspelt — is the
+                             default mode, so a typo cannot open the door in silence.
+    The two exits the check already honours still apply and are named in every denial:
+    `# locale-ok: <reason>` on the line above an identifier, and the name or the path listed in
+    .identifier-locale-allow (the only waiver a file name can carry).
+
 WHAT THIS HOOK DELIBERATELY DOES NOT DO
-    - It never blocks. The tool already ran, and the rite informs; the user waives.
+    - It never denies on PostToolUse (the tool already ran) and never denies on an advisory finding
+      alone: a word the English list does not know is a question, not a verdict.
+    - It never rewrites the tool input (`updatedInput` exists in the bundle): renaming on the model's
+      behalf would be an invented translation, and the rite forbids exactly that.
     - It never writes state, reads credentials, or calls the network.
     - It reports nothing when the shipped check is missing: a gate that is absent must not present
       itself to the user as an error.
     - It inherits every limit of the check it calls, including the open-vocabulary escape — a
       Portuguese word outside the lexicon passes here exactly as it passes in CI.
 
-Wiring (~/.claude/settings.json):
+KNOWN LIMIT
+    Only the harness write tools pass through here (Write, Edit, MultiEdit, NotebookEdit). A file
+    written by a Bash command — heredoc, `sed -i`, a script — is never seen, so a denied write is not
+    proof that no Portuguese name can land. Closing that path is the Stop gate of issue #138.
+
+Wiring (~/.claude/settings.json) — BOTH blocks, same command. PreToolUse is the one that denies;
+PostToolUse is the one that carries the advisory and the `inform` mode. Wiring only the first loses
+en-unknown; wiring only the second is the behaviour before issue #137.
 
     "hooks": {
+      "PreToolUse": [
+        {"matcher": "Write|Edit|MultiEdit|NotebookEdit",
+         "hooks": [{"type": "command",
+                    "command": "python3 ~/ai-skills/claude/global/hooks/locale-rite.py",
+                    "timeout": 10}]}
+      ],
       "PostToolUse": [
         {"matcher": "Write|Edit|MultiEdit|NotebookEdit",
          "hooks": [{"type": "command",
@@ -48,6 +100,9 @@ your own process instead of adopting it blindly.
 Modes: (default) read one payload from stdin   |   --selftest assert the decisions against synthetic payloads.
 Any other argument prints usage to stderr and exits 2 — the same contract as backlog-rite.py and
 verify-rite.py since #115, so a misspelt flag cannot fall through to the stdin path and exit 0.
+The selftest feeds only the fields this hook reads (`hook_event_name`, `tool_name`, `tool_input`,
+`cwd`), in the shape the 2.1.261 bundle declares; that the harness still sends them under those names
+is what the wired session proves, not the selftest.
 """
 
 import importlib.util
@@ -55,6 +110,7 @@ import json
 import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 # The check lives in the skill that owns the doctrine. parents[3] of this file is the repository
@@ -63,9 +119,21 @@ from pathlib import Path
 CHECK_PATH = Path(__file__).resolve().parents[3] / "skills/code-locale/references/check-identifier-locale.py"
 
 # The harness truncates a longer value; truncating here keeps the tail we choose rather than the
-# tail it chooses. Measured cap: `additionalContext:8000` in claude 2.1.246, 2.1.260 and 2.1.261
-# (see the docstring for the probe).
+# tail it chooses. Measured caps (see the docstring for the probes): `additionalContext:8000`
+# characters in claude 2.1.246, 2.1.260 and 2.1.261, plus 200 lines in 2.1.261;
+# `permissionDecisionReason:2000` characters and 20 lines in 2.1.261.
 CONTEXT_CAP = 8000
+CONTEXT_LINE_CAP = 200
+REASON_CAP = 2000
+REASON_LINE_CAP = 20
+# Header (1) + findings (<= 12) + "+N more" (1) + advisory count (1) + exits (3) = 18 < 20 lines.
+REASON_MAX_FINDINGS = 12
+
+PRE_EVENT = "PreToolUse"
+POST_EVENT = "PostToolUse"
+
+MODE_ENV = "LOCALE_RITE_MODE"
+MODE_INFORM = "inform"
 
 WRITE_TOOLS = {"Write", "Edit", "MultiEdit", "NotebookEdit"}
 
@@ -82,6 +150,21 @@ HEADER = (
     "reason the name is correct as written.\n\n"
 )
 
+DENY_HEADER = (
+    "CODE-LOCALE: write denied — {count} non-English name{plural} in the machine layer. Identifiers, "
+    "file and directory names are English (code-locale skill); comments, docstrings and strings keep "
+    "the repository's language. Rename, or waive with a reason:"
+)
+
+# The three exits, literal, so the model can act without opening the skill. A denial that only says
+# "there are exits" produces the blind second attempt issue #137 lists as a risk.
+EXITS = (
+    "Exits: (1) `# locale-ok: <reason>` on the line above the name (identifiers only — a file name "
+    "has nowhere to carry it);",
+    "  (2) list the name or the path in .identifier-locale-allow (the only waiver for a file name);",
+    f"  (3) export {MODE_ENV}={MODE_INFORM} to make this hook advisory for the whole session.",
+)
+
 
 def load_check():
     """Import the shipped check by path. Its file name has hyphens, so it is not importable by name."""
@@ -94,6 +177,11 @@ def load_check():
         return module
     except Exception:
         return None
+
+
+def current_mode() -> str:
+    """The session mode from the environment. Anything but `inform` is the default (denying) mode."""
+    return os.environ.get(MODE_ENV, "").strip().lower()
 
 
 def written_text(tool_name: str, tool_input: dict) -> str:
@@ -109,24 +197,29 @@ def written_text(tool_name: str, tool_input: dict) -> str:
     return ""
 
 
-def first_line_of(path: Path, text: str) -> int:
+def first_line_of(path: Path, anchor: str) -> int:
     """Where the written fragment starts in the file, so a finding points at a real line.
 
     An Edit hands over `new_string` alone, and scanning it in isolation numbers its lines from 1 —
     which reads as "line 1 of the file" and sends the reader to the wrong place. Locating the
-    fragment in the file that the tool has already written is what makes the number true. A fragment
-    that cannot be located (a replace_all whose copies differ, a file already changed again) falls
-    back to 1, which is the previous behaviour and never worse than it.
+    fragment in the file is what makes the number true. After the write (PostToolUse) the anchor is
+    the `new_string` the tool has already put there; before it (PreToolUse) the `new_string` is not
+    in the file yet, so the anchor is the `old_string` it will replace, which sits exactly where the
+    new text will start. An anchor that cannot be located (a replace_all whose copies differ, a file
+    already changed again, a Write) falls back to 1, which is the previous behaviour and never worse
+    than it.
     """
+    if not anchor:
+        return 1
     try:
         body = path.read_text(encoding="utf-8")
     except OSError:
         return 1
-    index = body.find(text)
+    index = body.find(anchor)
     return body.count("\n", 0, index) + 1 if index >= 0 else 1
 
 
-def findings_for(check, file_path: str, text: str, cwd: str) -> list:
+def findings_for(check, file_path: str, text: str, cwd: str, anchor: str) -> list:
     path = Path(file_path)
     if check.is_vendored(path):
         return []
@@ -138,15 +231,21 @@ def findings_for(check, file_path: str, text: str, cwd: str) -> list:
     if lang and text:
         rel = check.project_relative(path, root)
         findings.extend(check.scan_text(text, lang, str(rel), allow,
-                                        first_line=first_line_of(path, text), english=english))
+                                        first_line=first_line_of(path, anchor), english=english))
     return findings
 
 
-def report(findings: list) -> dict:
-    # Gating first, advisory after, and the header says which is which: an advisory finding is a
-    # question for the author ("is this English?"), not a defect the check is sure of.
+def split_findings(findings: list) -> "tuple[list, list]":
     gating = [f for f in findings if not getattr(f, "advisory", False)]
     advisory = [f for f in findings if getattr(f, "advisory", False)]
+    return gating, advisory
+
+
+def report(findings: list) -> dict:
+    """The PostToolUse envelope — advisory, the tool call already ran. Unchanged by issue #137."""
+    # Gating first, advisory after, and the header says which is which: an advisory finding is a
+    # question for the author ("is this English?"), not a defect the check is sure of.
+    gating, advisory = split_findings(findings)
     body = (HEADER if gating else ADVISORY_HEADER) + "\n".join(f.render() for f in gating + advisory)
     if len(body) > CONTEXT_CAP:
         body = body[:CONTEXT_CAP - 80].rstrip() + "\n    … truncated; run the check on the file for the rest."
@@ -156,13 +255,66 @@ def report(findings: list) -> dict:
     if advisory:
         parts.append(f"{len(advisory)} unrecognised word{'s' if len(advisory) != 1 else ''} (advisory)")
     return {
-        "hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": body},
+        "hookSpecificOutput": {"hookEventName": POST_EVENT, "additionalContext": body},
         "systemMessage": "code-locale: " + ", ".join(parts) + " in the last write",
     }
 
 
-def evaluate(payload: dict, check) -> "dict | None":
-    """The whole decision, isolated from stdin and stdout so the selftest can drive it."""
+def finding_line(f) -> str:
+    """One line per finding. The check's own render() spends 4-5 lines each, which the 20-line cap
+    would spend on the first four findings and then cut the exits — the part that must survive."""
+    where = f"{f.path}:{f.line}" if getattr(f, "line", 0) else f.path
+    return f"  {where}: {f.token}  [{f.tier}: '{f.segment}']"
+
+
+def deny_reason(gating: list, advisory: list) -> str:
+    """Header, one line per distinct (path, token), `+N more`, the advisory count, the three exits.
+
+    Built to fit REASON_LINE_CAP lines by construction and REASON_CAP characters by trimming finding
+    lines from the end — never the exits, which the harness would otherwise be the one to cut.
+    """
+    seen = set()
+    distinct = []
+    for f in gating:
+        key = (f.path, f.token)
+        if key not in seen:
+            seen.add(key)
+            distinct.append(f)
+    header = DENY_HEADER.format(count=len(distinct), plural="s" if len(distinct) != 1 else "")
+    tail = []
+    if advisory:
+        tail.append(f"  (+{len(advisory)} unrecognised word{'s' if len(advisory) != 1 else ''}, "
+                    "advisory: never denies, reported after a clean write lands)")
+    tail.extend(EXITS)
+    shown = min(len(distinct), REASON_MAX_FINDINGS)
+    while True:
+        lines = [header] + [finding_line(f) for f in distinct[:shown]]
+        if len(distinct) > shown:
+            lines.append(f"  (+{len(distinct) - shown} more — run the check on the file for the rest)")
+        text = "\n".join(lines + tail)
+        if len(text) <= REASON_CAP or shown == 0:
+            return text
+        shown -= 1
+
+
+def deny(findings: list) -> dict:
+    """The PreToolUse envelope. Shape probed on the 2.1.261 bundle (see the docstring)."""
+    gating, advisory = split_findings(findings)
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": PRE_EVENT,
+            "permissionDecision": "deny",
+            "permissionDecisionReason": deny_reason(gating, advisory),
+        }
+    }
+
+
+def evaluate(payload: dict, check, mode: "str | None" = None) -> "dict | None":
+    """The whole decision, isolated from stdin and stdout so the selftest can drive it.
+
+    `mode` defaults to the environment (LOCALE_RITE_MODE); the selftest passes it explicitly so it
+    fixes both modes without touching os.environ, and proves the default through a subprocess.
+    """
     if check is None:
         return None
     tool_name = payload.get("tool_name") or ""
@@ -172,14 +324,30 @@ def evaluate(payload: dict, check) -> "dict | None":
     if not isinstance(tool_input, dict):
         return None
     file_path = tool_input.get("file_path") or tool_input.get("notebook_path") or ""
-    if not file_path:
+    if not isinstance(file_path, str) or not file_path:
         return None
-    cwd = payload.get("cwd") or os.getcwd()
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd:
+        cwd = os.getcwd()
+    # In doubt the hook informs and never denies: a payload with no event name, or one this hook does
+    # not know, is treated as the event that follows the write.
+    pre = payload.get("hook_event_name") == PRE_EVENT
+    text = written_text(tool_name, tool_input)
+    anchor = (tool_input.get("old_string") or "") if (pre and tool_name == "Edit") else text
+    if not isinstance(anchor, str):
+        anchor = ""
     try:
-        findings = findings_for(check, file_path, written_text(tool_name, tool_input), cwd)
+        findings = findings_for(check, file_path, text, cwd, anchor)
     except Exception:
         return None                      # a check that crashes must not crash the write
-    return report(findings) if findings else None
+    if not findings:
+        return None
+    if not pre:
+        return report(findings)
+    if (mode if mode is not None else current_mode()) == MODE_INFORM:
+        return None                      # the write lands; PostToolUse informs, as before #137
+    gating, _ = split_findings(findings)
+    return deny(findings) if gating else None
 
 
 def selftest() -> int:
@@ -188,6 +356,8 @@ def selftest() -> int:
         print(f"selftest FAILED: check not found at {CHECK_PATH}")
         return 1
     cwd = "/tmp/locale-rite-selftest"
+    # The PostToolUse cases carry no hook_event_name on purpose: the payloads that reached this hook
+    # before issue #137 must decide exactly as they did, so a missing event name is the advisory path.
     cases = [
         ("portuguese path reported", True, {
             "tool_name": "Write", "cwd": cwd,
@@ -224,24 +394,143 @@ def selftest() -> int:
             "tool_name": "Edit", "cwd": cwd,
             "tool_input": {"file_path": f"{cwd}/servicos/x.py", "old_string": "a",
                            "new_string": "b = 1\n"}}),
+        ("PostToolUse by name is the advisory envelope", True, {
+            "hook_event_name": POST_EVENT, "tool_name": "Write", "cwd": cwd,
+            "tool_input": {"file_path": f"{cwd}/orders/service.py",
+                           "content": "def buscar_order(x):\n    return x\n"}}),
     ]
     failed = []
     for name, should_report, payload in cases:
         got = evaluate(payload, check)
-        ok = bool(got) == should_report
+        ok = bool(got) == should_report and (not got or "permissionDecision" not in got["hookSpecificOutput"])
         print(f"  {'OK     ' if ok else 'FAILED '} {name}")
         if not ok:
             failed.append(name)
     reported = evaluate(cases[0][2], check)
     shape_ok = (
         isinstance(reported, dict)
-        and reported["hookSpecificOutput"]["hookEventName"] == "PostToolUse"
+        and reported["hookSpecificOutput"]["hookEventName"] == POST_EVENT
         and isinstance(reported["hookSpecificOutput"]["additionalContext"], str)
         and len(reported["hookSpecificOutput"]["additionalContext"]) <= CONTEXT_CAP
     )
-    print(f"  {'OK     ' if shape_ok else 'FAILED '} output shape is the field the harness reads")
+    print(f"  {'OK     ' if shape_ok else 'FAILED '} output shape is the field the harness reads (PostToolUse)")
     if not shape_ok:
         failed.append("output shape")
+
+    # PreToolUse: `deny` is the denial envelope, None is silence, `advisory` is the PostToolUse
+    # envelope (only reachable here when the event name is missing — kept out of this list on
+    # purpose: a PreToolUse payload never gets the advisory shape, which the harness would drop).
+    def pre(tool_input, tool_name="Write", cwd_=cwd, event=PRE_EVENT):
+        return {"hook_event_name": event, "tool_name": tool_name, "cwd": cwd_, "tool_input": tool_input}
+
+    pt_ident = {"file_path": f"{cwd}/orders/service.py", "content": "def buscar_order(x):\n    return x\n"}
+    pre_cases = [
+        ("PreToolUse denies a portuguese identifier", "deny", None, pre(pt_ident)),
+        ("PreToolUse denies a portuguese path", "deny", None,
+         pre({"file_path": f"{cwd}/servicos_pedido/shipping.py", "content": "x = 1\n"})),
+        ("PreToolUse denies an Edit whose new_string is portuguese", "deny", None,
+         pre({"file_path": f"{cwd}/orders/service.py", "old_string": "a", "new_string": "usuario_count = 1\n"},
+             tool_name="Edit")),
+        ("PreToolUse allows the same name with locale-ok on the line above", None, None,
+         pre({"file_path": f"{cwd}/orders/service.py",
+              "content": "# locale-ok: legacy wire name mirrored in the adapter\ndef buscar_order(x):\n    return x\n"})),
+        ("PreToolUse allows a clean write", None, None,
+         pre({"file_path": f"{cwd}/orders/shipping_cost.py", "content": "def compute_shipping(order_id):\n    return 0\n"})),
+        ("PreToolUse in inform mode never denies", None, MODE_INFORM, pre(pt_ident)),
+        ("PreToolUse with a misspelt mode still denies", "deny", "informar", pre(pt_ident)),
+        ("PreToolUse ignores another tool", None, None,
+         pre({"command": "ls servicos_pedido"}, tool_name="Bash")),
+        ("PreToolUse ignores a payload without file_path", None, None, pre({})),
+        ("PreToolUse ignores a tool_input that is not an object", None, None, pre("x")),
+        ("PreToolUse ignores a file_path that is not a string", None, None, pre({"file_path": 42, "content": "a"})),
+        ("PreToolUse with a cwd that is not a string still denies", "deny", None,
+         pre(pt_ident, cwd_=42)),
+    ]
+    for name, expect, mode, payload in pre_cases:
+        got = evaluate(payload, check, mode=mode)
+        kind = None
+        if got:
+            kind = "deny" if got["hookSpecificOutput"].get("permissionDecision") == "deny" else "advisory"
+        ok = kind == expect
+        print(f"  {'OK     ' if ok else 'FAILED '} {name}")
+        if not ok:
+            failed.append(name)
+
+    # inform mode: the same payload, on the event that follows the write, is the advisory as before.
+    post_inform = evaluate({**pre(pt_ident), "hook_event_name": POST_EVENT}, check, mode=MODE_INFORM)
+    ok = bool(post_inform) and "additionalContext" in post_inform["hookSpecificOutput"]
+    print(f"  {'OK     ' if ok else 'FAILED '} inform mode: PostToolUse still carries the advisory")
+    if not ok:
+        failed.append("inform mode PostToolUse")
+
+    # en-unknown alone never denies on PreToolUse, and is the advisory on PostToolUse. The token is
+    # asserted to be an advisory-only finding first, so the case cannot pass on a clean write.
+    unknown = {"file_path": f"{cwd}/orders/service.py", "content": "zqxbrv_count = 1\n"}
+    gating, advisory = split_findings(findings_for(check, unknown["file_path"], unknown["content"], cwd, unknown["content"]))
+    only_advisory = not gating and bool(advisory)
+    pre_unknown = evaluate(pre(unknown), check)
+    post_unknown = evaluate({**pre(unknown), "hook_event_name": POST_EVENT}, check)
+    ok = only_advisory and pre_unknown is None and bool(post_unknown) and \
+        "additionalContext" in post_unknown["hookSpecificOutput"]
+    print(f"  {'OK     ' if ok else 'FAILED '} en-unknown alone: PreToolUse silent, PostToolUse advisory")
+    if not ok:
+        failed.append("en-unknown alone")
+
+    # The allowlist is found from the payload's cwd, so the case builds one in a temporary tree and
+    # never reads the allowlist of whoever runs the selftest.
+    with tempfile.TemporaryDirectory() as tmp:
+        (Path(tmp) / check.ALLOWLIST_FILE).write_text("buscar_order\n", encoding="utf-8")
+        allowed = pre({"file_path": f"{tmp}/orders/service.py", "content": "def buscar_order(x):\n    return x\n"}, cwd_=tmp)
+        ok = evaluate(allowed, check) is None and evaluate({**allowed, "hook_event_name": POST_EVENT}, check) is None
+        print(f"  {'OK     ' if ok else 'FAILED '} PreToolUse allows a name listed in {check.ALLOWLIST_FILE} of the cwd")
+        if not ok:
+            failed.append("allowlist")
+
+    # Denial envelope: the shape the 2.1.261 bundle parses, within both measured caps, each distinct
+    # name once, the three exits at the end — on a write with 30 gating findings plus an advisory one.
+    many = "\n".join(f"preco_{i} = {i}" for i in range(30)) + "\nzqxbrv_count = 1\n"
+    denied = evaluate(pre({"file_path": f"{cwd}/orders/service.py", "content": many}), check)
+    reason = denied["hookSpecificOutput"]["permissionDecisionReason"] if denied else ""
+    deny_ok = (
+        bool(denied)
+        and denied["hookSpecificOutput"]["hookEventName"] == PRE_EVENT
+        and denied["hookSpecificOutput"]["permissionDecision"] == "deny"
+        and len(reason) <= REASON_CAP
+        and reason.count("\n") + 1 <= REASON_LINE_CAP
+        and reason.startswith("CODE-LOCALE: write denied — 30 non-English names")
+        and reason.count("preco_0 ") == 1
+        and "(+18 more" in reason
+        and "(+1 unrecognised word, advisory" in reason
+        and reason.endswith(EXITS[-1])
+        and "locale-ok:" in reason and check.ALLOWLIST_FILE in reason and f"{MODE_ENV}={MODE_INFORM}" in reason
+    )
+    print(f"  {'OK     ' if deny_ok else 'FAILED '} denial envelope: PreToolUse shape, <= {REASON_CAP} chars, "
+          f"<= {REASON_LINE_CAP} lines, three exits last")
+    if not deny_ok:
+        failed.append("denial envelope")
+    # The issue's own example: preco on two lines is one line in the reason.
+    issue = evaluate(pre({"file_path": f"{cwd}/servico_pedido.py",
+                          "content": "def calcular_total(preco):\n    return preco\n"}), check)
+    reason = issue["hookSpecificOutput"]["permissionDecisionReason"] if issue else ""
+    distinct_ok = reason.startswith("CODE-LOCALE: write denied — 3 non-English names") and reason.count(" preco ") == 1
+    print(f"  {'OK     ' if distinct_ok else 'FAILED '} denial reason names each distinct token once")
+    if not distinct_ok:
+        failed.append("distinct tokens")
+
+    # The mode's default reads the environment; only the real entry point can prove that.
+    raw = json.dumps(pre(pt_ident))
+    env = {k: v for k, v in os.environ.items() if k != MODE_ENV}
+    run_default = subprocess.run([sys.executable, __file__], input=raw, capture_output=True, text=True, env=env)
+    run_inform = subprocess.run([sys.executable, __file__], input=raw, capture_output=True, text=True,
+                                env={**env, MODE_ENV: MODE_INFORM})
+    env_ok = (
+        run_default.returncode == 0 and '"permissionDecision": "deny"' in run_default.stdout
+        and run_inform.returncode == 0 and run_inform.stdout == "" and run_inform.stderr == ""
+    )
+    print(f"  {'OK     ' if env_ok else 'FAILED '} {MODE_ENV}={MODE_INFORM} read from the environment through stdin")
+    if not env_ok:
+        failed.append("environment mode")
+
     # The argv contract can only be measured through the real entry point: a misspelt flag must
     # print usage and exit 2, never read stdin and exit 0 (the silent no-op #115 closed in the
     # sibling hooks).
@@ -255,7 +544,8 @@ def selftest() -> int:
     if failed:
         print("selftest FAILED: " + "; ".join(failed))
         return 1
-    print(f"selftest OK: {len(cases)} decisions, the output shape, plus the argv contract")
+    print(f"selftest OK: {len(cases)} PostToolUse decisions, {len(pre_cases)} PreToolUse decisions, "
+          "inform mode, en-unknown, the allowlist, both envelopes, the environment and the argv contract")
     return 0
 
 

--- a/claude/global/personal-rules.md
+++ b/claude/global/personal-rules.md
@@ -53,10 +53,12 @@ field keys.
 - Existing code is not renamed for its own sake: new code is English, and a contract-bearing name
   (route, persisted column, event name, deployed config key) changes only through a deprecation window.
 - This is enforced, not only remembered: the `locale-rite.py` hook **denies** a Write/Edit whose
-  path or new content carries a Portuguese identifier (PreToolUse), and only informs after the write
-  for words it is unsure about. The exits are named in the denial itself — `# locale-ok: <reason>`
-  on the line above, the name or path in `.identifier-locale-allow`, or `LOCALE_RITE_MODE=inform`
-  for the session. Files written through Bash are not seen (issue #138).
+  new content, or whose path when the write creates it, carries a Portuguese identifier
+  (PreToolUse), and only informs after the write for words it is unsure about. A file that already
+  carries a Portuguese name is edited freely and its name is only reported afterwards — the previous
+  bullet applies. The exits are named in the denial itself — `# locale-ok: <reason>` on the line
+  above (already in the file counts), the name or path in `.identifier-locale-allow`, or
+  `LOCALE_RITE_MODE=inform` for the session. Files written through Bash are not seen (issue #138).
 - Full doctrine, exception protocol, migration policy and the detector: the `code-locale` skill.
 
 ## Commits & Pull Requests

--- a/claude/global/personal-rules.md
+++ b/claude/global/personal-rules.md
@@ -52,6 +52,11 @@ field keys.
   it is in neither. An invented translation is an unverified claim (see Grounding).
 - Existing code is not renamed for its own sake: new code is English, and a contract-bearing name
   (route, persisted column, event name, deployed config key) changes only through a deprecation window.
+- This is enforced, not only remembered: the `locale-rite.py` hook **denies** a Write/Edit whose
+  path or new content carries a Portuguese identifier (PreToolUse), and only informs after the write
+  for words it is unsure about. The exits are named in the denial itself — `# locale-ok: <reason>`
+  on the line above, the name or path in `.identifier-locale-allow`, or `LOCALE_RITE_MODE=inform`
+  for the session. Files written through Bash are not seen (issue #138).
 - Full doctrine, exception protocol, migration policy and the detector: the `code-locale` skill.
 
 ## Commits & Pull Requests

--- a/openspec/changes/enforce-locale-on-write/.openspec.yaml
+++ b/openspec/changes/enforce-locale-on-write/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/enforce-locale-on-write/design.md
+++ b/openspec/changes/enforce-locale-on-write/design.md
@@ -119,6 +119,51 @@ entrada em `.identifier-locale-allow` (a única saída para caminho), e
 `export LOCALE_RITE_MODE=inform`. O modelo que lê o motivo tem de conseguir agir sem abrir a skill;
 um motivo que só diz "há saídas" gera a segunda tentativa cega que a issue lista como risco.
 
+### D8 — Um caminho só nega em `PreToolUse` quando a escrita o **cria**
+
+Achado de revisão (2026-09-05, dois dos três findings): com o hook em `17fc01f`, um `Edit` com
+`new_string` inteiramente em inglês sobre um arquivo **já existente** de nome português era negado —
+`printf 'total = 0\n' > $X/servico_pedido.py` e depois `{PreToolUse, Edit, old_string:"total = 0",
+new_string:"total = 1"}` -> `permissionDecision: "deny"`, motivo `servico_pedido.py: servico_pedido
+[path-pt-noun: 'servico']`. O achado vinha de `check.scan_path()`, chamado sem distinguir se o
+caminho existe, e era gating. Isso bloqueava a manutenção de qualquer arquivo legado em todo projeto
+com o hook wired, contradizendo `personal-rules.md` ("Existing code is not renamed for its own sake
+... changes only through a deprecation window") e o próprio `written_text()` do hook ("never the
+file's existing content, which the rite does not judge"). E a justificativa do delta — "so that the
+name never reaches the file" — já era falsa para um arquivo no disco. As únicas saídas eram a
+allowlist por caminho ou `inform` para a sessão inteira.
+
+Decisão: em `PreToolUse`, `findings_for()` só inclui os achados de caminho quando
+`Path(file_path).exists()` é falso — a escrita **cria** o nome. A regra é por existência, não por
+ferramenta: um `Write` que sobrescreve um arquivo legado também não cria o nome; um `Edit`,
+`MultiEdit` ou `NotebookEdit` só existe sobre arquivo existente e nunca é negado pelo caminho. Os
+achados de caminho não entram no motivo nem quando a escrita é negada por um identificador — um
+motivo que nomeia um arquivo que o modelo não nomeou não tem saída além da allowlist. Em
+`PostToolUse` nada muda: o caminho legado continua reportado depois que a escrita cai, então o nome
+fica visível sem travar a manutenção. O teste de existência acontece dentro de `findings_for()`, sob
+o `try` de `evaluate()`, então um caminho que o sistema de arquivos recusa cai em silêncio como
+qualquer outro erro do check.
+
+### D9 — O `locale-ok:` que já está no arquivo, na linha acima do fragmento, vale
+
+Achado de revisão (2026-09-05, o terceiro): a negação instrui "`# locale-ok: <reason>` on the line
+above the name", mas em `PreToolUse` com `Edit` só o `new_string` é escaneado e `scan_text()` só
+olha `lines[offset-1]` dentro do fragmento que recebe. Um waiver que já está no arquivo na linha
+acima do `old_string` — inclusive um que o modelo acabou de acrescentar num `Edit` anterior,
+exatamente como instruído — era invisível: arquivo `a = 1\n# locale-ok: wire name from the legacy
+adapter\nb = 2\n`, `{PreToolUse, Edit, old_string:"b = 2", new_string:"usuario = 2"}` -> `deny`,
+`orders/two.py:3: usuario`. É o loop de segunda tentativa cega que a issue lista como risco,
+produzido por seguir a instrução do próprio hook.
+
+Decisão: `findings_for()` calcula `first_line = first_line_of(path, anchor)` uma vez; se
+`first_line > 1` (o fragmento foi localizado no arquivo) e a linha `first_line - 1` do arquivo casa
+`check.WAIVER_RE`, os achados do fragmento com `line == first_line` são descartados. Só a primeira
+linha do fragmento: as linhas seguintes têm a anterior dentro do próprio fragmento, que `scan_text()`
+já cobre. A regra vale nos dois eventos — em `PostToolUse` a âncora é o `new_string` já gravado e a
+linha acima dele é a mesma —, então o `PostToolUse` deixa de reportar um nome que o check, rodando
+sobre o arquivo inteiro em CI, já aceitaria. Os 13 casos de `PostToolUse` do selftest não mudam:
+nenhum deles tem waiver fora do fragmento. O regex vem do check (`WAIVER_RE`), não é duplicado.
+
 ## Canonical Home & Cross-Links (MANDATORY)
 
 | Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
@@ -144,6 +189,14 @@ Nenhuma skill do catálogo é editada por esta change, então não há doutrina 
 - **Wired só o bloco `PreToolUse`** -> `en-unknown` nunca chega e `inform` fica mudo, porque os dois
   dependem do `PostToolUse` (D4, D5). O docstring mostra os dois blocos juntos e diz por quê.
 - **Bash continua passando** -> KNOWN LIMIT declarado; fechado pela issue #138, não por esta.
+- **Negar a manutenção de arquivo legado pelo nome** -> era o comportamento em `17fc01f`, achado
+  em revisão e corrigido por D8: o caminho só nega quando a escrita o cria. O custo aceito: um
+  `Write` que sobrescreve um arquivo legado inteiro não é negado pelo nome — o nome já estava lá e
+  o `PostToolUse` o reporta.
+- **O primeiro exit do motivo não funciona quando seguido** -> era o comportamento em `17fc01f`
+  para `Edit` (waiver acima do `old_string` invisível), corrigido por D9. O que D9 não cobre: um
+  `new_string` cujo identificador está na segunda linha ou depois, com o waiver no arquivo acima do
+  fragmento — o check também não aceitaria isso (o waiver vale para a linha imediatamente abaixo).
 
 ## Open Questions
 

--- a/openspec/changes/enforce-locale-on-write/design.md
+++ b/openspec/changes/enforce-locale-on-write/design.md
@@ -1,0 +1,153 @@
+## Context
+
+`claude/global/hooks/locale-rite.py` lido em `80ee53c` (2026-09-05): 260 linhas. `evaluate(payload,
+check)` em 175-193 lê `tool_name`, `tool_input.file_path`/`notebook_path`, `cwd`, chama
+`findings_for()` e devolve `report(findings)`; `report()` em 155-172 monta sempre
+`{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": ...}, "systemMessage":
+...}` e trunca em `CONTEXT_CAP = 8000`. O hook não lê `hook_event_name`, então rodá-lo em
+`PreToolUse` hoje devolve um envelope com `hookEventName: "PostToolUse"` — que o bundle descarta por
+`hookSpecificOutput_event_mismatch` (ver D1). O docstring já registra o probe do
+`additionalContext:8000` contra o bundle 2.1.246/2.1.260/2.1.261.
+
+O que o bundle instalado (`readlink -f $(which claude)` -> `~/.local/share/claude/versions/2.1.261`,
+`claude --version` -> `2.1.261 (Claude Code)`, ELF único) mostra sobre `PreToolUse`, extraído com um
+`re.finditer` em Python sobre os bytes (o `grep` da máquina é `ugrep` e recusa o padrão):
+
+- Schema de saída aceito:
+  `c({hookEventName:C("PreToolUse"),permissionDecision:boe().optional(),permissionDecisionReason:s().optional(),updatedInput:pe(s(),se()).optional(),additionalContext:s().optional()})`.
+- Normalização: `case"PreToolUse":{let o=t.permissionDecision==="deny"||t.permissionDecision==="ask";
+  ... let d=o?X5(e,"permissionDecisionReason",t.permissionDecisionReason):void 0,
+  f=X5(e,"additionalContext",t.additionalContext);return{hookEventName:"PreToolUse",...o&&{permissionDecision:t.permissionDecision},...d!==void 0&&{permissionDecisionReason:d},...f!==void 0&&{additionalContext:f}}}`
+  — o motivo só sobrevive com `deny`/`ask`; `additionalContext` sobrevive em qualquer decisão.
+- Caps: `AKr={reason:2000,stopReason:2000,systemMessage:4000,additionalContext:8000,permissionDecisionReason:2000}`
+  (caracteres) e `RKr={reason:20,...,additionalContext:200,permissionDecisionReason:20}` (linhas);
+  `X5(e,t,r)` chama `Phn(r,AKr[t],RKr[t])`, que corta em `o.slice(0,r)` linhas e depois em `t`
+  caracteres. O cap de **linhas** não estava registrado no docstring: `additionalContext` também tem
+  um, de 200.
+- Payload de entrada: `c({hook_event_name:C("PreToolUse"),tool_name:s(),tool_input:se(),tool_use_id:s()})`
+  sobre a base `c({session_id:s(),transcript_path:s(),cwd:s(),...})`; `PostToolUse` acrescenta
+  `tool_response` e `duration_ms`.
+- Descarte por evento: `function PKr(e,t,r){if(t.hookEventName!==r){Ik(e,"hookSpecificOutput_event_mismatch",!0);return}`.
+- O caminho de `exit 2` também nega: `if(e!=="PreToolUse")return{...o,decision:"block",reason:t};
+  ... return{...o,hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"deny",permissionDecisionReason:t,...}}`
+  com o stderr como motivo — não usado aqui (D2).
+- O `additionalContext` de `PreToolUse` chega ao modelo: `yield{type:"additionalContext",message:{message:fn({type:"hook_additional_context",content:q.additionalContexts,hookName:\`PreToolUse:${t.name}\`,...,hookEvent:"PreToolUse"})}}`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Um `Write`/`Edit`/`MultiEdit`/`NotebookEdit` cujo conteúdo novo ou caminho carrega achado gating é
+  negado antes de gravar; o motivo lista cada achado (deduplicado por token) e termina com as três
+  saídas; cabe em 2000 caracteres e 20 linhas.
+- A mesma escrita com `# locale-ok: <motivo>` ou com o nome em `.identifier-locale-allow` é gravada
+  em silêncio; só `en-unknown` nunca nega; `LOCALE_RITE_MODE=inform` nunca nega.
+- `PostToolUse` idêntico ao de hoje: os 12 casos do selftest atual continuam verdes sem edição.
+- Payload sem `hook_event_name`, ou com um valor que não é `PreToolUse`, cai no envelope consultivo:
+  na dúvida o hook informa, nunca nega.
+
+**Non-Goals:**
+
+- Escritas via Bash. O hook só vê as ferramentas de escrita do harness; heredoc, `sed` e scripts
+  passam. É o gate de Stop da issue #138, declarado como KNOWN LIMIT no docstring.
+- `README.md`. A seção dos hooks é documentada por outro item, junto com o wiring de todos.
+- Reescrever `report()` do `PostToolUse` para o cap de 200 linhas recém-medido. O harness corta o
+  fim, e cada achado é autocontido; registrado no docstring, não tratado.
+- `updatedInput`. O bundle aceita reescrever o input da ferramenta; renomear por conta própria seria
+  inventar uma tradução — a regra de Grounding proíbe, e o motivo da negação já pede que o modelo
+  renomeie ou dispense.
+
+## Decisions
+
+### D1 — O evento vem do payload, e o envelope segue o evento
+
+`payload.get("hook_event_name")` decide o envelope; `evaluate()` continua a única função que decide
+se há achado. `"PreToolUse"` com achado gating -> envelope de negação com `hookEventName:
+"PreToolUse"`. Qualquer outro valor (`"PostToolUse"`, ausente, não-string) -> o envelope consultivo
+de hoje, byte a byte. O bundle descarta um `hookEventName` que não bate com o evento
+(`hookSpecificOutput_event_mismatch`), então errar o nome do evento não bloqueia nem informa: por
+isso o nome sai do payload e não de uma constante.
+
+### D2 — JSON com `permissionDecision`, não `exit 2`
+
+Os dois negam (Context). O JSON leva o motivo por um campo com cap conhecido (2000/20) e deixa o
+stderr livre; `exit 2` usa o stderr como motivo e o bundle o embrulha em `[label]: ...`, com um cap
+que não medimos. O hook já fala JSON no `PostToolUse`; um só formato de saída é mais fácil de fixar
+no selftest.
+
+### D3 — O motivo é compacto: uma linha por achado, deduplicado, as saídas no fim
+
+O `render()` do check gasta 5 linhas por identificador e 4 por caminho; com o cap de 20 linhas, 4
+achados já estourariam e o harness cortaria justamente as saídas, que ficam no fim. O motivo da
+negação usa uma forma própria: cabeçalho (1 linha), até `REASON_MAX_FINDINGS = 12` linhas
+`path:line: token  [tier: 'segment']` deduplicadas por `(path, token)` — no exemplo da issue, `preco`
+aparece em duas linhas e vira uma —, uma linha `+N more` quando sobra, uma linha contando os
+`en-unknown` (advisory, que não negam e chegam pelo `PostToolUse` quando a escrita limpa acontecer) e
+as três saídas em 3 linhas. Máximo 18 linhas. O corte em caracteres é feito no hook, antes do
+harness, preservando o rabo (as saídas) — o mesmo argumento do `CONTEXT_CAP` de hoje.
+
+### D4 — `en-unknown` sozinho não nega, e em `PreToolUse` fica mudo
+
+O bundle honra `additionalContext` em `PreToolUse` (Context), então o aviso **poderia** sair antes da
+escrita. Não sai: com os dois eventos wired, o mesmo aviso chegaria duas vezes — antes e depois da
+mesma escrita — e o `PostToolUse` já o entrega hoje. Em `PreToolUse`, achado só advisory -> `None`.
+Fica registrado que o campo é honrado, para quem vier a precisar dele; a decisão de não usar é por
+duplicação, não por limitação do harness.
+
+### D5 — `LOCALE_RITE_MODE=inform` desliga a negação, não o hook
+
+Com a variável em `inform` (comparação case-insensitive, espaços aparados), `PreToolUse` devolve
+`None` para qualquer achado: a escrita acontece e o `PostToolUse` informa como hoje. O aviso não é
+duplicado no `PreToolUse` pelo mesmo motivo de D4. Qualquer outro valor da variável (vazio, ausente,
+grafado errado) é o modo padrão, que nega: um `LOCALE_RITE_MODE=informar` por engano não abre a
+porta em silêncio. `evaluate()` recebe o modo como parâmetro com default lido do ambiente, para que
+o selftest fixe os dois modos sem tocar `os.environ`; um caso extra passa a variável pelo caminho
+real (subprocess com `env`), porque é a única forma de provar que o default lê o ambiente.
+
+### D6 — A linha do achado num `Edit` em `PreToolUse` é a do `old_string`
+
+`first_line_of()` localiza o `new_string` no arquivo já gravado. Antes da escrita ele ainda não está
+lá; o que está é o `old_string`, no ponto onde o `new_string` vai entrar. Em `PreToolUse` a âncora
+passa a ser `old_string` quando existe; para `Write` o conteúdo inteiro começa na linha 1 e nada
+muda. Fragmento não localizado cai em 1, como hoje.
+
+### D7 — As três saídas no motivo, nomeadas, não descritas
+
+O motivo termina com as três linhas literais: `# locale-ok: <reason>` na linha acima (só
+identificadores — um nome de arquivo não tem onde carregar comentário, como o check já diz), a
+entrada em `.identifier-locale-allow` (a única saída para caminho), e
+`export LOCALE_RITE_MODE=inform`. O modelo que lê o motivo tem de conseguir agir sem abrir a skill;
+um motivo que só diz "há saídas" gera a segunda tentativa cega que a issue lista como risco.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Camada de máquina em inglês; `locale-ok:` e `.identifier-locale-allow` como dispensas | `code-locale` | already canonical — o motivo da negação **nomeia** as dispensas e aponta para a skill; nada é reescrito |
+| O hook mede no momento da escrita e o que escapa dele | `skills-catalog` (spec do repositório, *The code-locale rite is enforced at the moment of the write*) | already canonical — o delta modifica esse requisito; o docstring declara o KNOWN LIMIT |
+| Forma da saída probada contra o bundle, não recordada | `verify-before-claiming` | already canonical — Context registra os fragmentos e a versão |
+| Regra em contexto na seção *Code Locale* das regras pessoais | `claude/global/personal-rules.md` (link para `code-locale`) | link — a seção ganha uma frase e continua apontando para a skill |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — `REASON_CAP`, `REASON_LINE_CAP`, `deny_reason`, `MODE_ENV`, `LOCALE_RITE_MODE` |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **Negar uma escrita legítima com termo de domínio** -> as três saídas estão no motivo, literais
+  (D7); `locale-ok:` custa uma linha. O check já mantém `DOMAIN_KEEP` (CPF, CNPJ, PIX...) fora dos
+  achados.
+- **Loop modelo-tenta-de-novo** -> o motivo pede "rename it, or waive it" e nomeia as saídas; o
+  número de tentativas até a saída é medido na sessão real do mantenedor (S.1 declara que a simulação
+  daqui é por stdin).
+- **O cap de 20 linhas corta as saídas** -> D3 limita o motivo a 18 linhas por construção; o selftest
+  afirma `len(reason) <= 2000` e `reason.count("\n") < 20` num payload com 30 achados.
+- **Wired só o bloco `PreToolUse`** -> `en-unknown` nunca chega e `inform` fica mudo, porque os dois
+  dependem do `PostToolUse` (D4, D5). O docstring mostra os dois blocos juntos e diz por quê.
+- **Bash continua passando** -> KNOWN LIMIT declarado; fechado pela issue #138, não por esta.
+
+## Open Questions
+
+Nenhuma sobre o harness: forma, caps, campo de evento e descarte por mismatch foram lidos no bundle
+instalado (Context), não na doc. O que esta change não mede é o comportamento numa sessão real com o
+hook wired — a simulação daqui alimenta o hook por stdin com payloads na forma do bundle, e a corrida
+na sessão do mantenedor é o passo de aceite (tasks.md, S.1).

--- a/openspec/changes/enforce-locale-on-write/proposal.md
+++ b/openspec/changes/enforce-locale-on-write/proposal.md
@@ -1,0 +1,69 @@
+# Change: Negar a escrita com nome em português na camada de máquina, não só avisar
+
+## Why
+
+O rito do code-locale existe em três camadas e nenhuma **impede** a escrita: a seção *Code Locale*
+de `claude/global/personal-rules.md` (texto em contexto), a skill `code-locale` (doutrina + detector)
+e o hook `claude/global/hooks/locale-rite.py`, que roda em `PostToolUse` — ou seja, depois que o
+arquivo já foi gravado. Medido em `80ee53c` (2026-09-05) com o payload que a issue #137 descreve:
+
+```
+printf '{"hook_event_name":"PostToolUse","tool_name":"Write","cwd":"/tmp/x","tool_input":{"file_path":"/tmp/x/servico_pedido.py","content":"def calcular_total(preco):\n    return preco\n"}}' | python3 claude/global/hooks/locale-rite.py
+-> {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "CODE-LOCALE: the write that just landed [...]
+-> "systemMessage": "code-locale: 4 non-English names in the last write"}
+-> rc=0
+```
+
+Quatro achados, e o arquivo já está no disco. O mantenedor relata que em sessões de várias
+aplicações o modelo lê o aviso e segue; nada o obriga a renomear. O próprio bundle instalado
+(`~/.local/share/claude/versions/2.1.261`) mostra o que o hook não usa: em `PreToolUse`,
+`hookSpecificOutput.permissionDecision: "deny"` + `permissionDecisionReason` cancela a chamada
+antes de ela rodar, e o payload desse evento já traz `tool_input.file_path` e o conteúdo — exatamente
+o que `evaluate()` mede hoje. É medição, não proxy.
+
+## What Changes
+
+- `locale-rite.py` decide pelo `hook_event_name` do payload. Em `PreToolUse`, um achado gating
+  (`pt-*`, `path-pt-*`) devolve `{"hookSpecificOutput": {"hookEventName": "PreToolUse",
+  "permissionDecision": "deny", "permissionDecisionReason": <cabeçalho + achados + as três
+  saídas>}}`; só `en-unknown` não nega. Em `PostToolUse` o comportamento é o de hoje, byte a byte
+  (consultivo, cobre o `en-unknown`). Uma decisão, dois envelopes: `evaluate()` continua a única
+  função.
+- O motivo da negação respeita o cap medido no bundle — `permissionDecisionReason:2000` caracteres
+  **e** 20 linhas — e termina com as três saídas: `# locale-ok: <motivo>` inline, o nome ou o
+  caminho em `.identifier-locale-allow`, e `LOCALE_RITE_MODE=inform` para a sessão inteira.
+- `LOCALE_RITE_MODE=inform` (novo): o hook nunca nega; o aviso continua vindo do `PostToolUse`,
+  como hoje.
+- Selftest: casos de `PreToolUse` (negação por identificador, por caminho, silêncio com
+  `locale-ok:`, silêncio com allowlist num cwd temporário, `inform`, só `en-unknown`, payload
+  malformado), a forma e o cap do envelope de negação, a variável de ambiente lida pelo caminho real,
+  e os casos de `PostToolUse` inalterados.
+- Docstring do hook: modos, bloco de wiring dos **dois** eventos, o probe do `permissionDecision` ao
+  lado do probe do `additionalContext`, e o KNOWN LIMIT de que escritas via Bash não passam por aqui.
+- `personal-rules.md`, seção *Code Locale*: uma frase dizendo que a escrita é **negada** pelo hook,
+  não só lembrada, e onde estão as saídas.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: o requisito *The code-locale rite is enforced at the moment of the write* deixa
+  de exigir que o artefato "nunca bloqueie" e passa a exigir que, no evento que **precede** a
+  escrita, um achado gating negue a chamada com os achados e as três saídas no motivo, que a mesma
+  escrita com `locale-ok:` ou com a allowlist seja gravada em silêncio, que o modo informativo
+  restaure o comportamento consultivo, e que `en-unknown` nunca negue. O evento que **segue** a
+  escrita fica como está.
+
+## Impact
+
+- `claude/global/hooks/locale-rite.py` — o envelope de `PreToolUse`, o modo `inform`, o selftest e o
+  docstring; a linha de comando não muda.
+- `claude/global/personal-rules.md` — só a seção *Code Locale*.
+- Wiring: quem já tem o bloco `PostToolUse` precisa **adicionar** um bloco `PreToolUse` com o mesmo
+  matcher em `~/.claude/settings.json` (configuração pessoal, fora do PR; o snippet vai no resultado).
+  Sem o bloco novo, o hook continua exatamente como hoje.
+- Nenhuma skill do catálogo muda; a composição do catálogo fica idêntica.
+
+Fora de escopo, por decisão da issue #137: escritas via Bash (heredoc, `sed`, scripts) — o hook não
+as vê e esse é o gate de Stop da issue #138; prosa em inglês em repositório português; a seção dos
+hooks no `README.md`, que outro item documenta junto com o wiring de todos os hooks.

--- a/openspec/changes/enforce-locale-on-write/proposal.md
+++ b/openspec/changes/enforce-locale-on-write/proposal.md
@@ -34,6 +34,11 @@ o que `evaluate()` mede hoje. É medição, não proxy.
   caminho em `.identifier-locale-allow`, e `LOCALE_RITE_MODE=inform` para a sessão inteira.
 - `LOCALE_RITE_MODE=inform` (novo): o hook nunca nega; o aviso continua vindo do `PostToolUse`,
   como hoje.
+- Um caminho português só nega quando a escrita o **cria** (o arquivo não existe antes); um `Edit`
+  limpo num arquivo legado de nome português é gravado em silêncio e o nome continua reportado pelo
+  `PostToolUse` (design, D8 — achado de revisão).
+- O `# locale-ok: <motivo>` que já está no arquivo, na linha acima do trecho que o `Edit` substitui,
+  vale como se estivesse no `new_string` (design, D9 — achado de revisão).
 - Selftest: casos de `PreToolUse` (negação por identificador, por caminho, silêncio com
   `locale-ok:`, silêncio com allowlist num cwd temporário, `inform`, só `en-unknown`, payload
   malformado), a forma e o cap do envelope de negação, a variável de ambiente lida pelo caminho real,

--- a/openspec/changes/enforce-locale-on-write/specs/skills-catalog/spec.md
+++ b/openspec/changes/enforce-locale-on-write/specs/skills-catalog/spec.md
@@ -1,0 +1,85 @@
+## MODIFIED Requirements
+
+### Requirement: The code-locale rite is enforced at the moment of the write
+
+The catalog SHALL ship an enforcement artifact that measures the locale rule when a file is written,
+not only when a diff is reviewed. Doctrine held in context and a check that must be invoked by hand
+SHALL NOT be treated as enforcement: the repository already states, for its other two rites, that
+enforcement must not depend on the assistant noticing a rule already in context.
+
+The artifact SHALL run on the harness events that surround a file write, SHALL measure the written
+path and the written content with the shipped check, and SHALL return its findings through the field
+that harness reads for each event — established against the installed version, never assumed, since
+plain standard output is not carried into context for those events and an envelope naming the wrong
+event is dropped by the harness.
+
+On the event that **precedes** the write, a gating finding — a Portuguese identifier or a Portuguese
+path segment — SHALL deny the tool call, so that the name never reaches the file. The denial reason
+SHALL list each finding and SHALL end with the three legitimate exits: the inline waiver with a
+stated reason, the allowlist file, and an explicit informative mode for the whole session. The reason
+SHALL fit the caps the installed harness applies to that field, in characters and in lines, so that
+the exits are never the part that is cut. The same event SHALL NOT deny on an advisory finding alone,
+because a word the English list does not know is a question and not a verdict.
+
+On the event that **follows** the write, the artifact SHALL keep its informative behaviour: findings,
+gating and advisory, reach the assistant as context and the tool call stands. The informative mode
+SHALL restore that behaviour for both events: with it set, nothing is denied and the advisory arrives
+as before.
+
+The artifact SHALL be silent when the write is clean and SHALL persist nothing outside the
+repository. Where the shipped check is absent, it SHALL exit silently rather than fail, because a
+missing gate must not present itself as an error to the user. The artifact SHALL state which writes
+it does not see — those made through a shell command rather than a write tool — so that a denied
+write is not read as proof that no Portuguese name can land.
+
+#### Scenario: A write that introduces a Portuguese name is denied before it lands
+
+- **WHEN** the event that precedes a write carries a path or added content with a Portuguese
+  identifier or path segment
+- **THEN** the artifact answers with the permission decision the harness reads for that event, set to
+  deny, and the file is not written
+- **AND** the reason names each offending segment once, and ends with the inline waiver, the
+  allowlist file and the informative mode as the three exits
+
+#### Scenario: The same write with a stated waiver or an allowlisted name lands
+
+- **WHEN** the added content carries the inline waiver with a reason on the line above the name, or
+  the name or path is listed in the allowlist file found from the working directory
+- **THEN** the artifact produces no output on either event, and the write lands in silence
+
+#### Scenario: The informative mode restores the advisory
+
+- **WHEN** the informative mode is set for the session and a write carries a gating finding
+- **THEN** the event that precedes the write denies nothing, and the event that follows it reports
+  the findings as context exactly as it does without the mode
+
+#### Scenario: An unrecognised word alone never denies
+
+- **WHEN** the only findings on a write are words the English list does not know
+- **THEN** the event that precedes the write denies nothing, and the event that follows it reports
+  them as advisory, so the write is never blocked on a question the check cannot answer
+
+#### Scenario: A write that introduces a Portuguese name is reported after it lands
+
+- **WHEN** a file is written whose path or added content carries a Portuguese identifier and the
+  event that follows the write fires
+- **THEN** the findings reach the assistant as context for the next turn, naming the offending
+  segments and the waiver that silences them
+
+#### Scenario: A clean write is silent
+
+- **WHEN** the written path and content are English
+- **THEN** the artifact produces no output at all on either event, so the reminder never becomes
+  background noise
+
+#### Scenario: A file type without a language profile still has its path measured
+
+- **WHEN** the written file's extension has no language profile in the check
+- **THEN** the path is still measured, and the content is reported as skipped rather than as passing
+
+#### Scenario: A payload the artifact cannot read produces no error
+
+- **WHEN** the payload is missing, malformed, names no written file, or names no event
+- **THEN** the artifact exits silently and successfully, writing no state and requiring no
+  credentials, and a payload that names no event is treated as the informative one, because in doubt
+  the artifact informs and never denies

--- a/openspec/changes/enforce-locale-on-write/specs/skills-catalog/spec.md
+++ b/openspec/changes/enforce-locale-on-write/specs/skills-catalog/spec.md
@@ -13,13 +13,23 @@ that harness reads for each event — established against the installed version,
 plain standard output is not carried into context for those events and an envelope naming the wrong
 event is dropped by the harness.
 
-On the event that **precedes** the write, a gating finding — a Portuguese identifier or a Portuguese
-path segment — SHALL deny the tool call, so that the name never reaches the file. The denial reason
-SHALL list each finding and SHALL end with the three legitimate exits: the inline waiver with a
-stated reason, the allowlist file, and an explicit informative mode for the whole session. The reason
-SHALL fit the caps the installed harness applies to that field, in characters and in lines, so that
-the exits are never the part that is cut. The same event SHALL NOT deny on an advisory finding alone,
-because a word the English list does not know is a question and not a verdict.
+On the event that **precedes** the write, a gating finding — a Portuguese identifier in the added
+content, or a Portuguese path segment in a path the write **creates** — SHALL deny the tool call, so
+that the name never reaches the disk. A Portuguese segment in the path of a file that already exists
+SHALL NOT deny on that event: the name is already on disk, existing names change through a
+deprecation window and not through a blocked edit, and a denial that names a file the model did not
+name has no exit but the allowlist. That path is still reported on the event that follows the write.
+The denial reason SHALL list each finding and SHALL end with the three legitimate exits: the inline
+waiver with a stated reason, the allowlist file, and an explicit informative mode for the whole
+session. The reason SHALL fit the caps the installed harness applies to that field, in characters
+and in lines, so that the exits are never the part that is cut. The same event SHALL NOT deny on an
+advisory finding alone, because a word the English list does not know is a question and not a
+verdict.
+
+The inline waiver SHALL be honoured wherever the check itself honours it — on the line above the
+name — whether that line is part of the added content or already sits in the file immediately above
+the fragment the edit replaces. A denial whose first exit cannot be satisfied by following it
+produces the blind second attempt the item lists as a risk.
 
 On the event that **follows** the write, the artifact SHALL keep its informative behaviour: findings,
 gating and advisory, reach the assistant as context and the tool call stands. The informative mode
@@ -46,6 +56,22 @@ write is not read as proof that no Portuguese name can land.
 - **WHEN** the added content carries the inline waiver with a reason on the line above the name, or
   the name or path is listed in the allowlist file found from the working directory
 - **THEN** the artifact produces no output on either event, and the write lands in silence
+
+#### Scenario: An edit to a file that already carries a Portuguese name is not denied for the name
+
+- **WHEN** the event that precedes an edit names a file that already exists and whose path carries a
+  Portuguese segment, and the added content is English
+- **THEN** the artifact produces no output on that event and the edit lands
+- **AND** the event that follows the write still reports the path, so the legacy name stays visible
+  without blocking its maintenance
+
+#### Scenario: A waiver already on the line above the edited fragment is honoured
+
+- **WHEN** the event that precedes an edit carries added content with a Portuguese identifier on its
+  first line, and the file line immediately above the fragment being replaced carries the inline
+  waiver with a reason
+- **THEN** the artifact denies nothing, exactly as it would had the waiver been part of the added
+  content
 
 #### Scenario: The informative mode restores the advisory
 

--- a/openspec/changes/enforce-locale-on-write/tasks.md
+++ b/openspec/changes/enforce-locale-on-write/tasks.md
@@ -1,0 +1,162 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `80ee53c` (`docs(openspec): arquiva as changes add-skill-version-gate e
+      define-cross-skill-references (#136)`), topo de `master` em 2026-09-05:
+
+      - `claude/global/hooks/locale-rite.py` — 260 linhas; `CONTEXT_CAP = 8000` em 71;
+        `written_text()` em 107-117; `first_line_of()` em 120-134 localiza o `new_string` no arquivo
+        já gravado; `findings_for()` em 137-152; `report()` em 155-172 monta sempre `hookEventName:
+        "PostToolUse"`; `evaluate()` em 175-193 não lê `hook_event_name`; `selftest()` em 196-259 com
+        12 casos, asserção de forma e o subprocess do argv; `main()` em 262-282.
+      - `skills/code-locale/references/check-identifier-locale.py` — `ALLOWLIST_FILE` em 98,
+        `WAIVER_RE` em 99, `Finding`/`PathFinding` em 245-292 (`path`, `line`, `token`, `segment`,
+        `tier`, `advisory`), `load_allowlist()` em 401-411 sobe do `start` até achar o arquivo,
+        `scan_text()` em 552-585 aceita o waiver na própria linha ou na anterior.
+      - `claude/global/personal-rules.md:39-55` — a seção *Code Locale*, a única que este item toca.
+      - `openspec/specs/skills-catalog/spec.md:781-822` — o requisito *The code-locale rite is
+        enforced at the moment of the write*, copiado por inteiro no delta; `:700-724` e `:726-779`
+        os dois requisitos vizinhos do check.
+      - `README.md:306-335` — a seção do hook (lida para não a editar: outro item a documenta).
+      - `openspec/changes/archive/2026-09-04-add-hook-selftests/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md` — modelo de estilo da casa.
+      - `openspec/schemas/skills-rite/templates/{proposal,design,tasks,spec}.md`,
+        `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py`,
+        `scripts/validate-spec-rite.py`, `scripts/validate-skill-version.py`,
+        `.github/workflows/ci.yml` — o que os gates exigem.
+      - `~/.claude/skills/execute-backlog/SKILL.md`, `references/spec-rite.md`,
+        `references/acceptance-tracking.md`, `~/.claude/skills/conventional-commit/SKILL.md`.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      ```
+      python3 --version                -> Python 3.14.5
+      openspec --version               -> 1.6.0
+      openspec list                    -> No active changes found.
+      which claude                     -> /home/diegops/.local/bin/claude
+      readlink -f $(which claude)      -> /home/diegops/.local/share/claude/versions/2.1.261
+      claude --version                 -> 2.1.261 (Claude Code)
+      file <bundle>                    -> ELF 64-bit LSB executable, x86-64 [...]
+      ```
+
+      O bundle é um ELF único e o `grep` da máquina é `ugrep`, que recusa o padrão com contexto
+      ("exceeds complexity limits"); os fragmentos abaixo vieram de `re.finditer` em Python sobre os
+      bytes do arquivo (`scratchpad/probe.py`), contagem de ocorrências e contexto de ±220 bytes:
+
+      ```
+      permissionDecision          -> 93 ocorrências;   permissionDecisionReason -> 31;   hookEventName -> 96
+      schema PreToolUse           -> c({hookEventName:C("PreToolUse"),permissionDecision:boe().optional(),
+                                       permissionDecisionReason:s().optional(),updatedInput:pe(s(),se()).optional(),
+                                       additionalContext:s().optional()})
+      caps (caracteres)           -> AKr={reason:2000,stopReason:2000,systemMessage:4000,additionalContext:8000,
+                                       permissionDecisionReason:2000}
+      caps (linhas)               -> j8t=200,RKr={reason:20,stopReason:20,systemMessage:20,additionalContext:j8t,
+                                       permissionDecisionReason:20}
+      X5                          -> function X5(e,t,r){if(typeof r!=="string")return;let{text:o,truncated:d}=Phn(r,AKr[t],RKr[t]);
+      normalização PreToolUse     -> let o=t.permissionDecision==="deny"||t.permissionDecision==="ask"; [...]
+                                       let d=o?X5(e,"permissionDecisionReason",t.permissionDecisionReason):void 0,
+                                       f=X5(e,"additionalContext",t.additionalContext);return{hookEventName:"PreToolUse",
+                                       ...o&&{permissionDecision:t.permissionDecision},...d!==void 0&&{permissionDecisionReason:d},
+                                       ...f!==void 0&&{additionalContext:f}}
+      mismatch de evento          -> function PKr(e,t,r){if(t.hookEventName!==r){Ik(e,"hookSpecificOutput_event_mismatch",!0);return}
+      payload de entrada          -> c({hook_event_name:C("PreToolUse"),tool_name:s(),tool_input:se(),tool_use_id:s()})
+                                       sobre be=c({session_id:s(),transcript_path:s(),cwd:s(),...})
+      additionalContext em Pre    -> yield{type:"additionalContext",message:{message:fn({type:"hook_additional_context",
+                                       content:q.additionalContexts,hookName:`PreToolUse:${t.name}`,...,hookEvent:"PreToolUse"})}}
+      ```
+
+      Comportamento atual do hook no payload da issue (o arquivo já estaria gravado):
+
+      ```
+      printf '{"hook_event_name":"PostToolUse","tool_name":"Write","cwd":"/tmp/x","tool_input":{"file_path":"/tmp/x/servico_pedido.py","content":"def calcular_total(preco):\n    return preco\n"}}' | python3 claude/global/hooks/locale-rite.py; echo "rc=$?"
+      -> {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "CODE-LOCALE: the write that just landed [...]
+      -> "systemMessage": "code-locale: 4 non-English names in the last write"}
+      -> rc=0
+      ```
+
+      Scaffold da change com o schema do repositório:
+
+      ```
+      openspec new change enforce-locale-on-write --schema skills-rite
+      -> Created change 'enforce-locale-on-write' at openspec/changes/enforce-locale-on-write/
+      -> Schema: skills-rite
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      Dois itens. (1) O hook real disparado pelo harness numa sessão com o bloco `PreToolUse` wired:
+      este item roda num subagente, que não pode disparar o hook da sessão; a simulação alimenta o hook
+      por stdin com payloads na forma que o bundle declara (E.2), e a corrida na sessão do mantenedor
+      é o passo de aceite — o primeiro critério da issue fica `manual`. (2) A doc pública
+      (code.claude.com/docs/en/hooks) não foi aberta nesta sessão; o texto da doc que o próprio bundle
+      embute ("`permissionDecision` - "allow", "deny", or "ask" (PreToolUse only)") foi lido no ELF, e o
+      bundle instalado é a fonte preferida por decisão da issue (TR1).
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a issue #137 pediu. Notados pelo caminho e **não** feitos, ficam como
+      follow-up:
+
+      - O `additionalContext` também tem cap de **linhas** (200), não registrado no docstring até
+        aqui; o `report()` do `PostToolUse` só corta por caracteres. O harness corta o fim e cada
+        achado é autocontido; registrado no docstring, comportamento do `PostToolUse` intocado.
+      - O bundle aceita `updatedInput` em `PreToolUse` (reescrever o input da ferramenta). Renomear por
+        conta do hook seria inventar uma tradução; fora, por Grounding (design, Non-Goals).
+      - `README.md:306-335` mostra o matcher `Write|Edit` e só o bloco `PostToolUse`; a seção é de
+        outro item, que documenta o wiring de todos os hooks — não tocado aqui.
+      - Escritas via Bash continuam passando; é a issue #138 (gate de Stop), declarada como KNOWN
+        LIMIT no docstring.
+
+## 2. Envelope de negação em PreToolUse, modo inform, selftest e docstring
+
+- [ ] 2.1 `locale-rite.py`: `evaluate()` lê `hook_event_name`; em `PreToolUse` um achado gating
+      devolve `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny",
+      "permissionDecisionReason": ...}}`; só advisory ou evento ausente/outro caem no envelope
+      consultivo de hoje (D1, D4)
+- [ ] 2.2 `deny_reason()`: cabeçalho, uma linha por achado deduplicado por `(path, token)`, `+N more`,
+      contagem de advisory, as três saídas literais no fim; `REASON_CAP = 2000` e `REASON_LINE_CAP =
+      20` medidos, com corte no hook preservando o rabo (D3, D7)
+- [ ] 2.3 `LOCALE_RITE_MODE=inform`: `evaluate(payload, check, mode=None)` com default do ambiente;
+      `inform` nunca nega; qualquer outro valor é o modo padrão (D5)
+- [ ] 2.4 `first_line_of()` ancora no `old_string` em `PreToolUse` para `Edit` (D6)
+- [ ] 2.5 Selftest: casos de `PreToolUse` (nega por identificador, nega por caminho, `locale-ok:`
+      silencia, allowlist num cwd temporário silencia, `inform` não nega e o `PostToolUse` do mesmo
+      payload informa, só `en-unknown` não nega, payload malformado mudo), forma e caps do envelope de
+      negação com 30 achados, variável de ambiente pelo caminho real (subprocess), os 12 casos de
+      `PostToolUse` inalterados
+- [ ] 2.6 Docstring: modos, probe do `permissionDecision` ao lado do do `additionalContext` (versão,
+      comando, fragmento, os dois caps), bloco de wiring com os **dois** eventos, KNOWN LIMIT das
+      escritas via Bash (issue #138)
+- [ ] 2.7 `personal-rules.md`, seção *Code Locale*: uma ou duas frases dizendo que a escrita é negada
+      pelo hook e onde estão as saídas; estrutura da seção mantida
+
+## 3. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 O artefato exercitado pelo caminho real (`python3 claude/global/hooks/locale-rite.py` lendo
+      stdin) com payloads na forma do bundle, para os dois eventos; comando e fragmento observado
+      registrados; a corrida na sessão com o hook wired é o passo de aceite do mantenedor
+- [ ] S.2 Matriz de casos em contagens: o que tinha de negar e negou, o que tinha de ficar mudo e
+      ficou, o que tinha de informar e informou, escapes conhecidos que ficaram mudos
+- [ ] S.3 O que escapou ou se comportou diferente do esperado — ou a declaração de que nada escapou
+
+## 4. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica se nenhuma skill for tocada;
+      o step do CI é rodado mesmo assim e o resultado registrado
+- [ ] Q.2 Conteúdo de skill tocado em inglês — idem; docstring, nomes de caso e delta de spec em
+      inglês, proposal/design/tasks em português como as changes da casa
+- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica se nenhuma descrição de skill muda
+- [ ] Q.4 Sem doutrina duplicada: o motivo da negação **nomeia** as dispensas e aponta para
+      `code-locale`; ver a tabela de Canonical Home em `design.md`
+- [ ] Q.5 Identificadores em inglês no que a change introduz, medidos com o check do repositório
+
+## 5. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate enforce-locale-on-write --strict` verde
+- [ ] V.2 Descoberta do catálogo intacta: `npx skills add . --list` acha todas as skills, contagem
+      esperada, sem órfão ou renomeado
+- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
+      não muda; `personal-rules.md` ganha a frase (2.7); o `README.md` é de outro item
+- [ ] V.4 `openspec archive enforce-locale-on-write --yes` depois que todos os grupos acima estiverem
+      `[x]` — PR separado, como o repositório já faz

--- a/openspec/changes/enforce-locale-on-write/tasks.md
+++ b/openspec/changes/enforce-locale-on-write/tasks.md
@@ -110,53 +110,222 @@
 
 ## 2. Envelope de negação em PreToolUse, modo inform, selftest e docstring
 
-- [ ] 2.1 `locale-rite.py`: `evaluate()` lê `hook_event_name`; em `PreToolUse` um achado gating
-      devolve `{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny",
-      "permissionDecisionReason": ...}}`; só advisory ou evento ausente/outro caem no envelope
-      consultivo de hoje (D1, D4)
-- [ ] 2.2 `deny_reason()`: cabeçalho, uma linha por achado deduplicado por `(path, token)`, `+N more`,
-      contagem de advisory, as três saídas literais no fim; `REASON_CAP = 2000` e `REASON_LINE_CAP =
-      20` medidos, com corte no hook preservando o rabo (D3, D7)
-- [ ] 2.3 `LOCALE_RITE_MODE=inform`: `evaluate(payload, check, mode=None)` com default do ambiente;
-      `inform` nunca nega; qualquer outro valor é o modo padrão (D5)
-- [ ] 2.4 `first_line_of()` ancora no `old_string` em `PreToolUse` para `Edit` (D6)
-- [ ] 2.5 Selftest: casos de `PreToolUse` (nega por identificador, nega por caminho, `locale-ok:`
-      silencia, allowlist num cwd temporário silencia, `inform` não nega e o `PostToolUse` do mesmo
-      payload informa, só `en-unknown` não nega, payload malformado mudo), forma e caps do envelope de
-      negação com 30 achados, variável de ambiente pelo caminho real (subprocess), os 12 casos de
-      `PostToolUse` inalterados
-- [ ] 2.6 Docstring: modos, probe do `permissionDecision` ao lado do do `additionalContext` (versão,
-      comando, fragmento, os dois caps), bloco de wiring com os **dois** eventos, KNOWN LIMIT das
-      escritas via Bash (issue #138)
-- [ ] 2.7 `personal-rules.md`, seção *Code Locale*: uma ou duas frases dizendo que a escrita é negada
-      pelo hook e onde estão as saídas; estrutura da seção mantida
+- [x] 2.1 `locale-rite.py`: `evaluate()` (linha 312) lê `hook_event_name`; em `PreToolUse` um achado
+      gating devolve o envelope de `deny()` (300) com `hookEventName: "PreToolUse"`; só advisory, ou
+      evento ausente/outro, cai em `report()` (244), intocado (D1, D4). Commit `bcfbc30`.
+
+      ```
+      printf '{"session_id":"sim","transcript_path":"/tmp/t.jsonl","cwd":"<X>","hook_event_name":"PreToolUse","tool_name":"Write","tool_use_id":"toolu_sim","tool_input":{"file_path":"<X>/servico_pedido.py","content":"def calcular_total(preco):\n    return preco\n"}}' | python3 claude/global/hooks/locale-rite.py
+      -> {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "CODE-LOCALE: write denied — 3 non-English names [...]"}}
+      -> rc=0        (o mesmo payload com "hook_event_name":"PostToolUse" -> additionalContext, "code-locale: 4 non-English names in the last write")
+      ```
+
+- [x] 2.2 `deny_reason()` (270): `DENY_HEADER` (153), uma linha por `(path, token)` via
+      `finding_line()` (263), `+N more`, contagem de advisory, `EXITS` (161) no fim; `REASON_CAP =
+      2000` e `REASON_LINE_CAP = 20` (127-128), `REASON_MAX_FINDINGS = 12` (130) (D3, D7)
+
+      Motivo observado no exemplo da issue — `preco` em duas linhas do conteúdo vira uma:
+
+      ```
+      CODE-LOCALE: write denied — 3 non-English names in the machine layer. Identifiers, file and directory names are English (code-locale skill); comments, docstrings and strings keep the repository's language. Rename, or waive with a reason:
+        servico_pedido.py: servico_pedido  [path-pt-noun: 'servico']
+        servico_pedido.py:1: calcular_total  [pt-verb: 'calcular']
+        servico_pedido.py:1: preco  [pt-noun: 'preco']
+      Exits: (1) `# locale-ok: <reason>` on the line above the name (identifiers only — a file name has nowhere to carry it);
+        (2) list the name or the path in .identifier-locale-allow (the only waiver for a file name);
+        (3) export LOCALE_RITE_MODE=inform to make this hook advisory for the whole session.
+      -> lines=7 chars=712
+      ```
+
+      Com 30 achados gating + 1 advisory (caso do selftest): `<= 2000` chars, `<= 20` linhas,
+      `preco_0` uma vez, `(+18 more`, `(+1 unrecognised word, advisory`, termina em `EXITS[-1]`
+      -> `OK      denial envelope: PreToolUse shape, <= 2000 chars, <= 20 lines, three exits last`.
+
+- [x] 2.3 `LOCALE_RITE_MODE=inform`: `MODE_ENV`/`MODE_INFORM` (135-136), `current_mode()` (182),
+      `evaluate(payload, check, mode=None)` com default do ambiente; `inform` nunca nega; qualquer
+      outro valor é o modo padrão (D5)
+
+      ```
+      (mesmo payload de 2.1) | LOCALE_RITE_MODE=inform python3 claude/global/hooks/locale-rite.py     -> rc=0 chars=0   (mudo; o PostToolUse do mesmo payload -> ADVISORY chars=1608)
+      (mesmo payload de 2.1) | LOCALE_RITE_MODE=informar python3 claude/global/hooks/locale-rite.py   -> rc=0 DENY chars=846   (grafia errada = modo padrão)
+      ```
+
+- [x] 2.4 `first_line_of(path, anchor)` (200): em `PreToolUse` com `Edit` a âncora é o `old_string`
+      (D6); `Write` e `PostToolUse` como antes
+
+      ```
+      printf 'a = 1\nb = 2\n' > <X>/edit_target.py
+      PreToolUse Edit {"old_string":"b = 2","new_string":"usuario_count = 2"} | python3 claude/global/hooks/locale-rite.py
+      -> "  edit_target.py:2: usuario_count  [pt-noun: 'usuario']"      (linha 2, onde o old_string está; antes seria 1)
+      ```
+
+- [x] 2.5 Selftest (353): 13 decisões de `PostToolUse` (as 12 originais sem `hook_event_name` +
+      uma nomeada), 12 de `PreToolUse`, `inform` nos dois eventos, `en-unknown` sozinho (o token é
+      afirmado advisory-only antes, para o caso não passar numa escrita limpa), allowlist em
+      `tempfile.TemporaryDirectory()`, envelope de negação com 30 achados, deduplicação, variável de
+      ambiente por subprocess com `env`, argv
+
+      ```
+      python3 claude/global/hooks/locale-rite.py --selftest; echo "rc=$?"
+      ->   OK      portuguese path reported
+      ->   [...]                       (as 12 decisões originais, inalteradas)
+      ->   OK      PostToolUse by name is the advisory envelope
+      ->   OK      output shape is the field the harness reads (PostToolUse)
+      ->   OK      PreToolUse denies a portuguese identifier
+      ->   OK      PreToolUse denies a portuguese path
+      ->   OK      PreToolUse denies an Edit whose new_string is portuguese
+      ->   OK      PreToolUse allows the same name with locale-ok on the line above
+      ->   OK      PreToolUse allows a clean write
+      ->   OK      PreToolUse in inform mode never denies
+      ->   OK      PreToolUse with a misspelt mode still denies
+      ->   OK      PreToolUse ignores another tool
+      ->   OK      PreToolUse ignores a payload without file_path
+      ->   OK      PreToolUse ignores a tool_input that is not an object
+      ->   OK      PreToolUse ignores a file_path that is not a string
+      ->   OK      PreToolUse with a cwd that is not a string still denies
+      ->   OK      inform mode: PostToolUse still carries the advisory
+      ->   OK      en-unknown alone: PreToolUse silent, PostToolUse advisory
+      ->   OK      PreToolUse allows a name listed in .identifier-locale-allow of the cwd
+      ->   OK      denial envelope: PreToolUse shape, <= 2000 chars, <= 20 lines, three exits last
+      ->   OK      denial reason names each distinct token once
+      ->   OK      LOCALE_RITE_MODE=inform read from the environment through stdin
+      ->   OK      unknown flag prints usage and exits 2
+      ->
+      -> selftest OK: 13 PostToolUse decisions, 12 PreToolUse decisions, inform mode, en-unknown, the allowlist, both envelopes, the environment and the argv contract
+      -> rc=0
+      ```
+
+- [x] 2.6 Docstring (`locale-rite.py:1-106`): modos, o bloco "WHY `hookSpecificOutput.permissionDecision`
+      AND NOT `exit 2`" com versão (2.1.261), comando (`re.finditer` sobre o ELF) e fragmentos
+      (schema, normalização, `AKr`/`RKr`, mismatch), ao lado do probe do `additionalContext`; wiring
+      com os **dois** eventos; KNOWN LIMIT das escritas via Bash (issue #138)
+
+      ```
+      grep -c -E "PreToolUse|PostToolUse" claude/global/hooks/locale-rite.py   -> 52
+      grep -n "KNOWN LIMIT" claude/global/hooks/locale-rite.py                  -> 73:KNOWN LIMIT
+      ```
+
+- [x] 2.7 `personal-rules.md`, seção *Code Locale*: um bullet novo (`claude/global/personal-rules.md:55-59`,
+      commit `cbeec33`) dizendo que o hook **nega** a escrita em `PreToolUse`, nomeando as três saídas
+      e o limite (Bash, #138); a estrutura da seção (bullets + link final para `code-locale`) mantida
+
+      ```
+      git diff -U0 80ee53c...HEAD -- claude/global/personal-rules.md | grep -E '^@@'   -> @@ -54,0 +55,5 @@ field keys.
+      ```
 
 ## 3. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 O artefato exercitado pelo caminho real (`python3 claude/global/hooks/locale-rite.py` lendo
-      stdin) com payloads na forma do bundle, para os dois eventos; comando e fragmento observado
-      registrados; a corrida na sessão com o hook wired é o passo de aceite do mantenedor
-- [ ] S.2 Matriz de casos em contagens: o que tinha de negar e negou, o que tinha de ficar mudo e
-      ficou, o que tinha de informar e informou, escapes conhecidos que ficaram mudos
-- [ ] S.3 O que escapou ou se comportou diferente do esperado — ou a declaração de que nada escapou
+- [x] S.1 O artefato exercitado pelo caminho real — `python3 claude/global/hooks/locale-rite.py` lendo
+      um payload por stdin, na forma que o bundle 2.1.261 declara (`session_id`, `transcript_path`,
+      `cwd`, `hook_event_name`, `tool_name`, `tool_use_id`, `tool_input`, e `tool_response` no
+      PostToolUse), 23 payloads, cada um num processo próprio (`scratchpad/sim.py`, 2026-09-05):
+
+      ```
+      python3 scratchpad/sim.py
+      -> OK     1 Pre Write pt path+identifiers (issue example)            rc=0 DENY     chars=846 stderr=0
+      -> OK     2 Pre Write pt identifier only                             rc=0 DENY     chars=727 stderr=0
+      -> OK     3 Pre Write pt path only                                   rc=0 DENY     chars=745 stderr=0
+      -> OK     4 Pre Edit pt new_string (anchor old_string, line 2)       rc=0 DENY     chars=726 stderr=0
+      -> OK     5 Pre Write locale-ok on the line above                    rc=0 silent   chars=0 stderr=0
+      -> OK     6 Pre Write name in .identifier-locale-allow of cwd        rc=0 silent   chars=0 stderr=0
+      -> OK     7 Pre Write pt, LOCALE_RITE_MODE=inform                    rc=0 silent   chars=0 stderr=0
+      -> OK     8 Post Write pt (advisory, as before)                      rc=0 ADVISORY chars=1608 stderr=0
+      -> OK     9 Post Write pt, LOCALE_RITE_MODE=inform                   rc=0 ADVISORY chars=1608 stderr=0
+      -> OK     10 Pre Write en-unknown only                               rc=0 silent   chars=0 stderr=0
+      -> OK     11 Post Write en-unknown only                              rc=0 ADVISORY chars=726 stderr=0
+      -> OK     12 Pre Write clean                                         rc=0 silent   chars=0 stderr=0
+      -> OK     13 Post Write clean                                        rc=0 silent   chars=0 stderr=0
+      -> OK     14 Pre MultiEdit pt                                        rc=0 DENY     chars=719 stderr=0
+      -> OK     15 Pre NotebookEdit pt notebook_path                       rc=0 DENY     chars=728 stderr=0
+      -> OK     16 Pre Bash writing pt (KNOWN LIMIT, must stay silent)     rc=0 silent   chars=0 stderr=0
+      -> OK     17 Pre Write without file_path                             rc=0 silent   chars=0 stderr=0
+      -> OK     18 malformed: json array                                   rc=0 silent   chars=0 stderr=0
+      -> OK     19 malformed: json string                                  rc=0 silent   chars=0 stderr=0
+      -> OK     20 malformed: empty stdin                                  rc=0 silent   chars=0 stderr=0
+      -> OK     21 Pre tool_input not an object                            rc=0 silent   chars=0 stderr=0
+      -> OK     22 Pre Write pt, LOCALE_RITE_MODE=informar (typo)          rc=0 DENY     chars=846 stderr=0
+      -> OK     23 no hook_event_name, pt (pre-#137 payload)               rc=0 ADVISORY chars=1608 stderr=0
+      -> mismatches: 0/23
+      -> files in the write target after all runs: ['edit_target.py']        (só a fixture do caso 4: o hook não grava nada)
+      ```
+
+      O envelope do caso 1 e a linha do caso 4 estão em 2.1, 2.2 e 2.4. O que esta simulação **não**
+      prova: o hook disparado pelo harness numa sessão com o bloco `PreToolUse` wired — um subagente
+      não dispara o hook da sessão. A corrida na sessão do mantenedor (Write de `servico_pedido.py`
+      negado, arquivo ausente, depois com `locale-ok:` e com `LOCALE_RITE_MODE=inform`, contando as
+      tentativas até a saída) é o passo de aceite; o snippet de `settings.json` vai no resultado.
+
+- [x] S.2 Matriz de casos em contagens, medida em S.1 e no selftest:
+
+      | Grupo | O que tinha de acontecer | Contagem | Nota |
+      |---|---|---|---|
+      | stdin, PreToolUse | tinha de negar e negou | 7/7 | casos 1-4, 14, 15, 22: caminho, identificador, Edit, MultiEdit, NotebookEdit, grafia errada do modo |
+      | stdin, PreToolUse | tinha de ficar mudo e ficou | 8/8 | casos 5-7, 10, 12, 17, 21 e 16: locale-ok, allowlist, inform, en-unknown, limpo, sem file_path, tool_input inválido, Bash |
+      | stdin, PostToolUse | tinha de informar e informou | 4/4 | casos 8, 9, 11, 23 (o caso 9 com inform é idêntico ao 8: 1608 chars) |
+      | stdin, PostToolUse | tinha de ficar mudo e ficou | 1/1 | caso 13 |
+      | stdin, malformado | mudo, exit 0, sem stderr | 3/3 | casos 18-20 |
+      | stdin, escape conhecido | ficou mudo | 1/1 | caso 16: Bash escrevendo `preco` (KNOWN LIMIT, issue #138) — contado também na linha dos mudos |
+      | `--selftest` | decisões OK | 13/13 PostToolUse + 12/12 PreToolUse + 7/7 asserções (forma Post, inform Post, en-unknown, allowlist, envelope, deduplicação, ambiente) + 1/1 argv | rc=0 |
+      | runner de gates | steps PASS | 19/19 PASS | ver V.1 |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Nada escapou na matriz: 0/23 desvios em S.1. Duas coisas foram diferentes do planejado antes de
+      medir, e estão registradas:
+
+      - O bundle honra `additionalContext` em `PreToolUse` (E.2). A opção de emitir o `en-unknown`
+        antes da escrita existe e **não** foi usada (D4): com os dois blocos wired o aviso chegaria
+        duas vezes por escrita. A decisão é por duplicação, não por limite do harness.
+      - O cap de `permissionDecisionReason` é duplo — 2000 caracteres **e** 20 linhas — e o
+        `additionalContext` também tem cap de 200 linhas, não registrado antes. O motivo da negação
+        foi desenhado para 18 linhas por construção (D3); o `render()` do check (5 linhas por achado)
+        estouraria o cap de linhas com 4 achados e o harness cortaria justamente as saídas.
+
+      O escape conhecido e mantido: um arquivo escrito por Bash (caso 16) passa em silêncio — issue
+      #138. E o que continua fora do alcance da simulação por stdin é o disparo pelo harness real,
+      declarado em E.3 e S.1 como passo de aceite do mantenedor.
 
 ## 4. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica se nenhuma skill for tocada;
-      o step do CI é rodado mesmo assim e o resultado registrado
-- [ ] Q.2 Conteúdo de skill tocado em inglês — idem; docstring, nomes de caso e delta de spec em
-      inglês, proposal/design/tasks em português como as changes da casa
-- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica se nenhuma descrição de skill muda
-- [ ] Q.4 Sem doutrina duplicada: o motivo da negação **nomeia** as dispensas e aponta para
-      `code-locale`; ver a tabela de Canonical Home em `design.md`
-- [ ] Q.5 Identificadores em inglês no que a change introduz, medidos com o check do repositório
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: esta change não toca
+      nenhuma skill (`git diff --stat 80ee53c...HEAD` -> `locale-rite.py`, `personal-rules.md`,
+      `openspec/changes/enforce-locale-on-write/**`). O step de frontmatter do CI foi rodado mesmo
+      assim pelo runner de gates: `PASS frontmatter`; `PASS validate-skills :: skills checked: 35
+      findings: 0`
+- [x] Q.2 Conteúdo de skill tocado em inglês — **não se aplica** pelo mesmo motivo; o docstring, os
+      nomes dos casos do selftest, o motivo da negação e o delta de spec estão em inglês, como o
+      catálogo exige; proposal/design/tasks em português, como as changes da casa; o bullet novo de
+      `personal-rules.md` em inglês, como o resto do arquivo
+- [x] Q.3 Gatilhos de descrição testáveis — **não se aplica**: nenhuma descrição de skill muda
+- [x] Q.4 Sem doutrina duplicada: o motivo da negação **nomeia** as dispensas (`locale-ok:`,
+      `.identifier-locale-allow`, `LOCALE_RITE_MODE=inform`) e aponta para `code-locale`; o bullet de
+      `personal-rules.md` aponta para o hook e para a issue #138 sem reescrever o check; ver a tabela
+      de Canonical Home em `design.md`
+- [x] Q.5 Identificadores em inglês no que a change introduz — `REASON_CAP`, `REASON_LINE_CAP`,
+      `REASON_MAX_FINDINGS`, `MODE_ENV`, `MODE_INFORM`, `PRE_EVENT`, `POST_EVENT`, `current_mode`,
+      `split_findings`, `finding_line`, `deny_reason`, `deny`, `distinct_ok` — e o glossário da issue
+      (`LOCALE_RITE_MODE`, `permissionDecision`):
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py claude/global/hooks/locale-rite.py
+      -> findings: 0
+      -> rc=0
+      ```
+
+      O próprio hook, wired em PostToolUse nesta sessão, apontou `dedup_ok  [en-unknown: 'dedup']`
+      na primeira escrita do selftest; renomeado para `distinct_ok` antes do commit.
 
 ## 5. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate enforce-locale-on-write --strict` verde
-- [ ] V.2 Descoberta do catálogo intacta: `npx skills add . --list` acha todas as skills, contagem
-      esperada, sem órfão ou renomeado
-- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
-      não muda; `personal-rules.md` ganha a frase (2.7); o `README.md` é de outro item
+- [x] V.1 `openspec validate enforce-locale-on-write --strict` -> `Change 'enforce-locale-on-write' is valid`;
+      `bash scripts/validate-rite.sh` (com `GITHUB_EVENT_PATH` apontando para um body com
+      `Spec-rite: enforce-locale-on-write`) -> `rite evidence gate: 0 findings` [...] `rite gate OK`;
+      `python3 scripts/validate-skill-version.py` (mesmo event, `SKILL_VERSION_BASE=master`) ->
+      `skill-version gate: 0 findings (base origin/master, 0 skill(s) changed, 0 with content changes)`
+- [x] V.2 Descoberta do catálogo intacta: `npx -y skills add . --list` -> `Found 35 skills`;
+      `ls -d skills/*/ | wc -l` -> `35`; sem órfão ou renomeado
+- [x] V.3 README / docs atualizados: a composição do catálogo não muda; `personal-rules.md` ganha o
+      bullet (2.7); a seção dos hooks do `README.md:306-335` é de outro item, que documenta o wiring
+      de todos os hooks, e não foi tocada aqui por decisão da issue
 - [ ] V.4 `openspec archive enforce-locale-on-write --yes` depois que todos os grupos acima estiverem
       `[x]` — PR separado, como o repositório já faz

--- a/openspec/changes/enforce-locale-on-write/tasks.md
+++ b/openspec/changes/enforce-locale-on-write/tasks.md
@@ -21,6 +21,16 @@
       - `README.md:306-335` — a seção do hook (lida para não a editar: outro item a documenta).
       - `openspec/changes/archive/2026-09-04-add-hook-selftests/{proposal,design,tasks}.md` e
         `specs/skills-catalog/spec.md` — modelo de estilo da casa.
+
+      Relidos em `17fc01f` (2026-09-05), na revisão que produziu D8 e D9:
+
+      - `skills/code-locale/references/check-identifier-locale.py:518-548` — `scan_path()` não
+        distingue caminho existente de caminho criado; `:552-563` — `scan_text()` só olha
+        `lines[offset - 1]` dentro do fragmento recebido.
+      - `claude/global/hooks/locale-rite.py` em `17fc01f` — `findings_for()` chamava `scan_path()`
+        incondicionalmente para toda ferramenta; `written_text()` (188) já dizia "never the file's
+        existing content, which the rite does not judge".
+      - `claude/global/personal-rules.md:53-54` — "Existing code is not renamed for its own sake".
       - `openspec/schemas/skills-rite/templates/{proposal,design,tasks,spec}.md`,
         `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py`,
         `scripts/validate-spec-rite.py`, `scripts/validate-skill-version.py`,
@@ -110,9 +120,9 @@
 
 ## 2. Envelope de negação em PreToolUse, modo inform, selftest e docstring
 
-- [x] 2.1 `locale-rite.py`: `evaluate()` (linha 312) lê `hook_event_name`; em `PreToolUse` um achado
-      gating devolve o envelope de `deny()` (300) com `hookEventName: "PreToolUse"`; só advisory, ou
-      evento ausente/outro, cai em `report()` (244), intocado (D1, D4). Commit `bcfbc30`.
+- [x] 2.1 `locale-rite.py`: `evaluate()` (linha 350 em `c83cd77`) lê `hook_event_name`; em `PreToolUse`
+      um achado gating devolve o envelope de `deny()` (338) com `hookEventName: "PreToolUse"`; só
+      advisory, ou evento ausente/outro, cai em `report()` (282), intocado (D1, D4). Commit `bcfbc30`.
 
       ```
       printf '{"session_id":"sim","transcript_path":"/tmp/t.jsonl","cwd":"<X>","hook_event_name":"PreToolUse","tool_name":"Write","tool_use_id":"toolu_sim","tool_input":{"file_path":"<X>/servico_pedido.py","content":"def calcular_total(preco):\n    return preco\n"}}' | python3 claude/global/hooks/locale-rite.py
@@ -120,9 +130,9 @@
       -> rc=0        (o mesmo payload com "hook_event_name":"PostToolUse" -> additionalContext, "code-locale: 4 non-English names in the last write")
       ```
 
-- [x] 2.2 `deny_reason()` (270): `DENY_HEADER` (153), uma linha por `(path, token)` via
-      `finding_line()` (263), `+N more`, contagem de advisory, `EXITS` (161) no fim; `REASON_CAP =
-      2000` e `REASON_LINE_CAP = 20` (127-128), `REASON_MAX_FINDINGS = 12` (130) (D3, D7)
+- [x] 2.2 `deny_reason()` (308): `DENY_HEADER` (162), uma linha por `(path, token)` via
+      `finding_line()` (301), `+N more`, contagem de advisory, `EXITS` (170) no fim; `REASON_CAP =
+      2000` e `REASON_LINE_CAP = 20` (136-137), `REASON_MAX_FINDINGS = 12` (139) (D3, D7)
 
       Motivo observado no exemplo da issue — `preco` em duas linhas do conteúdo vira uma:
 
@@ -141,7 +151,7 @@
       `preco_0` uma vez, `(+18 more`, `(+1 unrecognised word, advisory`, termina em `EXITS[-1]`
       -> `OK      denial envelope: PreToolUse shape, <= 2000 chars, <= 20 lines, three exits last`.
 
-- [x] 2.3 `LOCALE_RITE_MODE=inform`: `MODE_ENV`/`MODE_INFORM` (135-136), `current_mode()` (182),
+- [x] 2.3 `LOCALE_RITE_MODE=inform`: `MODE_ENV`/`MODE_INFORM` (144-145), `current_mode()` (191),
       `evaluate(payload, check, mode=None)` com default do ambiente; `inform` nunca nega; qualquer
       outro valor é o modo padrão (D5)
 
@@ -150,7 +160,7 @@
       (mesmo payload de 2.1) | LOCALE_RITE_MODE=informar python3 claude/global/hooks/locale-rite.py   -> rc=0 DENY chars=846   (grafia errada = modo padrão)
       ```
 
-- [x] 2.4 `first_line_of(path, anchor)` (200): em `PreToolUse` com `Edit` a âncora é o `old_string`
+- [x] 2.4 `first_line_of(path, anchor)` (209): em `PreToolUse` com `Edit` a âncora é o `old_string`
       (D6); `Write` e `PostToolUse` como antes
 
       ```
@@ -159,11 +169,12 @@
       -> "  edit_target.py:2: usuario_count  [pt-noun: 'usuario']"      (linha 2, onde o old_string está; antes seria 1)
       ```
 
-- [x] 2.5 Selftest (353): 13 decisões de `PostToolUse` (as 12 originais sem `hook_event_name` +
+- [x] 2.5 Selftest (391): 13 decisões de `PostToolUse` (as 12 originais sem `hook_event_name` +
       uma nomeada), 12 de `PreToolUse`, `inform` nos dois eventos, `en-unknown` sozinho (o token é
       afirmado advisory-only antes, para o caso não passar numa escrita limpa), allowlist em
-      `tempfile.TemporaryDirectory()`, envelope de negação com 30 achados, deduplicação, variável de
-      ambiente por subprocess com `env`, argv
+      `tempfile.TemporaryDirectory()`, arquivo legado e waiver acima do fragmento num segundo
+      diretório temporário (D8, D9 — 4 asserções, cada uma com o controle que nega), envelope de
+      negação com 30 achados, deduplicação, variável de ambiente por subprocess com `env`, argv
 
       ```
       python3 claude/global/hooks/locale-rite.py --selftest; echo "rc=$?"
@@ -186,31 +197,65 @@
       ->   OK      inform mode: PostToolUse still carries the advisory
       ->   OK      en-unknown alone: PreToolUse silent, PostToolUse advisory
       ->   OK      PreToolUse allows a name listed in .identifier-locale-allow of the cwd
+      ->   OK      PreToolUse allows a clean Edit on a legacy portuguese-named file; PostToolUse still reports the path
+      ->   OK      PreToolUse denies the identifier in that Edit and names only the identifier, not the legacy path
+      ->   OK      PreToolUse allows a clean Write over the legacy file and still denies the Write that creates a portuguese path
+      ->   OK      locale-ok already in the file above old_string: PreToolUse silent, PostToolUse silent, denied without it
       ->   OK      denial envelope: PreToolUse shape, <= 2000 chars, <= 20 lines, three exits last
       ->   OK      denial reason names each distinct token once
       ->   OK      LOCALE_RITE_MODE=inform read from the environment through stdin
       ->   OK      unknown flag prints usage and exits 2
       ->
-      -> selftest OK: 13 PostToolUse decisions, 12 PreToolUse decisions, inform mode, en-unknown, the allowlist, both envelopes, the environment and the argv contract
-      -> rc=0
+      -> selftest OK: 13 PostToolUse decisions, 12 PreToolUse decisions, inform mode, en-unknown, the allowlist, the legacy path, the waiver above the fragment, both envelopes, the environment and the argv contract
+      -> rc=0        (37 linhas OK; as 4 novas em `426801b`)
       ```
 
-- [x] 2.6 Docstring (`locale-rite.py:1-106`): modos, o bloco "WHY `hookSpecificOutput.permissionDecision`
+- [x] 2.6 Docstring (`locale-rite.py:1-115`): modos, a regra D8/D9 no cabeçalho dos eventos, o bloco "WHY `hookSpecificOutput.permissionDecision`
       AND NOT `exit 2`" com versão (2.1.261), comando (`re.finditer` sobre o ELF) e fragmentos
       (schema, normalização, `AKr`/`RKr`, mismatch), ao lado do probe do `additionalContext`; wiring
       com os **dois** eventos; KNOWN LIMIT das escritas via Bash (issue #138)
 
       ```
-      grep -c -E "PreToolUse|PostToolUse" claude/global/hooks/locale-rite.py   -> 52
-      grep -n "KNOWN LIMIT" claude/global/hooks/locale-rite.py                  -> 73:KNOWN LIMIT
+      grep -c -E "PreToolUse|PostToolUse" claude/global/hooks/locale-rite.py   -> 56
+      grep -n "KNOWN LIMIT" claude/global/hooks/locale-rite.py                  -> 82:KNOWN LIMIT
       ```
 
-- [x] 2.7 `personal-rules.md`, seção *Code Locale*: um bullet novo (`claude/global/personal-rules.md:55-59`,
-      commit `cbeec33`) dizendo que o hook **nega** a escrita em `PreToolUse`, nomeando as três saídas
-      e o limite (Bash, #138); a estrutura da seção (bullets + link final para `code-locale`) mantida
+- [x] 2.7 `personal-rules.md`, seção *Code Locale*: um bullet novo (`claude/global/personal-rules.md:55-61`,
+      commits `cbeec33` e `c83cd77`) dizendo que o hook **nega** a escrita em `PreToolUse` — pelo
+      conteúdo novo, ou pelo caminho quando a escrita o cria —, que um arquivo legado de nome
+      português é editado livremente e só reportado depois, nomeando as três saídas e o limite (Bash,
+      #138); a estrutura da seção (bullets + link final para `code-locale`) mantida
 
       ```
-      git diff -U0 80ee53c...HEAD -- claude/global/personal-rules.md | grep -E '^@@'   -> @@ -54,0 +55,5 @@ field keys.
+      git diff -U0 80ee53c...HEAD -- claude/global/personal-rules.md | grep -E '^@@'   -> @@ -54,0 +55,7 @@ field keys.
+      ```
+
+- [x] 2.8 D8 — um caminho só nega em `PreToolUse` quando a escrita o cria: `findings_for(..., pre)`
+      (250) calcula `creates = not path.exists()` (263) e só chama `scan_path()` quando `creates or
+      not pre`; `evaluate()` passa `pre=pre`. Achado de revisão reproduzido em `17fc01f` e corrigido
+      em `426801b`; a decisão registrada antes em `857fd95` (design D8, delta)
+
+      ```
+      printf 'def total(price):\n    return price\n' > <X>/servico_pedido.py
+      {PreToolUse, Edit, file_path:<X>/servico_pedido.py, old_string:"return price", new_string:"return price * 2"} | python3 claude/global/hooks/locale-rite.py | wc -c
+      -> em 17fc01f: {"permissionDecision": "deny", ... "servico_pedido.py: servico_pedido  [path-pt-noun: 'servico']" ...}
+      -> em 426801b: 0   (mudo; rc=0)
+      {PostToolUse, mesmo Edit}      -> {"hookEventName": "PostToolUse", "additionalContext": "CODE-LOCALE: the write that just landed carries a non-English name [...]   (o caminho legado continua reportado)
+      {PreToolUse, Write, file_path:<X>/novo_servico.py, content:"x = 1\n"}  -> {"permissionDecision": "deny" [...]   (o caminho que a escrita cria continua negado)
+      sim caso 25 (Edit com `preco` no arquivo legado) -> DENY, linhas do motivo com servico_legado: ["  servico_legado.py:1: preco  [pt-noun: 'preco']"]   (só o identificador; o caminho não entra no motivo)
+      ```
+
+- [x] 2.9 D9 — o `locale-ok:` já gravado na linha acima do fragmento vale: `waiver_above(check, path,
+      first_line)` (231) lê a linha `first_line - 1` do arquivo com `check.WAIVER_RE` e, quando casa,
+      `findings_for()` descarta os achados com `line == first_line`; vale nos dois eventos. Achado de
+      revisão reproduzido em `17fc01f` e corrigido em `426801b`
+
+      ```
+      printf 'a = 1\nb = 2\n' > <X>/orders/two.py
+      passo 0 {PreToolUse, Edit, old_string:"b = 2", new_string:"usuario = 2"}                                      -> DENY (controle; sem waiver)
+      passo 1 {PreToolUse, Edit, old_string:"a = 1", new_string:"a = 1\n# locale-ok: wire name from the legacy adapter"} -> 0 chars (mudo)
+      printf 'a = 1\n# locale-ok: wire name from the legacy adapter\nb = 2\n' > <X>/orders/two.py    (o passo 1 aplicado)
+      passo 2 {PreToolUse, Edit, old_string:"b = 2", new_string:"usuario = 2"}                                      -> em 17fc01f: DENY "orders/two.py:3: usuario";  em 426801b: 0 chars (mudo)
       ```
 
 ## 3. Simulation & Field Proof (MANDATORY)
@@ -218,7 +263,8 @@
 - [x] S.1 O artefato exercitado pelo caminho real — `python3 claude/global/hooks/locale-rite.py` lendo
       um payload por stdin, na forma que o bundle 2.1.261 declara (`session_id`, `transcript_path`,
       `cwd`, `hook_event_name`, `tool_name`, `tool_use_id`, `tool_input`, e `tool_response` no
-      PostToolUse), 23 payloads, cada um num processo próprio (`scratchpad/sim.py`, 2026-09-05):
+      PostToolUse), 31 payloads, cada um num processo próprio (`scratchpad/sim.py`, 2026-09-05; os
+      casos 24-31 acrescentados na revisão, para D8 e D9):
 
       ```
       python3 scratchpad/sim.py
@@ -245,11 +291,25 @@
       -> OK     21 Pre tool_input not an object                            rc=0 silent   chars=0 stderr=0
       -> OK     22 Pre Write pt, LOCALE_RITE_MODE=informar (typo)          rc=0 DENY     chars=846 stderr=0
       -> OK     23 no hook_event_name, pt (pre-#137 payload)               rc=0 ADVISORY chars=1608 stderr=0
-      -> mismatches: 0/23
-      -> files in the write target after all runs: ['edit_target.py']        (só a fixture do caso 4: o hook não grava nada)
+      -> OK     24 Pre Edit clean new_string on EXISTING pt-named file (D8) rc=0 silent   chars=0 stderr=0
+      -> OK     25 Pre Edit pt new_string on EXISTING pt-named file (D8)   rc=0 DENY     chars=719 stderr=0
+      -> OK     26 Pre Write clean content OVER existing pt-named file (D8) rc=0 silent   chars=0 stderr=0
+      -> OK     27 Post Edit clean on EXISTING pt-named file (path still reported) rc=0 ADVISORY chars=752 stderr=0
+      -> OK     28 Pre Edit pt new_string, NO waiver in file (D9 control)  rc=0 DENY     chars=717 stderr=0
+      -> OK     29 Pre Edit adding the waiver line as the denial instructs (D9 step 1) rc=0 silent   chars=0 stderr=0
+      -> OK     30 Pre Edit pt new_string under the waiver already in file (D9 step 2) rc=0 silent   chars=0 stderr=0
+      -> OK     31 Post Edit pt new_string under the waiver already in file (D9) rc=0 silent   chars=0 stderr=0
+      -> mismatches: 0/31
+      -> files in the write target after all runs: ['edit_target.py', 'servico_legado.py', 'unwaived.py', 'waived.py', 'waived_after.py']   (só as fixtures: o hook não grava nada)
+      -> --- case 25 reason lines (no path finding expected) --- ["  servico_legado.py:1: preco  [pt-noun: 'preco']"]
+      -> --- case 27 systemMessage --- code-locale: 1 non-English name in the last write
       ```
 
-      O envelope do caso 1 e a linha do caso 4 estão em 2.1, 2.2 e 2.4. O que esta simulação **não**
+      O envelope do caso 1 e a linha do caso 4 estão em 2.1, 2.2 e 2.4; os casos 24-31 em 2.8 e 2.9.
+      O caso 31 simula o estado **depois** do Edit (`waived_after.py` já contém o `new_string`),
+      porque o `PostToolUse` ancora no `new_string` gravado; a primeira versão da fixture usava o
+      arquivo pré-edit e reportava ADVISORY — erro da fixture, não do hook, corrigido antes desta
+      contagem. O que esta simulação **não**
       prova: o hook disparado pelo harness numa sessão com o bloco `PreToolUse` wired — um subagente
       não dispara o hook da sessão. A corrida na sessão do mantenedor (Write de `servico_pedido.py`
       negado, arquivo ausente, depois com `locale-ok:` e com `LOCALE_RITE_MODE=inform`, contando as
@@ -259,19 +319,23 @@
 
       | Grupo | O que tinha de acontecer | Contagem | Nota |
       |---|---|---|---|
-      | stdin, PreToolUse | tinha de negar e negou | 7/7 | casos 1-4, 14, 15, 22: caminho, identificador, Edit, MultiEdit, NotebookEdit, grafia errada do modo |
-      | stdin, PreToolUse | tinha de ficar mudo e ficou | 8/8 | casos 5-7, 10, 12, 17, 21 e 16: locale-ok, allowlist, inform, en-unknown, limpo, sem file_path, tool_input inválido, Bash |
-      | stdin, PostToolUse | tinha de informar e informou | 4/4 | casos 8, 9, 11, 23 (o caso 9 com inform é idêntico ao 8: 1608 chars) |
-      | stdin, PostToolUse | tinha de ficar mudo e ficou | 1/1 | caso 13 |
+      | stdin, PreToolUse | tinha de negar e negou | 9/9 | casos 1-4, 14, 15, 22, 25, 28: caminho criado, identificador, Edit, MultiEdit, NotebookEdit, grafia errada do modo, identificador em arquivo legado, sem waiver no arquivo |
+      | stdin, PreToolUse | tinha de ficar mudo e ficou | 12/12 | casos 5-7, 10, 12, 17, 21, 16, 24, 26, 29, 30: locale-ok, allowlist, inform, en-unknown, limpo, sem file_path, tool_input inválido, Bash, Edit limpo em arquivo legado, Write limpo sobre arquivo legado, Edit que acrescenta o waiver, Edit sob o waiver já gravado |
+      | stdin, PostToolUse | tinha de informar e informou | 5/5 | casos 8, 9, 11, 23, 27 (o caso 9 com inform é idêntico ao 8: 1608 chars; o 27 é o caminho legado ainda reportado depois do Edit) |
+      | stdin, PostToolUse | tinha de ficar mudo e ficou | 2/2 | casos 13 e 31 |
       | stdin, malformado | mudo, exit 0, sem stderr | 3/3 | casos 18-20 |
       | stdin, escape conhecido | ficou mudo | 1/1 | caso 16: Bash escrevendo `preco` (KNOWN LIMIT, issue #138) — contado também na linha dos mudos |
-      | `--selftest` | decisões OK | 13/13 PostToolUse + 12/12 PreToolUse + 7/7 asserções (forma Post, inform Post, en-unknown, allowlist, envelope, deduplicação, ambiente) + 1/1 argv | rc=0 |
-      | runner de gates | steps PASS | 19/19 PASS | ver V.1 |
+      | `--selftest` | decisões OK | 13/13 PostToolUse + 12/12 PreToolUse + 11/11 asserções (forma Post, inform Post, en-unknown, allowlist, Edit legado, identificador em legado, Write legado, waiver acima, envelope, deduplicação, ambiente) + 1/1 argv | rc=0, 37 linhas OK |
+      | runner de gates | steps PASS | 20/20 PASS | ver V.1 |
 
 - [x] S.3 O que escapou ou se comportou diferente do esperado
 
-      Nada escapou na matriz: 0/23 desvios em S.1. Duas coisas foram diferentes do planejado antes de
-      medir, e estão registradas:
+      Da matriz de 23 casos de `17fc01f`, **dois defeitos escaparam** e foram achados em revisão, não
+      pela simulação: todo caso escrevia um caminho novo (nenhum editava um arquivo legado de nome
+      português — D8) e nenhum tinha o waiver fora do fragmento (D9). Reproduzidos com os comandos de
+      2.8 e 2.9 em `17fc01f`, corrigidos em `426801b`, e a matriz ganhou os casos 24-31 com os seus
+      controles (25 e 28 negam) para que a ausência não se repita: 0/31 desvios em S.1. Duas coisas
+      foram diferentes do planejado antes de medir, e estão registradas:
 
       - O bundle honra `additionalContext` em `PreToolUse` (E.2). A opção de emitir o `en-unknown`
         antes da escrita existe e **não** foi usada (D4): com os dois blocos wired o aviso chegaria
@@ -317,11 +381,14 @@
 
 ## 5. Validation & Closure (MANDATORY)
 
-- [x] V.1 `openspec validate enforce-locale-on-write --strict` -> `Change 'enforce-locale-on-write' is valid`;
+- [x] V.1 (rodado de novo em `c83cd77` + este tasks.md) `openspec validate enforce-locale-on-write --strict` -> `Change 'enforce-locale-on-write' is valid`;
       `bash scripts/validate-rite.sh` (com `GITHUB_EVENT_PATH` apontando para um body com
       `Spec-rite: enforce-locale-on-write`) -> `rite evidence gate: 0 findings` [...] `rite gate OK`;
       `python3 scripts/validate-skill-version.py` (mesmo event, `SKILL_VERSION_BASE=master`) ->
-      `skill-version gate: 0 findings (base origin/master, 0 skill(s) changed, 0 with content changes)`
+      `skill-version gate: 0 findings (base origin/master, 0 skill(s) changed, 0 with content changes)`;
+      runner de gates (`gates.sh`, os steps de Validate do `ci.yml` mais os novos) -> 20 linhas `PASS`
+      (`PASS locale-rite :: selftest OK: 13 PostToolUse decisions, 12 PreToolUse decisions [...]`,
+      `PASS rite :: rite gate OK`, `PASS openspec-strict enforce-locale-on-write`) e `dirty-after: 0`
 - [x] V.2 Descoberta do catálogo intacta: `npx -y skills add . --list` -> `Found 35 skills`;
       `ls -d skills/*/ | wc -l` -> `35`; sem órfão ou renomeado
 - [x] V.3 README / docs atualizados: a composição do catálogo não muda; `personal-rules.md` ganha o


### PR DESCRIPTION
Closes #137

O rito do code-locale existia em três camadas — a seção *Code Locale* de `personal-rules.md`, a skill `code-locale` e o hook `locale-rite.py` em `PostToolUse` — e nenhuma **impedia** a escrita. Medido em `80ee53c` com o payload da issue: `Write` de `servico_pedido.py` com `calcular_total(preco)` -> `additionalContext` com 4 achados e o arquivo já no disco. O bundle instalado (`~/.local/share/claude/versions/2.1.261`) aceita em `PreToolUse` `hookSpecificOutput.permissionDecision: "deny"` + `permissionDecisionReason` (caps lidos no ELF: 2000 caracteres **e** 20 linhas), e o payload desse evento já traz o caminho e o conteúdo: é medição da escrita, não proxy.

## O que muda

- `locale-rite.py` decide pelo `hook_event_name`: em `PreToolUse` um achado gating (`pt-*` no conteúdo novo; `path-pt-*` num caminho que a escrita **cria**) nega a chamada com o motivo compacto — cabeçalho, uma linha por `(path, token)` deduplicado, `+N more`, contagem de advisory e as três saídas literais no fim (`# locale-ok: <motivo>`, `.identifier-locale-allow`, `LOCALE_RITE_MODE=inform`). Só `en-unknown` nunca nega. `PostToolUse` fica consultivo como antes.
- **Revisão (D8):** um arquivo que já existe nunca é negado pelo próprio nome — `findings_for()` só chama `scan_path()` em `PreToolUse` quando `Path(file_path).exists()` é falso. Um `Edit` limpo em `servico_pedido.py` legado passa em silêncio; o `PostToolUse` continua reportando o nome. Coerente com "Existing code is not renamed for its own sake".
- **Revisão (D9):** o `# locale-ok:` que já está no arquivo na linha acima do `old_string` vale como se estivesse no `new_string` (`waiver_above()` com o `WAIVER_RE` do próprio check), nos dois eventos — seguir o primeiro exit do motivo agora funciona, sem a segunda tentativa cega.
- `LOCALE_RITE_MODE=inform` (novo): nunca nega; grafia errada é o modo padrão.
- Selftest: 13 decisões `PostToolUse` (as 12 originais intocadas), 12 `PreToolUse`, inform, en-unknown, allowlist em cwd temporário, arquivo legado e waiver acima do fragmento (4 asserções com os controles que negam), envelope com 30 achados dentro dos dois caps, variável de ambiente pelo caminho real, argv.
- Docstring: probe do `permissionDecision` ao lado do do `additionalContext`, os dois blocos de wiring, KNOWN LIMIT (Bash, #138).
- `personal-rules.md`, seção *Code Locale*: um bullet dizendo que a escrita é **negada**, quando o caminho conta, e onde estão as saídas.

Nenhuma skill é tocada; a composição do catálogo fica idêntica.

## Simulação — saída observada

`python3 claude/global/hooks/locale-rite.py` lendo 31 payloads por stdin na forma do bundle 2.1.261, um processo cada (`mismatches: 0/31`; o hook não gravou nada):

| Expectativa | Casos | Resultado |
|---|---|---|
| PreToolUse tinha de negar e negou | **9/9** | caminho criado, identificador, Edit, MultiEdit, NotebookEdit, grafia errada do modo, identificador em arquivo legado, Edit sem waiver no arquivo |
| PreToolUse tinha de ficar mudo e ficou | **12/12** | locale-ok, allowlist, inform, en-unknown, limpo, sem file_path, tool_input inválido, Bash, Edit limpo em arquivo legado, Write limpo sobre legado, Edit que acrescenta o waiver, Edit sob o waiver já gravado |
| PostToolUse tinha de informar e informou | **5/5** | inclui o caminho legado ainda reportado depois do Edit |
| PostToolUse tinha de ficar mudo e ficou | **2/2** | escrita limpa; nome sob waiver já gravado |
| stdin malformado: mudo, exit 0, sem stderr | **3/3** | array, string, vazio |
| Escape conhecido ficou mudo | **1/1** | Bash escrevendo `preco` (issue #138) |

Motivo do exemplo da issue: 7 linhas, 712 caracteres, `preco` uma vez, as três saídas por último. Achados de revisão reproduzidos em `17fc01f` (Edit limpo em arquivo legado -> `deny` pelo caminho; waiver acima do `old_string` -> `deny usuario`) e mudos em `426801b`.

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Hook de locale | `claude/global/hooks/locale-rite.py --selftest` | 37 OK, rc=0 |
| Locale do próprio hook | `check-identifier-locale.py claude/global/hooks/locale-rite.py` | `findings: 0` |
| Wrappers em sincronia | `bash generate.sh && git diff` | sem diff |
| Skills / validador | `validate-skills.py` + `selftest-validate-skills.py` | `skills checked: 35 findings: 0`; 20/20 |
| Detector de locale | `check-identifier-locale.py --selftest` | OK |
| Hooks irmãos | `backlog-rite.py --selftest`, `verify-rite.py --selftest` | OK |
| Segredos / higiene | `scan-secrets.py` (+ `--selftest`), `validate-repo-hygiene.py` (+ `--selftest`) | OK |
| Rito | `bash scripts/validate-rite.sh` | `rite gate OK`, 0 findings |
| Evidência / spec-rite | `validate-rite-evidence.py --selftest`, `validate-spec-rite.py --selftest` | 7/7; 6/6 |
| Versão de skill | `validate-skill-version.py` | `0 findings (0 skill(s) changed)` |
| OpenSpec estrito | `openspec validate enforce-locale-on-write --strict` | `Change 'enforce-locale-on-write' is valid` |
| Validador do vendor | `claude plugin validate . --strict` | `Validation passed` |
| Smoke dos instaladores | `scripts/smoke-install-scripts.sh` | 17/17 |

## Rito

Spec-rite: enforce-locale-on-write — capability `skills-catalog` (MODIFIED requirement *"The code-locale rite is enforced at the moment of the write"*, 10 cenários; D8 e D9 registrados em `design.md` e no delta antes da edição do hook).

## Known gaps

- A corrida na sessão real com o bloco `PreToolUse` wired é o passo de aceite do mantenedor (um subagente não dispara o hook da sessão); o snippet de `settings.json` está no docstring.
- `README.md` (seção dos hooks, 306-335): documentado por outro item junto com o wiring de todos os hooks — não tocado aqui.
- Escritas via Bash continuam passando (issue #138).
- D8: um `Write` que sobrescreve um arquivo legado inteiro não é negado pelo nome — o nome já estava no disco; o `PostToolUse` o reporta.
- D9 vale para a primeira linha do fragmento editado, como o próprio check.
- V.4 (`openspec archive`) fica para o PR de arquivamento, como o repositório já faz.