### PR TITLE
✨ feat(hooks): gate de Stop mede o diff não commitado do turno e cobre Bash e heredoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,12 @@ jobs:
       - name: Locale write-gate hook self-test (the shipped hook is itself gated)
         run: python3 claude/global/hooks/locale-rite.py --selftest
 
+      - name: Locale stop-gate hook self-test (the shipped hook is itself gated)
+        # Builds throwaway git repositories under a temporary directory and drives the Stop decision
+        # through them: a heredoc-written Portuguese file blocks, renamed it does not, the second
+        # Stop (stop_hook_active) reports without blocking. Needs only python3 and git.
+        run: python3 claude/global/hooks/locale-stop-gate.py --selftest
+
       - name: Backlog rite hook self-test (the shipped hook is itself gated)
         run: python3 claude/global/hooks/backlog-rite.py --selftest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,9 @@ jobs:
       - name: Locale stop-gate hook self-test (the shipped hook is itself gated)
         # Builds throwaway git repositories under a temporary directory and drives the Stop decision
         # through them: a heredoc-written Portuguese file blocks, renamed it does not, the second
-        # Stop (stop_hook_active) reports without blocking. Needs only python3 and git.
+        # Stop (stop_hook_active) reports without blocking, a ~/.gitconfig with diff.external or
+        # mnemonicPrefix does not silence it, a non-ASCII file name is measured, and a diff over the
+        # cap is never a silent pass. Needs only python3 and git.
         run: python3 claude/global/hooks/locale-stop-gate.py --selftest
 
       - name: Backlog rite hook self-test (the shipped hook is itself gated)

--- a/README.md
+++ b/README.md
@@ -232,21 +232,15 @@ EOF
 
 To customize: edit `~/ai-skills/claude/global/personal-rules.md` (or fork the repo).
 
-### Enforcing the rite (optional hook)
+### Enforcing the rite (optional hooks)
 
 The rules file states that every code change starts as a backlog item ([`backlog`](skills/backlog/) →
 [`execute-backlog`](skills/execute-backlog/)). A rule in context only works if the assistant notices
 it — and the failure mode is specific: a request to *diagnose* something drifts into implementing the
 fix, and no new prompt ever arrives to trigger the rite.
 
-`claude/global/hooks/backlog-rite.py` closes that gap. It is a `UserPromptSubmit` hook: the harness
-runs it on every prompt, and its output becomes context for that turn. It **informs, never blocks** —
-no tool call is denied, and the user can waive the rite explicitly.
-
-Where the working directory carries `openspec/`, the reminder gains one extra sentence naming the
-spec gate: the item also becomes an OpenSpec change, validated strict before the first edit outside
-`openspec/`. The sentence is conditional on purpose — it never fires in a repo that has no such
-workflow, so the reminder does not teach a step that does not exist there.
+Four hooks under `claude/global/hooks/` close that gap, each on the harness event where its rule can
+be measured. This is the complete wiring; every block is optional, and each hook is described below.
 
 ```jsonc
 // ~/.claude/settings.json
@@ -267,10 +261,54 @@ workflow, so the reminder does not teach a step that does not exist there.
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-rite.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-rite.py",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-stop-gate.py",
+            "timeout": 30
+          }
+        ]
+      }
     ]
   }
 }
 ```
+
+**The backlog rite.** `claude/global/hooks/backlog-rite.py` is a `UserPromptSubmit` hook: the harness
+runs it on every prompt, and its output becomes context for that turn. It **informs, never blocks** —
+no tool call is denied, and the user can waive the rite explicitly.
+
+Where the working directory carries `openspec/`, the reminder gains one extra sentence naming the
+spec gate: the item also becomes an OpenSpec change, validated strict before the first edit outside
+`openspec/`. The sentence is conditional on purpose — it never fires in a repo that has no such
+workflow, so the reminder does not teach a step that does not exist there.
 
 It stays silent for prompts already inside the rite (`/backlog`, `/execute-backlog`, any slash
 command), for explicit waivers ("sem backlog", "skip the rite"), and for anything that does not look
@@ -282,11 +320,11 @@ while a false negative costs traceability, the reminder itself says diagnosis is
 
 ### The grounding rite (anti-achismo)
 
-`claude/global/hooks/verify-rite.py` is the second hook in the array above. It carries the
-[`verify-before-claiming`](skills/verify-before-claiming/) doctrine into context when a prompt reads
-as **a guess being caught or research being demanded** — "achismo", "você inventou", "de onde
-tirou", "essa flag não existe", "fora do escopo", "don't guess", "cite the source", "that's not what
-I asked". Same contract as the backlog hook: informs, never blocks, silent on explicit waivers
+`claude/global/hooks/verify-rite.py` is the second hook in the `UserPromptSubmit` array above. It
+carries the [`verify-before-claiming`](skills/verify-before-claiming/) doctrine into context when a
+prompt reads as **a guess being caught or research being demanded** — "achismo", "você inventou", "de
+onde tirou", "essa flag não existe", "fora do escopo", "don't guess", "cite the source", "that's not
+what I asked". Same contract as the backlog hook: informs, never blocks, silent on explicit waivers
 ("de cabeça", "pode chutar", "from memory is fine").
 
 **What it deliberately does not do.** It fires on *corrections*, not on the guess itself. The moment
@@ -303,42 +341,70 @@ it — it cannot enforce anything on a pull request. The gate that survives an u
 with an `Evidence & Sources (MANDATORY)` group. The hook makes the guess less likely; CI makes the
 missing evidence visible.
 
-### The locale rite (English machine layer, measured at the write)
+### The locale rite, at the write (English machine layer, measured on the tool call)
 
-`claude/global/hooks/locale-rite.py` is the third hook, and the only one that measures an artifact
-instead of matching a prompt. It runs on `PostToolUse` for `Write|Edit`, feeds the written **path**
-and the written **content** to [`check-identifier-locale.py`](skills/code-locale/references/check-identifier-locale.py),
-and returns the findings to the assistant. Silent when the write is clean.
+`claude/global/hooks/locale-rite.py` is the third hook, and the first that measures an artifact
+instead of matching a prompt. It runs for `Write|Edit|MultiEdit|NotebookEdit` on two events, and the
+event decides the envelope, not the measurement: it feeds the written **path** and the written
+**content** to [`check-identifier-locale.py`](skills/code-locale/references/check-identifier-locale.py)
+either way.
 
-```jsonc
-// ~/.claude/settings.json — alongside the UserPromptSubmit block above
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-rite.py",
-            "timeout": 10
-          }
-        ]
-      }
-    ]
-  }
-}
-```
+- On `PreToolUse` a gating finding (`pt-*`, `path-pt-*`) **denies the write** through
+  `hookSpecificOutput.permissionDecision: "deny"`, with every finding and the exits in the reason —
+  the file is never written (issue #137).
+- On `PostToolUse` it **informs**: the findings, including the advisory `en-unknown` question ("is
+  this word English?"), travel in `hookSpecificOutput.additionalContext`, not on plain stdout —
+  `PostToolUse` is not one of the events that turn stdout into context (`UserPromptSubmit`,
+  `UserPromptExpansion`, `SessionStart` are), so a hook that printed would be silently useless.
 
-**Why a different event.** The other two rites match a prompt, so a reminder is the best they can do.
-This one has the artifact in hand — the name that was just written — so it measures instead of
-reminding. The findings travel in `hookSpecificOutput.additionalContext`, not on plain stdout:
-`PostToolUse` is not one of the events that turn stdout into context (`UserPromptSubmit`,
-`UserPromptExpansion`, `SessionStart` are), so a hook that printed would be silently useless.
+Silent when the write is clean. The exits are the ones the `code-locale` skill defines: an inline
+`# locale-ok: <reason>` on the line or the line above, the token or path in the repository's
+`.identifier-locale-allow`, and `LOCALE_RITE_MODE=inform` in the session's environment, which turns
+the deny back into the advisory for the whole session. Where the check itself is missing it exits
+silently instead of failing, because an absent gate must not present itself as an error.
 
-Same contract as the other two: informs, never blocks, persists nothing, needs no credentials — and
-where the check itself is missing it exits silently instead of failing, because an absent gate must
-not present itself as an error.
+### The locale rite, at the end of the turn (the Stop gate)
+
+The write hooks see the **tool**, not the **result**. Anything written through Bash — a heredoc,
+`sed -i`, a script — never passes through them, and the harness's auto mode instructs the assistant
+to edit files exactly that way; measured live on 2026-09-05, a heredoc wrote `servico_cliente.py`
+with `def buscar_cliente(id_usuario)` and no hook fired (issue #138).
+
+`claude/global/hooks/locale-stop-gate.py` is the fourth hook and runs on `Stop`, once per turn. It
+finds the git work tree the working directory is in, builds the **uncommitted diff** — tracked files
+against `HEAD` (or the empty tree in a repository with no commit yet), plus every untracked file the
+repository does not ignore, each as an added file — and runs the same check over it in `--diff` mode,
+honouring the repository's `.identifier-locale-allow` and the check's vendored-path exclusions. A
+gating finding **blocks the end of the turn**: the hook answers `{"decision": "block", "reason": …}`
+and the reason lists every finding and the three exits. The shape was probed against the installed
+bundle (`claude 2.1.261`) rather than read from the docs, whose pages disagree: the bundle reads
+`decision`, `reason` and `systemMessage` at the **top level**, and for `Stop` the nested
+`hookSpecificOutput` carries only `additionalContext` — anything else nested is dropped without an
+error. The probe fragments and the version live in the hook's docstring.
+
+It never loops. The Stop that follows a block arrives with `stop_hook_active: true`; the hook then
+returns only a `systemMessage` naming what is still in Portuguese and lets the turn end. The second
+turn is the last chance, not a loop — whoever read the reason and did not rename has decided. It
+measures only what the turn left uncommitted, so a legacy repository is not judged for what it
+already had; a Portuguese file **moved** without an edit is a rename to git and does not fire. Over
+`MAX_DIFF_LINES` (4000) the rest is not measured and the reason **says so**; a git call that exceeds
+its timeout makes the hook silent rather than holding the turn forever. Silent — no output, exit 0,
+under a second — outside a git work tree, on an empty diff, on advisory-only findings, with
+`LOCALE_RITE_MODE=inform`, and on a payload it cannot read. What it does not see is declared in its
+docstring: a file committed inside the same turn, a repository other than the one `cwd` is in, and
+the event's other name (`SubagentStop`) inside a subagent.
+
+**Which layer catches what.** The three layers overlap on purpose; each covers a path the others
+cannot see.
+
+| What wrote the name | Layer that catches it | Effect |
+|---|---|---|
+| `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | `locale-rite.py` on `PreToolUse` (#137) | the write is **denied**; nothing reaches the disk |
+| Bash — heredoc, `sed -i`, a script, a generator | `locale-stop-gate.py` on `Stop` | the **turn does not end** until the diff is clean or waived |
+| another assistant (Codex, Cursor, Copilot), or a human commit | the per-repository kit of the [`code-locale`](skills/code-locale/) skill — pre-commit hook and CI step (issue #139) | the **commit or the pull request** fails |
+
+The hooks run only in a Claude Code session that wired them; they enforce nothing on a pull request
+from someone who did not. The third row is the layer that survives that.
 
 > Like `personal-rules.md`, this is the **maintainer's** process. Edit the signal lists and the
 > reminder text to match yours — both matchers cover Portuguese and English by default.

--- a/README.md
+++ b/README.md
@@ -262,18 +262,21 @@ be measured. This is the complete wiring; every block is optional, and each hook
         ]
       }
     ],
-    "PreToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit|NotebookEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-rite.py",
-            "timeout": 10
-          }
-        ]
-      }
-    ],
+    // Arrives with issue #137 (locale-rite.py learns PreToolUse and LOCALE_RITE_MODE there). Wire
+    // this block only once #137 has merged: before that the hook answers a PreToolUse payload with
+    // its PostToolUse envelope, which the harness drops as an event mismatch — no deny happens.
+    // "PreToolUse": [
+    //   {
+    //     "matcher": "Write|Edit|MultiEdit|NotebookEdit",
+    //     "hooks": [
+    //       {
+    //         "type": "command",
+    //         "command": "python3 /home/YOUR_USER/ai-skills/claude/global/hooks/locale-rite.py",
+    //         "timeout": 10
+    //       }
+    //     ]
+    //   }
+    // ],
     "PostToolUse": [
       {
         "matcher": "Write|Edit|MultiEdit|NotebookEdit",
@@ -344,24 +347,27 @@ missing evidence visible.
 ### The locale rite, at the write (English machine layer, measured on the tool call)
 
 `claude/global/hooks/locale-rite.py` is the third hook, and the first that measures an artifact
-instead of matching a prompt. It runs for `Write|Edit|MultiEdit|NotebookEdit` on two events, and the
-event decides the envelope, not the measurement: it feeds the written **path** and the written
-**content** to [`check-identifier-locale.py`](skills/code-locale/references/check-identifier-locale.py)
-either way.
+instead of matching a prompt. It runs for `Write|Edit|MultiEdit|NotebookEdit` and feeds the written
+**path** and the written **content** to
+[`check-identifier-locale.py`](skills/code-locale/references/check-identifier-locale.py).
 
-- On `PreToolUse` a gating finding (`pt-*`, `path-pt-*`) **denies the write** through
-  `hookSpecificOutput.permissionDecision: "deny"`, with every finding and the exits in the reason —
-  the file is never written (issue #137).
-- On `PostToolUse` it **informs**: the findings, including the advisory `en-unknown` question ("is
-  this word English?"), travel in `hookSpecificOutput.additionalContext`, not on plain stdout —
-  `PostToolUse` is not one of the events that turn stdout into context (`UserPromptSubmit`,
-  `UserPromptExpansion`, `SessionStart` are), so a hook that printed would be silently useless.
+- On `PostToolUse` — the event it has today — it **informs**: the findings, including the advisory
+  `en-unknown` question ("is this word English?"), travel in `hookSpecificOutput.additionalContext`,
+  not on plain stdout — `PostToolUse` is not one of the events that turn stdout into context
+  (`UserPromptSubmit`, `UserPromptExpansion`, `SessionStart` are), so a hook that printed would be
+  silently useless. The file is already on disk when it speaks.
+- Issue #137, in flight beside this one, gives it `PreToolUse` with the same matcher: there a gating
+  finding (`pt-*`, `path-pt-*`) **denies the write** through
+  `hookSpecificOutput.permissionDecision: "deny"`, with every finding and the exits in the reason, and
+  the file is never written. The `PreToolUse` block in the snippet above is commented out until that
+  lands; the event decides the envelope, not the measurement.
 
 Silent when the write is clean. The exits are the ones the `code-locale` skill defines: an inline
 `# locale-ok: <reason>` on the line or the line above, the token or path in the repository's
-`.identifier-locale-allow`, and `LOCALE_RITE_MODE=inform` in the session's environment, which turns
-the deny back into the advisory for the whole session. Where the check itself is missing it exits
-silently instead of failing, because an absent gate must not present itself as an error.
+`.identifier-locale-allow`, and `LOCALE_RITE_MODE=inform` in the session's environment (introduced by
+#137 for the write gate, read today by the Stop gate below), which turns a deny back into the advisory
+for the whole session. Where the check itself is missing it exits silently instead of failing,
+because an absent gate must not present itself as an error.
 
 ### The locale rite, at the end of the turn (the Stop gate)
 
@@ -374,8 +380,14 @@ with `def buscar_cliente(id_usuario)` and no hook fired (issue #138).
 finds the git work tree the working directory is in, builds the **uncommitted diff** — tracked files
 against `HEAD` (or the empty tree in a repository with no commit yet), plus every untracked file the
 repository does not ignore, each as an added file — and runs the same check over it in `--diff` mode,
-honouring the repository's `.identifier-locale-allow` and the check's vendored-path exclusions. A
-gating finding **blocks the end of the turn**: the hook answers `{"decision": "block", "reason": …}`
+honouring the repository's `.identifier-locale-allow` and the check's vendored-path exclusions
+(vendored, empty and binary untracked files are skipped before git is asked). The diff's shape is
+pinned against `~/.gitconfig`: every call runs with `core.quotePath=false`, `--no-ext-diff`,
+`--no-textconv`, `--no-relative` and explicit `a/`/`b/` prefixes, because measured `diff.external`
+(difftastic, delta) left the hook silent, `diff.mnemonicPrefix` reported every finding under a
+non-existent `w/` path, and the default `core.quotePath` hid a `relatório.py` behind
+`"relat\303\263rio.py"` — the very non-ASCII tier the check exists for. A gating finding **blocks the
+end of the turn**: the hook answers `{"decision": "block", "reason": …}`
 and the reason lists every finding and the three exits. The shape was probed against the installed
 bundle (`claude 2.1.261`) rather than read from the docs, whose pages disagree: the bundle reads
 `decision`, `reason` and `systemMessage` at the **top level**, and for `Stop` the nested
@@ -387,8 +399,11 @@ returns only a `systemMessage` naming what is still in Portuguese and lets the t
 turn is the last chance, not a loop — whoever read the reason and did not rename has decided. It
 measures only what the turn left uncommitted, so a legacy repository is not judged for what it
 already had; a Portuguese file **moved** without an edit is a rename to git and does not fire. Over
-`MAX_DIFF_LINES` (4000) the rest is not measured and the reason **says so**; a git call that exceeds
-its timeout makes the hook silent rather than holding the turn forever. Silent — no output, exit 0,
+`MAX_DIFF_LINES` (4000) the rest is not measured and the hook **says so** — in the reason when it has
+findings, and as a block of its own when the measured part is clean, because an unmeasured tail is
+not a clean result (measured before the fix: 5000 clean lines sorting ahead of `servico_cliente.py`
+left the hook silent). A git call that exceeds its timeout makes the hook silent rather than holding
+the turn forever. Silent — no output, exit 0,
 under a second — outside a git work tree, on an empty diff, on advisory-only findings, with
 `LOCALE_RITE_MODE=inform`, and on a payload it cannot read. What it does not see is declared in its
 docstring: a file committed inside the same turn, a repository other than the one `cwd` is in, and
@@ -399,7 +414,7 @@ cannot see.
 
 | What wrote the name | Layer that catches it | Effect |
 |---|---|---|
-| `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | `locale-rite.py` on `PreToolUse` (#137) | the write is **denied**; nothing reaches the disk |
+| `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | `locale-rite.py` — on `PostToolUse` today; on `PreToolUse` once #137 merges | today the finding is **context** after the write; with #137 the write is **denied** and nothing reaches the disk |
 | Bash — heredoc, `sed -i`, a script, a generator | `locale-stop-gate.py` on `Stop` | the **turn does not end** until the diff is clean or waived |
 | another assistant (Codex, Cursor, Copilot), or a human commit | the per-repository kit of the [`code-locale`](skills/code-locale/) skill — pre-commit hook and CI step (issue #139) | the **commit or the pull request** fails |
 

--- a/claude/global/hooks/locale-stop-gate.py
+++ b/claude/global/hooks/locale-stop-gate.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""Stop hook — measures the code-locale rite on the turn's uncommitted diff, whatever wrote it.
+
+Reads the Stop payload on stdin, finds the git work tree the working directory is in, builds the
+diff the turn left uncommitted — tracked files against the current commit, plus every untracked file
+the repository does not ignore, each as an added file — and runs the shipped identifier-locale check
+over it in diff mode. A gating finding blocks the end of the turn; the reason lists every finding and
+the exits. Silent when there is nothing to measure.
+
+WHY A STOP HOOK WHEN A WRITE HOOK ALREADY EXISTS
+    `locale-rite.py` sees `Write|Edit|MultiEdit|NotebookEdit`. Nothing written through Bash — a
+    heredoc, `sed -i`, a script — passes through it, and the harness's auto mode instructs the
+    assistant to edit files exactly that way. Measured live on 2026-09-05 (issue #138): a heredoc
+    wrote `servico_cliente.py` with `def buscar_cliente(id_usuario)` and no hook fired. The write
+    hook covers the tool; this one covers the result. It measures only what the turn left
+    uncommitted: history and untouched lines never enter, so a legacy repository is not judged for
+    what it already had.
+
+WHY `{"decision": "block", "reason": ...}` AT THE TOP LEVEL AND NOTHING NESTED
+    The docs pages disagree on whether Stop reads the decision at the top level or under
+    `hookSpecificOutput`. Probed against the installed bundle rather than recalled:
+    `readlink -f $(which claude)` -> ~/.local/share/claude/versions/2.1.261 (`claude --version` ->
+    `2.1.261 (Claude Code)`; a single ELF, so the grep needs `-a`). Fragments, minified names as
+    found:
+      - input schema:  `hook_event_name:C("Stop"),stop_hook_active:P(),last_assistant_message:...`
+        (and `C("SubagentStop"),stop_hook_active:P(),agent_id:s(),...`)
+      - what blocks:   `function eg(e){if("decision"in e&&e.decision==="block")return!0;
+                        if("continue"in e&&e.continue===!1)return!0; ...permissionDecision...}`
+      - what is read:  `f=...X5(r,"reason",o.reason), y=X5(r,"systemMessage",o.systemMessage)` and
+                       the answer is `{...o.decision==="block"&&{decision:"block"},
+                       ...y!==void 0&&{systemMessage:y}, ...f!==void 0&&{reason:f}, ...}`
+      - nested Stop:   `function LU(e,t,r){let o=X5(e,"additionalContext",r.additionalContext);
+                        return{hookEventName:t,...o!==void 0&&{additionalContext:o}}}` — for Stop,
+                       `hookSpecificOutput` yields only `additionalContext`; any other nested key
+                       (a nested `decision`) is dropped without an error.
+      - caps:          `AKr={reason:2000,stopReason:2000,systemMessage:4000,additionalContext:8000,...}`
+      - loop guard:    `let Od=a.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP??8;if(Od>0&&Pc>Od)` -> "A hook
+                       blocked the turn from ending N consecutive times — overriding and ending turn.
+                       For Stop/SubagentStop hooks, check stop_hook_active in the input and return
+                       success while it's true."
+    So the top level is what the bundle reads, the nested form is ignored, and this hook emits the
+    top level only — emitting both would document a shape the bundle demonstrably does not read.
+    Docs as the second source: code.claude.com/docs/en/hooks (read 2026-09-05).
+
+WHY `stop_hook_active` NEVER BLOCKS TWICE
+    The harness sets `stop_hook_active: true` on the Stop that follows a block. This hook blocks
+    once; on the next Stop it returns only a `systemMessage` naming what is still in Portuguese and
+    lets the turn end. The second turn is the last chance, not a loop: whoever read the reason and did
+    not rename has decided. The bundle's own cap (8 consecutive blocks) stays as the second net.
+
+KNOWN LIMIT — what this hook does NOT see
+    - A file committed inside the same turn: the diff is against HEAD, and a commit moves HEAD.
+    - A repository other than the one `cwd` is in, or a working directory outside any git work tree.
+    - Inside a subagent the event is `SubagentStop`, and this hook is wired on `Stop`; it accepts
+      both names, so wiring it on `SubagentStop` works without an edit, but nothing wires it there.
+    - A Portuguese file MOVED without an edit: rename detection stays at git's default, so it is a
+      rename, not an added file, and the path tier does not fire ("legacy enters only if the turn
+      touched it"). A binary file (NUL in its first 8 KiB) is skipped before git is called, so its
+      NAME is not measured either; an untracked EMPTY file gets no `+++` header from git and is not
+      measured (probed: `git diff --no-index /dev/null relatorio.py` on an empty file prints the
+      `diff --git` and `index` lines only).
+    - A diff longer than MAX_DIFF_LINES: the rest is not measured, and the reason SAYS so. A git call
+      that exceeds GIT_TIMEOUT makes the hook silent — the one case where "cannot measure" becomes
+      "does not block", because a gate that cannot measure must not hold the turn forever.
+    - Advisory findings (`en-unknown`): the check itself declares them non-gating; this hook runs
+      without the English word list and never blocks on a question.
+    - Whatever the check itself cannot see (open vocabulary, the escapes its docstring declares).
+    - Only `LOCALE_RITE_MODE=inform` (the same variable the write gate reads, issue #137) silences it
+      for a whole session; `locale-ok:` and `.identifier-locale-allow` are per name and per path.
+
+Wiring (~/.claude/settings.json), beside any Stop hook already there:
+
+    "hooks": {
+      "Stop": [
+        {"hooks": [{"type": "command",
+                    "command": "python3 ~/ai-skills/claude/global/hooks/locale-stop-gate.py",
+                    "timeout": 30}]}
+      ]
+    }
+
+Like personal-rules.md, this is the maintainer's config — edit the message and the cap to match your
+own process instead of adopting it blindly.
+
+Modes: (default) read one payload from stdin   |   --selftest assert the decisions against a temporary git repository.
+Any other argument prints usage to stderr and exits 2 — the same contract as the sibling hooks, so a
+misspelt flag cannot fall through to the stdin path and exit 0.
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# The check lives in the skill that owns the doctrine. parents[3] of this file is the repository
+# root (hooks -> global -> claude -> root); the path is resolved, never guessed, and a miss exits
+# silently — the same rule as locale-rite.py.
+CHECK_PATH = Path(__file__).resolve().parents[3] / "skills/code-locale/references/check-identifier-locale.py"
+
+# Declared, not silent: past this many diff lines the rest is not measured and the reason says so.
+MAX_DIFF_LINES = 4000
+# Per git call. The harness kills slow hooks; a git that does not answer makes this hook silent.
+GIT_TIMEOUT = 5
+# Measured caps in the bundle (see the docstring): truncating here keeps the tail we choose — the
+# exits — rather than the tail the harness chooses.
+REASON_CAP = 2000
+SYSTEM_MESSAGE_CAP = 4000
+# NUL in the first 8 KiB is git's own binary heuristic.
+BINARY_PROBE_BYTES = 8192
+
+STOP_EVENTS = {"Stop", "SubagentStop"}
+MODE_VAR = "LOCALE_RITE_MODE"
+INFORM = "inform"
+# `git hash-object -t tree /dev/null` in a SHA-1 repository — the base for a repository with no
+# commit yet, where `git diff HEAD` fails with rc=128. Recomputed per repository when git answers, so
+# a SHA-256 repository gets its own value; this constant is only the fallback.
+EMPTY_TREE_SHA1 = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+HEADER = (
+    "CODE-LOCALE (stop gate): the turn is ending with uncommitted changes that carry a non-English "
+    "name in the machine layer. Whatever wrote them — an edit tool, a shell heredoc, sed — the diff "
+    "is what is measured. Rename before ending the turn, or take one of the exits at the end.\n\n"
+)
+TRUNCATED_NOTE = (
+    "\n\n[diff truncated at {n} lines; the rest was NOT measured — run "
+    "`check-identifier-locale.py --diff -` on the full diff before trusting a clean result]"
+)
+FOOTER = (
+    "\n\nExits: `# locale-ok: <reason>` on the line or the line above; the token or path in "
+    "`.identifier-locale-allow` at the repository root (the only exit for a file name); "
+    "`LOCALE_RITE_MODE=inform` for the whole session. Doctrine: the code-locale skill."
+)
+ELLIPSIS = "\n    … more findings elided; run the check on the diff for the rest."
+
+
+def load_check():
+    """Import the shipped check by path. Its file name has hyphens, so it is not importable by name."""
+    if not CHECK_PATH.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("check_identifier_locale", CHECK_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:
+        return None
+
+
+def run_git(args: list, cwd: str, env=None) -> "tuple[int, str] | None":
+    """(returncode, stdout) or None when git is missing, hangs, or cannot be started."""
+    try:
+        run = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True,
+                             errors="replace", timeout=GIT_TIMEOUT)
+    except (OSError, subprocess.TimeoutExpired, ValueError):
+        return None
+    return run.returncode, run.stdout
+
+
+def is_binary(path: Path) -> bool:
+    try:
+        with open(path, "rb") as fh:
+            return b"\0" in fh.read(BINARY_PROBE_BYTES)
+    except OSError:
+        return True                      # unreadable is skipped like binary: nothing to measure
+
+
+def uncommitted_diff(cwd: str, max_lines: int, env=None) -> "tuple[str, list, bool] | None":
+    """(work tree root, diff lines, truncated) — or None when cwd is not inside a git work tree."""
+    top = run_git(["rev-parse", "--show-toplevel"], cwd, env)
+    if top is None or top[0] != 0 or not top[1].strip():
+        return None
+    root = top[1].strip()
+
+    head = run_git(["rev-parse", "--verify", "-q", "HEAD"], root, env)
+    if head is None:
+        return None
+    if head[0] == 0:
+        base = "HEAD"
+    else:
+        empty = run_git(["hash-object", "-t", "tree", "/dev/null"], root, env)
+        base = empty[1].strip() if empty and empty[0] == 0 and empty[1].strip() else EMPTY_TREE_SHA1
+
+    lines: list = []
+    truncated = False
+
+    def take(text: str) -> bool:
+        """Append diff text; False once the cap is reached (callers stop asking git)."""
+        nonlocal truncated
+        for line in text.splitlines():
+            if len(lines) >= max_lines:
+                truncated = True
+                return False
+            lines.append(line)
+        return True
+
+    tracked = run_git(["diff", base, "--no-color"], root, env)
+    if tracked is None or tracked[0] not in (0, 1):
+        return None
+    if not take(tracked[1]):
+        return root, lines, truncated
+
+    others = run_git(["ls-files", "--others", "--exclude-standard", "-z"], root, env)
+    if others is None or others[0] != 0:
+        return None
+    for rel in others[1].split("\0"):
+        if not rel:
+            continue
+        if is_binary(Path(root) / rel):
+            continue
+        added = run_git(["diff", "--no-index", "--no-color", "/dev/null", rel], root, env)
+        if added is None or added[0] not in (0, 1):
+            continue                     # one unreadable path must not silence the rest
+        if not take(added[1]):
+            break
+    return root, lines, truncated
+
+
+def gating_findings(check, root: str, lines: list) -> list:
+    """The findings the check is sure of, minus vendored paths (diff mode does not filter them)."""
+    allow = check.load_allowlist(Path(root))
+    findings = check.scan_diff(iter(line + "\n" for line in lines), allow, None)
+    return [f for f in findings
+            if not getattr(f, "advisory", False) and not check.is_vendored(Path(f.path))]
+
+
+def capped(head: str, body: str, tail: str, cap: int) -> str:
+    text = head + body + tail
+    if len(text) <= cap:
+        return text
+    room = cap - len(head) - len(tail) - len(ELLIPSIS)
+    return head + body[:max(room, 0)].rstrip() + ELLIPSIS + tail
+
+
+def block_reason(findings: list, truncated: bool) -> str:
+    body = "\n".join(f.render() for f in findings)
+    tail = (TRUNCATED_NOTE.format(n=MAX_DIFF_LINES) if truncated else "") + FOOTER
+    return capped(HEADER, body, tail, REASON_CAP)
+
+
+def remaining_message(findings: list, truncated: bool) -> str:
+    n = len(findings)
+    head = (f"code-locale: the turn is ending with {n} non-English name{'s' if n != 1 else ''} still "
+            "uncommitted (second Stop — not blocking again; rename or waive before committing):\n")
+    # A path finding carries line 0 (there is no line): print the path alone rather than `:0`.
+    body = "\n".join(f"  {f.path}{':' + str(f.line) if f.line else ''}: {f.token}  [{f.tier}]"
+                     for f in findings)
+    tail = TRUNCATED_NOTE.format(n=MAX_DIFF_LINES) if truncated else ""
+    return capped(head, body, tail, SYSTEM_MESSAGE_CAP)
+
+
+def evaluate(payload: dict, check, env=None, max_lines: int = MAX_DIFF_LINES) -> "dict | None":
+    """The whole decision, isolated from stdin and stdout so the selftest can drive it.
+
+    `env` is the process environment the mode is read from and git is run with; the selftest hands
+    its own so that no case mutates os.environ. `max_lines` exists so the truncation path is testable
+    without a 4000-line fixture.
+    """
+    if check is None:
+        return None
+    environment = os.environ if env is None else env
+    if str(environment.get(MODE_VAR, "")).strip().lower() == INFORM:
+        return None
+    event = payload.get("hook_event_name")
+    if event is not None and event not in STOP_EVENTS:
+        return None                      # a wrong matcher must not become a block on another event
+    cwd = payload.get("cwd")
+    if not isinstance(cwd, str) or not cwd or not os.path.isdir(cwd):
+        return None                      # a gate that cannot locate what to measure does not block
+    git_env = None if env is None else dict(env)
+    try:
+        measured = uncommitted_diff(cwd, max_lines, git_env)
+        if measured is None:
+            return None
+        root, lines, truncated = measured
+        if not lines:
+            return None
+        findings = gating_findings(check, root, lines)
+    except Exception:
+        return None                      # a check that crashes must not crash the turn
+    if not findings:
+        return None
+    if payload.get("stop_hook_active"):
+        return {"systemMessage": remaining_message(findings, truncated)}
+    return {"decision": "block", "reason": block_reason(findings, truncated)}
+
+
+# ── Self-test ─────────────────────────────────────────────────────────────
+
+PT_SOURCE = "def buscar_cliente(id_usuario):\n    return id_usuario\n"
+EN_SOURCE = "def find_customer(user_id):\n    return user_id\n"
+
+
+def _fixture_env(tmp: str, **extra) -> dict:
+    """An environment that ignores the machine's git config and never discovers a repo above tmp."""
+    env = dict(os.environ)
+    env.update({"GIT_CONFIG_GLOBAL": os.devnull, "GIT_CONFIG_SYSTEM": os.devnull,
+                "GIT_CEILING_DIRECTORIES": tmp, "GIT_AUTHOR_NAME": "selftest",
+                "GIT_AUTHOR_EMAIL": "selftest@example.invalid", "GIT_COMMITTER_NAME": "selftest",
+                "GIT_COMMITTER_EMAIL": "selftest@example.invalid"})
+    env.pop(MODE_VAR, None)
+    env.update(extra)
+    return env
+
+
+def _git(repo: Path, env: dict, *args) -> None:
+    subprocess.run(["git", "-c", "commit.gpgsign=false", "-c", "core.hooksPath=" + os.devnull, *args],
+                   cwd=repo, env=env, check=True, capture_output=True)
+
+
+def _repo(tmp: Path, env: dict, name: str, commit: bool = True) -> Path:
+    repo = tmp / name
+    (repo / "orders").mkdir(parents=True)
+    (repo / "orders" / "service.py").write_text("def compute_shipping(order_id):\n    return 0\n")
+    _git(repo, env, "init", "-q", "-b", "main")
+    if commit:
+        _git(repo, env, "add", "-A")
+        _git(repo, env, "commit", "-q", "-m", "init")
+    return repo
+
+
+def _payload(cwd, active: bool = False, event: str = "Stop") -> dict:
+    return {"session_id": "selftest", "transcript_path": "/dev/null", "cwd": str(cwd),
+            "hook_event_name": event, "stop_hook_active": active}
+
+
+def selftest() -> int:
+    check = load_check()
+    if check is None:
+        print(f"selftest FAILED: check not found at {CHECK_PATH}")
+        return 1
+    failed = []
+    decisions = 0
+
+    def case(name: str, expect: str, got) -> None:
+        nonlocal decisions
+        decisions += 1
+        kind = "silent" if got is None else "block" if got.get("decision") == "block" else \
+            "message" if set(got) == {"systemMessage"} else "other"
+        ok = kind == expect
+        print(f"  {'OK     ' if ok else 'FAILED '} {name}  ->  {kind}")
+        if not ok:
+            failed.append(name)
+
+    with tempfile.TemporaryDirectory(prefix="locale-stop-gate-") as td:
+        tmp = Path(td)
+        env = _fixture_env(td)
+
+        # ── the heredoc case: an untracked Portuguese file, no write tool involved ──
+        repo = _repo(tmp, env, "heredoc")
+        (repo / "servico_cliente.py").write_text(PT_SOURCE)
+        blocked = evaluate(_payload(repo), check, env)
+        case("untracked portuguese file blocks the stop", "block", blocked)
+        case("second stop (stop_hook_active) reports and does not block", "message",
+             evaluate(_payload(repo, active=True), check, env))
+        case("LOCALE_RITE_MODE=inform is silent", "silent",
+             evaluate(_payload(repo), check, {**env, MODE_VAR: INFORM}))
+        case("SubagentStop payload is evaluated too", "block",
+             evaluate(_payload(repo, event="SubagentStop"), check, env))
+        case("another event name is silent", "silent",
+             evaluate(_payload(repo, event="PostToolUse"), check, env))
+        case("payload without cwd is silent", "silent",
+             evaluate({"hook_event_name": "Stop", "stop_hook_active": False}, check, env))
+        case("cwd in a subdirectory still measures the whole work tree", "block",
+             evaluate(_payload(repo / "orders"), check, env))
+        # FR2: renamed and translated, the turn ends.
+        (repo / "servico_cliente.py").rename(repo / "customer_service.py")
+        (repo / "customer_service.py").write_text(EN_SOURCE)
+        case("renamed and translated, the stop is allowed", "silent",
+             evaluate(_payload(repo), check, env))
+
+        # ── a tracked file edited in place ──
+        repo = _repo(tmp, env, "tracked")
+        service = repo / "orders" / "service.py"
+        service.write_text(service.read_text() + "usuario_count = 1\n")
+        case("tracked file edited with a portuguese identifier blocks", "block",
+             evaluate(_payload(repo), check, env))
+        service.write_text(service.read_text().replace("usuario_count", "user_count"))
+        case("clean edit is silent", "silent", evaluate(_payload(repo), check, env))
+        service.write_text("def compute_shipping(order_id):\n    return 0\n"
+                           "# locale-ok: legal term with no faithful English name\nnota_fiscal_number = 1\n")
+        case("locale-ok waiver on the line above is silent", "silent",
+             evaluate(_payload(repo), check, env))
+        service.unlink()
+        case("deleted tracked file is silent", "silent", evaluate(_payload(repo), check, env))
+
+        # ── what the diff builder deliberately skips ──
+        repo = _repo(tmp, env, "skips")
+        (repo / "relatorio.bin").write_bytes(b"\0\1binary")
+        case("binary untracked file is skipped (declared limit)", "silent",
+             evaluate(_payload(repo), check, env))
+        (repo / "vendor").mkdir()
+        (repo / "vendor" / "servico.py").write_text(PT_SOURCE)
+        case("vendored untracked path is silent", "silent", evaluate(_payload(repo), check, env))
+        (repo / "node_modules").mkdir()
+        (repo / "node_modules" / "pedido.js").write_text("var valorTotal = 1\n")
+        (repo / ".gitignore").write_text("node_modules/\n")
+        case("ignored path never enters the diff", "silent", evaluate(_payload(repo), check, env))
+        (repo / ".identifier-locale-allow").write_text("fatura_id\n")
+        (repo / "orders" / "billing.py").write_text("fatura_id = 1\n")
+        case("token in the repository allowlist is silent", "silent",
+             evaluate(_payload(repo), check, env))
+        (repo / "orders" / "billing.py").write_text("fatura_id = 1\ncobranca_total = 2\n")
+        case("allowlist covers only what it names", "block", evaluate(_payload(repo), check, env))
+
+        # ── a repository with no commit yet, and a truncated diff ──
+        repo = _repo(tmp, env, "unborn", commit=False)
+        (repo / "servico.py").write_text(PT_SOURCE)
+        _git(repo, env, "add", "servico.py")
+        case("repository without a commit measures staged files", "block",
+             evaluate(_payload(repo), check, env))
+        repo = _repo(tmp, env, "long")
+        (repo / "big.py").write_text("".join(f"pedido_{i} = {i}\n" for i in range(600)))
+        long_diff = evaluate(_payload(repo), check, env, max_lines=100)
+        case("diff over the cap still blocks", "block", long_diff)
+        says_so = bool(long_diff) and "truncated" in long_diff.get("reason", "")
+        print(f"  {'OK     ' if says_so else 'FAILED '} truncation is stated in the reason")
+        if not says_so:
+            failed.append("truncation stated")
+
+        # ── outside any git work tree ──
+        outside = tmp / "no-repo"
+        outside.mkdir()
+        (outside / "servico_cliente.py").write_text(PT_SOURCE)
+        case("cwd outside a git work tree is silent", "silent",
+             evaluate(_payload(outside), check, env))
+
+        # ── output shape: the fields the bundle reads, and nothing nested ──
+        shape_ok = (
+            isinstance(blocked, dict) and set(blocked) == {"decision", "reason"}
+            and blocked["decision"] == "block" and isinstance(blocked["reason"], str)
+            and len(blocked["reason"]) <= REASON_CAP
+            and blocked["reason"].startswith("CODE-LOCALE") and blocked["reason"].endswith(FOOTER)
+            and "servico_cliente.py" in blocked["reason"] and "buscar_cliente" in blocked["reason"]
+            and "hookSpecificOutput" not in blocked
+        )
+        print(f"  {'OK     ' if shape_ok else 'FAILED '} block shape is top-level decision/reason within the cap, findings and exits named")
+        if not shape_ok:
+            failed.append("block shape")
+        repo = _repo(tmp, env, "active")
+        (repo / "servico_cliente.py").write_text(PT_SOURCE)
+        active = evaluate(_payload(repo, active=True), check, env)
+        active_ok = (isinstance(active, dict) and set(active) == {"systemMessage"}
+                     and len(active["systemMessage"]) <= SYSTEM_MESSAGE_CAP
+                     and "servico_cliente.py" in active["systemMessage"])
+        print(f"  {'OK     ' if active_ok else 'FAILED '} second-stop shape is systemMessage only, within the cap")
+        if not active_ok:
+            failed.append("second-stop shape")
+
+    # ── the entry point: malformed payloads and the argv contract ──
+    malformed = 0
+    for label, stdin in (("json array", "[]"), ("json string", '"x"'), ("empty stdin", ""),
+                         ("json null", "null"), ("not json", "{oops")):
+        run = subprocess.run([sys.executable, __file__], input=stdin, capture_output=True, text=True)
+        ok = run.returncode == 0 and run.stdout == "" and run.stderr == ""
+        print(f"  {'OK     ' if ok else 'FAILED '} malformed payload is silent, exit 0: {label}")
+        malformed += ok
+        if not ok:
+            failed.append(f"malformed {label}")
+    run = subprocess.run([sys.executable, __file__, "--bogus"], stdin=subprocess.DEVNULL,
+                         capture_output=True, text=True)
+    argv_ok = run.returncode == 2 and "usage:" in run.stderr and run.stdout == ""
+    print(f"  {'OK     ' if argv_ok else 'FAILED '} unknown flag prints usage and exits 2")
+    if not argv_ok:
+        failed.append("unknown flag")
+    run = subprocess.run([sys.executable, __file__, "--selftest", "extra"], stdin=subprocess.DEVNULL,
+                         capture_output=True, text=True)
+    extra_ok = run.returncode == 2 and "usage:" in run.stderr
+    print(f"  {'OK     ' if extra_ok else 'FAILED '} --selftest with an extra argument exits 2")
+    if not extra_ok:
+        failed.append("selftest extra argument")
+
+    print()
+    if failed:
+        print("selftest FAILED: " + "; ".join(failed))
+        return 1
+    print(f"selftest OK: {decisions} decisions in temporary git repositories, 2 output shapes, "
+          f"{malformed} malformed payloads, plus the argv contract")
+    return 0
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    if args == ["--selftest"]:
+        return selftest()
+    if args:
+        # An unknown argument must not fall through to the stdin path: a misspelt flag in a CI step
+        # would then read empty stdin and exit 0 — the silent no-op the selftest mode exists to make
+        # impossible (#115).
+        print(f"usage: {sys.argv[0]} [--selftest]", file=sys.stderr)
+        return 2
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+    result = evaluate(payload, load_check())
+    if result:
+        print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/claude/global/hooks/locale-stop-gate.py
+++ b/claude/global/hooks/locale-stop-gate.py
@@ -42,6 +42,38 @@ WHY `{"decision": "block", "reason": ...}` AT THE TOP LEVEL AND NOTHING NESTED
     top level only — emitting both would document a shape the bundle demonstrably does not read.
     Docs as the second source: code.claude.com/docs/en/hooks (read 2026-09-05).
 
+WHY THE DIFF SHAPE IS PINNED AGAINST THE USER'S GIT CONFIG
+    `scan_diff` reads `--- /dev/null`, `+++ b/<path>` and `+` lines. Three ordinary settings in
+    `~/.gitconfig` change that shape and, measured on git 2.47.3 (review of #138), each one silenced
+    or misreported the gate: `diff.external = true` (difftastic/delta users) hands the diff to the
+    tool and stdout is EMPTY — `git diff HEAD --no-color | wc -l` -> 0, hook silent on a Portuguese
+    edit; `diff.mnemonicPrefix = true` prints `+++ w/shipping.py`, so every finding named a path that
+    does not exist (`w/shipping.py`) and `.identifier-locale-allow` path entries no longer matched;
+    `core.quotePath` (default TRUE) prints `+++ "b/relat\303\263rio.py"` with the quotes, the suffix
+    becomes `.py"`, no language matches and the added lines are never scanned — exactly the
+    `non-ascii` tier the check exists for. A `.gitattributes` `textconv` rewrites the content the
+    same way (`tr a-z A-Z <` upper-cased every identifier). So every git call runs as
+    `git --no-pager -c core.quotePath=false`, and both diffs add `--no-ext-diff --no-textconv
+    --no-color --no-relative --src-prefix=a/ --dst-prefix=b/`; probed with all of those settings on
+    at once (plus `diff.noprefix`, `diff.relative`, `color.ui = always`): the headers come back as
+    `--- a/shipping.py` / `+++ b/shipping.py` and `+++ b/relatório.py`. The selftest carries that
+    gitconfig as a fixture, because its default fixture (`GIT_CONFIG_GLOBAL=/dev/null`) proves the
+    decisions only under a blank config. A path with a double quote or a control character is still
+    quoted by git with `quotePath=false`, and stays a declared limit.
+
+WHY A TRUNCATED DIFF IS NEVER A SILENT PASS
+    The cap (`MAX_DIFF_LINES`) exists so a huge diff cannot push the hook past the harness timeout.
+    The first version attached the truncation note to the reason — and only to the reason: when the
+    cap was eaten by clean or vendored content that sorts BEFORE the Portuguese file (`aaa_generated.py`
+    with 5000 English lines, 5000 lines appended to a tracked file, an unignored `build/gen.py`, 1500
+    empty files under `build/`), the Portuguese file was never measured and the hook emitted nothing
+    (measured, review of #138: rc=0, no output, in all four cases). Now: untracked paths the check
+    calls vendored, and empty files (git prints no `+++` for them anyway), are skipped BEFORE git is
+    called, so they consume neither the cap nor a subprocess; and when the cap was reached and the
+    measured part is clean, the hook still blocks once — the reason says the tail was NOT measured
+    and how to measure it — then, on the Stop that follows (`stop_hook_active`), reports and lets the
+    turn end. "Cannot measure" becomes "does not block" only on a git timeout (see KNOWN LIMIT).
+
 WHY `stop_hook_active` NEVER BLOCKS TWICE
     The harness sets `stop_hook_active: true` on the Stop that follows a block. This hook blocks
     once; on the next Stop it returns only a `systemMessage` naming what is still in Portuguese and
@@ -55,18 +87,24 @@ KNOWN LIMIT — what this hook does NOT see
       both names, so wiring it on `SubagentStop` works without an edit, but nothing wires it there.
     - A Portuguese file MOVED without an edit: rename detection stays at git's default, so it is a
       rename, not an added file, and the path tier does not fire ("legacy enters only if the turn
-      touched it"). A binary file (NUL in its first 8 KiB) is skipped before git is called, so its
-      NAME is not measured either; an untracked EMPTY file gets no `+++` header from git and is not
-      measured (probed: `git diff --no-index /dev/null relatorio.py` on an empty file prints the
-      `diff --git` and `index` lines only).
-    - A diff longer than MAX_DIFF_LINES: the rest is not measured, and the reason SAYS so. A git call
-      that exceeds GIT_TIMEOUT makes the hook silent — the one case where "cannot measure" becomes
-      "does not block", because a gate that cannot measure must not hold the turn forever.
+      touched it"). A binary file (NUL in its first 8 KiB) and an EMPTY file are skipped before git
+      is called, so their NAMES are not measured either (git itself prints no `+++` for an empty
+      file — probed: `git diff --no-index /dev/null relatorio.py` on an empty file prints the
+      `diff --git` and `index` lines only — and no `+` line for a binary).
+    - An untracked path with a double quote, a backslash or a control character in its name: git
+      quotes it even with `core.quotePath=false`, the check sees the quotes, and the file is not
+      measured. Non-ASCII letters (`relatório.py`) ARE measured; see the pinned diff shape above.
+    - A diff longer than MAX_DIFF_LINES: the rest is not measured, and the hook SAYS so — in the
+      reason when it has findings, and as a block of its own when the measured part is clean. A git
+      call that exceeds GIT_TIMEOUT makes the hook silent — the one case where "cannot measure"
+      becomes "does not block", because a gate that cannot measure must not hold the turn forever.
     - Advisory findings (`en-unknown`): the check itself declares them non-gating; this hook runs
       without the English word list and never blocks on a question.
     - Whatever the check itself cannot see (open vocabulary, the escapes its docstring declares).
-    - Only `LOCALE_RITE_MODE=inform` (the same variable the write gate reads, issue #137) silences it
-      for a whole session; `locale-ok:` and `.identifier-locale-allow` are per name and per path.
+    - Only `LOCALE_RITE_MODE=inform` silences it for a whole session; `locale-ok:` and
+      `.identifier-locale-allow` are per name and per path. The variable is the one issue #137 gives
+      the write gate (`locale-rite.py`, same name, same value); until #137 merges, this hook is its
+      only reader — one variable per rite, not per hook.
 
 Wiring (~/.claude/settings.json), beside any Stop hook already there:
 
@@ -109,6 +147,12 @@ REASON_CAP = 2000
 SYSTEM_MESSAGE_CAP = 4000
 # NUL in the first 8 KiB is git's own binary heuristic.
 BINARY_PROBE_BYTES = 8192
+# The diff shape scan_diff reads, pinned against ~/.gitconfig (see the docstring): every git call
+# gets GIT_PIN, every diff gets DIFF_FLAGS. Measured: `diff.external` empties stdout,
+# `diff.mnemonicPrefix` renames `b/` to `w/`, `core.quotePath` (default true) quotes `relatório.py`.
+GIT_PIN = ["--no-pager", "-c", "core.quotePath=false"]
+DIFF_FLAGS = ["--no-ext-diff", "--no-textconv", "--no-color", "--no-relative",
+              "--src-prefix=a/", "--dst-prefix=b/"]
 
 STOP_EVENTS = {"Stop", "SubagentStop"}
 MODE_VAR = "LOCALE_RITE_MODE"
@@ -126,6 +170,22 @@ HEADER = (
 TRUNCATED_NOTE = (
     "\n\n[diff truncated at {n} lines; the rest was NOT measured — run "
     "`check-identifier-locale.py --diff -` on the full diff before trusting a clean result]"
+)
+# The cap was reached and the measured part is clean: an unmeasured tail is not a clean result, so
+# the gate blocks once and says how to measure the rest (then the second Stop reports and lets go).
+UNMEASURED_REASON = (
+    "CODE-LOCALE (stop gate): the uncommitted diff is longer than {n} lines and was measured only up "
+    "to that cap. Nothing non-English was found in the measured part, but the rest was NOT measured, "
+    "and an unmeasured tail is not a clean result. Before ending the turn, run the check on the whole "
+    "diff — `git diff HEAD | python3 {check} --diff -`, plus `git diff --no-index /dev/null <path>` "
+    "for each untracked file — and rename or waive what it reports; then end the turn again (the next "
+    "Stop reports without blocking). If the bulk is generated, commit it or list it in .gitignore so "
+    "the gate measures what the turn wrote."
+)
+UNMEASURED_MESSAGE = (
+    "code-locale: the turn is ending with an uncommitted diff longer than {n} lines; the part past "
+    "the cap was NOT measured (second Stop — not blocking again). Run `python3 {check} --diff -` on "
+    "the full diff before trusting it."
 )
 FOOTER = (
     "\n\nExits: `# locale-ok: <reason>` on the line or the line above; the token or path in "
@@ -151,23 +211,32 @@ def load_check():
 def run_git(args: list, cwd: str, env=None) -> "tuple[int, str] | None":
     """(returncode, stdout) or None when git is missing, hangs, or cannot be started."""
     try:
-        run = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True,
-                             errors="replace", timeout=GIT_TIMEOUT)
+        run = subprocess.run(["git", *GIT_PIN, *args], cwd=cwd, env=env, capture_output=True,
+                             text=True, errors="replace", timeout=GIT_TIMEOUT)
     except (OSError, subprocess.TimeoutExpired, ValueError):
         return None
     return run.returncode, run.stdout
 
 
-def is_binary(path: Path) -> bool:
+def is_measurable(path: Path) -> bool:
+    """False for an empty or binary file — git prints no `+++` for the first and no `+` line for
+    the second, so asking it costs a subprocess and cap lines for nothing measurable."""
     try:
+        if path.stat().st_size == 0:
+            return False
         with open(path, "rb") as fh:
-            return b"\0" in fh.read(BINARY_PROBE_BYTES)
+            return b"\0" not in fh.read(BINARY_PROBE_BYTES)
     except OSError:
-        return True                      # unreadable is skipped like binary: nothing to measure
+        return False                     # unreadable is skipped like binary: nothing to measure
 
 
-def uncommitted_diff(cwd: str, max_lines: int, env=None) -> "tuple[str, list, bool] | None":
-    """(work tree root, diff lines, truncated) — or None when cwd is not inside a git work tree."""
+def uncommitted_diff(cwd: str, max_lines: int, env=None,
+                     vendored=None) -> "tuple[str, list, bool] | None":
+    """(work tree root, diff lines, truncated) — or None when cwd is not inside a git work tree.
+
+    `vendored(Path) -> bool` names the untracked paths that never enter the diff (the check's own
+    vendored rule): filtering them AFTER the scan let an unignored `build/` eat the whole cap.
+    """
     top = run_git(["rev-parse", "--show-toplevel"], cwd, env)
     if top is None or top[0] != 0 or not top[1].strip():
         return None
@@ -195,7 +264,7 @@ def uncommitted_diff(cwd: str, max_lines: int, env=None) -> "tuple[str, list, bo
             lines.append(line)
         return True
 
-    tracked = run_git(["diff", base, "--no-color"], root, env)
+    tracked = run_git(["diff", *DIFF_FLAGS, base], root, env)
     if tracked is None or tracked[0] not in (0, 1):
         return None
     if not take(tracked[1]):
@@ -207,9 +276,11 @@ def uncommitted_diff(cwd: str, max_lines: int, env=None) -> "tuple[str, list, bo
     for rel in others[1].split("\0"):
         if not rel:
             continue
-        if is_binary(Path(root) / rel):
+        if vendored is not None and vendored(Path(rel)):
             continue
-        added = run_git(["diff", "--no-index", "--no-color", "/dev/null", rel], root, env)
+        if not is_measurable(Path(root) / rel):
+            continue
+        added = run_git(["diff", *DIFF_FLAGS, "--no-index", "/dev/null", rel], root, env)
         if added is None or added[0] not in (0, 1):
             continue                     # one unreadable path must not silence the rest
         if not take(added[1]):
@@ -270,7 +341,8 @@ def evaluate(payload: dict, check, env=None, max_lines: int = MAX_DIFF_LINES) ->
         return None                      # a gate that cannot locate what to measure does not block
     git_env = None if env is None else dict(env)
     try:
-        measured = uncommitted_diff(cwd, max_lines, git_env)
+        measured = uncommitted_diff(cwd, max_lines, git_env,
+                                    vendored=lambda rel: check.is_vendored(rel))
         if measured is None:
             return None
         root, lines, truncated = measured
@@ -279,9 +351,16 @@ def evaluate(payload: dict, check, env=None, max_lines: int = MAX_DIFF_LINES) ->
         findings = gating_findings(check, root, lines)
     except Exception:
         return None                      # a check that crashes must not crash the turn
+    active = bool(payload.get("stop_hook_active"))
     if not findings:
-        return None
-    if payload.get("stop_hook_active"):
+        if not truncated:
+            return None
+        # Clean up to the cap is not clean: the tail was not measured, and silence would say it was.
+        fill = {"n": max_lines, "check": str(CHECK_PATH)}
+        if active:
+            return {"systemMessage": UNMEASURED_MESSAGE.format(**fill)[:SYSTEM_MESSAGE_CAP]}
+        return {"decision": "block", "reason": UNMEASURED_REASON.format(**fill)[:REASON_CAP]}
+    if active:
         return {"systemMessage": remaining_message(findings, truncated)}
     return {"decision": "block", "reason": block_reason(findings, truncated)}
 
@@ -418,6 +497,73 @@ def selftest() -> int:
         print(f"  {'OK     ' if says_so else 'FAILED '} truncation is stated in the reason")
         if not says_so:
             failed.append("truncation stated")
+
+        # ── a clean measured part over the cap is not a clean result ──
+        repo = _repo(tmp, env, "clean-ahead")
+        (repo / "aaa_generated.py").write_text("".join(f"value_{i} = {i}\n" for i in range(200)))
+        ahead = evaluate(_payload(repo), check, env, max_lines=100)
+        unmeasured_ok = (isinstance(ahead, dict) and ahead.get("decision") == "block"
+                         and "NOT measured" in ahead.get("reason", "")
+                         and str(CHECK_PATH) in ahead.get("reason", "")
+                         and len(ahead["reason"]) <= REASON_CAP)
+        print(f"  {'OK     ' if unmeasured_ok else 'FAILED '} clean diff over the cap blocks once and says the tail was not measured")
+        if not unmeasured_ok:
+            failed.append("unmeasured tail")
+        case("clean diff over the cap on the second stop reports and does not block", "message",
+             evaluate(_payload(repo, active=True), check, env, max_lines=100))
+        (repo / "servico_cliente.py").write_text(PT_SOURCE)
+        case("clean lines ahead of a portuguese file never make it a silent pass", "block",
+             evaluate(_payload(repo), check, env, max_lines=100))
+        # vendored and empty untracked files consume neither the cap nor a git call
+        repo = _repo(tmp, env, "cap-eaters")
+        (repo / "build").mkdir()
+        (repo / "build" / "gen.py").write_text("".join(f"value_{i} = {i}\n" for i in range(200)))
+        for i in range(60):                      # outside build/, so only the size rule skips them
+            (repo / "orders" / f"empty_{i}.py").touch()
+        (repo / "servico_cliente.py").write_text(PT_SOURCE)
+        eaters = evaluate(_payload(repo), check, env, max_lines=100)
+        case("unignored vendored and empty files do not eat the cap ahead of a portuguese file",
+             "block", eaters)
+        not_truncated = bool(eaters) and "truncated" not in eaters.get("reason", "") \
+            and "servico_cliente.py" in eaters.get("reason", "")
+        print(f"  {'OK     ' if not_truncated else 'FAILED '} the portuguese file is measured with no truncation note (cap untouched)")
+        if not not_truncated:
+            failed.append("cap eaters")
+
+        # ── the user's ~/.gitconfig must not change what is measured ──
+        gitconfig = tmp / "gitconfig"
+        # `diff.noprefix` is deliberately NOT in this fixture: it strips the prefix altogether, which
+        # scan_diff already reads correctly, and it overrides mnemonicPrefix — with it set, dropping
+        # the --src-prefix/--dst-prefix pin would go unnoticed (measured: that mutant stayed green).
+        gitconfig.write_text("[diff]\n\texternal = true\n\tmnemonicPrefix = true\n"
+                             "\trelative = true\n[core]\n\tquotePath = true\n"
+                             "[color]\n\tui = always\n\tdiff = always\n")
+        configured = {**env, "GIT_CONFIG_GLOBAL": str(gitconfig), "GIT_EXTERNAL_DIFF": "true"}
+        repo = _repo(tmp, configured, "configured")
+        service = repo / "orders" / "service.py"
+        service.write_text(service.read_text() + "usuario_count = 1\n")
+        pinned = evaluate(_payload(repo), check, configured)
+        case("diff.external, mnemonicPrefix, relative and color.ui do not silence the gate",
+             "block", pinned)
+        path_ok = bool(pinned) and "\norders/service.py:3: usuario_count" in pinned.get("reason", "")
+        print(f"  {'OK     ' if path_ok else 'FAILED '} the finding names the repository path, not w/ or a bare one")
+        if not path_ok:
+            failed.append("pinned prefix")
+        # non-ASCII names: core.quotePath (default true) would print `"b/relat\303\263rio.py"`
+        (repo / "orders" / "relatório.py").write_text(PT_SOURCE)
+        non_ascii = evaluate(_payload(repo), check, configured)
+        case("untracked file with a non-ASCII name is measured, name and content", "block", non_ascii)
+        named_ok = bool(non_ascii) and "orders/relatório.py: relatório" in non_ascii.get("reason", "") \
+            and "orders/relatório.py:1: buscar_cliente" in non_ascii.get("reason", "")
+        print(f"  {'OK     ' if named_ok else 'FAILED '} the non-ASCII path is reported unquoted, with its identifiers")
+        if not named_ok:
+            failed.append("non-ascii path")
+        service.write_text("def compute_shipping(order_id):\n    return 0\n")
+        _git(repo, configured, "add", "-A")
+        _git(repo, configured, "commit", "-q", "-m", "track")
+        (repo / "orders" / "relatório.py").write_text(EN_SOURCE + "id_pedido = 1\n")
+        case("tracked file with a non-ASCII name edited in place is measured", "block",
+             evaluate(_payload(repo), check, configured))
 
         # ── outside any git work tree ──
         outside = tmp / "no-repo"

--- a/openspec/changes/add-locale-stop-gate/.openspec.yaml
+++ b/openspec/changes/add-locale-stop-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/add-locale-stop-gate/design.md
+++ b/openspec/changes/add-locale-stop-gate/design.md
@@ -97,7 +97,7 @@ Rename detection fica no padrão do `git diff`: um arquivo em português **movid
 como rename, não como `--- /dev/null`, e o tier de caminho não dispara. É a leitura fiel de "legado só
 entra se o turno o tocou"; declarado no docstring.
 
-### D3 — Não rastreados entram um a um por `git diff --no-index /dev/null <path>`; binários pulados
+### D3 — Não rastreados entram um a um por `git diff --no-index /dev/null <path>`; vendored, vazios e binários pulados
 
 `git ls-files --others --exclude-standard` respeita `.gitignore` e `info/exclude` — `node_modules/`
 e `.venv/` ignorados nunca entram. Para cada caminho, `git diff --no-index --no-color /dev/null
@@ -105,12 +105,31 @@ e `.venv/` ignorados nunca entram. Para cada caminho, `git diff --no-index --no-
 medido; rc=1 é "há diferença", não erro). Um arquivo com NUL nos primeiros 8 KiB é binário e é pulado
 antes de chamar o git — o git também não emitiria linha `+` nenhuma, mas o `+++` que emitiria faria o
 tier de caminho medir um `.pdf`; o gate mede código, e um nome de binário fica declarado como limite.
+Pelo mesmo caminho, e antes do git, ficam de fora os não rastreados que o detector chama de vendored e
+os arquivos vazios — o que eles custavam ao teto está em D4.
 
 ### D4 — Um teto de linhas declarado, nunca um corte em silêncio
 
 O harness mata hooks lentos, e um `git diff` de milhares de linhas mais o detector por cima poderia
 passar do tempo. O total de linhas do diff é limitado a `MAX_DIFF_LINES = 4000`; passado o teto, o que
-sobra não é medido e o motivo **diz** isso ("diff truncated at N lines; run the check on the rest").
+sobra não é medido e o hook **diz** isso. Com achado na parte medida, a nota vai no motivo ("diff
+truncated at N lines; run the check on the rest"). **Sem** achado na parte medida, o hook bloqueia
+mesmo assim, uma vez: a revisão do PR mediu que a primeira versão só anexava a nota ao motivo, e
+quando o teto era comido por conteúdo limpo ou vendored que ordena **antes** do arquivo em português
+(`aaa_generated.py` com 5000 linhas em inglês; 5000 linhas anexadas a um rastreado; `build/gen.py`
+não ignorado; 1500 arquivos vazios em `build/`), o arquivo em português nunca era medido e o hook não
+dizia nada — rc=0, sem saída, nos quatro casos. Uma cauda não medida não é um resultado limpo; o
+motivo do bloqueio diz que a parte após o teto não foi medida e como medir (`git diff HEAD | check
+--diff -`, mais os não rastreados), e o Stop seguinte (`stop_hook_active`) só reporta e encerra —
+mesma cadência de D6.
+
+Para o teto medir o que o turno escreveu, e não o que ele gerou: caminhos não rastreados que o
+detector chama de vendored (`is_vendored`), arquivos vazios (o git não emite `+++` para eles) e
+binários são pulados **antes** de chamar o git — não consomem teto nem processo. Medido: 1500 vazios
+em `build/` custavam 1721 ms e engoliam o teto; pulados, 85 ms e o arquivo em português bloqueia sem
+nota de truncamento. O filtro de vendored **depois** do scan (D5) fica como segunda rede para um
+`vendor/` rastreado editado.
+
 Cada chamada ao git tem `timeout=5`; um git que estoura o tempo devolve silêncio, porque um gate que
 não consegue medir não pode segurar o turno para sempre — e esse é o único caso em que "não medir"
 vira "não bloquear", declarado como KNOWN LIMIT.
@@ -143,6 +162,35 @@ Os dois eventos têm o mesmo `stop_hook_active` no bundle. O README wira só `St
 dois para que um wiring em `SubagentStop` funcione sem edição, e ignora qualquer outro evento — um
 matcher errado não pode virar um bloqueio em PostToolUse.
 
+### D10 — A forma do diff é fixada contra o `~/.gitconfig` do usuário
+
+`scan_diff` lê `--- /dev/null`, `+++ b/<path>` e linhas `+`. Três configurações comuns mudam essa
+forma, e a revisão do PR mediu cada uma (git 2.47.3) silenciando ou desviando o gate:
+`diff.external = true` (quem usa difftastic/delta) entrega o diff à ferramenta e o stdout fica
+**vazio** — `git diff HEAD --no-color | wc -l` → 0, hook mudo com `id_pedido` em `shipping.py`;
+`diff.mnemonicPrefix = true` imprime `+++ w/shipping.py`, e todo achado saía sob um caminho que não
+existe (`w/shipping.py`), o que também quebra as entradas de caminho do `.identifier-locale-allow`;
+`core.quotePath` (padrão **true**) imprime `+++ "b/relat\303\263rio.py"` com as aspas, o sufixo vira
+`.py"`, nenhuma linguagem casa e as linhas `+` nunca são lidas — justamente o tier `non-ascii` que o
+detector existe para pegar, no rastreado e no não rastreado. Um `textconv` por `.gitattributes`
+reescreve o conteúdo do mesmo jeito (medido: `tr a-z A-Z <` deixou todo identificador em caixa alta).
+
+Decisão: toda chamada ao git roda como `git --no-pager -c core.quotePath=false`, e os dois diffs levam
+`--no-ext-diff --no-textconv --no-color --no-relative --src-prefix=a/ --dst-prefix=b/`. Probado com
+todas as configurações ligadas de uma vez (mais `diff.noprefix`, `diff.relative`, `color.ui =
+always`, e `GIT_EXTERNAL_DIFF` no ambiente): os cabeçalhos voltam como `--- a/shipping.py` /
+`+++ b/shipping.py` e `+++ b/relatório.py`. A alternativa — desfazer as aspas no detector — é edição
+em `skills/**` e fica anotada para a issue #139 (E.4); fixar a forma aqui resolve os três casos sem
+tocar o detector e é o que qualquer leitor de diff deveria fazer.
+
+O selftest carrega esse gitconfig como fixture (`GIT_CONFIG_GLOBAL` apontando para um arquivo com
+`diff.external`, `diff.mnemonicPrefix`, `diff.relative`, `core.quotePath`, `color.*`), porque a
+fixture padrão (`GIT_CONFIG_GLOBAL=/dev/null`) só provava as decisões sob config em branco.
+`diff.noprefix` fica **fora** da fixture de propósito: ele tira o prefixo (forma que o `scan_diff` já
+lê) e sobrepõe o `mnemonicPrefix` — com ele ligado, o mutante sem `--src-prefix/--dst-prefix` ficou
+verde. Limite declarado: um nome com aspas duplas, barra invertida ou caractere de controle continua
+sendo citado pelo git mesmo com `quotePath=false`, e não é medido.
+
 ### D9 — O selftest cria um repositório git em `tempfile.TemporaryDirectory()`
 
 Cada caso tem o repositório que precisa: um commit inicial com um arquivo limpo, depois o arquivo
@@ -172,6 +220,10 @@ Nenhuma skill do catálogo é editada por esta change, então não há doutrina 
 - **Diff enorme e lento** → teto de 4000 linhas declarado no motivo, `timeout=5` por chamada ao git,
   silêncio quando o git não responde (D4). O tempo em diff vazio e em 500 linhas está medido em
   `tasks.md`.
+- **Teto comido por conteúdo limpo antes do arquivo em português** → bloqueio único dizendo que a
+  cauda não foi medida; vendored e vazios não consomem o teto (D4).
+- **`~/.gitconfig` do usuário muda a forma do diff** → forma fixada por flag em toda chamada; fixture
+  do selftest com as configurações ligadas (D10).
 - **Loop de bloqueio** → uma vez, depois `systemMessage` (D6); a guarda do bundle (cap 8) fica como
   segunda rede.
 - **Nome legítimo de domínio bloqueado** → as três saídas no fim do motivo, sempre dentro do cap

--- a/openspec/changes/add-locale-stop-gate/design.md
+++ b/openspec/changes/add-locale-stop-gate/design.md
@@ -1,0 +1,191 @@
+## Context
+
+Três hooks vivem em `claude/global/hooks/` e nenhum vê o que Bash grava. Lidos em `80ee53c`
+(2026-09-05):
+
+- `locale-rite.py` (285 linhas): o modelo de forma. `evaluate(payload, check)` em 164-182,
+  `selftest()` em 185-259, `main()` em 262-284 com `args == ["--selftest"]` (264), usage + exit 2 para
+  qualquer outro argumento, `isinstance(payload, dict)` como guarda (276). Importa o detector por
+  caminho (`CHECK_PATH = parents[3] / "skills/code-locale/references/check-identifier-locale.py"`,
+  linha 63). Matcher `Write|Edit|MultiEdit|NotebookEdit`; a issue #137 acrescenta o `PreToolUse` que
+  nega.
+- `skills/code-locale/references/check-identifier-locale.py`: `scan_diff(stream, allow, english)` em
+  612-666 lê só linhas `+` de um diff unificado, agrupa por run, e dispara o tier de caminho só quando
+  o cabeçalho anterior foi `--- /dev/null` (633-641). `load_allowlist(start)` em 401-412 sobe pelos
+  pais até achar `.identifier-locale-allow`. `is_vendored(path)` em 393 **não** é chamado por
+  `scan_diff` — o `main()` só o aplica ao modo de caminhos.
+- `.github/workflows/ci.yml:146-147`: step `Locale write-gate hook self-test`; os steps dos irmãos em
+  149-153.
+- `README.md:235-346`: a seção dos hooks — `### Enforcing the rite` em 235, snippet `UserPromptSubmit`
+  em 252-271, `### The grounding rite` em 283, `### The locale rite` em 306 ("third hook" em 308),
+  `PostToolUse` com matcher `Write|Edit` em 314-330 (319), a citação final em 343-346.
+
+O bundle instalado (`readlink -f $(which claude)` → `~/.local/share/claude/versions/2.1.261`, um só
+ELF, `grep -a`) diz o que a doc deixa ambíguo. Trechos, com o nome minificado de cada função:
+
+- Entrada do Stop: `hook_event_name:C("Stop"),stop_hook_active:P(),last_assistant_message:s().optional()`
+  — e `SubagentStop` com o mesmo `stop_hook_active` mais `agent_id`, `agent_transcript_path`.
+- Leitura da resposta (`PMe`): `f=o.decision==="approve"?void 0:X5(r,"reason",o.reason)`,
+  `y=X5(r,"systemMessage",o.systemMessage)`, e o objeto devolvido é
+  `{...o.decision==="block"&&{decision:"block"}, ...y!==void 0&&{systemMessage:y},
+  ...f!==void 0&&{reason:f}, ...x!==void 0&&{hookSpecificOutput:x}}`. Ou seja, `decision`, `reason` e
+  `systemMessage` são lidos do **topo**.
+- O que bloqueia (`eg`): `if("decision"in e&&e.decision==="block")return!0; if("continue"in
+  e&&e.continue===!1)return!0;` e, no `hookSpecificOutput`, só `permissionDecision` deny/ask (que é
+  PreToolUse).
+- `hookSpecificOutput` de Stop (`LU(e,"Stop",r)`): `let o=X5(e,"additionalContext",
+  r.additionalContext);return{hookEventName:t,...o!==void 0&&{additionalContext:o}}` — qualquer outra
+  chave aninhada (um `decision` dentro de `hookSpecificOutput`) é **descartada sem erro**.
+- Caps (`AKr`): `{reason:2000,stopReason:2000,systemMessage:4000,additionalContext:8000,
+  permissionDecisionReason:2000}`.
+- Guarda de loop: `let Od=a.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP??8; if(Od>0&&Pc>Od)` … "A hook blocked
+  the turn from ending ${Pc} consecutive times — overriding and ending turn. For Stop/SubagentStop
+  hooks, check stop_hook_active in the input and return success while it's true."
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Um turno que gravou nome em português na camada de máquina por qualquer caminho — heredoc, `sed`,
+  ferramenta de escrita com o hook em `inform` — não encerra até renomear ou dispensar.
+- O gate mede só o **diff não commitado** (rastreado contra `HEAD`, mais os não rastreados): legado só
+  entra se o turno o tocou.
+- Silêncio, exit 0 e menos de 1 s quando não há nada a medir: fora de git, diff vazio, só achado
+  consultivo, modo `inform`, payload malformado.
+- Nunca um loop: o segundo Stop (`stop_hook_active: true`) não bloqueia; devolve o que sobrou como
+  `systemMessage` e encerra.
+
+**Non-Goals:**
+
+- Bloquear a chamada Bash em si (PreToolUse em `Bash`): parsear heredoc/`sed`/scripts é frágil, e o
+  que importa é o resultado no disco — a issue registra a decisão.
+- Medir repositórios fora do `cwd`, ou o que já foi commitado no mesmo turno (KNOWN LIMIT, no
+  docstring).
+- Achados consultivos (`en-unknown`) no Stop. São uma pergunta ("isso é inglês?"), não um veredito, e
+  o detector já os declara não-bloqueantes; bloquear o encerramento por uma pergunta seria mudar a
+  doutrina do check por dentro de um hook.
+- Tocar `locale-rite.py`, `personal-rules.md` ou `skills/**` — issues #137 e #139, em paralelo.
+
+## Decisions
+
+### D1 — A saída é `{"decision": "block", "reason": …}` no topo; nada aninhado
+
+As duas leituras da doc divergem (topo vs. `hookSpecificOutput`). O bundle decide: `eg` só bloqueia
+por `decision` no topo, `PMe` lê `reason`/`systemMessage` no topo, e `LU` descarta tudo que não seja
+`additionalContext` dentro de `hookSpecificOutput` de Stop. Emitir os dois seria tolerado (a chave
+aninhada é ignorada, não rejeitada), mas emitiria uma forma que o bundle comprovadamente não lê — e
+um leitor futuro copiaria a forma errada. Fica só o topo. O caso de forma do selftest afirma
+`decision == "block"`, `reason` string até 2000, e **ausência** de `hookSpecificOutput`.
+
+Motivo e mensagem respeitam os caps medidos (`reason:2000`, `systemMessage:4000`) truncando aqui,
+para que a cauda cortada seja a nossa (as saídas ficam no fim e são o que não pode sumir) e não a do
+harness.
+
+### D2 — O diff é montado do topo do work tree, contra `HEAD` ou contra a árvore vazia
+
+`git -C <cwd> rev-parse --show-toplevel` decide se há repositório (rc≠0 → silêncio) e de onde medir.
+Medir do topo, não do `cwd`, torna os caminhos do diff relativos à raiz do projeto — o que o tier de
+caminho do detector espera (`project_relative(path, None)`, "the caller already handed a
+project-relative path (diff mode does)") — e coerentes entre `git diff` e `ls-files`.
+
+`git diff HEAD` falha num repositório sem commit (`fatal: ambiguous argument 'HEAD'`, rc=128, medido).
+A base é `HEAD` quando `git rev-parse --verify -q HEAD` responde, senão a árvore vazia
+(`git hash-object -t tree /dev/null` → `4b825dc…`, medido): um repositório recém-criado mede tudo o
+que já foi adicionado ao índice como novo.
+
+Rename detection fica no padrão do `git diff`: um arquivo em português **movido sem edição** aparece
+como rename, não como `--- /dev/null`, e o tier de caminho não dispara. É a leitura fiel de "legado só
+entra se o turno o tocou"; declarado no docstring.
+
+### D3 — Não rastreados entram um a um por `git diff --no-index /dev/null <path>`; binários pulados
+
+`git ls-files --others --exclude-standard` respeita `.gitignore` e `info/exclude` — `node_modules/`
+e `.venv/` ignorados nunca entram. Para cada caminho, `git diff --no-index --no-color /dev/null
+<path>` produz exatamente o cabeçalho que `scan_diff` espera (`--- /dev/null` / `+++ b/<path>`,
+medido; rc=1 é "há diferença", não erro). Um arquivo com NUL nos primeiros 8 KiB é binário e é pulado
+antes de chamar o git — o git também não emitiria linha `+` nenhuma, mas o `+++` que emitiria faria o
+tier de caminho medir um `.pdf`; o gate mede código, e um nome de binário fica declarado como limite.
+
+### D4 — Um teto de linhas declarado, nunca um corte em silêncio
+
+O harness mata hooks lentos, e um `git diff` de milhares de linhas mais o detector por cima poderia
+passar do tempo. O total de linhas do diff é limitado a `MAX_DIFF_LINES = 4000`; passado o teto, o que
+sobra não é medido e o motivo **diz** isso ("diff truncated at N lines; run the check on the rest").
+Cada chamada ao git tem `timeout=5`; um git que estoura o tempo devolve silêncio, porque um gate que
+não consegue medir não pode segurar o turno para sempre — e esse é o único caso em que "não medir"
+vira "não bloquear", declarado como KNOWN LIMIT.
+
+### D5 — Só achados gating bloqueiam; vendored é filtrado depois do scan
+
+`scan_diff` é chamado com `english=None`: sem a lista inglesa não há tier `en-unknown`, o scan fica
+~110 ms mais rápido (`load_english` medido em 109 ms para 369 786 palavras) e o Stop julga só o que o
+detector tem certeza. `scan_diff` não aplica `is_vendored` (só o modo de caminhos aplica); o hook
+filtra os achados cujo `path` é vendored, para que um `vendor/` rastreado editado não segure o turno.
+
+### D6 — `stop_hook_active` verdadeiro nunca bloqueia; devolve `systemMessage`
+
+O bundle tem uma guarda própria (`CLAUDE_CODE_STOP_HOOK_BLOCK_CAP ?? 8`) que sobrescreve um hook que
+bloqueia 8 vezes seguidas. O gate não chega perto: bloqueia uma vez, e no Stop seguinte — o harness
+marca `stop_hook_active: true` — devolve só `{"systemMessage": …}` com o que ainda está em
+português. O segundo turno é a última chance, não um loop: quem leu o motivo e não renomeou decidiu; o
+gate registra e sai. Declarado no docstring e no README.
+
+### D7 — `LOCALE_RITE_MODE=inform` silencia o gate, e é a mesma variável da issue #137
+
+Uma sessão inteira em modo informativo é uma decisão do usuário, e as três saídas que o motivo lista
+são as mesmas do gate de escrita: `# locale-ok: <motivo>` inline (o detector já honra na linha ou na
+anterior), `.identifier-locale-allow` na raiz do repositório (para nomes de arquivo, a única saída) e
+`LOCALE_RITE_MODE=inform`. Um nome de variável por rito, não por hook.
+
+### D8 — Só `Stop` e `SubagentStop` são avaliados; qualquer outro `hook_event_name` é silêncio
+
+Os dois eventos têm o mesmo `stop_hook_active` no bundle. O README wira só `Stop`; o hook aceita os
+dois para que um wiring em `SubagentStop` funcione sem edição, e ignora qualquer outro evento — um
+matcher errado não pode virar um bloqueio em PostToolUse.
+
+### D9 — O selftest cria um repositório git em `tempfile.TemporaryDirectory()`
+
+Cada caso tem o repositório que precisa: um commit inicial com um arquivo limpo, depois o arquivo
+novo em português (não rastreado), a edição do rastreado, a edição limpa, o diretório sem `.git`, o
+mesmo payload com `stop_hook_active: true`, o modo `inform` (passado como parâmetro `env` ao
+`evaluate`, não mutando `os.environ`), o teto de linhas (parâmetro `max_lines`) e os três payloads
+malformados mais o argumento desconhecido pelo entry point real (`subprocess`), como o irmão faz.
+Identidade do git via `-c user.email -c user.name`, para não depender da máquina.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Camada de máquina em inglês; o que é prosa e o que é código; as saídas (`locale-ok:`, allowlist) | `code-locale` | already canonical — o motivo do bloqueio cita as saídas e aponta para a skill, não reescreve a regra |
+| O detector e seu modo `--diff` (linhas adicionadas, tier de caminho só em `--- /dev/null`) | `code-locale` (`references/check-identifier-locale.py`) | already canonical — o hook importa e chama; não duplica o scan |
+| Um check embarcado carrega selftest, declara o que não cobre e é gated pelo CI | `skills-catalog` (*A shipped enforcement script declares what escapes it*) | already canonical — o delta acrescenta um requisito que a cita |
+| O gate de escrita (PreToolUse/PostToolUse) e o modo `inform` | `skills-catalog` (*The code-locale rite is enforced at the moment of the write*) + issue #137 | link — o README descreve o wiring dos dois e a tabela diz qual camada pega o quê |
+| Prova observada pelo caminho real antes de declarar entrega | `verify-before-claiming` | already canonical — citado no grupo de simulação de `tasks.md` |
+| Kit por repositório (pre-commit, step de CI) para outros assistentes e humanos | `code-locale` (issue #139) | link — a tabela do README aponta; nada é implementado aqui |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **Repositório alheio cheio de legado em português segura o turno** → o gate mede só o diff não
+  commitado; linhas não tocadas nunca entram; um rename puro não dispara (D2).
+- **Diff enorme e lento** → teto de 4000 linhas declarado no motivo, `timeout=5` por chamada ao git,
+  silêncio quando o git não responde (D4). O tempo em diff vazio e em 500 linhas está medido em
+  `tasks.md`.
+- **Loop de bloqueio** → uma vez, depois `systemMessage` (D6); a guarda do bundle (cap 8) fica como
+  segunda rede.
+- **Nome legítimo de domínio bloqueado** → as três saídas no fim do motivo, sempre dentro do cap
+  (D1, D7).
+- **O hook não vê o que foi commitado no mesmo turno, nem outro repositório, e vira `SubagentStop`
+  em subagentes** → KNOWN LIMIT no docstring (TR3 da issue); o kit da issue #139 é a camada que
+  sobrevive a isso.
+- **A forma da saída muda numa versão futura do harness** → o docstring grava versão e trecho; o
+  selftest fixa a forma; a doc pinada é a segunda fonte.
+
+## Open Questions
+
+Nenhuma que vire achismo: a forma da saída, o cap, a guarda de loop, o cabeçalho do `--no-index`, o
+comportamento em `HEAD` inexistente e fora de git foram medidos antes de escrever, e estão em
+`tasks.md` com comando e saída. O que **não** foi medido nesta execução é o harness real disparando o
+hook num Stop de sessão — o wiring é configuração pessoal fora do PR; a simulação alimenta o entry
+point real com payloads no formato do schema do bundle (E.3).

--- a/openspec/changes/add-locale-stop-gate/proposal.md
+++ b/openspec/changes/add-locale-stop-gate/proposal.md
@@ -24,7 +24,10 @@ e um `decision: "block"` com `reason` impede o modelo de encerrar o turno. Proba
   e sai 2), payload malformado mudo com exit 0. Num payload de Stop: se `cwd` está num work tree git,
   monta o diff não commitado (`git diff <HEAD|árvore vazia> --no-color` mais, para cada arquivo de
   `git ls-files --others --exclude-standard`, `git diff --no-index --no-color /dev/null <path>`;
-  binários pulados; total de linhas limitado a um N declarado, e o truncamento é dito no motivo);
+  vendored, vazios e binários pulados antes do git; forma do diff fixada contra o `~/.gitconfig` —
+  `core.quotePath=false`, `--no-ext-diff --no-textconv --no-relative`, prefixos `a/`/`b/`; total de
+  linhas limitado a um N declarado, e o truncamento é dito sempre: no motivo quando há achado, e como
+  bloqueio único quando a parte medida está limpa);
   passa o diff ao detector embarcado (`scan_diff`, com o `.identifier-locale-allow` do repositório);
   havendo achado gating e `stop_hook_active` falso e `LOCALE_RITE_MODE != inform` → bloqueia o
   encerramento com os achados e as três saídas; `stop_hook_active` verdadeiro → não bloqueia de novo
@@ -34,8 +37,9 @@ e um `decision: "block"` com `reason` impede o modelo de encerrar o turno. Proba
   `locale-rite`.
 - `README.md`, seção dos hooks: snippet completo do `settings.json` com `UserPromptSubmit`,
   `PreToolUse` e `PostToolUse` (matcher `Write|Edit|MultiEdit|NotebookEdit`, o `PreToolUse` que a
-  issue #137 entrega em paralelo, com `LOCALE_RITE_MODE=inform`) e o bloco `Stop` novo, mais a tabela
-  "qual camada pega o quê".
+  issue #137 entrega em paralelo — comentado no snippet até #137 entrar, porque hoje `locale-rite.py`
+  não tem caminho de `PreToolUse` — com `LOCALE_RITE_MODE=inform`) e o bloco `Stop` novo, mais a
+  tabela "qual camada pega o quê".
 
 ## Capabilities
 

--- a/openspec/changes/add-locale-stop-gate/proposal.md
+++ b/openspec/changes/add-locale-stop-gate/proposal.md
@@ -1,0 +1,63 @@
+# Change: Gate de Stop — medir o diff não commitado do turno, cubra Bash e heredoc
+
+## Why
+
+O rito do code-locale é medido no momento da escrita por `claude/global/hooks/locale-rite.py`, que só
+vê `Write|Edit|MultiEdit|NotebookEdit`. Tudo o que chega ao disco por **Bash** — `cat > x <<'EOF'`,
+`sed -i`, um script — nunca é medido na sessão. Medido ao vivo em 2026-09-05 (issue #138):
+`cat > servico_cliente.py <<'EOF' … def buscar_cliente(id_usuario)` gravou o arquivo e nenhum hook
+disparou. O modo `auto` do harness ainda instrui a editar arquivos por Bash em vez das ferramentas
+dedicadas — o caminho mais usado é o que escapa.
+
+O harness tem o evento certo: **Stop** dispara uma vez por turno, recebe `cwd` e `stop_hook_active`,
+e um `decision: "block"` com `reason` impede o modelo de encerrar o turno. Probado no bundle instalado
+(`claude 2.1.261`), não só na doc: o schema de entrada é
+`hook_event_name:C("Stop"),stop_hook_active:P()`; o leitor da resposta copia `decision:"block"`,
+`reason` e `systemMessage` do **topo** do objeto, e para `Stop` o `hookSpecificOutput` só carrega
+`additionalContext` (`LU(e,"Stop",r)`). O detector já tem o modo certo: `check-identifier-locale.py
+--diff -` lê só linhas adicionadas de um diff unificado.
+
+## What Changes
+
+- `claude/global/hooks/locale-stop-gate.py` (novo), no formato dos hooks irmãos: `evaluate()` pura,
+  `--selftest`, contrato de `argv` explícito (só `--selftest`; qualquer outro argumento imprime usage
+  e sai 2), payload malformado mudo com exit 0. Num payload de Stop: se `cwd` está num work tree git,
+  monta o diff não commitado (`git diff <HEAD|árvore vazia> --no-color` mais, para cada arquivo de
+  `git ls-files --others --exclude-standard`, `git diff --no-index --no-color /dev/null <path>`;
+  binários pulados; total de linhas limitado a um N declarado, e o truncamento é dito no motivo);
+  passa o diff ao detector embarcado (`scan_diff`, com o `.identifier-locale-allow` do repositório);
+  havendo achado gating e `stop_hook_active` falso e `LOCALE_RITE_MODE != inform` → bloqueia o
+  encerramento com os achados e as três saídas; `stop_hook_active` verdadeiro → não bloqueia de novo
+  e devolve o que sobrou como `systemMessage` (o segundo turno é a última chance, não um loop); fora
+  de git, diff vazio, só achado consultivo, ou modo `inform` → silêncio.
+- `.github/workflows/ci.yml`: um step `Locale stop-gate hook self-test`, logo após o step do
+  `locale-rite`.
+- `README.md`, seção dos hooks: snippet completo do `settings.json` com `UserPromptSubmit`,
+  `PreToolUse` e `PostToolUse` (matcher `Write|Edit|MultiEdit|NotebookEdit`, o `PreToolUse` que a
+  issue #137 entrega em paralelo, com `LOCALE_RITE_MODE=inform`) e o bloco `Stop` novo, mais a tabela
+  "qual camada pega o quê".
+
+## Capabilities
+
+### Modified Capabilities
+
+- `skills-catalog`: requisito ADDED *The code-locale rite closes the turn, not only the write*. O
+  requisito existente *The code-locale rite is enforced at the moment of the write*
+  (`openspec/specs/skills-catalog/spec.md:781`) cobre a ferramenta de escrita; este cobre o resultado
+  — o diff não commitado ao fim do turno, independente de como o arquivo foi escrito — com os
+  cenários: heredoc com nome em português bloqueia o encerramento; renomeado, o turno encerra;
+  `stop_hook_active` não bloqueia de novo; fora de git, silêncio; modo `inform`, silêncio.
+
+## Impact
+
+- `claude/global/hooks/locale-stop-gate.py` — arquivo novo; só stdlib + `git`; importa o detector por
+  caminho, como `locale-rite.py` faz.
+- `.github/workflows/ci.yml` — um step de `Validate`.
+- `README.md` — seção dos hooks.
+- Nenhuma skill do catálogo muda: nenhum `SKILL.md` é tocado; `locale-rite.py`, `personal-rules.md` e
+  `skills/**` ficam com as issues #137 e #139, que rodam em paralelo. Quem já tem os hooks wired não
+  precisa mudar nada além de acrescentar o bloco `Stop`.
+
+Fora de escopo, por decisão registrada na issue #138: bloquear a chamada Bash em si (parsear heredoc
+é frágil; o resultado é o que importa), repositórios sem git, e o wiring em `~/.claude/settings.json`
+do mantenedor (configuração pessoal; o snippet vai no README e no resultado da execução).

--- a/openspec/changes/add-locale-stop-gate/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-locale-stop-gate/specs/skills-catalog/spec.md
@@ -1,0 +1,65 @@
+## ADDED Requirements
+
+### Requirement: The code-locale rite closes the turn, not only the write
+
+The catalog SHALL ship an enforcement artifact that measures the locale rule on the **result** of a
+turn — the repository's uncommitted diff — and not only on the tool that wrote it. A write that
+reaches the disk outside the harness's edit tools (a shell heredoc, `sed`, a script) is never seen by
+the write-time artifact, so the rite that covers only the write SHALL NOT be treated as covering the
+turn.
+
+The artifact SHALL run on the harness event that ends a turn, SHALL read the working directory from
+the payload, and, when that directory is inside a git work tree, SHALL build the uncommitted diff —
+tracked files against the current commit, plus every untracked file the repository does not ignore,
+each as an added file — and measure it with the shipped identifier-locale check in its diff mode,
+honouring the repository's allowlist and the check's own exclusions. It SHALL measure only what the
+turn left uncommitted: history and untouched lines never enter.
+
+When the diff carries a gating finding and the payload does not mark the block as already in
+progress, the artifact SHALL prevent the turn from ending, through the field the installed harness
+reads for that event — established against the installed version, never assumed — and its reason
+SHALL list every finding and the legitimate exits (an inline waiver with a reason, the repository
+allowlist, the session-wide informative mode). When the payload marks the block as already in
+progress, the artifact SHALL NOT block again: it SHALL report what remains as a message and let the
+turn end, because the second turn is the last chance and never a loop.
+
+The artifact SHALL be silent — no output, exit zero, under one second — outside a git work tree, on
+an empty diff, on advisory-only findings, in the informative mode, and on a payload it cannot read.
+It SHALL cap the diff it measures at a declared number of lines and SHALL say so in its reason when
+the cap was reached, never truncating in silence. It SHALL carry a self-test exercised by the
+repository's CI and SHALL declare what escapes it: a file committed inside the same turn, a
+repository outside the working directory, and the event's different name inside a subagent.
+
+#### Scenario: A heredoc-written Portuguese file blocks the end of the turn
+
+- **WHEN** a turn wrote `servico_cliente.py` with `def buscar_cliente(id_usuario)` through a shell
+  heredoc, so no write-time hook ran, and the turn ends with the file uncommitted
+- **THEN** the artifact answers with the block decision the installed harness reads for that event,
+  and the reason names the path, the identifiers, and the three exits
+
+#### Scenario: Once renamed, the turn ends
+
+- **WHEN** the same file has been renamed and its identifiers translated (or waived with a stated
+  reason) and the turn ends again
+- **THEN** the artifact produces no output and the turn ends
+
+#### Scenario: An active block is not repeated
+
+- **WHEN** the payload carries `stop_hook_active: true` and the diff still has a gating finding
+- **THEN** the artifact does not block; it emits a message listing what remains and exits zero
+
+#### Scenario: Outside a git work tree the artifact is silent
+
+- **WHEN** the working directory in the payload is not inside a git repository
+- **THEN** the artifact produces no output and exits zero
+
+#### Scenario: The informative mode silences the gate
+
+- **WHEN** the session runs with the informative mode set and the diff has a gating finding
+- **THEN** the artifact produces no output and exits zero, because the mode is the user's to set
+
+#### Scenario: A diff over the declared cap says so
+
+- **WHEN** the uncommitted diff has more lines than the declared cap and a gating finding within it
+- **THEN** the reason states that the diff was truncated at the cap and that the rest was not
+  measured, so the truncation is never silent

--- a/openspec/changes/add-locale-stop-gate/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-locale-stop-gate/specs/skills-catalog/spec.md
@@ -23,12 +23,22 @@ allowlist, the session-wide informative mode). When the payload marks the block 
 progress, the artifact SHALL NOT block again: it SHALL report what remains as a message and let the
 turn end, because the second turn is the last chance and never a loop.
 
+The artifact SHALL build the diff in a shape that does not depend on the user's git configuration:
+no external diff driver or text conversion, unquoted non-ASCII paths, fixed `a/` and `b/` prefixes,
+no colour — so that a setting in `~/.gitconfig` can neither silence the gate nor make it report a
+path that does not exist. Untracked files the check itself calls vendored, and empty or binary
+files, SHALL be skipped before git is asked, so they consume neither the measuring budget nor a
+process each.
+
 The artifact SHALL be silent — no output, exit zero, under one second — outside a git work tree, on
 an empty diff, on advisory-only findings, in the informative mode, and on a payload it cannot read.
-It SHALL cap the diff it measures at a declared number of lines and SHALL say so in its reason when
-the cap was reached, never truncating in silence. It SHALL carry a self-test exercised by the
-repository's CI and SHALL declare what escapes it: a file committed inside the same turn, a
-repository outside the working directory, and the event's different name inside a subagent.
+It SHALL cap the diff it measures at a declared number of lines and SHALL say so when the cap was
+reached, never truncating in silence: in its reason when the measured part has a finding, and as a
+block of its own — once, then a message on the Stop that follows — when the measured part is clean,
+because an unmeasured tail is not a clean result. It SHALL carry a self-test exercised by the
+repository's CI, exercised also under a git configuration that alters the diff's shape, and SHALL
+declare what escapes it: a file committed inside the same turn, a repository outside the working
+directory, and the event's different name inside a subagent.
 
 #### Scenario: A heredoc-written Portuguese file blocks the end of the turn
 
@@ -63,3 +73,18 @@ repository outside the working directory, and the event's different name inside 
 - **WHEN** the uncommitted diff has more lines than the declared cap and a gating finding within it
 - **THEN** the reason states that the diff was truncated at the cap and that the rest was not
   measured, so the truncation is never silent
+
+#### Scenario: A clean measured part over the cap is not a clean result
+
+- **WHEN** the uncommitted diff has more lines than the declared cap and the part within the cap has
+  no gating finding — clean or generated content that sorts ahead of a Portuguese file, for instance
+- **THEN** the artifact still blocks the end of the turn once, its reason says the tail was not
+  measured and how to measure it, and on the Stop that follows it reports as a message and lets the
+  turn end
+
+#### Scenario: The user's git configuration does not change what is measured
+
+- **WHEN** `~/.gitconfig` sets an external diff driver, mnemonic prefixes or the default path quoting,
+  and the turn edited a tracked file or wrote an untracked file whose name carries a non-ASCII letter
+- **THEN** the artifact blocks as it would under a blank configuration, and the reason names the
+  repository-relative path exactly as it is on disk

--- a/openspec/changes/add-locale-stop-gate/tasks.md
+++ b/openspec/changes/add-locale-stop-gate/tasks.md
@@ -152,64 +152,272 @@
         `Write|Edit|MultiEdit|NotebookEdit`: a seção dos hooks é reescrita aqui com o matcher
         completo, por ser o que a issue pede para o snippet; nenhuma outra seção do README é tocada.
       - Um caminho não rastreado com nome em português mas conteúdo vazio (`touch relatorio.py`):
-        `git diff --no-index /dev/null` de um arquivo vazio não emite `+++`; o tier de caminho não
-        dispara. Declarado como limite; não corrigido aqui.
+        `git diff --no-index /dev/null` de um arquivo vazio não emite `+++` (medido: só `diff --git` e
+        `index`, rc=1); o tier de caminho não dispara. Declarado como limite; não corrigido aqui.
 
 ## 2. Hook `locale-stop-gate.py`
 
-- [ ] 2.1 Forma dos irmãos: `evaluate(payload, check, env, max_lines) -> dict | None` pura; `main()`
+- [x] 2.1 Forma dos irmãos: `evaluate(payload, check, env, max_lines) -> dict | None` pura; `main()`
       só faz I/O; `args == ["--selftest"]` roda o selftest, vazio lê stdin, qualquer outro argumento
-      imprime usage em stderr e sai 2; payload que não é objeto JSON → exit 0 sem saída (D1, D9)
-- [ ] 2.2 Diff não commitado do topo do work tree: base `HEAD` ou árvore vazia; `git diff <base>
-      --no-color`; não rastreados por `ls-files --others --exclude-standard` + `diff --no-index
-      /dev/null <path>`; binários pulados; `timeout=5` por chamada; `MAX_DIFF_LINES` declarado e dito
-      no motivo (D2-D4)
-- [ ] 2.3 Decisão: `scan_diff` com o allowlist do topo e `english=None`; achados vendored filtrados;
-      gating + `stop_hook_active` falso + modo ≠ `inform` → `{"decision": "block", "reason": …}` no
-      topo, ≤ 2000; `stop_hook_active` verdadeiro → `{"systemMessage": …}` ≤ 4000; senão `None`
-      (D1, D5-D8)
-- [ ] 2.4 Docstring: por que Stop; a forma da saída com versão e trecho do bundle; KNOWN LIMIT
-      (commit no mesmo turno, repo fora do cwd, `SubagentStop`, rename puro, binário, git lento);
-      wiring; sem atribuição a IA
-- [ ] 2.5 `--selftest` num repositório git em `tempfile`: novo não rastreado em pt → bloqueia;
-      rastreado editado com identificador pt → bloqueia; edição limpa → mudo; cwd fora de git → mudo;
-      `stop_hook_active: true` → sem bloqueio + `systemMessage`; `LOCALE_RITE_MODE=inform` → mudo;
-      renomeado/`locale-ok:` → mudo; teto de linhas dito no motivo; forma da saída; malformados e
-      argumento desconhecido pelo entry point real (D9)
-- [ ] 2.6 Tempo medido neste repositório: diff vazio (< 1 s) e diff de 500 linhas
-- [ ] 2.7 `.github/workflows/ci.yml`: step `Locale stop-gate hook self-test` logo após o step do
-      `locale-rite`
-- [ ] 2.8 `README.md`, seção dos hooks: snippet completo (`UserPromptSubmit`, `PreToolUse`,
-      `PostToolUse` com `Write|Edit|MultiEdit|NotebookEdit` e `LOCALE_RITE_MODE=inform`, `Stop`),
-      parágrafo do gate de Stop, tabela "qual camada pega o quê" (write tools → PreToolUse deny;
-      Bash/heredoc/sed → Stop; outros assistentes e humanos → kit da issue #139)
+      imprime usage em stderr e sai 2; payload que não é objeto JSON → exit 0 sem saída (D1, D9).
+      Commit `a3d56fd`:
+
+      ```
+      python3 claude/global/hooks/locale-stop-gate.py --bogus </dev/null; echo "rc=$?"
+      -> usage: [...]/claude/global/hooks/locale-stop-gate.py [--selftest]
+      -> rc=2
+      for p in '[]' '"x"' '' 'null' '{oops'; do printf '%s' "$p" | python3 claude/global/hooks/locale-stop-gate.py; echo "rc=$? chars=..."; done
+      -> payload=[]    rc=0 chars=0
+      -> payload="x"   rc=0 chars=0
+      -> payload=''    rc=0 chars=0
+      -> payload=null  rc=0 chars=0
+      -> payload={oops rc=0 chars=0
+      ```
+
+- [x] 2.2 Diff não commitado do topo do work tree: `rev-parse --show-toplevel` decide se há repo e de
+      onde medir; base `HEAD` se `rev-parse --verify -q HEAD` responde, senão `hash-object -t tree
+      /dev/null`; `git diff <base> --no-color`; não rastreados por `ls-files --others
+      --exclude-standard -z` + `diff --no-index --no-color /dev/null <path>`; NUL nos primeiros 8 KiB
+      pula o arquivo; `timeout=5` por chamada; `MAX_DIFF_LINES = 4000` e o teto dito no motivo
+      (D2-D4). Commit `a3d56fd`. Provado pelo selftest (2.5): "cwd in a subdirectory still measures
+      the whole work tree", "repository without a commit measures staged files", "binary untracked
+      file is skipped", "ignored path never enters the diff", "diff over the cap still blocks" +
+      "truncation is stated in the reason" — todos `OK`.
+
+- [x] 2.3 Decisão: `scan_diff` com `load_allowlist(<topo>)` e `english=None`; achados `advisory` e
+      `is_vendored` filtrados; gating + `stop_hook_active` falso + modo ≠ `inform` →
+      `{"decision": "block", "reason": …}` no topo, ≤ 2000; `stop_hook_active` verdadeiro →
+      `{"systemMessage": …}` ≤ 4000; senão `None` (D1, D5-D8). Commit `a3d56fd`; `1627bf8` não toca o
+      hook. Forma medida pelo entry point real (S.1):
+
+      ```
+      heredoc pt, stop_hook_active=false -> rc=0 chars=1742 keys=decision,reason
+      mesmo tree, stop_hook_active=true  -> rc=0 chars=371  keys=systemMessage
+      500 linhas pt                       -> rc=0 chars=2084 keys=decision,reason   (reason no cap de 2000; JSON escapa o resto)
+      ```
+
+- [x] 2.4 Docstring: por que Stop; a forma da saída com versão (`2.1.261`) e os trechos do bundle
+      (`eg`, `PMe`, `LU`, `AKr`, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`); KNOWN LIMIT (commit no mesmo
+      turno, repo fora do cwd, `SubagentStop`, rename puro, binário, arquivo vazio, git lento,
+      consultivo); wiring; sem atribuição a IA:
+
+      ```
+      grep -c 'KNOWN LIMIT\|2.1.261\|stop_hook_active' claude/global/hooks/locale-stop-gate.py   -> 12
+      grep -i -c 'co-authored\|generated with\|claude fable\|anthropic' claude/global/hooks/locale-stop-gate.py   -> 0
+      ```
+
+- [x] 2.5 `--selftest` em repositórios git criados em `tempfile` (D9). Commit `a3d56fd`:
+
+      ```
+      python3 claude/global/hooks/locale-stop-gate.py --selftest; echo "rc=$?"
+      ->   OK      untracked portuguese file blocks the stop  ->  block
+      ->   OK      second stop (stop_hook_active) reports and does not block  ->  message
+      ->   OK      LOCALE_RITE_MODE=inform is silent  ->  silent
+      ->   OK      SubagentStop payload is evaluated too  ->  block
+      ->   OK      another event name is silent  ->  silent
+      ->   OK      payload without cwd is silent  ->  silent
+      ->   OK      cwd in a subdirectory still measures the whole work tree  ->  block
+      ->   OK      renamed and translated, the stop is allowed  ->  silent
+      ->   OK      tracked file edited with a portuguese identifier blocks  ->  block
+      ->   OK      clean edit is silent  ->  silent
+      ->   OK      locale-ok waiver on the line above is silent  ->  silent
+      ->   OK      deleted tracked file is silent  ->  silent
+      ->   OK      binary untracked file is skipped (declared limit)  ->  silent
+      ->   OK      vendored untracked path is silent  ->  silent
+      ->   OK      ignored path never enters the diff  ->  silent
+      ->   OK      token in the repository allowlist is silent  ->  silent
+      ->   OK      allowlist covers only what it names  ->  block
+      ->   OK      repository without a commit measures staged files  ->  block
+      ->   OK      diff over the cap still blocks  ->  block
+      ->   OK      truncation is stated in the reason
+      ->   OK      cwd outside a git work tree is silent  ->  silent
+      ->   OK      block shape is top-level decision/reason within the cap, findings and exits named
+      ->   OK      second-stop shape is systemMessage only, within the cap
+      ->   OK      malformed payload is silent, exit 0: json array
+      ->   [...]                       (json string, empty stdin, json null, not json)
+      ->   OK      unknown flag prints usage and exits 2
+      ->   OK      --selftest with an extra argument exits 2
+      -> selftest OK: 20 decisions in temporary git repositories, 2 output shapes, 5 malformed payloads, plus the argv contract
+      -> rc=0
+      ```
+
+      Duas fixtures da primeira rodada não mediam nada e foram corrigidas antes do commit: `valor_{i}`
+      (o caso do teto) — `valor` está em `ENGLISH_COLLISIONS`, o caso saía `silent`; e `boleto_id` (o
+      caso do allowlist) — `boleto` está em `DOMAIN_KEEP`, o caso passava sem ler o allowlist. Viraram
+      `pedido_{i}` e `fatura_id`/`cobranca_total`, e o caso "allowlist covers only what it names"
+      entrou para provar que o allowlist foi lido e não é um passe geral.
+
+      O selftest fica vermelho quando uma decisão regride — cópias com um defeito injetado cada
+      (`scratchpad/negative-138.sh`, `CHECK_PATH` reescrito para o absoluto):
+
+      ```
+      nested-output   (decision/reason dentro de hookSpecificOutput)   -> FAILED block shape + 7 casos "-> other"   rc=1
+      blocks-twice    (ignora stop_hook_active)                          -> FAILED second stop ... -> block          rc=1
+      ignores-inform  (LOCALE_RITE_MODE não lido)                        -> FAILED LOCALE_RITE_MODE=inform is silent rc=1
+      silent-truncation (nota de truncamento removida)                   -> FAILED truncation is stated in the reason rc=1
+      skips-untracked (ls-files ignorado)                                -> FAILED untracked portuguese file blocks + 8  rc=1
+      control (só CHECK_PATH reescrito)                                  -> selftest OK: 20 decisions [...]            rc=0
+      ```
+
+- [x] 2.6 Tempo medido pelo entry point real (`date +%s%N` em volta do `python3`, payload por stdin),
+      commit `a3d56fd`:
+
+      ```
+      repo de rascunho, tree limpa (diff vazio)        -> rc=0 ms=44 chars=0
+      repo de rascunho, cwd fora de git                -> rc=0 ms=41 chars=0
+      repo de rascunho, heredoc pt (bloqueia)          -> rc=0 ms=47 chars=1742
+      repo de rascunho, 500 linhas pt (bloqueia)       -> rc=0 ms=55 chars=2084
+      este repositório (worktree), tree limpa, 3 runs  -> rc=0 ms=67 / 63 / 64 chars=0
+      ```
+
+      Todos abaixo de 1 s (FR4); `load_english` (109 ms medido em E.2) fica de fora por D5.
+
+- [x] 2.7 `.github/workflows/ci.yml`: step `Locale stop-gate hook self-test` logo após o step do
+      `locale-rite`. Commit `44a6597`:
+
+      ```
+      git diff 80ee53c...HEAD -- .github/workflows/ci.yml | grep '^+' | grep -v '^+ *#'
+      -> +      - name: Locale stop-gate hook self-test (the shipped hook is itself gated)
+      -> +        run: python3 claude/global/hooks/locale-stop-gate.py --selftest
+      ```
+
+- [x] 2.8 `README.md`, seção dos hooks (235-410 depois da edição), commit `1627bf8`: snippet completo
+      com `UserPromptSubmit` (backlog-rite, verify-rite), `PreToolUse` e `PostToolUse` com matcher
+      `Write|Edit|MultiEdit|NotebookEdit` e a menção a `LOCALE_RITE_MODE=inform`, `Stop`
+      (locale-stop-gate); parágrafo do gate de Stop com a forma probada no bundle e o
+      `stop_hook_active`; tabela "Which layer catches what":
+
+      ```
+      grep -n '^### \|^| ' README.md | grep -i 'enforcing\|grounding\|locale rite\|What wrote\|Write. /\|Bash —\|another assistant'
+      -> 235:### Enforcing the rite (optional hooks)
+      -> 321:### The grounding rite (anti-achismo)
+      -> 344:### The locale rite, at the write (English machine layer, measured on the tool call)
+      -> 366:### The locale rite, at the end of the turn (the Stop gate)
+      -> 400:| What wrote the name | Layer that catches it | Effect |
+      -> 402:| `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | `locale-rite.py` on `PreToolUse` (#137) | the write is **denied**; nothing reaches the disk |
+      -> 403:| Bash — heredoc, `sed -i`, a script, a generator | `locale-stop-gate.py` on `Stop` | the **turn does not end** until the diff is clean or waived |
+      -> 404:| another assistant (Codex, Cursor, Copilot), or a human commit | the per-repository kit of the [`code-locale`](skills/code-locale/) skill — pre-commit hook and CI step (issue #139) | the **commit or the pull request** fails |
+      ```
+
+      O `PreToolUse` que nega é entregue pela issue #137 em paralelo; o README descreve o wiring e
+      aponta para a issue em vez de descrever a implementação dela (Q.4).
 
 ## 3. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 O artefato foi exercitado pelo caminho real — payloads de Stop no formato do schema do
-      bundle (`session_id`, `transcript_path`, `cwd`, `hook_event_name`, `stop_hook_active`) por
-      stdin do entry point real, contra um repositório de rascunho com um arquivo em português gravado
-      por heredoc, e depois renomeado; stdout, exit e tempos registrados
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado
+- [x] S.1 O artefato foi exercitado pelo caminho real — payloads de Stop no formato do schema do
+      bundle, por stdin do entry point real, contra um repositório de rascunho
+      (`scratchpad/sim-138.sh`, commit `a3d56fd` do hook)
+
+      Payload, construído do schema lido em E.2:
+      `{"session_id":"sim-138","transcript_path":"<S>/transcript.jsonl","cwd":"<repo>","permission_mode":"default","hook_event_name":"Stop","stop_hook_active":false}`.
+      Repositório: `git init -b main`, `shipping.py` limpo commitado. Depois, **exatamente o heredoc
+      da issue**, sem ferramenta de escrita:
+
+      ```
+      cat > servico_cliente.py <<'EOF'
+      def buscar_cliente(id_usuario):
+          return id_usuario
+      EOF
+      payload | python3 claude/global/hooks/locale-stop-gate.py
+      -> rc=0  ms=47  chars=1742  keys=decision,reason
+      -> CODE-LOCALE (stop gate): the turn is ending with uncommitted changes that carry a non-English name in the machine layer. [...]
+      -> servico_cliente.py: servico_cliente  [path-pt-noun: 'servico']
+      -> servico_cliente.py:1: buscar_cliente  [pt-verb: 'buscar']
+      -> [...] id_usuario ×2, Exits: `# locale-ok: <reason>` [...] `.identifier-locale-allow` [...] `LOCALE_RITE_MODE=inform` [...]
+      mesmo tree, "stop_hook_active":true
+      -> rc=0  ms=42  chars=371  keys=systemMessage
+      -> code-locale: the turn is ending with 4 non-English names still uncommitted (second Stop — not blocking again; rename or waive before committing):
+      ->   servico_cliente.py: servico_cliente  [path-pt-noun]
+      ->   servico_cliente.py:1: buscar_cliente  [pt-verb]
+      ->   [...]
+      mv servico_cliente.py customer_service.py; sed -i 's/buscar_cliente/find_customer/; s/id_usuario/user_id/g' customer_service.py
+      -> rc=0  ms=43  chars=0                                     (FR2: renomeado, o turno encerra)
+      sed -i 's/order_id/id_pedido/g' shipping.py                 (rastreado editado por sed)
+      -> rc=0  ms=42  chars=856  keys=decision,reason
+      -> shipping.py:1: id_pedido  [pt-noun: 'pedido']
+      LOCALE_RITE_MODE=inform, com servico_cliente.py de volta   -> rc=0 chars=0
+      cwd fora de git (<S>/nowhere, com servico.py em pt dentro) -> rc=0  ms=41  chars=0
+      tree limpa                                                  -> rc=0  ms=44  chars=0
+      500 linhas pt (lista_pedidos.py)                            -> rc=0  ms=55  chars=2084  keys=decision,reason
+      malformados [] "x" '' null {oops                            -> rc=0 chars=0 ×5
+      --bogus                                                     -> usage: [...] [--selftest]   rc=2
+      este worktree, tree limpa, 3 runs                           -> rc=0 ms=67 / 63 / 64 chars=0
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Artefato | Expectativa | Casos | Resultado |
+      |---|---|---|---|
+      | entry point real (stdin, repo de rascunho) | tinha de bloquear e bloqueou | 3/3 | heredoc pt, rastreado editado por sed, 500 linhas pt |
+      | entry point real (stdin) | tinha de ficar mudo e ficou | 4/4 | renomeado+traduzido, modo inform, fora de git, tree limpa |
+      | entry point real (stdin) | `stop_hook_active` → mensagem sem bloqueio | 1/1 | keys=systemMessage |
+      | entry point real (stdin) | payload malformado mudo, exit 0 | 5/5 | `[]`, `"x"`, vazio, `null`, `{oops` |
+      | entry point real (argv) | argumento desconhecido sai 2 com usage | 1/1 | `--bogus` |
+      | entry point real (tempo) | abaixo de 1 s | 10/10 | 41-75 ms, inclusive neste repositório |
+      | `--selftest` | decisões OK | 20/20 + 2/2 formas + 5/5 malformados + 2/2 argv | rc=0 |
+      | `--selftest` (cópias com defeito injetado) | tinha de ficar vermelho e ficou | 5/5 | nested-output, blocks-twice, ignores-inform, silent-truncation, skips-untracked — rc=1 cada |
+      | `--selftest` (cópia de controle) | tinha de ficar verde e ficou | 1/1 | rc=0 |
+      | escapes conhecidos | ficaram mudos, como declarado | 2/2 | binário em pt pulado; vendored em pt filtrado (ver S.3) |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Três coisas se comportaram diferente do escrito na primeira rodada, nenhuma no hook entregue:
+
+      - Duas fixtures do selftest não mediam nada (`valor_{i}` é colisão com inglês; `boleto` está em
+        `DOMAIN_KEEP`) — o caso do teto saía `silent` e o do allowlist passava sem ler o allowlist.
+        Corrigidas antes de `a3d56fd` (2.5). Lição registrada: um caso que "passa" com o mecanismo
+        desligado não prova o mecanismo; por isso entrou o caso "allowlist covers only what it names".
+      - O passo de rename da simulação usava `git mv -k` num arquivo não rastreado: `-k` engole o erro
+        e sai 0, o `||` nunca rodou, e o caso "renomeado" continuou bloqueando porque o arquivo em
+        português seguia lá. Defeito do script de simulação, trocado por `mv`; rerodado, `chars=0`.
+      - A `systemMessage` do segundo Stop imprimia `servico_cliente.py:0` para o achado de caminho
+        (`PathFinding` carrega `line=0`); passou a imprimir só o caminho. Cosmético, dentro de
+        `a3d56fd`.
+
+      Escapes conhecidos e mantidos de propósito, todos declarados no docstring: um binário com nome em
+      português (`relatorio.bin`) é pulado e o nome não é medido; um arquivo **vazio** não rastreado
+      não recebe `+++` do git e o nome não é medido (probado em E.2/E.4); um arquivo em português
+      movido sem edição é rename para o git e não dispara; um `git` que estoura `timeout=5` deixa o
+      hook mudo. O que a simulação **não** prova: o harness real disparando o hook num Stop de sessão
+      e entregando o `reason` ao modelo — o wiring é configuração pessoal fora do PR e esta execução
+      roda como subagente isolado (E.3); o payload foi construído do schema do bundle, não capturado.
 
 ## 4. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — esta change não toca nenhuma skill; o step
-      de frontmatter roda mesmo assim
-- [ ] Q.2 Conteúdo de skill tocado em inglês — não se aplica; o delta de spec, o docstring, os nomes
-      dos casos e o README em inglês; proposal/design/tasks em português, como as changes da casa
-- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição de skill muda
-- [ ] Q.4 Sem doutrina duplicada: o motivo do bloqueio cita as saídas e aponta para `code-locale`;
-      o README aponta para #137 e #139 em vez de descrever o que eles implementam; tabela de
-      Canonical Home em `design.md`
-- [ ] Q.5 Identificadores em inglês no que a change introduz; detector rodado sobre o hook novo
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: esta change não toca
+      nenhuma skill. O step de frontmatter rodou mesmo assim pelo runner de gates: `PASS frontmatter`;
+      `python3 scripts/validate-skills.py -> skills checked: 35   findings: 0`
+- [x] Q.2 Conteúdo de skill tocado em inglês — **não se aplica** pelo mesmo motivo; o delta de spec, o
+      docstring, os nomes dos casos do selftest, o step de CI e a seção do README estão em inglês, como
+      o catálogo exige; proposal/design/tasks em português, como as changes da casa
+- [x] Q.3 Gatilhos de descrição testáveis — **não se aplica**: nenhuma descrição de skill muda
+- [x] Q.4 Sem doutrina duplicada: o motivo do bloqueio lista as três saídas e aponta para a skill
+      `code-locale` ("Doctrine: the code-locale skill") em vez de reescrever a regra; o README descreve
+      o **wiring** do PreToolUse e aponta para #137, e aponta para #139 na terceira linha da tabela em
+      vez de descrever o kit; tabela de Canonical Home em `design.md`
+- [x] Q.5 Identificadores em inglês no que a change introduz — `evaluate`, `run_git`, `is_binary`,
+      `uncommitted_diff`, `gating_findings`, `capped`, `block_reason`, `remaining_message`,
+      `MAX_DIFF_LINES`, `GIT_TIMEOUT`, `REASON_CAP`, `SYSTEM_MESSAGE_CAP`, `STOP_EVENTS`, `MODE_VAR`;
+      o nome do arquivo vem do glossário da issue (`locale-stop-gate.py`):
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py claude/global/hooks/locale-stop-gate.py
+      -> findings: 0
+      ```
 
 ## 5. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-locale-stop-gate --strict` green
-- [ ] V.2 Descoberta do catálogo intacta: contagem de skills igual antes e depois; sem órfão ou
-      renomeado
-- [ ] V.3 README / docs atualizados: seção dos hooks com o bloco `Stop` e a tabela
+- [x] V.1 `openspec validate add-locale-stop-gate --strict` -> `Change 'add-locale-stop-gate' is valid`;
+      `bash scripts/validate-rite.sh` -> `rite evidence gate: 0 findings` / `spec-rite gate: 0
+      findings` / `Totals: 3 passed, 0 failed (3 items)` / `rite gate OK`
+- [x] V.2 Descoberta do catálogo intacta: `ls -d skills/*/ | wc -l` -> `35` antes e depois (nenhum
+      `skills/**` tocado — `git diff --stat 80ee53c...HEAD` lista 8 arquivos, nenhum sob `skills/`);
+      `python3 scripts/validate-repo-hygiene.py` -> `repo hygiene: 0 findings`;
+      `claude plugin validate . --strict` -> `✔ Validation passed`; `bash generate.sh` deixa a árvore
+      limpa (`PASS tree-clean-after-generate`). `npx skills add . --list` não foi rodado nesta execução
+      (subagente isolado, sem rede garantida); a contagem local e o validador de hygiene, que mede as
+      contagens publicadas, cobrem o que ele mediria.
+- [x] V.3 README / docs atualizados: `README.md:235-410` reescrita com o snippet completo, o parágrafo
+      do gate de Stop e a tabela (2.8); a composição do catálogo não muda
 - [ ] V.4 `openspec archive add-locale-stop-gate --yes` depois que todos os grupos acima estiverem
       `[x]` — PR separado, como o repositório já faz

--- a/openspec/changes/add-locale-stop-gate/tasks.md
+++ b/openspec/changes/add-locale-stop-gate/tasks.md
@@ -37,6 +37,26 @@
         `memory-autopush.sh` (`async: true`); `PostToolUse` com matcher
         `Write|Edit|MultiEdit|NotebookEdit`; nenhum `PreToolUse` para as ferramentas de escrita.
 
+      Relidos em `11c416d` (topo do branch antes da rodada de revisão, 2026-09-05):
+
+      - `claude/global/hooks/locale-stop-gate.py` — `run_git()` 151-158 sem flag de forma;
+        `uncommitted_diff()` 169-217 (`diff <base> --no-color` em 198, `diff --no-index --no-color`
+        em 212; `is_binary` antes do git, vendored só depois do scan); `evaluate()` 253-286 — o
+        `if not findings: return None` em 282 descartava `truncated`; `_fixture_env()` 295-304 com
+        `GIT_CONFIG_GLOBAL=os.devnull` (toda decisão provada só sob config em branco).
+      - `skills/code-locale/references/check-identifier-locale.py:638-643` — `scan_diff` guarda o
+        caminho do `+++` com as aspas que o git imprime; `EXT_LANG.get(Path(path).suffix.lower())`
+        com sufixo `.py"` → `None`, e as linhas `+` não são lidas.
+      - `claude/global/hooks/locale-rite.py` neste branch —
+        `grep -n 'LOCALE_RITE_MODE\|PreToolUse\|permissionDecision'` → nada, rc=1: não há caminho de
+        PreToolUse aqui.
+      - Worktree irmão da issue #137 (`.claude/worktrees/wf_3d89aff2-ea2-1`, `17fc01f`, não mergeado,
+        só leitura) — `locale-rite.py:84,90` `"matcher": "Write|Edit|MultiEdit|NotebookEdit"`; `:135`
+        `MODE_ENV = "LOCALE_RITE_MODE"`; `:306` `"permissionDecision": "deny"`. O wiring que o README
+        descreve bate com o código da #137, lido e não presumido.
+      - `README.md:352-354, 362-363, 402` (em `11c416d`) — afirmavam a negação em PreToolUse como
+        fato presente.
+
 - [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
 
       ```
@@ -117,6 +137,57 @@
       ->    ('servico_cliente.py', 1, 'id_usuario', 'pt-noun', False), ('servico_cliente.py', 2, 'id_usuario', 'pt-noun', False)]
       ```
 
+      Rodada de revisão — o `~/.gitconfig` do usuário e a forma do diff (git 2.47.3; repositório de
+      sondagem `scratchpad/repro138`, `shipping.py` rastreado editado por
+      `sed -i 's/order_id/id_pedido/g'`; hook em `11c416d`, antes da correção):
+
+      ```
+      GIT_CONFIG_GLOBAL=<[diff] external = /bin/true>   git diff HEAD --no-color | wc -l     -> 0
+      mesmo gitconfig, payload de Stop | locale-stop-gate.py                                -> rc=0 chars=0
+      GIT_CONFIG_GLOBAL=/dev/null (controle, mesma árvore)                                  -> rc=0 chars=856 keys=decision,reason
+      GIT_CONFIG_GLOBAL=<[diff] mnemonicPrefix = true>  git diff HEAD --no-color | sed -n 3,4p -> --- c/shipping.py / +++ w/shipping.py
+      mesmo gitconfig, hook                        -> reason: `w/shipping.py:1: id_pedido  [pt-noun: 'pedido']`
+      git diff --no-index --no-color /dev/null 'serviço.py'   (core.quotePath padrão)
+      -> diff --git "a/servi\303\247o.py" "b/servi\303\247o.py"             hook -> rc=0 chars=0
+      git -c core.quotePath=false diff --no-index --no-color /dev/null 'serviço.py'
+      -> diff --git a/serviço.py b/serviço.py
+      rastreado relatório.py editado: git diff HEAD --no-color | sed -n 3,4p
+      -> --- "a/relat\303\263rio.py" / +++ "b/relat\303\263rio.py"           hook -> rc=0 chars=0
+      GIT_CONFIG_GLOBAL=<noprefix + external + mnemonicPrefix + relative + color.ui=always>:
+        git diff HEAD | sed -n 1,4p                                                         -> (vazio)
+        git -c core.quotePath=false diff --no-ext-diff --no-textconv --no-color --src-prefix=a/ --dst-prefix=b/ HEAD | sed -n 1,4p
+        -> diff --git a/shipping.py b/shipping.py / index 0c0b18e..fa663ce 100644 / --- a/shipping.py / +++ b/shipping.py
+      GIT_EXTERNAL_DIFF=true git diff --no-color HEAD | wc -l -> 0;   com --no-ext-diff -> 8
+      .gitattributes `*.py diff=pyx` + -c diff.pyx.command=true: | wc -l -> 0;   com --no-ext-diff -> 8
+      .gitattributes + -c 'diff.pyx.textconv=tr a-z A-Z <'  -> -DEF COMPUTE_SHIPPING(ORDER_ID): / +DEF COMPUTE_SHIPPING(ID_PEDIDO):
+        com --no-textconv                                    -> -def compute_shipping(order_id): / +def compute_shipping(id_pedido):
+      git -c diff.relative=true diff --no-relative --no-color HEAD | wc -l -> 8      (flag aceita no 2.47.3)
+      git -c core.quotePath=false diff --no-index /dev/null 'we"ird.py' | sed -n 4p -> --- /dev/null  (o `+++` segue citado: limite)
+      ```
+
+      O teto (`scratchpad/repro138b`, hook em `11c416d`; `servico_cliente.py` em português em todos os
+      casos, ordenando depois do conteúdo limpo):
+
+      ```
+      controle: só servico_cliente.py                               -> rc=0 ms=43   chars=1742 (bloqueia)
+      A: aaa_generated.py, 5000 linhas `value_i = i`, não rastreado  -> rc=0 ms=121  chars=0
+      B: 5000 linhas anexadas ao shipping.py rastreado               -> rc=0 ms=124  chars=0
+      C: build/gen.py 5000 linhas, não ignorado                      -> rc=0 ms=135  chars=0
+      H: 1500 arquivos vazios em build/                              -> rc=0 ms=1721 chars=0
+      git diff --no-index --no-color /dev/null build/f1.py (vazio)   -> diff --git / new file mode / index 0000000..e69de29   rc=1  (3 linhas, sem +++)
+      detector em memória, scan_diff: 4000 linhas limpas -> 83 ms; 20000 -> 442 ms
+      ```
+
+      O `locale-rite.py` deste branch num payload de PreToolUse, e o que o bundle faz com a resposta:
+
+      ```
+      printf '{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/tmp/servico.py","content":"def buscar_cliente(id_usuario):..."}}' | python3 claude/global/hooks/locale-rite.py
+      -> {"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "CODE-LOCALE: the write that just landed [...]   rc=0
+      grep -a -o -E 'function PKr\(e,t,r\)\{.{80}' $B
+      -> function PKr(e,t,r){if(t.hookEventName!==r){Ik(e,"hookSpecificOutput_event_mismatch",!0);return}swit
+      grep -a -c hookSpecificOutput_event_mismatch $B   -> 2
+      ```
+
       Scaffold da change com o schema do repositório:
 
       ```
@@ -153,7 +224,22 @@
         completo, por ser o que a issue pede para o snippet; nenhuma outra seção do README é tocada.
       - Um caminho não rastreado com nome em português mas conteúdo vazio (`touch relatorio.py`):
         `git diff --no-index /dev/null` de um arquivo vazio não emite `+++` (medido: só `diff --git` e
-        `index`, rc=1); o tier de caminho não dispara. Declarado como limite; não corrigido aqui.
+        `index`, rc=1); o tier de caminho não dispara. Declarado como limite; agora o arquivo vazio é
+        pulado antes do git (não consome teto nem processo), com o mesmo efeito no nome.
+      - O detector guarda as aspas do `+++` (`scan_diff`, 638-643): com `core.quotePath` padrão um
+        caminho não ASCII vira `"b/relat\303\263rio.py"` e o sufixo `.py"` não casa linguagem. O hook
+        contorna com `-c core.quotePath=false`; desfazer as aspas e o octal dentro do detector é
+        edição em `skills/**` — anotado para a issue #139, cujo kit lê diffs de outros produtores.
+      - Um caminho com aspas duplas, barra invertida ou caractere de controle continua citado pelo
+        git mesmo com `quotePath=false` (medido: `'we"ird.py'` → `+++` citado) e não é medido.
+        Declarado no docstring; não corrigido aqui.
+      - Falso positivo do modo `--diff` do detector, observado no próprio hook: rodado contra este
+        worktree com o docstring editado e ainda não commitado, o gate bloqueou por `relatório` e
+        `relatorio` nas linhas 59, 92 e 96 do docstring (`rc=0 chars=1548 keys=decision,reason`) —
+        o run de linhas `+` começa dentro do docstring, não carrega o `"""` de abertura e é lido como
+        código; no arquivo inteiro o mesmo detector devolve `findings: 0`. Mesma família da issue
+        #85; o bloqueio dura enquanto a edição está não commitada. Detector-side (`skills/**`):
+        follow-up, não corrigido aqui.
 
 ## 2. Hook `locale-stop-gate.py`
 
@@ -176,37 +262,71 @@
 
 - [x] 2.2 Diff não commitado do topo do work tree: `rev-parse --show-toplevel` decide se há repo e de
       onde medir; base `HEAD` se `rev-parse --verify -q HEAD` responde, senão `hash-object -t tree
-      /dev/null`; `git diff <base> --no-color`; não rastreados por `ls-files --others
-      --exclude-standard -z` + `diff --no-index --no-color /dev/null <path>`; NUL nos primeiros 8 KiB
-      pula o arquivo; `timeout=5` por chamada; `MAX_DIFF_LINES = 4000` e o teto dito no motivo
-      (D2-D4). Commit `a3d56fd`. Provado pelo selftest (2.5): "cwd in a subdirectory still measures
-      the whole work tree", "repository without a commit measures staged files", "binary untracked
-      file is skipped", "ignored path never enters the diff", "diff over the cap still blocks" +
-      "truncation is stated in the reason" — todos `OK`.
+      /dev/null`; toda chamada como `git --no-pager -c core.quotePath=false`, e os dois diffs com
+      `--no-ext-diff --no-textconv --no-color --no-relative --src-prefix=a/ --dst-prefix=b/`
+      (D10); não rastreados por `ls-files --others --exclude-standard -z` + `diff --no-index
+      /dev/null <path>`, pulando ANTES do git o que o detector chama de vendored, o arquivo vazio e o
+      binário (NUL nos primeiros 8 KiB); `timeout=5` por chamada; `MAX_DIFF_LINES = 4000` e o teto
+      dito sempre (D2-D4). Commits `a3d56fd` e `e8c1f1d`:
+
+      ```
+      grep -n 'GIT_PIN = \|DIFF_FLAGS = \|\*GIT_PIN\|\*DIFF_FLAGS\|vendored(Path(rel))\|st_size == 0' claude/global/hooks/locale-stop-gate.py
+      -> 153:GIT_PIN = ["--no-pager", "-c", "core.quotePath=false"]
+      -> 154:DIFF_FLAGS = ["--no-ext-diff", "--no-textconv", "--no-color", "--no-relative",
+      -> 214:        run = subprocess.run(["git", *GIT_PIN, *args], cwd=cwd, env=env, capture_output=True,
+      -> 225:        if path.stat().st_size == 0:
+      -> 267:    tracked = run_git(["diff", *DIFF_FLAGS, base], root, env)
+      -> 279:        if vendored is not None and vendored(Path(rel)):
+      -> 283:        added = run_git(["diff", *DIFF_FLAGS, "--no-index", "/dev/null", rel], root, env)
+      ```
+
+      Provado pelo selftest (2.5): "cwd in a subdirectory still measures the whole work tree",
+      "repository without a commit measures staged files", "binary untracked file is skipped",
+      "ignored path never enters the diff", "diff over the cap still blocks" + "truncation is stated
+      in the reason", "diff.external, mnemonicPrefix, relative and color.ui do not silence the gate",
+      "untracked file with a non-ASCII name is measured", "tracked file with a non-ASCII name edited
+      in place is measured", "unignored vendored and empty files do not eat the cap" — todos `OK`; e
+      pelo entry point real em S.1 (gitconfig ligado, `GIT_EXTERNAL_DIFF`, `serviço.py`,
+      `relatório.py`).
 
 - [x] 2.3 Decisão: `scan_diff` com `load_allowlist(<topo>)` e `english=None`; achados `advisory` e
       `is_vendored` filtrados; gating + `stop_hook_active` falso + modo ≠ `inform` →
       `{"decision": "block", "reason": …}` no topo, ≤ 2000; `stop_hook_active` verdadeiro →
-      `{"systemMessage": …}` ≤ 4000; senão `None` (D1, D5-D8). Commit `a3d56fd`; `1627bf8` não toca o
-      hook. Forma medida pelo entry point real (S.1):
+      `{"systemMessage": …}` ≤ 4000; sem achado e teto atingido → bloqueio único com
+      `UNMEASURED_REASON` (a cauda NÃO foi medida, como medir) e `UNMEASURED_MESSAGE` no Stop
+      seguinte (D4, revisado); senão `None` (D1, D5-D8). Commits `a3d56fd` e `e8c1f1d`. Forma medida
+      pelo entry point real (S.1):
 
       ```
-      heredoc pt, stop_hook_active=false -> rc=0 chars=1742 keys=decision,reason
-      mesmo tree, stop_hook_active=true  -> rc=0 chars=371  keys=systemMessage
-      500 linhas pt                       -> rc=0 chars=2084 keys=decision,reason   (reason no cap de 2000; JSON escapa o resto)
+      heredoc pt, stop_hook_active=false                 -> rc=0 chars=1742 keys=decision,reason
+      mesmo tree, stop_hook_active=true                  -> rc=0 chars=371  keys=systemMessage
+      500 linhas pt                                       -> rc=0 chars=2084 keys=decision,reason   (reason no cap de 2000; JSON escapa o resto)
+      5000 linhas limpas antes de servico_cliente.py     -> rc=0 chars=770  keys=decision,reason   "the uncommitted diff is longer than 4000 lines [...] NOT measured"
+      mesmo tree, stop_hook_active=true                  -> rc=0 chars=358  keys=systemMessage     "longer than 4000 lines; the part past the cap was NOT measured"
       ```
 
 - [x] 2.4 Docstring: por que Stop; a forma da saída com versão (`2.1.261`) e os trechos do bundle
-      (`eg`, `PMe`, `LU`, `AKr`, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`); KNOWN LIMIT (commit no mesmo
-      turno, repo fora do cwd, `SubagentStop`, rename puro, binário, arquivo vazio, git lento,
-      consultivo); wiring; sem atribuição a IA:
+      (`eg`, `PMe`, `LU`, `AKr`, `CLAUDE_CODE_STOP_HOOK_BLOCK_CAP`); por que a forma do diff é fixada
+      contra o gitconfig (com as medições da revisão); por que o teto nunca passa mudo; KNOWN LIMIT
+      (commit no mesmo turno, repo fora do cwd, `SubagentStop`, rename puro, binário e vazio pulados,
+      nome com aspas/controle, git lento, consultivo); `LOCALE_RITE_MODE` como a variável que a #137
+      dá ao gate de escrita — este hook é o único leitor até ela entrar; wiring; sem atribuição a IA.
+      Commits `a3d56fd` e `e8c1f1d`:
 
       ```
-      grep -c 'KNOWN LIMIT\|2.1.261\|stop_hook_active' claude/global/hooks/locale-stop-gate.py   -> 12
+      grep -n '^WHY \|^KNOWN LIMIT' claude/global/hooks/locale-stop-gate.py
+      -> 10:WHY A STOP HOOK WHEN A WRITE HOOK ALREADY EXISTS
+      -> 19:WHY `{"decision": "block", "reason": ...}` AT THE TOP LEVEL AND NOTHING NESTED
+      -> 45:WHY THE DIFF SHAPE IS PINNED AGAINST THE USER'S GIT CONFIG
+      -> 64:WHY A TRUNCATED DIFF IS NEVER A SILENT PASS
+      -> 77:WHY `stop_hook_active` NEVER BLOCKS TWICE
+      -> 83:KNOWN LIMIT — what this hook does NOT see
+      grep -c 'KNOWN LIMIT\|2.1.261\|stop_hook_active' claude/global/hooks/locale-stop-gate.py   -> 14
       grep -i -c 'co-authored\|generated with\|claude fable\|anthropic' claude/global/hooks/locale-stop-gate.py   -> 0
       ```
 
-- [x] 2.5 `--selftest` em repositórios git criados em `tempfile` (D9). Commit `a3d56fd`:
+- [x] 2.5 `--selftest` em repositórios git criados em `tempfile` (D9), com a fixture de gitconfig
+      de D10. Commits `a3d56fd` e `e8c1f1d`:
 
       ```
       python3 claude/global/hooks/locale-stop-gate.py --selftest; echo "rc=$?"
@@ -230,6 +350,16 @@
       ->   OK      repository without a commit measures staged files  ->  block
       ->   OK      diff over the cap still blocks  ->  block
       ->   OK      truncation is stated in the reason
+      ->   OK      clean diff over the cap blocks once and says the tail was not measured
+      ->   OK      clean diff over the cap on the second stop reports and does not block  ->  message
+      ->   OK      clean lines ahead of a portuguese file never make it a silent pass  ->  block
+      ->   OK      unignored vendored and empty files do not eat the cap ahead of a portuguese file  ->  block
+      ->   OK      the portuguese file is measured with no truncation note (cap untouched)
+      ->   OK      diff.external, mnemonicPrefix, relative and color.ui do not silence the gate  ->  block
+      ->   OK      the finding names the repository path, not w/ or a bare one
+      ->   OK      untracked file with a non-ASCII name is measured, name and content  ->  block
+      ->   OK      the non-ASCII path is reported unquoted, with its identifiers
+      ->   OK      tracked file with a non-ASCII name edited in place is measured  ->  block
       ->   OK      cwd outside a git work tree is silent  ->  silent
       ->   OK      block shape is top-level decision/reason within the cap, findings and exits named
       ->   OK      second-stop shape is systemMessage only, within the cap
@@ -237,9 +367,16 @@
       ->   [...]                       (json string, empty stdin, json null, not json)
       ->   OK      unknown flag prints usage and exits 2
       ->   OK      --selftest with an extra argument exits 2
-      -> selftest OK: 20 decisions in temporary git repositories, 2 output shapes, 5 malformed payloads, plus the argv contract
+      -> selftest OK: 26 decisions in temporary git repositories, 2 output shapes, 5 malformed payloads, plus the argv contract
       -> rc=0
       ```
+
+      Duas fixtures da rodada de revisão também não mediam nada na primeira escrita e foram corrigidas
+      antes de `e8c1f1d`: o repositório da fixture de gitconfig chamava-se `gitconfig`, o mesmo nome
+      do arquivo (`NotADirectoryError`); e os 60 arquivos vazios estavam em `build/`, onde o pulo de
+      vendored os engolia antes do pulo de tamanho — o mutante "vazio não pulado" ficava verde. Foram
+      para `orders/`. `diff.noprefix` saiu da fixture de propósito: sobrepõe o `mnemonicPrefix` e
+      deixava verde o mutante sem `--src-prefix/--dst-prefix` (D10).
 
       Duas fixtures da primeira rodada não mediam nada e foram corrigidas antes do commit: `valor_{i}`
       (o caso do teto) — `valor` está em `ENGLISH_COLLISIONS`, o caso saía `silent`; e `boleto_id` (o
@@ -259,6 +396,19 @@
       control (só CHECK_PATH reescrito)                                  -> selftest OK: 20 decisions [...]            rc=0
       ```
 
+      Mutantes da rodada de revisão (`scratchpad/negative-138b.py`, um fix removido por cópia, hook
+      em `e8c1f1d`):
+
+      ```
+      control                    rc=0 FAILED=0
+      no-ext-diff                rc=1 FAILED=5 :: diff.external, mnemonicPrefix, relative and color.ui do not silence the gate -> silent | the finding names the repository path [...]
+      no-prefix-pin              rc=1 FAILED=1 :: the finding names the repository path, not w/ or a bare one
+      no-quotepath               rc=1 FAILED=2 :: the non-ASCII path is reported unquoted [...] | tracked file with a non-ASCII name edited in place is measured -> silent
+      vendored-after-scan        rc=1 FAILED=1 :: the portuguese file is measured with no truncation note (cap untouched)
+      empty-not-skipped          rc=1 FAILED=1 :: the portuguese file is measured with no truncation note (cap untouched)
+      silent-clean-truncation    rc=1 FAILED=3 :: clean diff over the cap blocks once and says the tail was not measured | [...] second stop [...] -> silent
+      ```
+
 - [x] 2.6 Tempo medido pelo entry point real (`date +%s%N` em volta do `python3`, payload por stdin),
       commit `a3d56fd`:
 
@@ -268,6 +418,20 @@
       repo de rascunho, heredoc pt (bloqueia)          -> rc=0 ms=47 chars=1742
       repo de rascunho, 500 linhas pt (bloqueia)       -> rc=0 ms=55 chars=2084
       este repositório (worktree), tree limpa, 3 runs  -> rc=0 ms=67 / 63 / 64 chars=0
+      ```
+
+      Depois de `e8c1f1d` (`scratchpad/sim138b`, mesmo método):
+
+      ```
+      heredoc pt (bloqueia)                                         -> rc=0 ms=46  chars=1742
+      renomeado+traduzido                                           -> rc=0 ms=42  chars=0
+      gitconfig external+mnemonic+quotePath+color, sed no rastreado -> rc=0 ms=44  chars=856
+      untracked serviço.py                                          -> rc=0 ms=50  chars=1731
+      5000 linhas limpas antes do arquivo pt (bloqueio "not measured") -> rc=0 ms=125 chars=770
+      build/gen.py 5000 linhas não ignorado + arquivo pt            -> rc=0 ms=43  chars=1742   (antes: 135 ms e mudo)
+      1500 arquivos vazios em gen/ + arquivo pt                     -> rc=0 ms=60  chars=1742   (antes, em build/: 1721 ms e mudo)
+      tree limpa / cwd fora de git                                  -> rc=0 ms=42 / 45 chars=0
+      este worktree, 3 runs                                         -> rc=0 ms=60 / 60 / 67
       ```
 
       Todos abaixo de 1 s (FR4); `load_english` (109 ms medido em E.2) fica de fora por D5.
@@ -281,26 +445,45 @@
       -> +        run: python3 claude/global/hooks/locale-stop-gate.py --selftest
       ```
 
-- [x] 2.8 `README.md`, seção dos hooks (235-410 depois da edição), commit `1627bf8`: snippet completo
-      com `UserPromptSubmit` (backlog-rite, verify-rite), `PreToolUse` e `PostToolUse` com matcher
-      `Write|Edit|MultiEdit|NotebookEdit` e a menção a `LOCALE_RITE_MODE=inform`, `Stop`
-      (locale-stop-gate); parágrafo do gate de Stop com a forma probada no bundle e o
-      `stop_hook_active`; tabela "Which layer catches what":
+      `9dd5e83` só muda o comentário do step, para nomear o que o selftest passou a cobrir:
+
+      ```
+      git diff 11c416d...HEAD -- .github/workflows/ci.yml | grep '^[+-] '
+      -> -        # Stop (stop_hook_active) reports without blocking. Needs only python3 and git.
+      -> +        # Stop (stop_hook_active) reports without blocking, a ~/.gitconfig with diff.external or
+      -> +        # mnemonicPrefix does not silence it, a non-ASCII file name is measured, and a diff over the
+      -> +        # cap is never a silent pass. Needs only python3 and git.
+      ```
+
+- [x] 2.8 `README.md`, seção dos hooks (235-425 depois da edição), commits `1627bf8` e `71e9a66`:
+      snippet completo com `UserPromptSubmit` (backlog-rite, verify-rite), `PostToolUse` com matcher
+      `Write|Edit|MultiEdit|NotebookEdit`, o bloco `PreToolUse` **comentado** com a razão (chega com a
+      #137; neste branch `locale-rite.py` responde a um payload de PreToolUse com o envelope de
+      PostToolUse, que o bundle descarta como `hookSpecificOutput_event_mismatch` — E.2), a menção a
+      `LOCALE_RITE_MODE=inform`, `Stop` (locale-stop-gate); parágrafo do gate de escrita dizendo "hoje
+      PostToolUse informa; com a #137 PreToolUse nega"; parágrafo do gate de Stop com a forma probada
+      no bundle, o `stop_hook_active`, a forma fixada contra o `~/.gitconfig` e o teto que bloqueia
+      uma vez quando a parte medida está limpa; tabela "Which layer catches what" com a primeira
+      linha em dois tempos:
 
       ```
       grep -n '^### \|^| ' README.md | grep -i 'enforcing\|grounding\|locale rite\|What wrote\|Write. /\|Bash —\|another assistant'
       -> 235:### Enforcing the rite (optional hooks)
-      -> 321:### The grounding rite (anti-achismo)
-      -> 344:### The locale rite, at the write (English machine layer, measured on the tool call)
-      -> 366:### The locale rite, at the end of the turn (the Stop gate)
-      -> 400:| What wrote the name | Layer that catches it | Effect |
-      -> 402:| `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | `locale-rite.py` on `PreToolUse` (#137) | the write is **denied**; nothing reaches the disk |
-      -> 403:| Bash — heredoc, `sed -i`, a script, a generator | `locale-stop-gate.py` on `Stop` | the **turn does not end** until the diff is clean or waived |
-      -> 404:| another assistant (Codex, Cursor, Copilot), or a human commit | the per-repository kit of the [`code-locale`](skills/code-locale/) skill — pre-commit hook and CI step (issue #139) | the **commit or the pull request** fails |
+      -> 324:### The grounding rite (anti-achismo)
+      -> 347:### The locale rite, at the write (English machine layer, measured on the tool call)
+      -> 372:### The locale rite, at the end of the turn (the Stop gate)
+      -> 415:| What wrote the name | Layer that catches it | Effect |
+      -> 417:| `Write` / `Edit` / `MultiEdit` / `NotebookEdit` | `locale-rite.py` — on `PostToolUse` today; on `PreToolUse` once #137 merges | today the finding is **context** after the write; with #137 the write is **denied** and nothing reaches the disk |
+      -> 418:| Bash — heredoc, `sed -i`, a script, a generator | `locale-stop-gate.py` on `Stop` | the **turn does not end** until the diff is clean or waived |
+      -> 419:| another assistant (Codex, Cursor, Copilot), or a human commit | the per-repository kit of the [`code-locale`](skills/code-locale/) skill — pre-commit hook and CI step (issue #139) | the **commit or the pull request** fails |
+      grep -n 'Arrives with issue #137\|// "PreToolUse"' README.md
+      -> 265:    // Arrives with issue #137 (locale-rite.py learns PreToolUse and LOCALE_RITE_MODE there). Wire
+      -> 268:    // "PreToolUse": [
       ```
 
-      O `PreToolUse` que nega é entregue pela issue #137 em paralelo; o README descreve o wiring e
-      aponta para a issue em vez de descrever a implementação dela (Q.4).
+      O `PreToolUse` que nega é entregue pela issue #137 em paralelo; o README descreve o wiring, diz
+      quando ele passa a valer e aponta para a issue em vez de descrever a implementação dela (Q.4).
+      O matcher e o nome da variável foram conferidos no código da #137 (E.1), não presumidos.
 
 ## 3. Simulation & Field Proof (MANDATORY)
 
@@ -344,6 +527,28 @@
       este worktree, tree limpa, 3 runs                           -> rc=0 ms=67 / 63 / 64 chars=0
       ```
 
+      Rodada de revisão, hook em `e8c1f1d` (`scratchpad/sim138b`, mesmo payload, mesmo método):
+
+      ```
+      heredoc pt                                                  -> rc=0 ms=46 chars=1742 keys=decision,reason  servico_cliente.py: servico_cliente [path-pt-noun] | :1: buscar_cliente [pt-verb] | :1: id_usuario [pt-noun]
+      mesmo tree, stop_hook_active=true                           -> rc=0 ms=43 chars=371  keys=systemMessage
+      mv + sed (renomeado e traduzido)                            -> rc=0 ms=42 chars=0
+      sed -i 's/order_id/id_pedido/g' shipping.py                 -> rc=0 ms=44 chars=856  shipping.py:1: id_pedido  [pt-noun: 'pedido']
+      mesma árvore, GIT_CONFIG_GLOBAL=<external+mnemonicPrefix+relative+quotePath+color.ui=always>
+                                                                  -> rc=0 ms=44 chars=856  shipping.py:1: id_pedido      (antes: chars=0 / w/shipping.py)
+      mesma árvore, + GIT_EXTERNAL_DIFF=true no ambiente          -> rc=0 ms=46 chars=856  shipping.py:1: id_pedido
+      untracked serviço.py com PT_SOURCE                          -> rc=0 ms=50 chars=1731 serviço.py: serviço [path-non-ascii: 'serviço'] | serviço.py:1: buscar_cliente   (antes: chars=0)
+      rastreado relatório.py editado com id_pedido                -> rc=0 ms=50 chars=862  relatório.py:1: id_pedido  [pt-noun: 'pedido']            (antes: chars=0)
+      5000 linhas limpas não rastreadas antes de servico_cliente.py -> rc=0 ms=125 chars=770 keys=decision,reason  "the uncommitted diff is longer than 4000 lines [...] NOT measured"   (antes: chars=0)
+      mesmo tree, stop_hook_active=true                           -> rc=0 ms=128 chars=358 keys=systemMessage  "longer than 4000 lines; the part past the cap was NOT measured"
+      5000 linhas anexadas ao shipping.py rastreado + arquivo pt  -> rc=0 ms=128 chars=770  (bloqueio "not measured"; antes: chars=0)
+      build/gen.py 5000 linhas não ignorado + arquivo pt          -> rc=0 ms=43  chars=1742 servico_cliente.py [...]   (vendored pulado antes do git; antes: chars=0)
+      1500 arquivos vazios em gen/ (não vendored) + arquivo pt    -> rc=0 ms=60  chars=1742 servico_cliente.py [...]   (vazios pulados; antes, em build/: 1721 ms e chars=0)
+      5000 linhas limpas e nada em pt                             -> rc=0 ms=146 chars=770  (bloqueio único "not measured"; depois systemMessage)
+      tree limpa / cwd fora de git                                -> rc=0 ms=42 / 45 chars=0
+      este worktree com o docstring do hook editado e não commitado, 3 runs -> rc=0 ms=60 / 60 / 67 chars=1548  relatório [non-ascii] ×2, relatorio [pt-noun] — o falso positivo de E.4 (S.3)
+      ```
+
 - [x] S.2 Matriz de casos medida, em contagens
 
       | Artefato | Expectativa | Casos | Resultado |
@@ -351,13 +556,19 @@
       | entry point real (stdin, repo de rascunho) | tinha de bloquear e bloqueou | 3/3 | heredoc pt, rastreado editado por sed, 500 linhas pt |
       | entry point real (stdin) | tinha de ficar mudo e ficou | 4/4 | renomeado+traduzido, modo inform, fora de git, tree limpa |
       | entry point real (stdin) | `stop_hook_active` → mensagem sem bloqueio | 1/1 | keys=systemMessage |
+      | entry point real (stdin), rodada de revisão | os cinco achados da revisão reproduzidos no hook de `11c416d` | 5/5 | diff.external mudo; mnemonicPrefix → `w/`; quotePath esconde `serviço.py`/`relatório.py`; teto mudo em A/B/C/H; README afirmava PreToolUse presente |
+      | entry point real (stdin), hook em `e8c1f1d` | tinha de bloquear e bloqueou | 9/9 | gitconfig ligado, `GIT_EXTERNAL_DIFF`, `serviço.py`, `relatório.py`, 5000 limpas + pt (×2), `build/` + pt, 1500 vazios + pt, 5000 limpas sem pt |
+      | entry point real (stdin), hook em `e8c1f1d` | `stop_hook_active` no teto limpo → mensagem sem bloqueio | 2/2 | keys=systemMessage, "NOT measured" |
+      | entry point real (stdin), hook em `e8c1f1d` | tinha de ficar mudo e ficou | 3/3 | renomeado+traduzido, tree limpa, fora de git |
       | entry point real (stdin) | payload malformado mudo, exit 0 | 5/5 | `[]`, `"x"`, vazio, `null`, `{oops` |
       | entry point real (argv) | argumento desconhecido sai 2 com usage | 1/1 | `--bogus` |
       | entry point real (tempo) | abaixo de 1 s | 10/10 | 41-75 ms, inclusive neste repositório |
-      | `--selftest` | decisões OK | 20/20 + 2/2 formas + 5/5 malformados + 2/2 argv | rc=0 |
-      | `--selftest` (cópias com defeito injetado) | tinha de ficar vermelho e ficou | 5/5 | nested-output, blocks-twice, ignores-inform, silent-truncation, skips-untracked — rc=1 cada |
-      | `--selftest` (cópia de controle) | tinha de ficar verde e ficou | 1/1 | rc=0 |
+      | `--selftest` | decisões OK | 26/26 + 2/2 formas + 6/6 asserções de conteúdo + 5/5 malformados + 2/2 argv | rc=0 (`selftest OK: 26 decisions [...]`) |
+      | `--selftest` (cópias com defeito injetado, 1ª rodada) | tinha de ficar vermelho e ficou | 5/5 | nested-output, blocks-twice, ignores-inform, silent-truncation, skips-untracked — rc=1 cada |
+      | `--selftest` (cópias com defeito injetado, revisão) | tinha de ficar vermelho e ficou | 6/6 | no-ext-diff, no-prefix-pin, no-quotepath, vendored-after-scan, empty-not-skipped, silent-clean-truncation — rc=1 cada |
+      | `--selftest` (cópia de controle) | tinha de ficar verde e ficou | 2/2 | rc=0 nas duas rodadas |
       | escapes conhecidos | ficaram mudos, como declarado | 2/2 | binário em pt pulado; vendored em pt filtrado (ver S.3) |
+      | escape observado e não corrigido aqui | detector lê run `+` iniciado dentro de docstring como código | 1/1 | o próprio hook, editado e não commitado, bloqueia por `relatório` no docstring (E.4, S.3) |
 
 - [x] S.3 O que escapou ou se comportou diferente do esperado
 
@@ -373,6 +584,35 @@
       - A `systemMessage` do segundo Stop imprimia `servico_cliente.py:0` para o achado de caminho
         (`PathFinding` carrega `line=0`); passou a imprimir só o caminho. Cosmético, dentro de
         `a3d56fd`.
+
+      Rodada de revisão — cinco achados, todos reproduzidos antes de tocar o código (E.2) e nenhum
+      disputado:
+
+      - `diff.external` no `~/.gitconfig` deixava o hook mudo; `diff.mnemonicPrefix` reportava
+        `w/shipping.py`; `core.quotePath` (padrão) escondia `serviço.py` e `relatório.py` atrás das
+        aspas — nome e conteúdo não medidos. Causa comum: o diff era montado na forma que o config do
+        usuário quisesse. Corrigido fixando a forma por flag em toda chamada (D10); a fixture padrão do
+        selftest (`GIT_CONFIG_GLOBAL=/dev/null`) provava as decisões só sob config em branco, e agora
+        há uma fixture com as opções ligadas.
+      - O teto passava mudo quando conteúdo limpo/vendored/vazio ordenava antes do arquivo em
+        português (A/B/C/H em E.2): a nota de truncamento só existia colada a um motivo, e
+        `if not findings: return None` descartava `truncated`. Corrigido em dois pontos (D4): vendored
+        e vazios pulados antes do git; sem achado e teto atingido → bloqueio único dizendo que a cauda
+        não foi medida, `systemMessage` no Stop seguinte.
+      - O README afirmava a negação em PreToolUse como fato presente, e neste branch `locale-rite.py`
+        não tem esse caminho (E.1/E.2). Corrigido no texto: bloco comentado no snippet, parágrafo e
+        tabela em dois tempos, docstring reconciliado (linha do `LOCALE_RITE_MODE`).
+
+      Duas fixtures da revisão precisaram de segunda escrita (2.5): nome do repositório colidindo com o
+      arquivo de gitconfig, e vazios dentro de `build/` (engolidos pelo pulo de vendored antes de
+      testar o pulo de tamanho). O critério continua o mesmo da primeira rodada: um caso que passa com
+      o mecanismo desligado não prova o mecanismo — por isso cada fix novo tem um mutante vermelho.
+
+      Escape novo, observado e **não** corrigido aqui: com o docstring do hook editado e não commitado,
+      o gate rodado contra este worktree bloqueia por `relatório`/`relatorio` (linhas 59, 92 e 96 do
+      docstring) — o run de linhas `+` começa dentro do docstring e o detector o lê como código; no
+      arquivo inteiro devolve `findings: 0`. É limite do modo `--diff` do detector (família da #85),
+      dura enquanto a edição está não commitada, e é `skills/**` — anotado em E.4.
 
       Escapes conhecidos e mantidos de propósito, todos declarados no docstring: um binário com nome em
       português (`relatorio.bin`) é pulado e o nome não é medido; um arquivo **vazio** não rastreado
@@ -397,11 +637,12 @@
       vez de descrever o kit; tabela de Canonical Home em `design.md`
 - [x] Q.5 Identificadores em inglês no que a change introduz — `evaluate`, `run_git`, `is_binary`,
       `uncommitted_diff`, `gating_findings`, `capped`, `block_reason`, `remaining_message`,
-      `MAX_DIFF_LINES`, `GIT_TIMEOUT`, `REASON_CAP`, `SYSTEM_MESSAGE_CAP`, `STOP_EVENTS`, `MODE_VAR`;
+      `MAX_DIFF_LINES`, `GIT_TIMEOUT`, `REASON_CAP`, `SYSTEM_MESSAGE_CAP`, `STOP_EVENTS`, `MODE_VAR`,
+      e da revisão `GIT_PIN`, `DIFF_FLAGS`, `is_measurable`, `UNMEASURED_REASON`, `UNMEASURED_MESSAGE`;
       o nome do arquivo vem do glossário da issue (`locale-stop-gate.py`):
 
       ```
-      python3 skills/code-locale/references/check-identifier-locale.py claude/global/hooks/locale-stop-gate.py
+      python3 skills/code-locale/references/check-identifier-locale.py claude/global/hooks/locale-stop-gate.py   (em e8c1f1d)
       -> findings: 0
       ```
 
@@ -409,15 +650,25 @@
 
 - [x] V.1 `openspec validate add-locale-stop-gate --strict` -> `Change 'add-locale-stop-gate' is valid`;
       `bash scripts/validate-rite.sh` -> `rite evidence gate: 0 findings` / `spec-rite gate: 0
-      findings` / `Totals: 3 passed, 0 failed (3 items)` / `rite gate OK`
+      findings` / `Totals: 3 passed, 0 failed (3 items)` / `rite gate OK`. Rerodados depois da rodada
+      de revisão (`71e9a66` + este tasks.md): `Change 'add-locale-stop-gate' is valid`; `Totals: 3
+      passed, 0 failed (3 items)` / `rite gate OK`; runner dos gates (`scratchpad/gates.sh`, os steps
+      de Validate do `ci.yml`) só `PASS` — `locale-detector`, `locale-rite`, `backlog-rite-selftest`,
+      `verify-rite-selftest`, `scan-secrets`, `hygiene`, `rite`, `rite-evidence-selftest`,
+      `spec-rite-selftest`, `smoke: 17/17`, `plugin-validate`, `openspec-strict add-locale-stop-gate`;
+      `GITHUB_EVENT_PATH=<body com "Spec-rite: add-locale-stop-gate"> python3 scripts/validate-skill-version.py`
+      -> `skill-version gate: 0 findings (base origin/master, 0 skill(s) changed, 0 with content changes)`
+      rc=0
 - [x] V.2 Descoberta do catálogo intacta: `ls -d skills/*/ | wc -l` -> `35` antes e depois (nenhum
-      `skills/**` tocado — `git diff --stat 80ee53c...HEAD` lista 8 arquivos, nenhum sob `skills/`);
+      `skills/**` tocado — `git diff --stat 80ee53c...HEAD` lista 8 arquivos, nenhum sob `skills/`;
+      depois da revisão: `git diff --name-only 80ee53c...HEAD | grep -c '^skills/'` -> `0`);
       `python3 scripts/validate-repo-hygiene.py` -> `repo hygiene: 0 findings`;
       `claude plugin validate . --strict` -> `✔ Validation passed`; `bash generate.sh` deixa a árvore
       limpa (`PASS tree-clean-after-generate`). `npx skills add . --list` não foi rodado nesta execução
       (subagente isolado, sem rede garantida); a contagem local e o validador de hygiene, que mede as
       contagens publicadas, cobrem o que ele mediria.
-- [x] V.3 README / docs atualizados: `README.md:235-410` reescrita com o snippet completo, o parágrafo
-      do gate de Stop e a tabela (2.8); a composição do catálogo não muda
+- [x] V.3 README / docs atualizados: `README.md:235-425` reescrita com o snippet completo (bloco
+      `PreToolUse` comentado até a #137), o parágrafo do gate de Stop com a forma fixada e o teto, e a
+      tabela em dois tempos (2.8, `71e9a66`); a composição do catálogo não muda
 - [ ] V.4 `openspec archive add-locale-stop-gate --yes` depois que todos os grupos acima estiverem
       `[x]` — PR separado, como o repositório já faz

--- a/openspec/changes/add-locale-stop-gate/tasks.md
+++ b/openspec/changes/add-locale-stop-gate/tasks.md
@@ -1,0 +1,215 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `80ee53c` (`docs(openspec): arquiva as changes add-skill-version-gate e
+      define-cross-skill-references`), topo de `master` em 2026-09-05:
+
+      - `claude/global/hooks/locale-rite.py` — 285 linhas; `CHECK_PATH` em 63 (import do detector por
+        caminho, `parents[3]`); `evaluate()` em 164-182; `selftest()` em 185-259 com a lista
+        `(nome, deve_reportar, payload)`, a asserção de forma e o caso de argv por `subprocess`;
+        `main()` em 262-284 com `args == ["--selftest"]` (264) e `isinstance(payload, dict)` (276).
+      - `claude/global/hooks/backlog-rite.py`, `claude/global/hooks/verify-rite.py` — o mesmo
+        contrato de argv e de payload malformado (#115).
+      - `skills/code-locale/references/check-identifier-locale.py` — `scan_diff()` em 612-666 (tier
+        de caminho só após `--- /dev/null`, 633-641; linhas `+` agrupadas em run); `load_allowlist()`
+        em 401-412; `is_vendored()` em 393 e `VENDOR_PARTS` em 386-389; `project_relative()` em
+        473-486 ("root=None means the caller already handed a project-relative path (diff mode
+        does)"); `advisory_for()` em 499-516 (`english is None` → sem tier `en-unknown`);
+        `Finding.render()` em 252-267 e `PathFinding` em 269-296; `main()` em 828-880 — só o modo
+        de caminhos aplica `is_vendored`.
+      - `.github/workflows/ci.yml` — step `Locale write-gate hook self-test` em 146-147; os steps dos
+        hooks irmãos em 149-153.
+      - `README.md` — seção dos hooks em 235-346: `### Enforcing the rite (optional hook)` (235),
+        snippet `UserPromptSubmit` (252-271), `### The grounding rite` (283), `### The locale rite`
+        (306; "third hook" em 308), snippet `PostToolUse` com `"matcher": "Write|Edit"` (314-330,
+        319), citação final (343-346).
+      - `openspec/specs/skills-catalog/spec.md:781-822` — *The code-locale rite is enforced at the
+        moment of the write*, o requisito que este delta complementa (ADDED, não MODIFIED);
+        `:700` — *A shipped enforcement script declares what escapes it*.
+      - `openspec/changes/archive/2026-09-04-add-hook-selftests/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md` — modelo de estilo da casa.
+      - `openspec/schemas/skills-rite/templates/{proposal,design,tasks,spec}.md`,
+        `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py`,
+        `scripts/validate-spec-rite.py:1-80`, `scripts/validate-skill-version.py:1-60` — o que os
+        gates exigem.
+      - `~/.claude/settings.json` (fora do repositório, lido para o snippet): `Stop` já carrega
+        `memory-autopush.sh` (`async: true`); `PostToolUse` com matcher
+        `Write|Edit|MultiEdit|NotebookEdit`; nenhum `PreToolUse` para as ferramentas de escrita.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      ```
+      python3 --version                -> Python 3.14.5
+      openspec --version               -> 1.6.0
+      openspec list                    -> No active changes found.
+      claude --version                 -> 2.1.261 (Claude Code)
+      readlink -f $(which claude)      -> /home/diegops/.local/share/claude/versions/2.1.261
+      file $(readlink -f $(which claude)) | cut -c1-80 -> ELF 64-bit LSB executable, x86-64  (grep precisa de -a)
+      ```
+
+      A forma da saída de Stop, no bundle (TR1). Entrada:
+
+      ```
+      grep -a -o -E '.{200}stop_hook_active.{300}' $B | head -5
+      -> xoe=m(()=>be().and(c({hook_event_name:C("Stop"),stop_hook_active:P(),last_assistant_message:s().optional()[...]
+      -> zoe=m(()=>be().and(c({hook_event_name:C("SubagentStop"),stop_hook_active:P(),agent_id:s(),agent_transcript_path:s(),agent_type:s()[...]
+      -> [...]hook_event_name:"Stop",stop_hook_active:o,last_assistant_message:B,...q}[...]
+      grep -a -c stop_hook_active $B   -> 5
+      ```
+
+      Leitura da resposta (o que decide "topo vs. aninhado"):
+
+      ```
+      grep -a -o -E 'function eg\(e\)\{.{500}' $B
+      -> function eg(e){if("decision"in e&&e.decision==="block")return!0;if("continue"in e&&e.continue===!1)return!0;
+      -> let t="hookSpecificOutput"in e?e.hookSpecificOutput:void 0;return t!==void 0&&typeof t==="object"&&t!==null
+      -> &&"permissionDecision"in t&&(t.permissionDecision==="deny"||t.permissionDecision==="ask")}
+      grep -a -o -E '.{900}return\{answer:\{\.\.\.o\.continue' $B
+      -> [...]f=o.decision==="approve"?void 0:X5(r,"reason",o.reason),y=X5(r,"systemMessage",o.systemMessage),
+      -> E=o.hookSpecificOutput,[...]x=v?PKr(r,E,t):void 0;return{answer:{...o.continue===!1&&{continue:!1},
+      -> [...]...o.decision==="block"&&{decision:"block"},...y!==void 0&&{systemMessage:y},...f!==void 0&&{reason:f},
+      -> ...x!==void 0&&{hookSpecificOutput:x}}
+      grep -a -o -E 'function LU\(e,t,r\)\{.{400}' $B
+      -> function LU(e,t,r){let o=X5(e,"additionalContext",r.additionalContext);return{hookEventName:t,...o!==void 0&&{additionalContext:o}}}
+      -> [...]case"SubagentStop":return LU(e,"SubagentStop",t)   (e "Stop" pelo mesmo LU)
+      grep -a -o -E '(AKr|RKr)=\{[^}]{0,400}\}' $B
+      -> AKr={reason:2000,stopReason:2000,systemMessage:4000,additionalContext:8000,permissionDecisionReason:2000}
+      -> RKr={reason:20,stopReason:20,systemMessage:20,additionalContext:j8t,permissionDecisionReason:20}
+      grep -a -o -E '.{200}CLAUDE_CODE_STOP_HOOK_BLOCK_CAP.{100}' $B
+      -> [...]let Od=a.CLAUDE_CODE_STOP_HOOK_BLOCK_CAP??8;if(Od>0&&Pc>Od)return[...]
+      -> [...]For Stop/SubagentStop hooks, check stop_hook_active in the input and return success while it's true.
+      ```
+
+      Conclusão medida, não lida: `decision`/`reason`/`systemMessage` são lidos do **topo**;
+      `hookSpecificOutput` de Stop só devolve `additionalContext` (qualquer outra chave aninhada é
+      descartada sem erro); `reason` cabe em 2000 e `systemMessage` em 4000; a guarda de loop do
+      bundle é 8 bloqueios seguidos. A doc (code.claude.com/docs/en/hooks) é a segunda fonte.
+
+      Git, no repositório de sondagem (`scratchpad/probe138`, `probe-unborn.sh`):
+
+      ```
+      git ls-files --others --exclude-standard            -> sub/blob.bin  sub/servico_cliente.py
+      git diff --no-index --no-color /dev/null sub/servico_cliente.py; echo rc=$?
+      -> diff --git a/sub/servico_cliente.py b/sub/servico_cliente.py
+      -> new file mode 100644
+      -> --- /dev/null
+      -> +++ b/sub/servico_cliente.py
+      -> @@ -0,0 +1,2 @@
+      -> +def buscar_cliente(id_usuario):
+      -> rc=1                          (1 = "há diferença", não erro)
+      git diff --no-index --no-color /dev/null sub/blob.bin
+      -> Binary files /dev/null and b/sub/blob.bin differ     (sem +++, sem linhas +)
+      git diff HEAD --no-color   (repo sem commit)
+      -> fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.   rc=128
+      git rev-parse --verify -q HEAD                       -> rc=1
+      git hash-object -t tree /dev/null                    -> 4b825dc642cb6eb9a060e54bf8d69288fbee4904
+      git diff 4b825dc… --no-color | head -5               -> diff --git a/a.py b/a.py / new file mode / --- /dev/null / +++ b/a.py
+      cd /tmp && git rev-parse --show-toplevel             -> fatal: not a git repository [...]   rc=128
+      ```
+
+      O detector, importado por caminho (`importlib`), em `80ee53c`:
+
+      ```
+      import: 12.7 ms | load_english: 109.1 ms, 369786 words
+      scan_diff(<diff de servico_cliente.py>, set(), None)
+      -> 4 [('servico_cliente.py', 0, 'servico_cliente', 'path-pt-noun', False), ('servico_cliente.py', 1, 'buscar_cliente', 'pt-verb', False),
+      ->    ('servico_cliente.py', 1, 'id_usuario', 'pt-noun', False), ('servico_cliente.py', 2, 'id_usuario', 'pt-noun', False)]
+      ```
+
+      Scaffold da change com o schema do repositório:
+
+      ```
+      openspec new change add-locale-stop-gate --schema skills-rite
+      -> Created change 'add-locale-stop-gate' at openspec/changes/add-locale-stop-gate/
+      -> Schema: skills-rite
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      Dois itens. (1) O harness real disparando o hook num Stop de sessão: o wiring em
+      `~/.claude/settings.json` é configuração pessoal fora do PR, e esta execução roda como subagente
+      isolado — o payload que a simulação alimenta é construído à mão a partir do schema lido no
+      bundle (`hook_event_name`, `stop_hook_active`, `cwd`, `session_id`, `transcript_path`), não
+      capturado de uma sessão. (2) Que o bundle **entregue** o `reason` ao modelo como texto do turno
+      seguinte: o grep mostra que `reason` é lido e guardado (`X5(r,"reason",o.reason)`) e que
+      `decision:"block"` impede o encerramento (`eg`), mas o caminho do `reason` até a mensagem que o
+      modelo lê não foi seguido no minificado além disso; a doc pinada diz que ele é "fed back to the
+      model". Nenhum dos dois vira afirmação no docstring além do que o grep mostra.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a issue #138 pediu. Notados pelo caminho e **não** feitos, ficam como
+      follow-up:
+
+      - `scan_diff` não aplica `is_vendored` (`check-identifier-locale.py:612-666` vs. o `main()` em
+        828-880 que só o aplica ao modo de caminhos): o hook filtra os achados depois do scan (D5);
+        mover o filtro para dentro do detector é edição em `skills/**`, fora do que este item possui.
+      - `git diff --no-index` de um binário emite `+++`-menos "Binary files … differ": o hook pula
+        binários antes de chamar o git (NUL nos primeiros 8 KiB), e um nome de binário em português
+        fica declarado como limite, não medido.
+      - O README ainda diz `"matcher": "Write|Edit"` (319) enquanto o `settings.json` real usa
+        `Write|Edit|MultiEdit|NotebookEdit`: a seção dos hooks é reescrita aqui com o matcher
+        completo, por ser o que a issue pede para o snippet; nenhuma outra seção do README é tocada.
+      - Um caminho não rastreado com nome em português mas conteúdo vazio (`touch relatorio.py`):
+        `git diff --no-index /dev/null` de um arquivo vazio não emite `+++`; o tier de caminho não
+        dispara. Declarado como limite; não corrigido aqui.
+
+## 2. Hook `locale-stop-gate.py`
+
+- [ ] 2.1 Forma dos irmãos: `evaluate(payload, check, env, max_lines) -> dict | None` pura; `main()`
+      só faz I/O; `args == ["--selftest"]` roda o selftest, vazio lê stdin, qualquer outro argumento
+      imprime usage em stderr e sai 2; payload que não é objeto JSON → exit 0 sem saída (D1, D9)
+- [ ] 2.2 Diff não commitado do topo do work tree: base `HEAD` ou árvore vazia; `git diff <base>
+      --no-color`; não rastreados por `ls-files --others --exclude-standard` + `diff --no-index
+      /dev/null <path>`; binários pulados; `timeout=5` por chamada; `MAX_DIFF_LINES` declarado e dito
+      no motivo (D2-D4)
+- [ ] 2.3 Decisão: `scan_diff` com o allowlist do topo e `english=None`; achados vendored filtrados;
+      gating + `stop_hook_active` falso + modo ≠ `inform` → `{"decision": "block", "reason": …}` no
+      topo, ≤ 2000; `stop_hook_active` verdadeiro → `{"systemMessage": …}` ≤ 4000; senão `None`
+      (D1, D5-D8)
+- [ ] 2.4 Docstring: por que Stop; a forma da saída com versão e trecho do bundle; KNOWN LIMIT
+      (commit no mesmo turno, repo fora do cwd, `SubagentStop`, rename puro, binário, git lento);
+      wiring; sem atribuição a IA
+- [ ] 2.5 `--selftest` num repositório git em `tempfile`: novo não rastreado em pt → bloqueia;
+      rastreado editado com identificador pt → bloqueia; edição limpa → mudo; cwd fora de git → mudo;
+      `stop_hook_active: true` → sem bloqueio + `systemMessage`; `LOCALE_RITE_MODE=inform` → mudo;
+      renomeado/`locale-ok:` → mudo; teto de linhas dito no motivo; forma da saída; malformados e
+      argumento desconhecido pelo entry point real (D9)
+- [ ] 2.6 Tempo medido neste repositório: diff vazio (< 1 s) e diff de 500 linhas
+- [ ] 2.7 `.github/workflows/ci.yml`: step `Locale stop-gate hook self-test` logo após o step do
+      `locale-rite`
+- [ ] 2.8 `README.md`, seção dos hooks: snippet completo (`UserPromptSubmit`, `PreToolUse`,
+      `PostToolUse` com `Write|Edit|MultiEdit|NotebookEdit` e `LOCALE_RITE_MODE=inform`, `Stop`),
+      parágrafo do gate de Stop, tabela "qual camada pega o quê" (write tools → PreToolUse deny;
+      Bash/heredoc/sed → Stop; outros assistentes e humanos → kit da issue #139)
+
+## 3. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 O artefato foi exercitado pelo caminho real — payloads de Stop no formato do schema do
+      bundle (`session_id`, `transcript_path`, `cwd`, `hook_event_name`, `stop_hook_active`) por
+      stdin do entry point real, contra um repositório de rascunho com um arquivo em português gravado
+      por heredoc, e depois renomeado; stdout, exit e tempos registrados
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+## 4. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — esta change não toca nenhuma skill; o step
+      de frontmatter roda mesmo assim
+- [ ] Q.2 Conteúdo de skill tocado em inglês — não se aplica; o delta de spec, o docstring, os nomes
+      dos casos e o README em inglês; proposal/design/tasks em português, como as changes da casa
+- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição de skill muda
+- [ ] Q.4 Sem doutrina duplicada: o motivo do bloqueio cita as saídas e aponta para `code-locale`;
+      o README aponta para #137 e #139 em vez de descrever o que eles implementam; tabela de
+      Canonical Home em `design.md`
+- [ ] Q.5 Identificadores em inglês no que a change introduz; detector rodado sobre o hook novo
+
+## 5. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-locale-stop-gate --strict` green
+- [ ] V.2 Descoberta do catálogo intacta: contagem de skills igual antes e depois; sem órfão ou
+      renomeado
+- [ ] V.3 README / docs atualizados: seção dos hooks com o bloco `Stop` e a tabela
+- [ ] V.4 `openspec archive add-locale-stop-gate --yes` depois que todos os grupos acima estiverem
+      `[x]` — PR separado, como o repositório já faz


### PR DESCRIPTION
Closes #138

O rito do code-locale é medido no momento da escrita por `claude/global/hooks/locale-rite.py`, que só vê `Write|Edit|MultiEdit|NotebookEdit`. Tudo o que chega ao disco por **Bash** — `cat > x <<'EOF'`, `sed -i`, um script — nunca é medido na sessão. Medido ao vivo em 2026-09-05: `cat > servico_cliente.py <<'EOF' … def buscar_cliente(id_usuario)` gravou o arquivo e nenhum hook disparou. O modo `auto` do harness instrui a editar arquivos exatamente assim — o caminho mais usado é o que escapa.

## O que muda

- **`claude/global/hooks/locale-stop-gate.py` (novo)**, hook de `Stop`: acha o work tree do `cwd`, monta o diff não commitado (rastreado contra `HEAD` ou a árvore vazia, mais cada não rastreado como arquivo novo) e roda o detector da skill `code-locale` em modo `--diff`. Achado gating → `{"decision": "block", "reason": …}` no **topo** (forma probada no bundle `2.1.261`, não só na doc: `eg`, `PMe`, `LU`, caps `reason:2000`/`systemMessage:4000`); `stop_hook_active: true` → só `systemMessage`, nunca bloqueia duas vezes; fora de git, diff vazio, só consultivo, `LOCALE_RITE_MODE=inform` ou payload malformado → silêncio, exit 0, menos de 1 s.
- **Forma do diff fixada contra o `~/.gitconfig`** (achado da revisão): toda chamada roda `git --no-pager -c core.quotePath=false`, e os diffs levam `--no-ext-diff --no-textconv --no-color --no-relative --src-prefix=a/ --dst-prefix=b/`. Medido em git 2.47.3: `diff.external` deixava o hook mudo, `diff.mnemonicPrefix` reportava `w/shipping.py`, e o `core.quotePath` padrão escondia `relatório.py` atrás de `"relat\303\263rio.py"` — nome e conteúdo sem medir.
- **Teto nunca mudo** (achado da revisão): vendored, vazios e binários não rastreados são pulados antes do git (não comem teto nem processo); com o teto atingido e a parte medida limpa, o hook bloqueia uma vez dizendo que a cauda **não** foi medida e como medir, e no Stop seguinte só reporta. Antes, 5000 linhas limpas ordenando antes de `servico_cliente.py` passavam em silêncio.
- `.github/workflows/ci.yml`: step `Locale stop-gate hook self-test` logo após o do `locale-rite`.
- `README.md`, seção dos hooks: snippet completo (`UserPromptSubmit`, `PostToolUse`, `Stop`; o bloco `PreToolUse` fica **comentado** até a #137 entrar — neste branch `locale-rite.py` não tem esse caminho, e um payload de PreToolUse recebe o envelope de PostToolUse que o bundle descarta como `hookSpecificOutput_event_mismatch`), parágrafo do gate de Stop e a tabela "qual camada pega o quê".

Nenhuma skill do catálogo é tocada; `locale-rite.py`, `personal-rules.md` e `skills/**` ficam com as issues #137 e #139. **Ordem de merge:** este PR e o da #137 são independentes; se a #137 entrar primeiro, basta descomentar o bloco `PreToolUse` do README (matcher e variável conferidos no código da #137: `Write|Edit|MultiEdit|NotebookEdit`, `LOCALE_RITE_MODE`).

## Simulação — saída observada

Payload de Stop no formato do schema do bundle, por stdin do entry point real, contra repositórios de rascunho:

| Expectativa | Casos | Resultado |
|---|---|---|
| Tinha de bloquear e bloqueou | **12/12** | heredoc pt (chars=1742, 46 ms); rastreado editado por `sed` (856); mesma árvore com gitconfig `diff.external`+`mnemonicPrefix`+`quotePath`+`color.ui=always` (856, `shipping.py:1: id_pedido`); `GIT_EXTERNAL_DIFF=true` (856); `serviço.py` não rastreado (1731, `path-non-ascii`); `relatório.py` rastreado (862); 5000 linhas limpas antes do arquivo pt ×2 (770, "NOT measured"); `build/gen.py` 5000 linhas + pt (1742, 43 ms); 1500 vazios + pt (1742, 60 ms); 5000 limpas sem pt (770); 500 linhas pt (2084) |
| Tinha de ficar mudo e ficou | **5/5** | renomeado+traduzido, modo `inform`, fora de git, tree limpa (42-45 ms), rename puro |
| `stop_hook_active` → mensagem sem bloqueio | **3/3** | keys=systemMessage (371 / 358 chars) |
| Achados da revisão reproduzidos antes do fix | **5/5** | diff.external mudo; `w/shipping.py`; quotePath (`serviço.py`, `relatório.py` mudos); teto mudo em A/B/C/H (H: 1721 ms); README com PreToolUse como fato |
| `--selftest` | **26/26** decisões + 2 formas + 6 asserções | rc=0 |
| Mutantes (um fix removido cada) | **11/11** vermelhos, 2/2 controles verdes | nested-output, blocks-twice, ignores-inform, silent-truncation, skips-untracked, no-ext-diff, no-prefix-pin, no-quotepath, vendored-after-scan, empty-not-skipped, silent-clean-truncation |

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Wrappers em sincronia | `bash generate.sh && git status --porcelain` | limpo |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| Self-test do validador | `python3 scripts/selftest-validate-skills.py` | `20/20 defect classes detected` |
| Detector de locale | `check-identifier-locale.py --selftest` | OK |
| Hook de escrita | `locale-rite.py --selftest` | `12 decisions` OK |
| Hook de Stop | `locale-stop-gate.py --selftest` | `26 decisions, 2 output shapes, 5 malformed payloads, plus the argv contract` |
| Locale do próprio hook | `check-identifier-locale.py claude/global/hooks/locale-stop-gate.py` | `findings: 0` |
| Hooks irmãos | `backlog-rite.py` / `verify-rite.py --selftest` | OK |
| Segredos | `scan-secrets.py` (+`--selftest`) | `no credentials found`; 12/12 |
| Higiene do repo | `validate-repo-hygiene.py` (+`--selftest`) | `0 findings`; 4/4 |
| Rito | `bash scripts/validate-rite.sh` | `Totals: 3 passed, 0 failed` / `rite gate OK` |
| Evidência / spec-rite | `validate-rite-evidence.py --selftest`, `validate-spec-rite.py --selftest` | 7/7; 6/6 |
| Versão de skill | `validate-skill-version.py` (body com a linha Spec-rite) | `0 findings (0 skill(s) changed)` |
| Smoke dos instaladores | `bash scripts/smoke-install-scripts.sh` | `17/17` |
| OpenSpec estrito | `openspec validate add-locale-stop-gate --strict` | `Change 'add-locale-stop-gate' is valid` |
| Validador do vendor | `claude plugin validate . --strict` | `Validation passed` |

## Rito

Spec-rite: add-locale-stop-gate — capability `skills-catalog` (ADDED requirement *The code-locale rite closes the turn, not only the write*, 8 cenários; a forma fixada do diff e o teto nunca mudo entraram como cenários na rodada de revisão).

Skill-version: none — nenhum `SKILL.md` tocado (`git diff --name-only 80ee53c...HEAD | grep -c '^skills/'` → 0).

## Known gaps

- O harness real disparando o hook num Stop de sessão não foi exercitado: o wiring em `~/.claude/settings.json` é configuração pessoal fora do PR; o payload foi construído do schema lido no bundle (E.3). Snippet do bloco `Stop` no README.
- Falso positivo do modo `--diff` do detector (fora do escopo, `skills/**`): um run de linhas `+` que começa dentro de um docstring é lido como código — o próprio hook, com o docstring editado e não commitado, bloqueia por `relatório` no docstring (arquivo inteiro: `findings: 0`). Dura enquanto a edição está não commitada; família da #85; anotado em E.4.
- O detector guarda as aspas do `+++` (contornado aqui por `core.quotePath=false`); um nome com aspas duplas, barra invertida ou caractere de controle continua citado e não é medido — limite declarado no docstring; desfazer as aspas no detector fica para a #139.
- Limites declarados no docstring: arquivo commitado no mesmo turno, repositório fora do `cwd`, `SubagentStop` em subagentes (aceito, não wired), rename puro, binário e vazio pulados, git acima de 5 s → silêncio.
- A change fica **ativa** até o arquivamento (`openspec archive add-locale-stop-gate --yes`, V.4) em PR separado, como o repositório já faz.