### PR TITLE
✨ feat(code-locale): kit de adoção por repositório com pre-commit e step de CI

### DIFF
--- a/claude/skills/code-locale/SKILL.md
+++ b/claude/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.4.0
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/code-locale.mdc
+++ b/cursor/rules/code-locale.mdc
@@ -24,6 +24,9 @@ without a taste debate.
 - **Existing names: the three migration tiers**: `references/migration.md`
 - **The detector** — measures the path of every file it is given and the contents of the types
   it tokenizes: `references/check-identifier-locale.py`
+- **Adopting the gate in a repository, without the assistant**: the pre-commit hook
+  `references/pre-commit-locale.sh` and the CI step `references/ci-step.md` (section *Wire it in
+  one minute*)
 
 ## The two layers
 
@@ -172,6 +175,32 @@ depend on the assistant noticing a rule it already has.
 The findings travel in the field the harness reads for that event, not on plain standard output;
 the hook's own docstring records the probe that established which one. Wiring: the README's hooks
 section.
+
+## Wire it in one minute
+
+The session hook above exists only where a harness runs it with this machine's settings. A
+repository adopts the same detector on its own, for every tool and every human, with one file or one
+YAML block — both invoke `check-identifier-locale.py --diff` on added lines only, pin it to a tagged
+release of the catalog, and print the exits the *Reviewing a diff* section already explains:
+
+- **Pre-commit hook**: [`references/pre-commit-locale.sh`](https://github.com/solvelab/ai-skills/blob/master/skills/code-locale/references/pre-commit-locale.sh) — copy
+  to `.git/hooks/pre-commit` (or into a `core.hooksPath` directory); it finds the detector in a local
+  clone or downloads it once, digest-checked, and refuses a commit whose staged diff adds a
+  non-English name.
+- **CI step**: [`references/ci-step.md`](https://github.com/solvelab/ai-skills/blob/master/skills/code-locale/references/ci-step.md) — a copy-paste GitHub Actions job
+  (`pull_request`, `fetch-depth: 0`, `curl` at a tag with `sha256sum -c`,
+  `git diff origin/<base>...HEAD | python3 check-identifier-locale.py --diff -`).
+
+Each layer catches a different moment, and each has a hole the next one covers:
+
+| Layer | Runs | Catches | Misses |
+|---|---|---|---|
+| Session hook (`locale-rite.py`, the catalog's global rules) | on the assistant's `Write`/`Edit`, in a Claude Code session with the hook wired | the name at the moment it is written, before it spreads across a diff | every other tool (Codex, Cursor, Copilot), a human typing in an editor, a machine without the wiring; informs, never blocks |
+| Pre-commit hook | on `git commit`, on the author's machine | the staged diff of any author and any tool, before it leaves the machine | `git commit --no-verify`, rebases and merges, a clone that never installed it; only added lines in tokenized file types |
+| CI step | on every pull request | the pull request's added lines regardless of how they were produced or bypassed | direct pushes to the default branch (branch protection's job); existing content; the advisory tier unless the word lists are shipped |
+
+Each file states in its own header what it does not cover; a green run at any layer is a
+measurement of what the tiers reach, not proof of compliance.
 
 ## Existing code
 

--- a/openspec/changes/add-locale-adoption-kit/.openspec.yaml
+++ b/openspec/changes/add-locale-adoption-kit/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/add-locale-adoption-kit/design.md
+++ b/openspec/changes/add-locale-adoption-kit/design.md
@@ -1,0 +1,140 @@
+## Context
+
+O detector `skills/code-locale/references/check-identifier-locale.py` (45,6 KB, lido em `80ee53c`)
+já tem o modo de adoção: `--diff FILE` lê linhas adicionadas de um unified diff (`-` para stdin) e
+sai 1 quando um tier que gate (`pt-verb`, `pt-noun`, `pt-morphology`, path) reporta; `en-unknown` é
+consultivo e nunca muda o exit code sem `--gate-unknown`. As saídas já existem: `WAIVER_RE`
+(`locale-ok:`) na linha 99 e `ALLOWLIST_FILE = ".identifier-locale-allow"` na 98. `EXT_LANG`
+(211-216) tokeniza `.py .lua .js .jsx .mjs .cjs .ts .tsx .cs .sql .yml .yaml .json .sh .bash`; outra
+extensão tem o caminho medido e o conteúdo reportado como *skipped*.
+
+`load_english()` (414-445) resolve as listas de palavras por `Path(__file__).resolve().parent` e
+**não falha** quando faltam: o conjunto fica vazio, e todo segmento vira `en-unknown`. Medido nesta
+sessão com o detector copiado sozinho para um diretório vazio: o fixture `def calcular_total(itens)`
+dá o mesmo `findings: 1` e `rc=1`, mas passa a listar `orders` (o nome do arquivo) como
+`path-en-unknown`. Um detector baixado por URL, sozinho, é correto no gate e ruidoso no consultivo.
+
+O que já existe por camada: `locale-rite.py` (hook `PostToolUse`, README 306-347) mede o **write**
+de uma sessão Claude Code com o `settings.json` wired; o step C9 de `scripts/validate-skills.py`
+mede os **fences** dos `.md` deste catálogo. Nenhuma das duas roda num repositório de destino, e
+nenhuma roda para um humano digitando `git commit`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Um repositório qualquer adota o gate copiando **um arquivo** (o hook) ou **um bloco YAML** (o
+  step), sem clonar este catálogo e sem assistente.
+- O hook recusa um commit cujo diff staged introduz um identificador em português, e aceita o mesmo
+  commit com `# locale-ok: <motivo>` — o mesmo detector, o mesmo exit code, as mesmas saídas.
+- O step de CI falha o PR com um achado e passa sem; o detector vem de uma **tag** deste
+  repositório, nunca de `master`, e o download é conferido por sha256.
+- Cada arquivo declara no próprio cabeçalho o que não cobre.
+
+**Non-Goals:**
+
+- Reimplementar qualquer tier do detector no hook ou no step: os dois só o **invocam**.
+- Gate no tier consultivo (`--gate-unknown`): decisão de cada repositório, documentada como opt-in.
+- Suporte a outro CI que não GitHub Actions; o comando de uma linha serve de base para os demais.
+- Wiring nos repositórios do mantenedor; opção no `install.sh`.
+
+## Decisions
+
+### D1 — O hook invoca o detector, não o reimplementa
+
+`git diff --cached --no-color | python3 <detector> --diff -` é o comando inteiro. O que o hook
+acrescenta é **onde encontrar** o detector e **como explicar** o exit 1. Alternativa rejeitada:
+embutir um subconjunto das regras em bash/awk — o requisito *A shipped enforcement script declares
+what escapes it* exige que o que roda seja o script embarcado, e o CI deste catálogo prova
+exatamente ele (`ci.yml`, step *Identifier-locale detector self-test*).
+
+### D2 — Ordem de localização: explícito → clone → download pinado
+
+1. `$LOCALE_CHECK` — caminho explícito, para quem vendorizou o detector no próprio repositório.
+2. `$AI_SKILLS_HOME/skills/code-locale/references/check-identifier-locale.py`, depois
+   `~/ai-skills/...` — o clone que `install.sh` deste catálogo cria; é o caminho do mantenedor e
+   traz as listas de palavras ao lado, então o tier consultivo funciona por inteiro.
+3. Download de `https://raw.githubusercontent.com/solvelab/ai-skills/<TAG>/skills/code-locale/references/check-identifier-locale.py`
+   com `curl -fsSL`, sha256 conferido por `python3 -c 'import hashlib...'` (sem depender de
+   `sha256sum`/`shasum`, que variam entre Linux e macOS), cache em
+   `$(git rev-parse --git-dir)/locale-check/<TAG>/` — dentro de `.git/`, nunca versionado, nunca
+   baixado duas vezes para a mesma tag.
+
+`TAG` e `SHA256` são defaults no topo do arquivo (`v2.21.0`,
+`4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2` — medido com
+`git show v2.21.0:... | sha256sum`, idêntico ao HEAD) e podem ser sobrescritos por
+`LOCALE_CHECK_TAG` / `LOCALE_CHECK_SHA256`. Trocar a tag sem trocar o hash **falha alto** de
+propósito: um pin que aceita qualquer conteúdo não é um pin. `LOCALE_CHECK_SHA256=skip` desliga a
+conferência, por escrito, para quem quer só o pin por tag.
+
+Alternativa rejeitada: baixar também as três listas de palavras (`english-words.txt.gz`, 1,0 MB,
+`programming-words.txt`, `not-english.txt`). São quatro URLs e quatro hashes para copiar; o ganho é
+só o tier consultivo. No modo download o hook passa `--no-english` e diz isso na saída — o gate é
+idêntico, e quem quiser o consultivo tem o caminho 2 ou vendoriza as listas ao lado (caminho 1).
+
+### D3 — Sem `python3` o hook recusa, não aprova
+
+"A gate that cannot measure must not approve" é a regra que `validate-spec-rite.py` já aplica ao
+`fetch-depth`. Aqui: `python3` ausente → mensagem nomeando o binário e o `--no-verify`, exit 1.
+Alternativa rejeitada: sair 0 com aviso — um hook silenciosamente inerte é o estado que a issue
+descreve como problema.
+
+### D4 — A saída do hook é a saída do detector mais um rodapé com as três saídas
+
+O detector já imprime `path:line:token [tier]` e a linha exata de waiver a adicionar. O hook não
+reformata: repassa e acrescenta um rodapé de quatro linhas — `# locale-ok: <motivo>` na linha ou
+imediatamente acima, `.identifier-locale-allow` para nome de arquivo, `git commit --no-verify` como
+o bypass **deliberado** (nomeado, não escondido: a doutrina do catálogo é informar e deixar a
+decisão com o autor). Tudo em stderr: um hook de git que escreve em stdout polui `git commit -v`.
+
+### D5 — O step de CI é um job inteiro, com `permissions: contents: read`
+
+O que o `ci.yml` deste repositório já faz (issue #117): job com permissão mínima,
+`persist-credentials: false`, `fetch-depth: 0` porque `git diff origin/<base>...HEAD` precisa da
+merge-base, e `pull_request` como único gatilho — em `push` não há `github.base_ref` e o comando
+não tem o que medir. O pin é a tag na URL do `curl` mais `sha256sum -c` (no runner Ubuntu o
+coreutils está garantido; no hook, que roda em qualquer máquina, é python3 — D2). O shell padrão de
+um `run:` é `bash -e {0}` **sem** `pipefail`; aqui isso é o que se quer: o exit code do pipe é o do
+`python3`, o do `git diff` não importa.
+
+### D6 — A seção do `SKILL.md` cabe numa tela e não repete a doutrina
+
+Uma frase, dois links relativos (`references/pre-commit-locale.sh`, `references/ci-step.md`) e a
+tabela de três camadas. O corpo da skill já explica `--diff`, `locale-ok:` e o allowlist; a seção
+aponta para *Reviewing a diff* em vez de reescrever. Links relativos porque `generate.sh` reescreve
+`](references/` para a URL do repositório no wrapper do Cursor e `plugins/` copia `references/`
+inteira — as duas formas resolvem.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Camada de máquina em inglês; `--diff` como modo de adoção; `locale-ok:` e `.identifier-locale-allow` | `code-locale` | already canonical — os dois arquivos novos vivem dentro dela e apontam para *Reviewing a diff* em vez de reescrever |
+| Um script embarcado declara o que não cobre | `skills-catalog` (spec, *A shipped enforcement script declares what escapes it*) | already canonical — o hook e o step carregam a própria lista de escapes no cabeçalho |
+| Um gate que não consegue medir não aprova (base ausente, `python3` ausente) | `scripts/validate-spec-rite.py` (precedente) + spec `skills-catalog`, *The rite gates evidence before it gates quality* | already canonical — D3 e D5 citam, não reescrevem |
+| Pin por versão probada, com a regra de bump ao lado | `ci.yml` (precedente dos pins de `claude-code` e `openspec`) | already canonical — o hook e o step trazem TAG + sha256 e a frase de bump |
+| Prova pelo caminho real antes de declarar entrega | `verify-before-claiming` | already canonical — grupo de simulação de `tasks.md` |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — `LOCALE_CHECK`, `LOCALE_CHECK_TAG`, `locate_check`, `run_check`, ids de step em inglês |
+
+## Risks / Trade-offs
+
+- **O detector baixado por URL muda** → pin por tag + sha256 embutido; trocar um sem o outro falha
+  alto (D2). A frase de bump está no cabeçalho do hook e no `ci-step.md`.
+- **Modo download sem as listas de palavras vira ruído consultivo** → medido (Context); o hook passa
+  `--no-english` nesse modo e imprime uma linha dizendo que o tier consultivo está desligado e como
+  ligá-lo. O gate não muda.
+- **`git commit --no-verify` anula o hook** → é o bypass deliberado e está **nomeado** no rodapé e
+  no cabeçalho; o step de CI é a camada que o pega, e a tabela do `SKILL.md` diz isso.
+- **`git diff --cached` inclui só o que está staged** → é o comportamento correto para `git add -p`
+  (mede o hunk que vai no commit), e um commit vazio (`--allow-empty`) passa com `findings: 0`.
+- **Um repositório legado fica vermelho no primeiro commit** → não: `--diff` mede só linhas
+  adicionadas (docstring do detector, *WHY --diff IS THE DEFAULT ADOPTION MODE*); conteúdo existente
+  nunca é reportado, e isso está na lista de escapes.
+- **`shellcheck` e `act` não estão nesta máquina** → `bash -n` roda; o step é validado com o
+  mesmo comando do `run:` sobre um clone com `origin/main`, e a simulação declara qual foi.
+
+## Open Questions
+
+Nenhuma. As três lacunas que poderiam virar achismo — se a raw URL na tag responde 200, qual é o
+sha256 do detector na tag, e o que o detector faz sem as listas de palavras ao lado — foram medidas
+antes de escrever e estão em `tasks.md` E.2 com comando e saída.

--- a/openspec/changes/add-locale-adoption-kit/design.md
+++ b/openspec/changes/add-locale-adoption-kit/design.md
@@ -42,8 +42,9 @@ nenhuma roda para um humano digitando `git commit`.
 
 ### D1 — O hook invoca o detector, não o reimplementa
 
-`git diff --cached --no-color | python3 <detector> --diff -` é o comando inteiro. O que o hook
-acrescenta é **onde encontrar** o detector e **como explicar** o exit 1. Alternativa rejeitada:
+`git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ |
+PYTHONIOENCODING=utf-8:surrogateescape python3 <detector> --diff -` é o comando inteiro (os flags e a
+variável: D7). O que o hook acrescenta é **onde encontrar** o detector e **como explicar** o exit 1. Alternativa rejeitada:
 embutir um subconjunto das regras em bash/awk — o requisito *A shipped enforcement script declares
 what escapes it* exige que o que roda seja o script embarcado, e o CI deste catálogo prova
 exatamente ele (`ci.yml`, step *Identifier-locale detector self-test*).
@@ -66,6 +67,16 @@ exatamente ele (`ci.yml`, step *Identifier-locale detector self-test*).
 `LOCALE_CHECK_TAG` / `LOCALE_CHECK_SHA256`. Trocar a tag sem trocar o hash **falha alto** de
 propósito: um pin que aceita qualquer conteúdo não é um pin. `LOCALE_CHECK_SHA256=skip` desliga a
 conferência, por escrito, para quem quer só o pin por tag.
+
+O pin vale **só para a fonte 3**. As fontes 1 e 2 rodam o arquivo que está naquele caminho, sem
+digest: `LOCALE_CHECK` é a cópia vendorizada de quem a definiu, e `~/ai-skills` é o clone que
+`install.sh` cria com `git clone` sem `--branch` (`install.sh:186`), no commit em que o dono deu o
+último `pull`. Um commit aceito localmente e o step de CI (sempre pinado) podem rodar versões
+diferentes do detector — o cabeçalho do hook diz isso em *THE PIN*, e o delta da spec exige o pin e o
+digest **quando o artefato baixa**, não em toda fonte. Alternativa rejeitada (review de 2026-09-05):
+conferir o sha256 do arquivo local e cair para download quando divergir — quebraria o caminho do
+mantenedor sempre que o clone estivesse à frente da tag (o detector mudou em `master`), e o modo
+download perde o tier consultivo (listas ausentes). O trade-off fica declarado, não escondido.
 
 Alternativa rejeitada: baixar também as três listas de palavras (`english-words.txt.gz`, 1,0 MB,
 `programming-words.txt`, `not-english.txt`). São quatro URLs e quatro hashes para copiar; o ganho é
@@ -93,9 +104,58 @@ O que o `ci.yml` deste repositório já faz (issue #117): job com permissão mí
 `persist-credentials: false`, `fetch-depth: 0` porque `git diff origin/<base>...HEAD` precisa da
 merge-base, e `pull_request` como único gatilho — em `push` não há `github.base_ref` e o comando
 não tem o que medir. O pin é a tag na URL do `curl` mais `sha256sum -c` (no runner Ubuntu o
-coreutils está garantido; no hook, que roda em qualquer máquina, é python3 — D2). O shell padrão de
-um `run:` é `bash -e {0}` **sem** `pipefail`; aqui isso é o que se quer: o exit code do pipe é o do
-`python3`, o do `git diff` não importa.
+coreutils está garantido; no hook, que roda em qualquer máquina, é python3 — D2).
+
+O bloco `run:` começa com `set -o pipefail`. O shell padrão de um `run:` é `bash -e {0}` **sem**
+`pipefail` (página *workflow syntax* do GitHub; não probado num runner), e a primeira versão deste
+design tomou isso como desejável — "o exit code do pipe é o do `python3`". Medido no review de
+2026-09-05 com o bloco verbatim sob `bash -e`: base ausente do clone → `fatal: ambiguous argument
+'origin/release/9...HEAD'`, o detector lê um stream vazio, imprime `findings: 0` e o step fica
+**verde** (rc=0). Isso viola a regra que o próprio `ci-step.md` enuncia ("a gate that cannot measure
+must not approve") e que D3 aplica ao hook. Com `pipefail` o mesmo caso sai 128 e o step falha. O
+`fetch-depth: 0` continua necessário — ele é o que faz a medição possível; o `pipefail` é o que
+impede a aprovação quando ela não aconteceu. `shell: bash` daria o mesmo efeito (a mesma página o
+documenta como `bash --noprofile --norc -eo pipefail {0}`); a linha explícita viaja para outro CI.
+
+### D7 — O diff tem a forma fixada, e um exit 1 sem `findings:` não é uma medição
+
+Quatro flags em `git diff`, nos dois artefatos, cada um contra um caso medido no review de
+2026-09-05 em que a configuração git do repositório ou do usuário mudava o que o detector lê:
+
+| Flag | Sem ele (medido) |
+|---|---|
+| `--no-ext-diff` | `diff.external` troca o unified diff pela saída do driver: `wc -c` → 0, `findings: 0`, commit com `buscar_cliente` aprovado (rc=0) |
+| `--no-renames` | `git mv orders.py relatorio.py` vira `rename to` sem `--- /dev/null`; o detector só mede o caminho nesse header (`check-identifier-locale.py:632-646`) → rc=0. Com o flag o rename é delete + add e `relatorio.py` é reportado pelo caminho |
+| `--src-prefix=a/ --dst-prefix=b/` | `diff.mnemonicPrefix=true` escreve `+++ i/relatorio.txt`; o detector tira só `b/` e o allowlist `relatorio.txt` deixa de casar → recusa de um caminho legitimamente grandfathered |
+
+`PYTHONIOENCODING=utf-8:surrogateescape` no `python3`: um hunk com bytes fora de UTF-8 (arquivo
+legado latin-1, comum nas bases que a skill mira) abortava o detector com `UnicodeDecodeError` na
+leitura do stdin — exit 1 — e o hook explicava esse exit 1 como "the staged diff adds a non-English
+name", com três saídas que não consertam nada. Com o handler os bytes passam e só os nomes são
+julgados (`legacy.py` latin-1 + linha inglesa → rc=0; + `buscar_cliente` → achado, rc=1).
+
+E o hook só trata exit 1 como recusa por achado quando a saída traz a linha `findings:` que o
+detector imprime ao terminar o scan; qualquer outro exit 1 (traceback, `LOCALE_CHECK` apontando para
+um script errado) vira `rc=70` e cai no ramo "the detector itself failed" — ainda recusa, porque nada
+foi medido, mas com a causa certa.
+
+Trade-off aceito do `--no-renames`: renomear um arquivo legado cujo conteúdo ainda tem nomes em
+português relê o conteúdo inteiro como adicionado e encontra o gate naquele momento (medido:
+`relatorio.py` com `calcular_total` → `report.py` recusado no conteúdo). É o mesmo caso que o
+`ci-step.md` já declarava para "mover um nome legado de um arquivo para outro": a hora da migração
+é a hora do waiver ou do rename de tier 2. Um rename puro de arquivo limpo fica mudo; um rename
+**para** nome em português é reportado pelo caminho — a razão do flag. Alternativa rejeitada:
+ensinar o detector a ler `rename to` — edição no detector, fora do escopo desta issue e desta
+ownership; fica em `tasks.md` E.4 como follow-up.
+
+### D8 — bash 3.2 é o piso, porque o macOS de fábrica é bash 3.2
+
+Sob `set -u`, `"${EXTRA_ARGS[@]}"` com array vazio é *unbound variable* em todo bash < 4.4 — o
+`/bin/bash` de qualquer macOS. Medido em `docker run bash:3.2` e `bash:4.3`: o hook original recusava
+**100 %** dos commits (`line 154: EXTRA_ARGS[@]: unbound variable`, rc=1, 0 commits), inclusive os
+em inglês, e a primeira simulação só tinha rodado em bash 5.2. A expansão `${arr[@]+"${arr[@]}"}`
+é a forma que sobrevive nos dois; o cabeçalho declara `bash 3.2+` em *Dependencies* e a simulação
+tem os dois containers como casos.
 
 ### D6 — A seção do `SKILL.md` cabe numa tela e não repete a doutrina
 
@@ -132,9 +192,15 @@ inteira — as duas formas resolvem.
   nunca é reportado, e isso está na lista de escapes.
 - **`shellcheck` e `act` não estão nesta máquina** → `bash -n` roda; o step é validado com o
   mesmo comando do `run:` sobre um clone com `origin/main`, e a simulação declara qual foi.
+- **O hook roda em bash antigo (macOS)** → piso declarado 3.2 e probado em container (D8).
+- **`--no-renames` relê o conteúdo de um arquivo renomeado** → trade-off declarado nos dois
+  cabeçalhos e em D7; a alternativa (detector lendo `rename to`) é follow-up.
+- **Fontes 1 e 2 do hook não têm pin** → declarado em *THE PIN* e em D2; o CI é a camada pinada.
 
 ## Open Questions
 
-Nenhuma. As três lacunas que poderiam virar achismo — se a raw URL na tag responde 200, qual é o
+Nenhuma. As nove observações do review de 2026-09-05 foram reproduzidas antes de qualquer edição
+(`$SCR/repro139.py`, `before`: 7 de 10 casos fora do esperado; `after`: 10/10) e estão em D2, D5,
+D7 e D8. As três lacunas que poderiam virar achismo — se a raw URL na tag responde 200, qual é o
 sha256 do detector na tag, e o que o detector faz sem as listas de palavras ao lado — foram medidas
 antes de escrever e estão em `tasks.md` E.2 com comando e saída.

--- a/openspec/changes/add-locale-adoption-kit/proposal.md
+++ b/openspec/changes/add-locale-adoption-kit/proposal.md
@@ -19,13 +19,16 @@ palavras `en-unknown` consultivas. O gate existe por ferramenta, não por reposi
   Localiza o detector — `$LOCALE_CHECK`, depois `$AI_SKILLS_HOME` ou `~/ai-skills`, depois download
   pinado por tag (`v2.21.0`, o `VERSION` atual) com sha256 conferido em python3 e cache em
   `$(git rev-parse --git-dir)/locale-check/` — e roda
-  `git diff --cached --no-color | python3 <detector> --diff -`. Sai 1 com os achados e nomeia as três
+  `git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ |
+  PYTHONIOENCODING=utf-8:surrogateescape python3 <detector> --diff -` (a forma do diff fixada contra
+  a configuração git do usuário; bash 3.2+). Sai 1 com os achados e nomeia as três
   saídas: `# locale-ok: <motivo>`, `.identifier-locale-allow`, `git commit --no-verify`. O cabeçalho
   declara instalação (`cp` para `.git/hooks/pre-commit` ou `core.hooksPath`) e o que **não** cobre.
 - `skills/code-locale/references/ci-step.md`, novo: um job de GitHub Actions copiável — `checkout`
-  com `fetch-depth: 0`, `curl -fsSL` do detector na tag com `sha256sum -c`,
-  `git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff -` —
-  com o pin, o `fetch-depth` e o gatilho `pull_request` explicados.
+  com `fetch-depth: 0`, `curl -fsSL` do detector na tag com `sha256sum -c`, e um `run:` com
+  `set -o pipefail` e `git diff <os mesmos flags> origin/${{ github.base_ref }}...HEAD | python3
+  check-identifier-locale.py --diff -` — com o pin, o `fetch-depth`, o `pipefail` e o gatilho
+  `pull_request` explicados.
 - `skills/code-locale/SKILL.md`: seção *Wire it in one minute* apontando os dois arquivos e uma
   tabela de três camadas (hook de sessão, pre-commit, CI) dizendo o que cada uma pega e o que deixa
   passar. `metadata.version` `1.3.1 → 1.4.0`; wrappers regenerados por `./generate.sh`.

--- a/openspec/changes/add-locale-adoption-kit/proposal.md
+++ b/openspec/changes/add-locale-adoption-kit/proposal.md
@@ -1,0 +1,57 @@
+# Change: Kit de adoção do code-locale por repositório — pre-commit e step de CI
+
+## Why
+
+A regra "a camada de máquina é inglês" só é medida onde há um harness com o `settings.json` desta
+máquina: `claude/global/hooks/locale-rite.py` roda em `PostToolUse` de sessões Claude Code. Codex,
+Cursor e Copilot recebem o texto da skill e nenhum gate; um commit escrito à mão não encontra nada.
+A skill `code-locale` diz que o detector "pode ser wired em pre-commit e CI" (`SKILL.md:33-34`,
+`references/migration.md:16`, docstring do detector, linha 10) e o único exemplo real é o step C9
+do `ci.yml` **deste** repositório — que roda `scripts/validate-skills.py`, não um comando copiável.
+
+Medido em 2026-09-05 (issue #139) nos projetos do mantenedor disponíveis nesta máquina:
+`server_addons` (8 `.py`) sem workflow nem `.identifier-locale-allow` — 0 achados gating, 114
+palavras `en-unknown` consultivas. O gate existe por ferramenta, não por repositório.
+
+## What Changes
+
+- `skills/code-locale/references/pre-commit-locale.sh`, novo: hook `pre-commit` em bash + python3.
+  Localiza o detector — `$LOCALE_CHECK`, depois `$AI_SKILLS_HOME` ou `~/ai-skills`, depois download
+  pinado por tag (`v2.21.0`, o `VERSION` atual) com sha256 conferido em python3 e cache em
+  `$(git rev-parse --git-dir)/locale-check/` — e roda
+  `git diff --cached --no-color | python3 <detector> --diff -`. Sai 1 com os achados e nomeia as três
+  saídas: `# locale-ok: <motivo>`, `.identifier-locale-allow`, `git commit --no-verify`. O cabeçalho
+  declara instalação (`cp` para `.git/hooks/pre-commit` ou `core.hooksPath`) e o que **não** cobre.
+- `skills/code-locale/references/ci-step.md`, novo: um job de GitHub Actions copiável — `checkout`
+  com `fetch-depth: 0`, `curl -fsSL` do detector na tag com `sha256sum -c`,
+  `git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff -` —
+  com o pin, o `fetch-depth` e o gatilho `pull_request` explicados.
+- `skills/code-locale/SKILL.md`: seção *Wire it in one minute* apontando os dois arquivos e uma
+  tabela de três camadas (hook de sessão, pre-commit, CI) dizendo o que cada uma pega e o que deixa
+  passar. `metadata.version` `1.3.1 → 1.4.0`; wrappers regenerados por `./generate.sh`.
+
+Fora de escopo, por decisão da issue: opção `--git-hooks` no `install.sh`, publicar o detector como
+pacote, wiring automático nos repositórios do mantenedor.
+
+## Capabilities
+
+### New Capabilities
+
+Nenhuma.
+
+### Modified Capabilities
+
+- `skills-catalog`: o requisito *Code locale has a canonical home* ganha a cláusula de que a skill
+  canônica embarca o meio de adoção por repositório — um hook de pre-commit e um step de CI
+  copiáveis, pinados por tag — e não só o detector, com o cenário *A repository adopts the gate
+  without the assistant*.
+
+## Impact
+
+- Skill afetada: `code-locale` (dois arquivos novos em `references/`, uma seção no `SKILL.md`, bump
+  minor). Nenhuma skill é adicionada, removida ou renomeada: a composição do catálogo (35) e a
+  descoberta via `npx` não mudam.
+- Wrappers gerados de `code-locale` em `claude/`, `codex/`, `cursor/`, `copilot/` e
+  `plugins/workflow/` (a árvore de `plugins/` copia `references/` inteira, então os dois arquivos
+  novos aparecem lá).
+- Nada em `hooks/`, `README.md`, `ci.yml` ou `install.sh` muda.

--- a/openspec/changes/add-locale-adoption-kit/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-locale-adoption-kit/specs/skills-catalog/spec.md
@@ -1,0 +1,77 @@
+## MODIFIED Requirements
+
+### Requirement: Code locale has a canonical home
+
+The catalog SHALL contain one skill that governs which natural language each artifact of a change is
+written in. It SHALL draw the boundary by what consumes the artifact, not by who wrote it: prose read
+by humans — commit subjects and bodies, pull-request and issue text, documentation, code comments,
+user-facing strings — follows the repository's working language, while anything a machine parses —
+identifiers, file and module names, REST path segments and query parameters, database tables,
+columns and indexes, enum values, event and topic names, configuration keys, structured-log field
+keys and test names — is English and ASCII.
+
+The doctrine SHALL be stack-agnostic. Skills that state a format-level naming convention for one
+stack — a test-method naming pattern, a DTO naming triple, a config-file naming scheme — SHALL keep
+that text and link to the canonical skill for the language rule rather than restating it.
+
+The canonical skill SHALL ship the means of adopting the rule **per repository**, not only the
+detector: a git pre-commit hook and a continuous-integration step, each copyable into a target
+repository without cloning the catalog and without an assistant in the loop. Both SHALL invoke the
+shipped detector rather than reimplement any of its tiers, SHALL measure only the lines the change
+adds, and SHALL obtain the detector from a tagged release of the catalog — never from its default
+branch — with the pin and its bump rule stated beside it. Each SHALL declare, in its own header, what
+it does not cover, and SHALL name the exits the doctrine already defines — the inline waiver, the
+allowlist file, and the deliberate bypass — so that a refused commit or a failed pull request tells
+its author what to do next. The skill SHALL state which layer catches what: a session hook measures
+the assistant's write, the pre-commit hook measures the human's commit, and the CI step measures the
+pull request regardless of how it was produced.
+
+#### Scenario: A prose rule and an identifier rule do not collide
+
+- **WHEN** a repository's convention is to write commit subjects, issues and documentation in a
+  language other than English
+- **THEN** that convention is preserved, and only the machine layer is required to be English
+- **AND** the skills carrying the prose rules gain a scope clause and a link, rather than being
+  rewritten
+
+#### Scenario: An untranslatable domain term is kept and enumerated
+
+- **WHEN** a domain term has legal or regulatory meaning and no faithful English translation
+- **THEN** the term is kept, ASCII-folded, inside English grammar
+- **AND** it is legitimate only when the change's glossary lists it or the code carries an inline
+  waiver naming the reason, so that "it is a domain term" cannot become an unbounded exception
+
+#### Scenario: A foreign payload is mirrored at the boundary, not carried inward
+
+- **WHEN** an external API's payload field names are in another language
+- **THEN** those names are mirrored verbatim only inside the adapter or transport schema, and are
+  translated to the English domain model at a single mapping point
+
+#### Scenario: The translation decision is taken before implementation, not during it
+
+- **WHEN** a backlog item written in another language will produce code
+- **THEN** the item carries a glossary mapping each domain term to its identifier, with each row
+  marked as harvested from the codebase or decided in the item
+- **AND** the implementing agent takes names from that glossary instead of improvising a translation,
+  and an unlisted term is raised as a question rather than translated on the spot
+
+#### Scenario: Existing names migrate by tier rather than by rename
+
+- **WHEN** a repository already contains identifiers in another language
+- **THEN** the doctrine requires English only for new code, permits opportunistic renaming of
+  internal names in files already being changed, and forbids renaming a contract-bearing name in
+  place — routes, persisted columns, event names and deployed configuration keys change through an
+  expand/contract window
+- **AND** a whole-repository rename is named as the anti-pattern it is, because names referenced as
+  strings fail silently at runtime
+
+#### Scenario: A repository adopts the gate without the assistant
+
+- **WHEN** the shipped pre-commit hook is installed in a repository and a commit is attempted whose
+  staged diff adds an identifier in another language
+- **THEN** the commit is refused with the detector's finding, and the message names the inline
+  waiver, the allowlist file and the deliberate bypass
+- **AND** the same commit with the inline waiver on the offending line is accepted
+- **AND** the shipped CI step, pasted into that repository's workflow, fails a pull request whose
+  added lines carry such an identifier and passes one whose added lines are English, downloading the
+  detector from a tagged release and verifying its digest before running it

--- a/openspec/changes/add-locale-adoption-kit/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-locale-adoption-kit/specs/skills-catalog/spec.md
@@ -17,12 +17,18 @@ that text and link to the canonical skill for the language rule rather than rest
 The canonical skill SHALL ship the means of adopting the rule **per repository**, not only the
 detector: a git pre-commit hook and a continuous-integration step, each copyable into a target
 repository without cloning the catalog and without an assistant in the loop. Both SHALL invoke the
-shipped detector rather than reimplement any of its tiers, SHALL measure only the lines the change
-adds, and SHALL obtain the detector from a tagged release of the catalog — never from its default
-branch — with the pin and its bump rule stated beside it. Each SHALL declare, in its own header, what
-it does not cover, and SHALL name the exits the doctrine already defines — the inline waiver, the
-allowlist file, and the deliberate bypass — so that a refused commit or a failed pull request tells
-its author what to do next. The skill SHALL state which layer catches what: a session hook measures
+shipped detector rather than reimplement any of its tiers, and SHALL measure only the lines the
+change adds. Whenever either artifact downloads the detector it SHALL do so from a tagged release of
+the catalog — never from its default branch — and SHALL verify the file's digest before running it,
+with the pin and its bump rule stated beside it; the hook MAY instead run a detector the machine
+already holds (an explicit path, or the catalog's local clone) and SHALL state in its header that
+those sources carry no pin. Both SHALL fix the shape of the diff they read so that a repository's or
+a user's git configuration cannot empty it or alter its paths, and neither SHALL approve when it
+could not measure — a diff command that fails, or a detector that exits without completing its scan,
+fails the commit or the step. Each SHALL declare, in its own header, what it does not cover, and
+SHALL name the exits the doctrine already defines — the inline waiver, the allowlist file, and the
+deliberate bypass — so that a refused commit or a failed pull request tells its author what to do
+next. The skill SHALL state which layer catches what: a session hook measures
 the assistant's write, the pre-commit hook measures the human's commit, and the CI step measures the
 pull request regardless of how it was produced.
 
@@ -75,3 +81,11 @@ pull request regardless of how it was produced.
 - **AND** the shipped CI step, pasted into that repository's workflow, fails a pull request whose
   added lines carry such an identifier and passes one whose added lines are English, downloading the
   detector from a tagged release and verifying its digest before running it
+
+#### Scenario: A gate that cannot measure does not approve
+
+- **WHEN** the CI step's base revision is absent from the clone, or the hook's detector exits without
+  printing its findings line, or a git configuration would replace or empty the diff the detector reads
+- **THEN** the step or the commit fails, naming the cause, instead of reporting zero findings
+- **AND** a commit whose staged diff renames a file to a name in another language is refused on the
+  new path, and a staged hunk carrying non-UTF-8 bytes is measured rather than aborting the detector

--- a/openspec/changes/add-locale-adoption-kit/tasks.md
+++ b/openspec/changes/add-locale-adoption-kit/tasks.md
@@ -98,6 +98,24 @@
       -> (vazio) diff-rc=0
       ```
 
+      Probado no review de 2026-09-05, antes de editar (a hipótese "roda em qualquer bash" tinha sido
+      testada só em 5.2). Imagens `bash:3.2` e `bash:4.3` estão nesta máquina (`docker images`):
+
+      ```
+      docker run --rm bash:3.2 bash -c 'set -u; EXTRA_ARGS=(); args=("${EXTRA_ARGS[@]}"); echo ok'
+      -> bash: EXTRA_ARGS[@]: unbound variable          rc=127
+      docker run --rm bash:3.2 bash -c 'set -u; EXTRA_ARGS=(); args=(${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"}); echo "fixed ok n=${#args[@]}"'
+      -> fixed ok n=0                                   rc=0
+      docker run --rm bash:3.2 sh -c 'apk add --no-cache git python3 >/dev/null && git --version && python3 --version'
+      -> git version 2.49.1 / Python 3.12.14            (o container consegue rodar o hook inteiro)
+      git -c diff.external=<sh que sai 0> diff --cached --no-color | wc -c   -> 0
+      git diff --cached --no-color   (após git mv orders.py relatorio.py)
+      -> diff --git a/orders.py b/relatorio.py / similarity index 100% / rename from orders.py / rename to relatorio.py
+      git -c diff.mnemonicPrefix=true diff --cached --no-color | grep '^+++'   -> +++ i/relatorio.txt
+      git diff --cached --no-color --src-prefix=a/ --dst-prefix=b/ | grep '^+++'   -> +++ b/relatorio.txt
+      PYTHONIOENCODING=utf-8:surrogateescape python3 <detector> --diff - < latin1.diff   -> findings: 1  (sem a variável: UnicodeDecodeError)
+      ```
+
       Scaffold da change com o schema do repositório:
 
       ```
@@ -121,6 +139,11 @@
       A versão do bash foi lida do pacote (`dpkg -s bash`), não de `bash --version`: o sandbox desta
       sessão recusa invocar `bash` com argumentos computados. Mesmo pacote, mesma versão.
 
+      Terceiro item, do review: o shell padrão de um `run:` (`bash -e {0}`) e o de `shell: bash`
+      (`bash --noprofile --norc -eo pipefail {0}`) vêm da página *workflow syntax* do GitHub, não de
+      um runner probado — por isso o `set -o pipefail` é explícito no bloco, e o efeito foi medido
+      localmente com `bash -e -c` (S.1).
+
 - [x] E.4 Checagem de escopo
 
       A change faz só o que a issue #139 pediu. Notados pelo caminho e **não** feitos, ficam como
@@ -136,21 +159,37 @@
       - `README.md:558` (linha do índice de `code-locale`) diz "any project can wire into pre-commit"
         e continuaria verdadeiro; a issue exclui `README.md` do escopo e nada foi tocado lá.
       - Uma opção `--git-hooks <repo>` no `install.sh` — rejeitada na própria issue.
+      - Ensinar o detector a medir o caminho num header `rename to` (hoje só em `--- /dev/null`,
+        `check-identifier-locale.py:632-646`; o KNOWN LIMIT 12 diz "a rename appears as an add", o
+        que só é verdade com `--no-renames`). O kit contorna com o flag nos dois artefatos (D7);
+        a edição no detector fica fora desta issue.
+      - `PYTHONIOENCODING` aparece como `en-unknown` consultivo quando o detector lê o próprio hook
+        e o `ci-step.md` — é o nome da variável do Python; uma linha em `programming-words.txt`
+        resolveria, fora desta issue.
 
 ## 2. Hook de pre-commit
 
-- [x] 2.1 `skills/code-locale/references/pre-commit-locale.sh` (183 linhas, commit `79a171b`):
-      cabeçalho com instalação (`cp` para `.git/hooks/pre-commit` ou `core.hooksPath`), ordem de
-      localização do detector (D2), pin `v2.21.0` + sha256 e a frase de bump, a lista do que não
-      cobre (`--no-verify`, extensões fora de `EXT_LANG`, conteúdo existente, tier consultivo no
-      modo download); corpo que roda `git diff --cached --no-color | python3 <detector> --diff -` e
-      sai 1 com os achados mais o rodapé das três saídas (D4); `python3` ausente recusa (D3)
+- [x] 2.1 `skills/code-locale/references/pre-commit-locale.sh` (217 linhas; commit `79a171b`, corrigido
+      no review em `4c82e0a`): cabeçalho com instalação (`cp` para `.git/hooks/pre-commit` ou
+      `core.hooksPath`), ordem de localização do detector (D2) com *THE PIN* restrito ao modo
+      download, pin `v2.21.0` + sha256 e a frase de bump, a lista do que não cobre (`--no-verify`,
+      extensões fora de `EXT_LANG`, conteúdo existente, renames relidos como add, exit 1 sem
+      `findings:`, tier consultivo no modo download); corpo que roda `git diff --cached --no-color
+      --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ | PYTHONIOENCODING=utf-8:surrogateescape
+      python3 <detector> --diff -` (D7) com expansões seguras para bash 3.2 (D8) e sai 1 com os
+      achados mais o rodapé das três saídas (D4); `python3` ausente recusa (D3)
 
       ```
-      grep -c "" skills/code-locale/references/pre-commit-locale.sh   -> 183
-      grep -n "^LOCALE_CHECK_TAG=\|^LOCALE_CHECK_SHA256=" skills/code-locale/references/pre-commit-locale.sh
-      -> 81:LOCALE_CHECK_TAG="${LOCALE_CHECK_TAG:-v2.21.0}"
-      -> 82:LOCALE_CHECK_SHA256="${LOCALE_CHECK_SHA256:-4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2}"
+      grep -c "" skills/code-locale/references/pre-commit-locale.sh   -> 217
+      grep -n "^LOCALE_CHECK_TAG=\|^LOCALE_CHECK_SHA256=\|^args=\|rc=70" skills/code-locale/references/pre-commit-locale.sh
+      -> 106:LOCALE_CHECK_TAG="${LOCALE_CHECK_TAG:-v2.21.0}"
+      -> 107:LOCALE_CHECK_SHA256="${LOCALE_CHECK_SHA256:-4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2}"
+      -> 181:args=(${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"})
+      -> 194:  rc=70
+      grep -n "no-renames --src-prefix" skills/code-locale/references/pre-commit-locale.sh
+      -> 6:#   git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ \
+      -> 187:output="$(git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ \
+      grep -n "^# Dependencies" skills/code-locale/references/pre-commit-locale.sh   -> 99:# Dependencies: bash 3.2+ [...]
       ```
 
 - [x] 2.2 `bash -n` limpo; o detector sobre o próprio hook (`.sh` está em `EXT_LANG`) reporta
@@ -160,24 +199,30 @@
       bash -n skills/code-locale/references/pre-commit-locale.sh; echo "bash-n rc=$?"
       -> bash-n rc=0
       python3 skills/code-locale/references/check-identifier-locale.py skills/code-locale/references/pre-commit-locale.sh
+      -> pre-commit-locale.sh:188: PYTHONIOENCODING  [en-unknown: 'PYTHONIOENCODING']   advisory (nome da variável do Python, E.4)
       -> findings: 0
       -> rc=0
       ```
 
 ## 3. Step de CI
 
-- [x] 3.1 `skills/code-locale/references/ci-step.md` (108 linhas, commit `f4b8bd0`): job copiável
-      (`pull_request`, `permissions: contents: read`, `checkout@v5` com `fetch-depth: 0` e
-      `persist-credentials: false`, `curl -fsSL` na tag `v2.21.0` + `sha256sum -c`,
-      `git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff -`);
-      o pin, o `fetch-depth`, o gatilho e o `pipefail` explicados (D5); o que o step não cobre
+- [x] 3.1 `skills/code-locale/references/ci-step.md` (136 linhas; commit `f4b8bd0`, corrigido no review):
+      job copiável (`pull_request`, `permissions: contents: read`, `checkout@v5` com `fetch-depth: 0`
+      e `persist-credentials: false`, `curl -fsSL` na tag `v2.21.0` + `sha256sum -c`, `run:` com
+      `set -o pipefail` e `git diff --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/
+      origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff -` sob
+      `PYTHONIOENCODING=utf-8:surrogateescape`); o pin, o `fetch-depth`, o gatilho, o `pipefail`, os
+      quatro flags e o handler explicados (D5, D7); o que o step não cobre, com o trade-off do
+      `--no-renames`
 
       ```
-      grep -n "fetch-depth\|sha256sum -c\|github.base_ref\|AI_SKILLS_TAG: " skills/code-locale/references/ci-step.md
+      grep -n "fetch-depth\|sha256sum -c\|github.base_ref\|AI_SKILLS_TAG: \|pipefail$\|PYTHONIOENCODING:" skills/code-locale/references/ci-step.md
       -> 25:          fetch-depth: 0
       -> 30:          AI_SKILLS_TAG: v2.21.0
       -> 35:          echo "${CHECK_SHA256}  check-identifier-locale.py" | sha256sum -c -
-      -> 39:          git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff - --no-english
+      -> 39:          PYTHONIOENCODING: utf-8:surrogateescape
+      -> 41:          set -o pipefail
+      -> 42:          git diff --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ origin/${{ github.base_ref }}...HEAD \
       ```
 
 - [x] 3.2 O bloco `yaml` parseia (C3 via `validate-skills.py`, e à parte)
@@ -185,6 +230,7 @@
       ```
       python3 -c "import re,yaml; ... yaml.safe_load_all(block)"   (sobre o fence yaml de ci-step.md)
       -> yaml ok; jobs: ['identifier-locale'] steps: 3 on: {'pull_request': None}
+      (após o review) steps[2]['env'] -> {'PYTHONIOENCODING': 'utf-8:surrogateescape'}; steps[2]['run'] começa com "set -o pipefail"
       python3 scripts/validate-skills.py
       -> skills checked: 35   findings: 0
       ```
@@ -222,6 +268,8 @@
       -> plugins hook mirror identical
       grep -c "blob/master/skills/code-locale/references/pre-commit-locale.sh" cursor/rules/code-locale.mdc
       -> 1            (o Cursor reescreve o link relativo para a URL do repositório)
+      (após o review) bash generate.sh; cmp skills/.../pre-commit-locale.sh plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
+      -> plugins hook mirror identical; plugins ci-step mirror identical
       ```
 
 ## 5. Simulation & Field Proof (MANDATORY)
@@ -298,8 +346,67 @@
 
       `bash -n` e o detector sobre o hook: 2.2. `shellcheck`: ausente nesta máquina, não rodado.
 
-- [x] S.2 Matriz de casos medida, em contagens (`sim_cases.py` -> `cases: 16  as expected: 16
-      unexpected: 0`, mais os dois casos manuais de S.1)
+      **Após o review (2026-09-05)** — os nove achados foram reproduzidos contra o hook original e
+      re-medidos contra o corrigido, todos pelo `git commit` real com o hook em `.git/hooks/pre-commit`
+      e `LOCALE_CHECK` apontando para o detector do worktree (`$SCR/repro139.py <hook> <detector>
+      before|after`; saída em `$SCR/repro139-{before,after}.txt`). Antes: `cases: 10  as expected: 3
+      unexpected: 7`. Depois:
+
+      ```
+      [F3] git -c diff.external=<sh que sai 0> commit   (customers.py: def buscar_cliente)
+      -> antes: rc=0, commits=1 (aprovado sem medir)        depois: buscar_cliente [pt-verb] / refused  rc=1
+      [F4a] git mv orders.py relatorio.py; git commit
+      -> antes: rc=0, commits=2                             depois: relatorio.py: relatorio [path-pt-noun] / refused  rc=1
+      [F4b] git mv base.py cadastro.py + uma linha; git commit
+      -> antes: rc=0                                         depois: cadastro.py: cadastro [path-pt-noun]  rc=1
+      [F4c] relatorio.py (def calcular_total) -> git mv report.py; git commit   (o trade-off de D7)
+      -> antes: rc=0 (mudo)                                  depois: report.py:1: calcular_total [pt-verb]  rc=1
+      [F5a] legacy.py latin-1 já commitado + "count = 1"; git commit
+      -> antes: UnicodeDecodeError [...] refused: the staged diff adds a non-English name  rc=1
+      -> depois: rc=0, commits=2, sem saída
+      [F5b] legacy.py latin-1 + "def buscar_cliente(x):"; git commit
+      -> depois: legacy.py:3: buscar_cliente [pt-verb] / findings: 1 / refused  rc=1  (sem traceback)
+      [F5c] LOCALE_CHECK=crash.py (raise RuntimeError) sobre código inglês
+      -> antes: RuntimeError: boom / refused: the staged diff adds a non-English name [...]  rc=1
+      -> depois: RuntimeError: boom / the detector itself failed (exit 70, no findings: line); nothing was measured  rc=1
+      [F6] diff.mnemonicPrefix=true + .identifier-locale-allow com relatorio.txt; git commit
+      -> antes: i/relatorio.txt: relatorio [path-pt-noun] / refused  rc=1     depois: rc=0, commits=1
+      cases: 10  as expected: 10  unexpected: 0
+      ```
+
+      **Entry point 3** — o hook inteiro em bash 3.2 e 4.3 (`docker run --rm -v $SCR/b32-kit:/kit:ro
+      -v $SCR/b32-run.sh:/run.sh:ro bash:3.2 sh /run.sh`: `apk add git python3`, `git init`, `cp` do
+      hook para `.git/hooks/pre-commit`, dois `git commit`; saída em `$SCR/b32-{before,after}.txt`):
+
+      ```
+      [B-3.2 antes]  .git/hooks/pre-commit: line 154: EXTRA_ARGS[@]: unbound variable / english commit rc=1  commits=0 / pt commit rc=1  commits=0
+      [B-3.2 depois] GNU bash, version 3.2.57(1)-release / english commit rc=0  commits=1 / customers.py:1: buscar_cliente [pt-verb] / refused / pt commit rc=1  commits=1
+      [B-4.3 depois] GNU bash, version 4.3.48(1)-release / english commit rc=0  commits=1 / [...] refused / pt commit rc=1  commits=1
+      ```
+
+      A matriz original de 16 casos foi re-rodada num repositório novo contra o hook corrigido
+      (`$SCR/sim139_full.py`, saída em `$SCR/sim139_full_output.txt`): `cases: 18  as expected: 18
+      unexpected: 0` (os 16 mais os dois manuais de S.1, agora no driver). E o bloco `run:` do
+      `ci-step.md` foi relido do próprio arquivo (fence `yaml` parseado, `origin/main` no lugar de
+      `origin/${{ github.base_ref }}`, `env` do step aplicado) e rodado sob `bash -e -c` num clone com
+      quatro branches (`$SCR/ci139.py`, saída em `$SCR/ci139-out.txt`):
+
+      ```
+      [CI-pt]      feature/pt  (def calcular_frete)          -> shipping.py:1: calcular_frete [pt-verb] / findings: 1   rc=1
+      [CI-en]      feature/en  (def compute_shipping)        -> findings: 0   rc=0
+      [CI-rename]  feature/rename-pt (git mv orders.py relatorio.py) -> relatorio.py: relatorio [path-pt-noun] / findings: 1   rc=1
+      [CI-latin1]  feature/latin1 (linha inglesa num .py latin-1)    -> findings: 0   rc=0
+      [CI-nobase]  origin/release/9...HEAD (base ausente)    -> fatal: ambiguous argument [...] / findings: 0   rc=128  (antes do pipefail: rc=0, verde)
+      [CI-depth1]  clone --depth 1                           -> fatal: ambiguous argument 'origin/main...HEAD' / findings: 0   rc=128
+      cases: 8  as expected: 8  unexpected: 0     (com CI-1 fetch OK e CI-4 digest errado FAILED)
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens. Primeira entrega: `sim_cases.py` -> `cases: 16  as
+      expected: 16  unexpected: 0`, mais os dois casos manuais de S.1. Após o review, sobre o hook
+      corrigido: `sim139_full.py` -> `cases: 18  as expected: 18  unexpected: 0`; `repro139.py after`
+      -> `cases: 10  as expected: 10  unexpected: 0`; `ci139.py` -> `cases: 8  as expected: 8
+      unexpected: 0`; bash 3.2 e 4.3 -> 2/2 commits ingleses aceitos, 2/2 commits `buscar_cliente`
+      recusados
 
       | Artefato | Expectativa | Casos | Resultado |
       |---|---|---|---|
@@ -313,6 +420,13 @@
       | hook (fora de `EXT_LANG`) | caminho medido, conteúdo pulado | 1/1 | [11] `relatorio.txt` recusado pelo nome |
       | hook | escape conhecido ficou mudo | 1/1 | [8] `--no-verify`, rc=0 — ver S.3 |
       | step de CI (`run:` verbatim, `origin/main`) | fetch + digest OK; PR com achado falha; PR limpo passa; digest errado falha | 4/4 | CI-1 rc=0; CI-2 rc=1; CI-3 rc=0; CI-4 rc=1 |
+      | hook (config git do repo/usuário) — review | `diff.external`, rename puro, rename+edit tinham de recusar | 3/3 | F3, F4a, F4b rc=1 (antes: 3/3 aprovados, rc=0) |
+      | hook (allowlist sob `mnemonicPrefix`) — review | tinha de aceitar | 1/1 | F6 rc=0 (antes: recusado) |
+      | hook (latin-1) — review | linha inglesa aceita; `buscar_cliente` recusado como achado | 2/2 | F5a rc=0; F5b rc=1 sem traceback |
+      | hook (detector que crasha) — review | recusa como falha do detector, não como achado | 1/1 | F5c "detector itself failed (exit 70 [...])" |
+      | hook (trade-off `--no-renames`) — review | rename de legado com conteúdo PT encontra o gate | 1/1 | F4c rc=1, `calcular_total` no conteúdo — declarado em D7 |
+      | hook em bash 3.2 / 4.3 (container) — review | inglês aceito, PT recusado | 4/4 | 2 imagens × 2 commits (antes: 0/4 — `unbound variable`) |
+      | step de CI — review | rename para PT falha; latin-1 passa; base ausente e `--depth 1` falham em vez de aprovar | 4/4 | rc=1; rc=0; rc=128; rc=128 (antes: base ausente rc=0, verde) |
       | `bash -n` | limpo | 1/1 | rc=0 |
       | `shellcheck` | — | 0/0 | não instalado; declarado |
 
@@ -332,7 +446,16 @@
         está três linhas acima. Aceito: a mensagem específica vem primeiro.
       - O que a simulação **não** prova: que o runner do Actions resolve `github.base_ref` e faz o
         checkout do merge commit com `fetch-depth: 0` — `origin/main` foi o substituto (E.3), e a
-        premissa vem do `ci.yml` deste repositório, que já depende dos dois.
+        premissa vem do `ci.yml` deste repositório, que já depende dos dois. Nem que o shell padrão
+        do runner é `bash -e {0}` sem `pipefail` — vem da doc (E.3); por isso o `set -o pipefail`
+        está escrito no bloco, e não confiado ao `shell:`.
+
+      O que o review de 2026-09-05 mostrou que **tinha** escapado da primeira simulação, e que agora
+      está medido acima (S.1, F3-F6, B-3.2, CI-nobase): sete comportamentos fora do desenhado,
+      todos reproduzidos antes da edição e re-medidos depois. Um comportamento novo, deliberado e
+      declarado (D7, cabeçalhos): com `--no-renames`, renomear um arquivo legado cujo conteúdo ainda
+      tem nomes em português encontra o gate (F4c) — antes passava mudo. O escape `--no-verify`
+      permanece e continua nomeado.
 
 ## 6. Quality Gates (MANDATORY)
 

--- a/openspec/changes/add-locale-adoption-kit/tasks.md
+++ b/openspec/changes/add-locale-adoption-kit/tasks.md
@@ -1,0 +1,197 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `80ee53c` (`docs(openspec): arquiva as changes add-skill-version-gate e
+      define-cross-skill-references`), topo de `master` em 2026-09-05:
+
+      - `skills/code-locale/SKILL.md` — 211 linhas; `metadata.version: 1.3.1` na linha 17; a frase
+        "a shipped detector a repository can wire into CI" em 33-34; *Reviewing a diff* em 121-146
+        (o exemplo `git diff origin/main... | python3 references/check-identifier-locale.py --diff -`
+        na 125); *Catching it at the write* em 176-193; *See also* em 201-210.
+      - `skills/code-locale/references/check-identifier-locale.py` — 45,6 KB; `ALLOWLIST_FILE` na
+        linha 98, `WAIVER_RE` na 99, `EXT_LANG` em 211-216, `load_english()` em 414-445 (resolve as
+        listas por `Path(__file__).resolve().parent` e não falha quando faltam), `--no-english` em
+        841 e 849; docstring 1-90 com *WHY --diff IS THE DEFAULT ADOPTION MODE* e os 17 KNOWN LIMITs.
+      - `skills/code-locale/references/migration.md:16` — "Wire this into pre-commit and CI".
+      - `claude/global/hooks/locale-rite.py` — `CHECK_PATH` por `parents[3]`, `WRITE_TOOLS`,
+        `written_text()`: a camada de sessão mede só o texto escrito pela ferramenta.
+      - `README.md:306-347` — seção *The locale rite*: `PostToolUse` para `Write|Edit`, snippet do
+        `settings.json`, "informs, never blocks".
+      - `.github/workflows/ci.yml` — step *Skill content checks* (C9 via `validate-skills.py`),
+        *Identifier-locale detector self-test*, o checkout com `fetch-depth: 0` e
+        `persist-credentials: false` e o comentário que os justifica; job `validate` com
+        `permissions: contents: read`.
+      - `scripts/validate-skills.py` — C1 (`check_refs`, 77-135: links e inline `references/...`
+        resolvidos contra o diretório da skill), C3 (`check_blocks`, 136-166: fences `bash` com `<`,
+        `$(` ou `${` são pulados; fences `yaml` passam por `yaml.safe_load_all`), C10 (300-357,
+        `description` ≤ 1024 no valor parseado), C11 (358-417: só `*.md` sob `references/` é
+        julgado como órfão; `.sh` é "loaded by the markdown that names them"), C12 (419-492), C13.
+      - `scripts/validate-rite.sh`, `scripts/validate-rite-evidence.py` (1-140),
+        `scripts/validate-spec-rite.py` e `scripts/validate-skill-version.py` (1-60, `resolve_base`
+        em 120-127) — o que os gates exigem e como resolvem a base fora do CI.
+      - `generate.sh:140-200` — Cursor reescreve `](references/` para a URL do repositório;
+        `plugins/` copia `references/` inteira (`ls plugins/workflow/skills/code-locale/references/`
+        -> 8 arquivos, os mesmos de `skills/`).
+      - `openspec/specs/skills-catalog/spec.md:647-698` — o requisito *Code locale has a canonical
+        home* que o delta modifica (copiado por inteiro); `:700-725` *A shipped enforcement script
+        declares what escapes it*.
+      - `openspec/changes/archive/2026-09-04-add-hook-selftests/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md`; `2026-09-05-add-skill-version-gate/{proposal,design}.md` —
+        modelo de estilo da casa.
+      - `openspec/schemas/skills-rite/templates/{proposal,design,tasks,spec}.md` e `schema.yaml`.
+      - Issue #139 (`gh issue view 139 --json body`): escopo, FR1-FR3, TR1-TR3, os quatro critérios
+        de aceite, o glossário (`pre-commit-locale.sh`, `ci-step.md`), o veredito
+        `add-locale-adoption-kit`.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      ```
+      python3 --version                -> Python 3.14.5
+      /usr/bin/git --version           -> git version 2.47.3
+      dpkg -s bash | grep ^Version     -> Version: 5.2.37-2+b9
+      openspec --version               -> 1.6.0
+      cat VERSION                      -> 2.21.0
+      git tag --list 'v*' --sort=-v:refname | head -1   -> v2.21.0
+      which shellcheck                 -> shellcheck not found
+      which act                        -> act not found
+      ```
+
+      O detector em `--diff` sobre um fixture (arquivo novo, `def calcular_total(itens)`), pelo
+      caminho e por stdin `-`:
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py --diff fixtures/pt.diff; echo rc=$?
+      -> orders.py:1: calcular_total  [pt-verb: 'calcular']
+      ->     machine layer must be English (code-locale). If this name is correct as written, add a reason:
+      ->       # locale-ok: <why this term has no faithful English name>
+      ->     or grandfather it in .identifier-locale-allow:
+      ->       calcular_total
+      -> orders.py:1: itens  [en-unknown: 'itens']   [...] advisory: this finding does not fail the run
+      -> findings: 1
+      -> rc=1
+      python3 ... --diff - < fixtures/pt.diff          -> findings: 1  rc=1   (saída idêntica)
+      python3 ... --diff fixtures/en.diff              -> findings: 0  rc=0   (def compute_total(items))
+      ```
+
+      O detector copiado **sozinho** para um diretório vazio (o que um `curl` do arquivo único dá):
+
+      ```
+      cp skills/code-locale/references/check-identifier-locale.py $SCR/standalone/ && python3 $SCR/standalone/check-identifier-locale.py --diff fixtures/pt.diff
+      -> orders.py:1: calcular_total  [pt-verb: 'calcular']
+      -> orders.py: orders  [path-en-unknown: 'orders']   (novo: a lista inglesa não está ao lado)
+      -> findings: 1
+      ->   en-unknown: 3 segment(s) not in the English word list — advisory
+      -> rc=1
+      ```
+
+      A raw URL na tag responde, e o detector é byte a byte o mesmo da tag e do HEAD:
+
+      ```
+      curl -sI https://raw.githubusercontent.com/solvelab/ai-skills/v2.21.0/skills/code-locale/references/check-identifier-locale.py | head -1
+      -> HTTP/2 200
+      /usr/bin/git show v2.21.0:skills/code-locale/references/check-identifier-locale.py | sha256sum
+      -> 4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2  -
+      sha256sum skills/code-locale/references/check-identifier-locale.py
+      -> 4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2
+      /usr/bin/git diff --stat v2.21.0 HEAD -- skills/code-locale/references/{check-identifier-locale.py,english-words.txt.gz,programming-words.txt,not-english.txt}
+      -> (vazio) diff-rc=0
+      ```
+
+      Scaffold da change com o schema do repositório:
+
+      ```
+      openspec new change add-locale-adoption-kit --schema skills-rite
+      -> Created change 'add-locale-adoption-kit' at openspec/changes/add-locale-adoption-kit/
+      -> Schema: skills-rite
+      openspec validate add-locale-adoption-kit --strict
+      -> Change 'add-locale-adoption-kit' is valid
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      Dois itens. `shellcheck` e `act` não estão instalados nesta máquina (`which` acima), então o
+      hook é verificado com `bash -n` e o step de CI é validado rodando o **mesmo comando** do bloco
+      `run:` num clone local com `origin/main` no lugar de `origin/${{ github.base_ref }}` — a
+      simulação (S.1) declara isso por extenso, como o critério de aceite da issue pede. O que essa
+      substituição não prova: que o runner resolve `github.base_ref` e faz o checkout do merge
+      commit do PR com `fetch-depth: 0` — isso vem da doc do Actions e do precedente do `ci.yml`
+      deste repositório, que já depende dos dois.
+
+      A versão do bash foi lida do pacote (`dpkg -s bash`), não de `bash --version`: o sandbox desta
+      sessão recusa invocar `bash` com argumentos computados. Mesmo pacote, mesma versão.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz só o que a issue #139 pediu. Notados pelo caminho e **não** feitos, ficam como
+      follow-up:
+
+      - O detector copiado sozinho não falha sem as listas de palavras, mas reporta todo segmento
+        como `en-unknown` (E.2). O kit contorna com `--no-english` no modo download e documenta; um
+        aviso do próprio detector quando `english-words.txt.gz` não está ao lado seria uma edição no
+        detector, fora desta issue.
+      - `SKILL.md:125` exemplifica `git diff origin/main...` sem `...HEAD`; forma válida, mas o step
+        de CI usa a forma com `HEAD` explícito. Não harmonizado: a seção nova aponta para a doutrina,
+        não a reescreve.
+      - `README.md:558` (linha do índice de `code-locale`) diz "any project can wire into pre-commit"
+        e continuaria verdadeiro; a issue exclui `README.md` do escopo e nada foi tocado lá.
+      - Uma opção `--git-hooks <repo>` no `install.sh` — rejeitada na própria issue.
+
+## 2. Hook de pre-commit
+
+- [ ] 2.1 `skills/code-locale/references/pre-commit-locale.sh`: cabeçalho com instalação (`cp` para
+      `.git/hooks/pre-commit` ou `core.hooksPath`), ordem de localização do detector (D2), pin
+      `v2.21.0` + sha256 e a frase de bump, a lista do que não cobre (`--no-verify`, extensões fora
+      de `EXT_LANG`, conteúdo existente, tier consultivo no modo download); corpo que roda
+      `git diff --cached --no-color | python3 <detector> --diff -` e sai 1 com os achados mais o
+      rodapé das três saídas (D4); `python3` ausente recusa (D3)
+- [ ] 2.2 `bash -n` limpo; o detector sobre o próprio hook (`.sh` está em `EXT_LANG`) reporta
+      `findings: 0`
+
+## 3. Step de CI
+
+- [ ] 3.1 `skills/code-locale/references/ci-step.md`: job copiável (`pull_request`,
+      `permissions: contents: read`, `checkout@v5` com `fetch-depth: 0` e
+      `persist-credentials: false`, `curl -fsSL` na tag `v2.21.0` + `sha256sum -c`,
+      `git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff -`);
+      o pin, o `fetch-depth`, o gatilho e o `pipefail` explicados (D5); o que o step não cobre
+- [ ] 3.2 O bloco `yaml` parseia (C3 via `validate-skills.py`)
+
+## 4. Seção da skill e wrappers
+
+- [ ] 4.1 `skills/code-locale/SKILL.md`: seção *Wire it in one minute* com os dois links relativos
+      e a tabela de três camadas (hook de sessão / pre-commit / CI: o que pega, o que deixa passar);
+      `metadata.version` `1.3.1 → 1.4.0`; description intacta (mesmos gatilhos, ≤ 1024 chars)
+- [ ] 4.2 `bash generate.sh` duas vezes; a segunda sem diff; os dois arquivos novos aparecem em
+      `plugins/workflow/skills/code-locale/references/`
+
+## 5. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 O artefato foi exercitado pelo caminho real: hook instalado em `.git/hooks/pre-commit` de
+      um repositório git de rascunho, `git commit` recusado com o achado, aceito com `# locale-ok:`;
+      o comando do step de CI rodado sobre um clone com `origin/main` (declarado em E.3); `bash -n`;
+      `shellcheck` ausente e dito
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado — ou declaração de que nada escapou
+
+## 6. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em `skills/code-locale/SKILL.md`: name == diretório, description
+      folded, author solvelab, semver `1.4.0`, category `process`, license MIT, compatibility
+- [ ] Q.2 Conteúdo tocado em inglês (catalog locale): `SKILL.md`, `pre-commit-locale.sh`,
+      `ci-step.md` — sem comentário em português
+- [ ] Q.3 Gatilhos da description testáveis e sem colisão — a description não muda
+- [ ] Q.4 Sem doutrina duplicada: a seção nova e os dois arquivos apontam para *Reviewing a diff* e
+      para o docstring do detector (tabela de Canonical Home em `design.md`)
+- [ ] Q.5 Identificadores em inglês no que a change introduz (`LOCALE_CHECK`, `LOCALE_CHECK_TAG`,
+      `LOCALE_CHECK_SHA256`, funções e ids de step); o detector sobre os arquivos novos
+
+## 7. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-locale-adoption-kit --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage — a composição
+      não muda; `README.md` fora do escopo por decisão da issue
+- [ ] V.4 `openspec archive add-locale-adoption-kit --yes` after all groups above are `[x]` — PR
+      separado, como o repositório já faz

--- a/openspec/changes/add-locale-adoption-kit/tasks.md
+++ b/openspec/changes/add-locale-adoption-kit/tasks.md
@@ -139,59 +139,237 @@
 
 ## 2. Hook de pre-commit
 
-- [ ] 2.1 `skills/code-locale/references/pre-commit-locale.sh`: cabeçalho com instalação (`cp` para
-      `.git/hooks/pre-commit` ou `core.hooksPath`), ordem de localização do detector (D2), pin
-      `v2.21.0` + sha256 e a frase de bump, a lista do que não cobre (`--no-verify`, extensões fora
-      de `EXT_LANG`, conteúdo existente, tier consultivo no modo download); corpo que roda
-      `git diff --cached --no-color | python3 <detector> --diff -` e sai 1 com os achados mais o
-      rodapé das três saídas (D4); `python3` ausente recusa (D3)
-- [ ] 2.2 `bash -n` limpo; o detector sobre o próprio hook (`.sh` está em `EXT_LANG`) reporta
-      `findings: 0`
+- [x] 2.1 `skills/code-locale/references/pre-commit-locale.sh` (183 linhas, commit `79a171b`):
+      cabeçalho com instalação (`cp` para `.git/hooks/pre-commit` ou `core.hooksPath`), ordem de
+      localização do detector (D2), pin `v2.21.0` + sha256 e a frase de bump, a lista do que não
+      cobre (`--no-verify`, extensões fora de `EXT_LANG`, conteúdo existente, tier consultivo no
+      modo download); corpo que roda `git diff --cached --no-color | python3 <detector> --diff -` e
+      sai 1 com os achados mais o rodapé das três saídas (D4); `python3` ausente recusa (D3)
+
+      ```
+      grep -c "" skills/code-locale/references/pre-commit-locale.sh   -> 183
+      grep -n "^LOCALE_CHECK_TAG=\|^LOCALE_CHECK_SHA256=" skills/code-locale/references/pre-commit-locale.sh
+      -> 81:LOCALE_CHECK_TAG="${LOCALE_CHECK_TAG:-v2.21.0}"
+      -> 82:LOCALE_CHECK_SHA256="${LOCALE_CHECK_SHA256:-4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2}"
+      ```
+
+- [x] 2.2 `bash -n` limpo; o detector sobre o próprio hook (`.sh` está em `EXT_LANG`) reporta
+      `findings: 0`; `shellcheck` não está instalado (E.2) e por isso não foi rodado
+
+      ```
+      bash -n skills/code-locale/references/pre-commit-locale.sh; echo "bash-n rc=$?"
+      -> bash-n rc=0
+      python3 skills/code-locale/references/check-identifier-locale.py skills/code-locale/references/pre-commit-locale.sh
+      -> findings: 0
+      -> rc=0
+      ```
 
 ## 3. Step de CI
 
-- [ ] 3.1 `skills/code-locale/references/ci-step.md`: job copiável (`pull_request`,
-      `permissions: contents: read`, `checkout@v5` com `fetch-depth: 0` e
+- [x] 3.1 `skills/code-locale/references/ci-step.md` (108 linhas, commit `f4b8bd0`): job copiável
+      (`pull_request`, `permissions: contents: read`, `checkout@v5` com `fetch-depth: 0` e
       `persist-credentials: false`, `curl -fsSL` na tag `v2.21.0` + `sha256sum -c`,
       `git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff -`);
       o pin, o `fetch-depth`, o gatilho e o `pipefail` explicados (D5); o que o step não cobre
-- [ ] 3.2 O bloco `yaml` parseia (C3 via `validate-skills.py`)
+
+      ```
+      grep -n "fetch-depth\|sha256sum -c\|github.base_ref\|AI_SKILLS_TAG: " skills/code-locale/references/ci-step.md
+      -> 25:          fetch-depth: 0
+      -> 30:          AI_SKILLS_TAG: v2.21.0
+      -> 35:          echo "${CHECK_SHA256}  check-identifier-locale.py" | sha256sum -c -
+      -> 39:          git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff - --no-english
+      ```
+
+- [x] 3.2 O bloco `yaml` parseia (C3 via `validate-skills.py`, e à parte)
+
+      ```
+      python3 -c "import re,yaml; ... yaml.safe_load_all(block)"   (sobre o fence yaml de ci-step.md)
+      -> yaml ok; jobs: ['identifier-locale'] steps: 3 on: {'pull_request': None}
+      python3 scripts/validate-skills.py
+      -> skills checked: 35   findings: 0
+      ```
 
 ## 4. Seção da skill e wrappers
 
-- [ ] 4.1 `skills/code-locale/SKILL.md`: seção *Wire it in one minute* com os dois links relativos
-      e a tabela de três camadas (hook de sessão / pre-commit / CI: o que pega, o que deixa passar);
-      `metadata.version` `1.3.1 → 1.4.0`; description intacta (mesmos gatilhos, ≤ 1024 chars)
-- [ ] 4.2 `bash generate.sh` duas vezes; a segunda sem diff; os dois arquivos novos aparecem em
+- [x] 4.1 `skills/code-locale/SKILL.md` (commit `9060d47`): seção *Wire it in one minute* com os
+      dois links relativos e a tabela de três camadas (hook de sessão / pre-commit / CI: o que pega,
+      o que deixa passar); item novo no índice de `references/`; `metadata.version` `1.3.1 → 1.4.0`;
+      description intacta (mesmos gatilhos, 996 chars ≤ 1024)
+
+      ```
+      python3 -c "import yaml; ... print(len(d['description']), len(d['compatibility']), d['metadata']['version'])"
+      -> description chars: 996 compat chars: 490 version: 1.4.0
+      git diff 80ee53c HEAD -- skills/code-locale/SKILL.md | grep -c '^[-+].*description'
+      -> 0            (nenhuma linha da description mudou)
+      ```
+
+- [x] 4.2 `bash generate.sh` duas vezes; a segunda sem diff; os dois arquivos novos aparecem em
       `plugins/workflow/skills/code-locale/references/`
+
+      ```
+      bash generate.sh; git status --porcelain --untracked-files=all
+      ->  M claude/skills/code-locale/SKILL.md
+      ->  M cursor/rules/code-locale.mdc
+      ->  M plugins/workflow/skills/code-locale/SKILL.md
+      ->  M skills/code-locale/SKILL.md
+      -> ?? plugins/workflow/skills/code-locale/references/ci-step.md
+      -> ?? plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
+      -> ?? skills/code-locale/references/ci-step.md
+      -> ?? skills/code-locale/references/pre-commit-locale.sh
+      bash generate.sh; git status --porcelain --untracked-files=all | wc -l
+      -> 8            (os mesmos 8 caminhos: a segunda rodada não muda nada)
+      cmp skills/code-locale/references/pre-commit-locale.sh plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
+      -> plugins hook mirror identical
+      grep -c "blob/master/skills/code-locale/references/pre-commit-locale.sh" cursor/rules/code-locale.mdc
+      -> 1            (o Cursor reescreve o link relativo para a URL do repositório)
+      ```
 
 ## 5. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 O artefato foi exercitado pelo caminho real: hook instalado em `.git/hooks/pre-commit` de
-      um repositório git de rascunho, `git commit` recusado com o achado, aceito com `# locale-ok:`;
-      o comando do step de CI rodado sobre um clone com `origin/main` (declarado em E.3); `bash -n`;
-      `shellcheck` ausente e dito
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado — ou declaração de que nada escapou
+- [x] S.1 O artefato foi exercitado pelo caminho real. **Entry point 1**: `git commit` num
+      repositório git de rascunho (`$SCR/kit-probe`, `git init -b main`) com o hook copiado para
+      `.git/hooks/pre-commit` (`cp` + `chmod +x`, como o cabeçalho instrui). Nesta máquina
+      `~/ai-skills` existe, então o caso base roda no modo clone (tiers completos):
+
+      ```
+      printf 'def calcular_total(itens):\n    return sum(itens)\n' > orders.py; git add orders.py; git commit -q -m "add orders"; echo "commit rc=$?"
+      -> orders.py:1: calcular_total  [pt-verb: 'calcular']
+      ->     machine layer must be English (code-locale). If this name is correct as written, add a reason:
+      ->       # locale-ok: <why this term has no faithful English name>
+      -> orders.py:1: itens  [en-unknown: 'itens']   [...]  advisory: this finding does not fail the run
+      -> findings: 1
+      -> pre-commit-locale: refused: the staged diff adds a non-English name to the machine layer (code-locale).
+      -> pre-commit-locale:   waive one line:   # locale-ok: <why this term has no faithful English name>   (on the line, or the one above)
+      -> pre-commit-locale:   waive a path:     add it to .identifier-locale-allow (one path or segment per line)
+      -> pre-commit-locale:   bypass:           git commit --no-verify   — the deliberate exit; CI measures it anyway
+      -> commit rc=1
+      -> fatal: your current branch 'main' does not have any commits yet     (git log: 0 commits — nada entrou)
+      printf '# locale-ok: probe\ndef calcular_total(itens):\n    return sum(itens)\n' > orders.py; git add orders.py; git commit -q -m "add orders"; echo "commit rc=$?"
+      -> orders.py:3: itens  [en-unknown: 'itens']   [...]  advisory
+      -> findings: 0
+      -> commit rc=0
+      ```
+
+      Os demais casos do hook foram disparados por `$SCR/sim_cases.py` — um driver que só monta o
+      ambiente por caso (`HOME`, `AI_SKILLS_HOME`, `LOCALE_CHECK*`, `PATH`) e chama o mesmo
+      `git commit`; o sandbox desta sessão recusa `HOME=... git` direto no shell. Saída completa em
+      `$SCR/sim_output.txt`; fragmentos:
+
+      ```
+      [3] HOME=<vazio> AI_SKILLS_HOME=/nonexistent git commit   (customers.py: def buscar_cliente)
+      -> pre-commit-locale: downloading the detector once, pinned at v2.21.0: https://raw.githubusercontent.com/solvelab/ai-skills/v2.21.0/skills/code-locale/references/[...]
+      -> pre-commit-locale: advisory English tier off: english-words.txt.gz is not beside .git/locale-check/v2.21.0/check-identifier-locale.py (gating tiers unaffected)
+      -> customers.py:1: buscar_cliente  [pt-verb: 'buscar']
+      -> findings: 1
+      -> pre-commit-locale: refused: [...]   rc=1
+      -> cached detector: .git/locale-check/v2.21.0/check-identifier-locale.py sha256=4e72af47…3ff2 matches_pin=True
+      [3b] mesmo comando de novo            -> sem a linha "downloading" (cache), buscar_cliente, rc=1
+      [4] LOCALE_CHECK_SHA256=deadbeef      -> digest mismatch for the detector at tag v2.21.0 / expected deadbeef / got 4e72af47…3ff2 / could not locate [...]  rc=1
+      [4b] LOCALE_CHECK_TAG=v0.0.0-nope LOCALE_CHECK_SHA256=skip
+                                           -> curl: (22) The requested URL returned error: 404 / download failed (is v0.0.0-nope a published tag [...])  rc=1
+      [5] LOCALE_CHECK=$SCR/standalone/check-identifier-locale.py
+                                           -> advisory English tier off [...] / buscar_cliente / refused  rc=1
+      [6] LOCALE_CHECK=/nonexistent/check.py -> LOCALE_CHECK is set but is not a file: /nonexistent/check.py / could not locate  rc=1
+      [7] PATH=<dir sem python3>            -> python3 not found on PATH — the detector needs Python 3.9+, and a gate that cannot measure must not approve / bypass, if you mean it: git commit --no-verify  rc=1
+      [8] git commit --no-verify (buscar_cliente)  -> rc=0   (escape conhecido e nomeado)
+      [9] git commit --allow-empty          -> rc=0, sem saída
+      [10] totals.py: def compute_total(items)  -> rc=0, sem saída
+      [11] relatorio.txt (fora de EXT_LANG) -> relatorio.txt: relatorio  [path-pt-noun: 'relatorio'] / A file name carries no inline waiver — grandfather the path [...] .identifier-locale-allow / refused  rc=1
+      [12] .identifier-locale-allow com relatorio.txt  -> rc=0
+      ```
+
+      **Entry point 2** — o step de CI. `act` não está instalado (E.3); rodado o **mesmo texto dos
+      dois blocos `run:`** de `ci-step.md` sob `bash -e -c`, num clone do repositório de rascunho
+      (`git clone kit-probe kit-probe-ci`, então `origin/main` existe) com `origin/main` no lugar de
+      `origin/${{ github.base_ref }}`, num branch `feature/pt` que adiciona `shipping.py` com
+      `def calcular_frete(order)` (commitado com `--no-verify`, como um autor que dribla o hook):
+
+      ```
+      [CI-1] curl -fsSL -o check-identifier-locale.py "https://raw.githubusercontent.com/solvelab/ai-skills/v2.21.0/[...]" && echo "4e72af47…3ff2  check-identifier-locale.py" | sha256sum -c -
+      -> check-identifier-locale.py: OK          rc=0
+      [CI-2] git diff origin/main...HEAD | python3 check-identifier-locale.py --diff - --no-english   (feature/pt)
+      -> shipping.py:1: calcular_frete  [pt-verb: 'calcular']
+      -> findings: 1                              rc=1
+      [CI-3] mesmo comando em feature/en (def compute_shipping(order))
+      -> findings: 0                              rc=0
+      [CI-4] fetch com CHECK_SHA256 errado
+      -> check-identifier-locale.py: FAILED / sha256sum: WARNING: 1 computed checksum did NOT match   rc=1
+      ```
+
+      `bash -n` e o detector sobre o hook: 2.2. `shellcheck`: ausente nesta máquina, não rodado.
+
+- [x] S.2 Matriz de casos medida, em contagens (`sim_cases.py` -> `cases: 16  as expected: 16
+      unexpected: 0`, mais os dois casos manuais de S.1)
+
+      | Artefato | Expectativa | Casos | Resultado |
+      |---|---|---|---|
+      | hook (`git commit`, modo clone) | tinha de recusar e recusou | 1/1 | `calcular_total`, rc=1, 0 commits |
+      | hook (modo clone) | tinha de aceitar e aceitou | 1/1 | `# locale-ok: probe`, rc=0 |
+      | hook (modo download, `HOME` vazio) | tinha de baixar uma vez, conferir sha e recusar | 2/2 | [3] download + `matches_pin=True`; [3b] cache, sem download |
+      | hook (pin) | tinha de recusar sem medir | 2/2 | [4] sha errado; [4b] tag inexistente (404) |
+      | hook (`LOCALE_CHECK`) | caminho explícito mede; caminho inválido recusa | 2/2 | [5] rc=1 com achado; [6] rc=1 nomeando a variável |
+      | hook (sem `python3`) | tinha de recusar e recusou | 1/1 | [7] rc=1, nomeia o `--no-verify` |
+      | hook | tinha de ficar mudo e ficou | 3/3 | [9] commit vazio; [10] `compute_total`; [12] allowlist |
+      | hook (fora de `EXT_LANG`) | caminho medido, conteúdo pulado | 1/1 | [11] `relatorio.txt` recusado pelo nome |
+      | hook | escape conhecido ficou mudo | 1/1 | [8] `--no-verify`, rc=0 — ver S.3 |
+      | step de CI (`run:` verbatim, `origin/main`) | fetch + digest OK; PR com achado falha; PR limpo passa; digest errado falha | 4/4 | CI-1 rc=0; CI-2 rc=1; CI-3 rc=0; CI-4 rc=1 |
+      | `bash -n` | limpo | 1/1 | rc=0 |
+      | `shellcheck` | — | 0/0 | não instalado; declarado |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Um escape conhecido e mantido de propósito: `git commit --no-verify` com `buscar_cliente`
+      passa ([8], rc=0). É o bypass **nomeado** no cabeçalho e no rodapé do hook, e é exatamente o
+      que o step de CI pegou em CI-2 — o mesmo commit driblado, medido no clone. Nada se comportou
+      diferente do escrito no design; três observações que não são defeitos, registradas para o
+      revisor:
+
+      - No modo clone, um commit aceito **com** achados consultivos imprime a saída inteira do
+        detector (inclusive `findings: 0`) — decisão D4: linhas `advisory` merecem os olhos do
+        autor. Um commit sem nenhum achado fica mudo ([9], [10]).
+      - Quando o digest falha ([4]), a última linha antes do bypass é a genérica "could not locate
+        the identifier-locale detector"; a razão específica ("digest mismatch … expected … got …")
+        está três linhas acima. Aceito: a mensagem específica vem primeiro.
+      - O que a simulação **não** prova: que o runner do Actions resolve `github.base_ref` e faz o
+        checkout do merge commit com `fetch-depth: 0` — `origin/main` foi o substituto (E.3), e a
+        premissa vem do `ci.yml` deste repositório, que já depende dos dois.
 
 ## 6. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em `skills/code-locale/SKILL.md`: name == diretório, description
-      folded, author solvelab, semver `1.4.0`, category `process`, license MIT, compatibility
-- [ ] Q.2 Conteúdo tocado em inglês (catalog locale): `SKILL.md`, `pre-commit-locale.sh`,
-      `ci-step.md` — sem comentário em português
-- [ ] Q.3 Gatilhos da description testáveis e sem colisão — a description não muda
-- [ ] Q.4 Sem doutrina duplicada: a seção nova e os dois arquivos apontam para *Reviewing a diff* e
-      para o docstring do detector (tabela de Canonical Home em `design.md`)
-- [ ] Q.5 Identificadores em inglês no que a change introduz (`LOCALE_CHECK`, `LOCALE_CHECK_TAG`,
-      `LOCALE_CHECK_SHA256`, funções e ids de step); o detector sobre os arquivos novos
+- [x] Q.1 Frontmatter uniforme em `skills/code-locale/SKILL.md`: name == diretório, description
+      folded, author solvelab, semver `1.4.0`, category `process`, license MIT, compatibility —
+      `gates.sh` -> `PASS frontmatter` (o mesmo loop do step *Skill frontmatter checks*);
+      `agentskills validate skills/code-locale/` -> `Valid skill: skills/code-locale`
+- [x] Q.2 Conteúdo tocado em inglês (catalog locale): `SKILL.md`, `pre-commit-locale.sh`,
+      `ci-step.md` — sem comentário em português; `grep -nP '[àáâãéêíóôõúç…]'` sobre os dois
+      arquivos novos -> nenhuma linha (rc=1); as únicas palavras portuguesas são os fixtures
+      (`calcular_total`, `relatorio`) citados como exemplo do que o gate recusa
+- [x] Q.3 Gatilhos da description testáveis e sem colisão — a description não muda
+      (`git diff 80ee53c HEAD -- skills/code-locale/SKILL.md | grep -c '^[-+].*description'` -> 0);
+      996 chars; o "Do NOT use for" permanece
+- [x] Q.4 Sem doutrina duplicada: a seção nova e os dois arquivos apontam para *Reviewing a diff*,
+      para `references/migration.md` e para o docstring do detector em vez de reescrever os tiers
+      ou as saídas (tabela de Canonical Home em `design.md`); nenhum tier é reimplementado
+      (`grep -c "pt-verb\|pt-noun" pre-commit-locale.sh` -> 1, a linha do cabeçalho que os nomeia)
+- [x] Q.5 Identificadores em inglês no que a change introduz (`LOCALE_CHECK`, `LOCALE_CHECK_TAG`,
+      `LOCALE_CHECK_SHA256`, `EXTRA_ARGS`, `locate_check`, `verify_digest`, `refuse`, `log`,
+      `identifier-locale` como id de job e step):
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py skills/code-locale/references/pre-commit-locale.sh
+      -> findings: 0
+      python3 skills/code-locale/references/check-identifier-locale.py --markdown-fences skills/code-locale/references/ci-step.md skills/code-locale/SKILL.md
+      -> findings: 0   (cada um)
+      ```
 
 ## 7. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-locale-adoption-kit --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
-      no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage — a composição
-      não muda; `README.md` fora do escopo por decisão da issue
+- [x] V.1 `openspec validate add-locale-adoption-kit --strict` -> `Change 'add-locale-adoption-kit' is valid`
+- [x] V.2 Descoberta do catálogo intacta: `npx -y skills add . --list` -> `Found 35 skills`;
+      `ls -d skills/*/ | wc -l` -> `35`; `validate-skills.py` -> `skills checked: 35   findings: 0`
+      (sem órfão: C11 não reporta os dois arquivos novos, ambos linkados do `SKILL.md`)
+- [x] V.3 README / docs atualizados onde a composição ou o uso mudam — a composição não muda; o uso
+      novo está documentado na própria skill (seção *Wire it in one minute*); `README.md` fora do
+      escopo por decisão da issue #139 e não tocado
 - [ ] V.4 `openspec archive add-locale-adoption-kit --yes` after all groups above are `[x]` — PR
       separado, como o repositório já faz

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.4.0
   category: process
 license: MIT
 compatibility: >-
@@ -43,6 +43,9 @@ without a taste debate.
 - **Existing names: the three migration tiers**: `references/migration.md`
 - **The detector** — measures the path of every file it is given and the contents of the types
   it tokenizes: `references/check-identifier-locale.py`
+- **Adopting the gate in a repository, without the assistant**: the pre-commit hook
+  `references/pre-commit-locale.sh` and the CI step `references/ci-step.md` (section *Wire it in
+  one minute*)
 
 ## The two layers
 
@@ -191,6 +194,32 @@ depend on the assistant noticing a rule it already has.
 The findings travel in the field the harness reads for that event, not on plain standard output;
 the hook's own docstring records the probe that established which one. Wiring: the README's hooks
 section.
+
+## Wire it in one minute
+
+The session hook above exists only where a harness runs it with this machine's settings. A
+repository adopts the same detector on its own, for every tool and every human, with one file or one
+YAML block — both invoke `check-identifier-locale.py --diff` on added lines only, pin it to a tagged
+release of the catalog, and print the exits the *Reviewing a diff* section already explains:
+
+- **Pre-commit hook**: [`references/pre-commit-locale.sh`](references/pre-commit-locale.sh) — copy
+  to `.git/hooks/pre-commit` (or into a `core.hooksPath` directory); it finds the detector in a local
+  clone or downloads it once, digest-checked, and refuses a commit whose staged diff adds a
+  non-English name.
+- **CI step**: [`references/ci-step.md`](references/ci-step.md) — a copy-paste GitHub Actions job
+  (`pull_request`, `fetch-depth: 0`, `curl` at a tag with `sha256sum -c`,
+  `git diff origin/<base>...HEAD | python3 check-identifier-locale.py --diff -`).
+
+Each layer catches a different moment, and each has a hole the next one covers:
+
+| Layer | Runs | Catches | Misses |
+|---|---|---|---|
+| Session hook (`locale-rite.py`, the catalog's global rules) | on the assistant's `Write`/`Edit`, in a Claude Code session with the hook wired | the name at the moment it is written, before it spreads across a diff | every other tool (Codex, Cursor, Copilot), a human typing in an editor, a machine without the wiring; informs, never blocks |
+| Pre-commit hook | on `git commit`, on the author's machine | the staged diff of any author and any tool, before it leaves the machine | `git commit --no-verify`, rebases and merges, a clone that never installed it; only added lines in tokenized file types |
+| CI step | on every pull request | the pull request's added lines regardless of how they were produced or bypassed | direct pushes to the default branch (branch protection's job); existing content; the advisory tier unless the word lists are shipped |
+
+Each file states in its own header what it does not cover; a green run at any layer is a
+measurement of what the tiers reach, not proof of compliance.
 
 ## Existing code
 

--- a/plugins/workflow/skills/code-locale/references/ci-step.md
+++ b/plugins/workflow/skills/code-locale/references/ci-step.md
@@ -35,8 +35,12 @@ jobs:
           echo "${CHECK_SHA256}  check-identifier-locale.py" | sha256sum -c -
 
       - name: Identifier locale on the lines this pull request adds
+        env:
+          PYTHONIOENCODING: utf-8:surrogateescape
         run: |
-          git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff - --no-english
+          set -o pipefail
+          git diff --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ origin/${{ github.base_ref }}...HEAD \
+            | python3 check-identifier-locale.py --diff - --no-english
 ```
 
 ## Why each line is there
@@ -46,8 +50,9 @@ jobs:
   nothing to measure. A gate that cannot measure must not approve, so it is not wired where it
   cannot run.
 - **`fetch-depth: 0`.** `git diff A...HEAD` measures from the merge base. The default depth of 1
-  leaves no base revision in the clone and the diff fails or measures the wrong thing; the
-  catalog's own `ci.yml` carries the same setting for the same reason.
+  leaves no base revision in the clone and `git diff` fails — which, with `pipefail` below, fails the
+  step instead of approving an empty diff; the catalog's own `ci.yml` carries the same setting for
+  the same reason.
 - **`persist-credentials: false`.** Nothing after the checkout needs the token; the default leaves
   it in `.git/config` for every later step.
 - **`permissions: contents: read`.** The job reads the repository and nothing else.
@@ -73,10 +78,29 @@ jobs:
   assumed. The gating tiers (`pt-verb`, `pt-noun`, `pt-morphology`, path) do not depend on those
   lists, so the exit code is identical with or without this flag. Want the advisory tier in CI?
   Download the three files beside the detector (same URL shape, same tag) and drop the flag.
-- **The pipe's exit code.** A `run:` block on Linux runs `bash -e {0}` **without** `pipefail`, so
-  the step's status is `python3`'s — exactly what is wanted: exit 1 on a gating finding, 0
-  otherwise. A `git diff` failure (no base revision) prints its error and the detector, reading an
-  empty diff, reports `findings: 0`; that is why `fetch-depth: 0` is not optional here.
+- **`set -o pipefail`.** The default shell of a `run:` block on Linux is `bash -e {0}` (GitHub's
+  workflow-syntax page; not probed on a runner here), and `-e` alone takes the pipe's status from its
+  **last** command. Without `pipefail` a failed `git diff` — a base ref that was not fetched, an empty
+  `github.base_ref`, a `fetch-depth` left at 1 — prints its error, the detector reads an empty
+  stream, prints `findings: 0`, and the step is green: measured on 2026-09-05 with the block verbatim
+  (`fatal: ambiguous argument 'origin/release/9...HEAD'` then `findings: 0`, exit 0). With `pipefail`
+  the same case exits 128. A gate that cannot measure must not approve, and this is the line that
+  makes the step obey its own rule. The same effect comes from declaring `shell: bash`, which the same
+  page documents as `bash --noprofile --norc -eo pipefail {0}`; the explicit line travels to other CI
+  systems unchanged.
+- **The four `git diff` flags.** They pin the diff's *shape*, so a runner's or a repository's git
+  config cannot change what the detector reads — the pre-commit hook passes the same four, for the
+  same measured reasons (its header, *WHAT IT DOES*): `--no-ext-diff` (a `diff.external` driver
+  replaces the unified diff with its own output — an empty stream and `findings: 0`), `--no-renames`
+  (with rename detection, git's default, `git mv orders.py relatorio.py` is a `rename to` header with
+  no `--- /dev/null`, and the detector never measures the new name; without it a rename is a delete
+  plus an add and the new path is measured), `--src-prefix=a/ --dst-prefix=b/` (`diff.mnemonicPrefix`
+  writes `+++ i/…`, and a path grandfathered in `.identifier-locale-allow` stops matching). A fresh
+  `ubuntu-latest` runner carries none of these settings; a self-hosted runner may.
+- **`PYTHONIOENCODING: utf-8:surrogateescape`.** A hunk carrying non-UTF-8 bytes — a latin-1 legacy
+  file, common in the codebases this skill targets — otherwise aborts the detector with
+  `UnicodeDecodeError` before any name is judged, and the step fails for the wrong reason. With the
+  handler the undecodable bytes pass through and only the names are measured.
 
 ## Reading a failure
 
@@ -95,7 +119,11 @@ guide: the skill's *Reviewing a diff* section.
   skipped, never as passing.
 - **Existing content.** Only added lines. A pull request that moves a legacy Portuguese name from
   one file to another adds it, and is reported — that is the migration policy meeting the gate, and
-  the waiver line is the answer when the move is deliberate.
+  the waiver line is the answer when the move is deliberate. With `--no-renames` a **renamed file** is
+  the same case: every line of the moved file is read as added, so renaming a legacy file whose
+  content still carries Portuguese names turns the pull request red at that moment (fix the names,
+  waive them, or grandfather the path). A pure rename of an English-clean file is silent; a rename
+  **to** a Portuguese name is reported on the path, which is why the flag is there.
 - **The advisory tier**, unless you ship the word lists and drop `--no-english`.
 - **Everything the detector's own `KNOWN LIMIT` list names** — words that are both English and
   Portuguese, abbreviations under the minimum segment length, identifiers built at runtime, Spanish

--- a/plugins/workflow/skills/code-locale/references/ci-step.md
+++ b/plugins/workflow/skills/code-locale/references/ci-step.md
@@ -1,0 +1,108 @@
+# CI step — the identifier-locale gate on every pull request
+
+One job, copy-paste. It downloads the detector the `code-locale` skill ships at a **tagged release**
+of `solvelab/ai-skills`, verifies its digest, and measures only the lines the pull request adds.
+No clone of the catalog, no assistant, no Python package: `python3` 3.9+ and `curl` are already on
+`ubuntu-latest`.
+
+```yaml
+name: identifier-locale
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  identifier-locale:
+    name: Identifier locale (added lines are English)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch the detector, pinned
+        env:
+          AI_SKILLS_TAG: v2.21.0
+          CHECK_SHA256: 4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2
+        run: |
+          curl -fsSL -o check-identifier-locale.py \
+            "https://raw.githubusercontent.com/solvelab/ai-skills/${AI_SKILLS_TAG}/skills/code-locale/references/check-identifier-locale.py"
+          echo "${CHECK_SHA256}  check-identifier-locale.py" | sha256sum -c -
+
+      - name: Identifier locale on the lines this pull request adds
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff - --no-english
+```
+
+## Why each line is there
+
+- **`on: pull_request` only.** The command diffs the branch against its base, and `github.base_ref`
+  exists only on `pull_request` events — on `push` it is empty and `git diff origin/...HEAD` has
+  nothing to measure. A gate that cannot measure must not approve, so it is not wired where it
+  cannot run.
+- **`fetch-depth: 0`.** `git diff A...HEAD` measures from the merge base. The default depth of 1
+  leaves no base revision in the clone and the diff fails or measures the wrong thing; the
+  catalog's own `ci.yml` carries the same setting for the same reason.
+- **`persist-credentials: false`.** Nothing after the checkout needs the token; the default leaves
+  it in `.git/config` for every later step.
+- **`permissions: contents: read`.** The job reads the repository and nothing else.
+- **The pin.** `AI_SKILLS_TAG` is a release tag of `solvelab/ai-skills`, never `master`: a gate on
+  a moving branch fails your pull requests on someone else's release schedule. `CHECK_SHA256` is the
+  digest of the detector **at that tag** — `sha256sum -c` fails the step on any other content, so
+  the tag cannot drift under you and a compromised or mistyped URL cannot run. Bump the two
+  together:
+
+  ```bash
+  TAG=v2.22.0
+  curl -fsSL "https://raw.githubusercontent.com/solvelab/ai-skills/${TAG}/skills/code-locale/references/check-identifier-locale.py" | sha256sum
+  ```
+
+  The value shipped above (`4e72af47…3ff2`) is the detector at `v2.21.0`, measured on 2026-09-05.
+- **`--diff -`.** Added lines only. Whole-tree enforcement turns a legacy repository red on day one
+  and a gate that blocks every pipeline is switched off within a week — the detector's docstring
+  records this as the reason `--diff` exists. Existing names migrate by the skill's tiers
+  (`references/migration.md`), not by this step.
+- **`--no-english`.** The advisory "is this word English?" tier needs the three word-list files
+  that sit beside the detector in the catalog (`english-words.txt.gz`, `programming-words.txt`,
+  `not-english.txt`). Without them every segment would be reported as unknown — measured, not
+  assumed. The gating tiers (`pt-verb`, `pt-noun`, `pt-morphology`, path) do not depend on those
+  lists, so the exit code is identical with or without this flag. Want the advisory tier in CI?
+  Download the three files beside the detector (same URL shape, same tag) and drop the flag.
+- **The pipe's exit code.** A `run:` block on Linux runs `bash -e {0}` **without** `pipefail`, so
+  the step's status is `python3`'s — exactly what is wanted: exit 1 on a gating finding, 0
+  otherwise. A `git diff` failure (no base revision) prints its error and the detector, reading an
+  empty diff, reports `findings: 0`; that is why `fetch-depth: 0` is not optional here.
+
+## Reading a failure
+
+The detector prints `path:line:token [tier]` and the exact waiver line to add. The exits are the
+skill's, not this step's: `# locale-ok: <reason>` on the offending line or the one above it; the
+`.identifier-locale-allow` file for a file or directory name; and, for a term with no faithful
+English name, the change's glossary (`references/glossary-protocol.md`). Doctrine and the reading
+guide: the skill's *Reviewing a diff* section.
+
+## What this step does not cover
+
+- **Pushes to the default branch.** It runs on pull requests only. A repository that accepts direct
+  pushes has no gate on them here; branch protection is what closes that.
+- **Content outside the detector's `EXT_LANG`** (`.py .lua .js .jsx .mjs .cjs .ts .tsx .cs .sql .yml
+  .yaml .json .sh .bash`): the path of an added file is still measured; its content is reported as
+  skipped, never as passing.
+- **Existing content.** Only added lines. A pull request that moves a legacy Portuguese name from
+  one file to another adds it, and is reported — that is the migration policy meeting the gate, and
+  the waiver line is the answer when the move is deliberate.
+- **The advisory tier**, unless you ship the word lists and drop `--no-english`.
+- **Everything the detector's own `KNOWN LIMIT` list names** — words that are both English and
+  Portuguese, abbreviations under the minimum segment length, identifiers built at runtime, Spanish
+  and Italian. A green step is a measurement of what the tiers reach, not proof of compliance.
+- **Other CI systems.** The one-line command is the whole contract; the YAML around it is GitHub
+  Actions. On GitLab CI the base is `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME` with `GIT_DEPTH: 0`; the
+  pin and the digest check are the same.
+
+For the layer that catches the name **before** it reaches a pull request — the human's own
+`git commit` — see `references/pre-commit-locale.sh`.

--- a/plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
+++ b/plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
@@ -3,9 +3,22 @@
 # identifier in the machine layer. Doctrine: the `code-locale` skill (solvelab/ai-skills).
 #
 # WHAT IT DOES
-#   git diff --cached --no-color | python3 check-identifier-locale.py --diff -
+#   git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ \
+#     | PYTHONIOENCODING=utf-8:surrogateescape python3 check-identifier-locale.py --diff -
 #   That is the whole check. The detector is the one the skill ships; this file only finds it,
 #   runs it on the staged diff, and explains a refusal. Exit 0 and silent when the diff is clean.
+#   The four diff flags pin the diff's SHAPE, so a repository's or a user's git config cannot change
+#   what the detector reads (measured 2026-09-05, each one a silent approval or a false refusal):
+#     --no-ext-diff    `diff.external` replaces the unified diff with a driver's output — an empty
+#                      stream, `findings: 0`, and the commit is approved unmeasured.
+#     --no-renames     with rename detection (git's default) `git mv orders.py relatorio.py` is a
+#                      `rename to` header with no `--- /dev/null`, and the new name is never measured.
+#                      Without it a rename is a delete plus an add: the new PATH is measured, and the
+#                      moved content is read as added lines (see DOES NOT COVER).
+#     --src/dst-prefix `diff.mnemonicPrefix` writes `+++ i/relatorio.txt`; the detector strips only
+#                      `b/`, so a path grandfathered in .identifier-locale-allow stops matching.
+#   PYTHONIOENCODING=utf-8:surrogateescape keeps a hunk with non-UTF-8 bytes (a latin-1 legacy file)
+#   from aborting the detector: undecodable bytes pass through, and only the names are judged.
 #   Exit 1 with the detector's findings when a gating tier (pt-verb, pt-noun, pt-morphology, path)
 #   reports — the same exit code the detector itself uses. The `en-unknown` tier stays advisory:
 #   it prints, and it never refuses a commit (the detector's --gate-unknown is deliberately not
@@ -33,7 +46,10 @@
 #      English word lists are absent, so the hook passes --no-english and says so on stderr. The
 #      gating tiers are identical in every mode; only the advisory tier is off here.
 #
-# THE PIN — bump the two together:
+# THE PIN — applies to source 3 only. Sources 1 and 2 run whatever file is at that path, with no
+# digest check: an explicit LOCALE_CHECK is your vendored copy, and the ~/ai-skills clone is at
+# whatever commit its owner last pulled — so a commit accepted locally and the CI step
+# (references/ci-step.md, always pinned) can run different detector versions. Bump the two together:
 #   LOCALE_CHECK_TAG     a release tag of solvelab/ai-skills (`git tag --list 'v*'` in the catalog,
 #                        or the Releases page). Never `master`: a gate on a moving branch fails
 #                        your commits on someone else's schedule.
@@ -68,12 +84,21 @@
 #   - Existing content. Only ADDED lines are read (`--diff`); a legacy name already in the tree is
 #     never reported, and renaming it is the skill's migration policy, not this hook's job. Partial
 #     staging (`git add -p`) is measured as staged: hunks left out of the commit are not read.
+#   - A rename is read as delete + add (--no-renames, above). The new path is measured — that is the
+#     point — and every line of the moved file is read as ADDED, so renaming a legacy file whose
+#     content still carries Portuguese names meets the gate at that moment: fix the names, waive
+#     them, or `--no-verify` and let CI record it. A pure rename of an English-clean file is silent.
+#   - A detector exit 1 counts as a refusal only when its output carries the `findings:` line the
+#     detector prints after a completed scan. Any other exit 1 — a traceback, a wrong LOCALE_CHECK —
+#     is reported as the detector failing, and the commit is still refused: nothing was measured.
 #   - The advisory English tier in download mode (see 3 above), and everything the detector's own
 #     docstring lists under KNOWN LIMIT — a curated word list is not a language model.
 #   - A missing python3 REFUSES the commit (exit 1, naming the bypass) instead of approving it: a
 #     gate that cannot measure must not approve. Install python3 (3.9+) or commit with --no-verify.
 #
-# Dependencies: bash, git, python3 (3.9+). curl only for the download fallback.
+# Dependencies: bash 3.2+ (macOS's stock /bin/bash included — every array expansion here is written
+# for `set -u` on bash < 4.4, where `"${empty[@]}"` is an unbound variable), git 2.x, python3 (3.9+).
+# curl only for the download fallback.
 
 set -u
 set -o pipefail
@@ -151,14 +176,23 @@ check_path="$(locate_check)" || refuse "could not locate the identifier-locale d
 # The English word lists live beside the detector. Absent (download mode, or a vendored copy of
 # the single file) every segment would be reported as unknown, so the advisory tier is switched
 # off and the switch is announced — the gating tiers do not depend on those lists.
-args=("${EXTRA_ARGS[@]}")
+# `${arr[@]+"${arr[@]}"}` is the expansion that survives `set -u` with an empty array on bash 3.2
+# and 4.3; the plain `"${arr[@]}"` aborts the hook there (measured on bash:3.2 and bash:4.3).
+args=(${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"})
 if [ ! -f "$(dirname "$check_path")/english-words.txt.gz" ]; then
   args+=(--no-english)
   log "advisory English tier off: english-words.txt.gz is not beside ${check_path} (gating tiers unaffected)"
 fi
 
-output="$(git diff --cached --no-color | python3 "$check_path" --diff - "${args[@]}" 2>&1)"
+output="$(git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ \
+  | PYTHONIOENCODING=utf-8:surrogateescape python3 "$check_path" --diff - ${args[@]+"${args[@]}"} 2>&1)"
 rc=$?
+
+# The detector prints `findings: N` only after a completed scan. Exit 1 without that line is a
+# crash (an uncaught exception also exits 1), not a measurement — and must not be explained as one.
+if [ "$rc" -eq 1 ] && ! printf '%s\n' "$output" | grep -q '^findings: '; then
+  rc=70
+fi
 
 case "$rc" in
   0)
@@ -178,6 +212,6 @@ case "$rc" in
     ;;
   *)
     printf '%s\n' "$output" >&2
-    refuse "the detector itself failed (exit ${rc}); nothing was measured, so nothing is approved"
+    refuse "the detector itself failed (exit ${rc}, no findings: line); nothing was measured, so nothing is approved"
     ;;
 esac

--- a/plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
+++ b/plugins/workflow/skills/code-locale/references/pre-commit-locale.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# pre-commit-locale.sh — git pre-commit hook: the lines this commit ADDS carry no non-English
+# identifier in the machine layer. Doctrine: the `code-locale` skill (solvelab/ai-skills).
+#
+# WHAT IT DOES
+#   git diff --cached --no-color | python3 check-identifier-locale.py --diff -
+#   That is the whole check. The detector is the one the skill ships; this file only finds it,
+#   runs it on the staged diff, and explains a refusal. Exit 0 and silent when the diff is clean.
+#   Exit 1 with the detector's findings when a gating tier (pt-verb, pt-noun, pt-morphology, path)
+#   reports — the same exit code the detector itself uses. The `en-unknown` tier stays advisory:
+#   it prints, and it never refuses a commit (the detector's --gate-unknown is deliberately not
+#   passed here; add it to EXTRA_ARGS below once your repository has measured its own noise).
+#
+# INSTALL — one of:
+#   cp pre-commit-locale.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+#     (per clone; .git/ is never versioned)
+#   mkdir -p .githooks && cp pre-commit-locale.sh .githooks/pre-commit && chmod +x .githooks/pre-commit
+#   git config core.hooksPath .githooks
+#     (versioned hooks; the `git config` line runs once per clone — git never sets hooksPath
+#     from a repository file, on purpose)
+#   A repository that already has a pre-commit hook chains this one from it: `exec` or call
+#   `.githooks/pre-commit-locale.sh` at the end of the existing script and keep its exit code.
+#
+# WHERE THE DETECTOR COMES FROM — first match wins:
+#   1. $LOCALE_CHECK — an explicit path, for a repository that vendored the detector.
+#   2. $AI_SKILLS_HOME/skills/code-locale/references/check-identifier-locale.py, then the same path
+#      under ~/ai-skills — the clone the catalog's install.sh creates. The word lists sit beside
+#      the detector there, so the advisory English tier runs in full.
+#   3. Download, pinned: https://raw.githubusercontent.com/solvelab/ai-skills/<TAG>/skills/code-locale/references/check-identifier-locale.py
+#      fetched with `curl -fsSL`, its sha256 checked with python3 (hashlib — no sha256sum/shasum
+#      dependency), cached under `$(git rev-parse --git-dir)/locale-check/<TAG>/` so it is fetched
+#      once per tag and never enters the tree. Only the detector is downloaded: in this mode the
+#      English word lists are absent, so the hook passes --no-english and says so on stderr. The
+#      gating tiers are identical in every mode; only the advisory tier is off here.
+#
+# THE PIN — bump the two together:
+#   LOCALE_CHECK_TAG     a release tag of solvelab/ai-skills (`git tag --list 'v*'` in the catalog,
+#                        or the Releases page). Never `master`: a gate on a moving branch fails
+#                        your commits on someone else's schedule.
+#   LOCALE_CHECK_SHA256  sha256 of the detector AT THAT TAG:
+#                        curl -fsSL <raw url at the tag> | sha256sum
+#                        or, from a clone: git show <tag>:skills/code-locale/references/check-identifier-locale.py | sha256sum
+#   A tag changed without its hash fails loudly — a pin that accepts any content is not a pin.
+#   LOCALE_CHECK_SHA256=skip disables the digest check, in writing, for a tag-only pin.
+#   Both accept an environment override (`LOCALE_CHECK_TAG=v2.22.0 LOCALE_CHECK_SHA256=... git commit`).
+#
+# THE EXITS — every finding prints the exact line to add:
+#   # locale-ok: <why this term has no faithful English name>   on the offending line or the one
+#                                                                above it (the waiver covers its
+#                                                                own line and the next, nothing further)
+#   .identifier-locale-allow                                     one path or segment per line — the
+#                                                                only waiver a FILE NAME can carry
+#   git commit --no-verify                                       the deliberate bypass. Named, not
+#                                                                hidden: the rite informs, the author
+#                                                                decides — and the CI step
+#                                                                (references/ci-step.md) is the layer
+#                                                                that measures a bypassed commit.
+#
+# WHAT THIS HOOK DOES NOT COVER — a clean commit is not proof of compliance:
+#   - `git commit --no-verify`, and every path that never runs pre-commit: `git merge` with a
+#     conflict-free fast-forward, `git rebase`, `git cherry-pick`, `git commit --amend --no-verify`,
+#     pushes made by another machine or by a GUI with hooks disabled. The CI step is the layer
+#     that measures those.
+#   - Content outside the detector's EXT_LANG (.py .lua .js .jsx .mjs .cjs .ts .tsx .cs .sql .yml
+#     .yaml .json .sh .bash): the file's PATH is still measured when the diff adds the file, and
+#     its content is reported as skipped, never as passing. Markdown fences are not scanned here
+#     (that is the detector's --markdown-fences mode, for documentation repositories).
+#   - Existing content. Only ADDED lines are read (`--diff`); a legacy name already in the tree is
+#     never reported, and renaming it is the skill's migration policy, not this hook's job. Partial
+#     staging (`git add -p`) is measured as staged: hunks left out of the commit are not read.
+#   - The advisory English tier in download mode (see 3 above), and everything the detector's own
+#     docstring lists under KNOWN LIMIT — a curated word list is not a language model.
+#   - A missing python3 REFUSES the commit (exit 1, naming the bypass) instead of approving it: a
+#     gate that cannot measure must not approve. Install python3 (3.9+) or commit with --no-verify.
+#
+# Dependencies: bash, git, python3 (3.9+). curl only for the download fallback.
+
+set -u
+set -o pipefail
+
+LOCALE_CHECK_TAG="${LOCALE_CHECK_TAG:-v2.21.0}"
+LOCALE_CHECK_SHA256="${LOCALE_CHECK_SHA256:-4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2}"
+# Extra detector flags for this repository, e.g. EXTRA_ARGS=(--gate-unknown) once measured.
+EXTRA_ARGS=()
+
+CHECK_REL="skills/code-locale/references/check-identifier-locale.py"
+RAW_URL="https://raw.githubusercontent.com/solvelab/ai-skills/${LOCALE_CHECK_TAG}/${CHECK_REL}"
+
+log() { printf '%s\n' "pre-commit-locale: $*" >&2; }
+
+refuse() {
+  log "$*"
+  log "bypass, if you mean it: git commit --no-verify"
+  exit 1
+}
+
+verify_digest() {
+  # $1 = file. Compares its sha256 with LOCALE_CHECK_SHA256 unless that is `skip`.
+  [ "$LOCALE_CHECK_SHA256" = "skip" ] && return 0
+  local actual
+  actual="$(python3 -c 'import hashlib, sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$1")" || return 1
+  if [ "$actual" != "$LOCALE_CHECK_SHA256" ]; then
+    log "digest mismatch for the detector at tag ${LOCALE_CHECK_TAG}"
+    log "  expected ${LOCALE_CHECK_SHA256}"
+    log "  got      ${actual}"
+    log "  bump LOCALE_CHECK_TAG and LOCALE_CHECK_SHA256 together (header: THE PIN), or set LOCALE_CHECK_SHA256=skip in writing"
+    return 1
+  fi
+}
+
+locate_check() {
+  # Prints the detector path on stdout; returns 1 when no source works.
+  if [ -n "${LOCALE_CHECK:-}" ]; then
+    if [ -f "$LOCALE_CHECK" ]; then printf '%s\n' "$LOCALE_CHECK"; return 0; fi
+    log "LOCALE_CHECK is set but is not a file: ${LOCALE_CHECK}"
+    return 1
+  fi
+  local candidate
+  for candidate in "${AI_SKILLS_HOME:-}/${CHECK_REL}" "${HOME}/ai-skills/${CHECK_REL}"; do
+    case "$candidate" in /"${CHECK_REL}") continue ;; esac   # AI_SKILLS_HOME unset
+    if [ -f "$candidate" ]; then printf '%s\n' "$candidate"; return 0; fi
+  done
+
+  local git_dir cache_dir cached tmp
+  git_dir="$(git rev-parse --git-dir)" || return 1
+  cache_dir="${git_dir}/locale-check/${LOCALE_CHECK_TAG}"
+  cached="${cache_dir}/check-identifier-locale.py"
+  if [ -f "$cached" ]; then
+    verify_digest "$cached" || return 1
+    printf '%s\n' "$cached"; return 0
+  fi
+  command -v curl >/dev/null 2>&1 || { log "no local detector and no curl to download it (header: WHERE THE DETECTOR COMES FROM)"; return 1; }
+  mkdir -p "$cache_dir" || return 1
+  tmp="${cached}.part"
+  log "downloading the detector once, pinned at ${LOCALE_CHECK_TAG}: ${RAW_URL}"
+  if ! curl -fsSL "$RAW_URL" -o "$tmp"; then
+    rm -f "$tmp"
+    log "download failed (is ${LOCALE_CHECK_TAG} a published tag of solvelab/ai-skills?)"
+    return 1
+  fi
+  verify_digest "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$cached" || return 1
+  printf '%s\n' "$cached"
+}
+
+command -v git >/dev/null 2>&1 || refuse "git not found on PATH"
+command -v python3 >/dev/null 2>&1 || refuse "python3 not found on PATH — the detector needs Python 3.9+, and a gate that cannot measure must not approve"
+
+check_path="$(locate_check)" || refuse "could not locate the identifier-locale detector"
+
+# The English word lists live beside the detector. Absent (download mode, or a vendored copy of
+# the single file) every segment would be reported as unknown, so the advisory tier is switched
+# off and the switch is announced — the gating tiers do not depend on those lists.
+args=("${EXTRA_ARGS[@]}")
+if [ ! -f "$(dirname "$check_path")/english-words.txt.gz" ]; then
+  args+=(--no-english)
+  log "advisory English tier off: english-words.txt.gz is not beside ${check_path} (gating tiers unaffected)"
+fi
+
+output="$(git diff --cached --no-color | python3 "$check_path" --diff - "${args[@]}" 2>&1)"
+rc=$?
+
+case "$rc" in
+  0)
+    # Clean. Advisory lines, when any, still deserve the author's eyes.
+    if [ -n "$output" ] && printf '%s\n' "$output" | grep -q 'advisory'; then
+      printf '%s\n' "$output" >&2
+    fi
+    exit 0
+    ;;
+  1)
+    printf '%s\n' "$output" >&2
+    log "refused: the staged diff adds a non-English name to the machine layer (code-locale)."
+    log "  waive one line:   # locale-ok: <why this term has no faithful English name>   (on the line, or the one above)"
+    log "  waive a path:     add it to .identifier-locale-allow (one path or segment per line)"
+    log "  bypass:           git commit --no-verify   — the deliberate exit; CI measures it anyway"
+    exit 1
+    ;;
+  *)
+    printf '%s\n' "$output" >&2
+    refuse "the detector itself failed (exit ${rc}); nothing was measured, so nothing is approved"
+    ;;
+esac

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.4.0
   category: process
 license: MIT
 compatibility: >-
@@ -43,6 +43,9 @@ without a taste debate.
 - **Existing names: the three migration tiers**: `references/migration.md`
 - **The detector** — measures the path of every file it is given and the contents of the types
   it tokenizes: `references/check-identifier-locale.py`
+- **Adopting the gate in a repository, without the assistant**: the pre-commit hook
+  `references/pre-commit-locale.sh` and the CI step `references/ci-step.md` (section *Wire it in
+  one minute*)
 
 ## The two layers
 
@@ -191,6 +194,32 @@ depend on the assistant noticing a rule it already has.
 The findings travel in the field the harness reads for that event, not on plain standard output;
 the hook's own docstring records the probe that established which one. Wiring: the README's hooks
 section.
+
+## Wire it in one minute
+
+The session hook above exists only where a harness runs it with this machine's settings. A
+repository adopts the same detector on its own, for every tool and every human, with one file or one
+YAML block — both invoke `check-identifier-locale.py --diff` on added lines only, pin it to a tagged
+release of the catalog, and print the exits the *Reviewing a diff* section already explains:
+
+- **Pre-commit hook**: [`references/pre-commit-locale.sh`](references/pre-commit-locale.sh) — copy
+  to `.git/hooks/pre-commit` (or into a `core.hooksPath` directory); it finds the detector in a local
+  clone or downloads it once, digest-checked, and refuses a commit whose staged diff adds a
+  non-English name.
+- **CI step**: [`references/ci-step.md`](references/ci-step.md) — a copy-paste GitHub Actions job
+  (`pull_request`, `fetch-depth: 0`, `curl` at a tag with `sha256sum -c`,
+  `git diff origin/<base>...HEAD | python3 check-identifier-locale.py --diff -`).
+
+Each layer catches a different moment, and each has a hole the next one covers:
+
+| Layer | Runs | Catches | Misses |
+|---|---|---|---|
+| Session hook (`locale-rite.py`, the catalog's global rules) | on the assistant's `Write`/`Edit`, in a Claude Code session with the hook wired | the name at the moment it is written, before it spreads across a diff | every other tool (Codex, Cursor, Copilot), a human typing in an editor, a machine without the wiring; informs, never blocks |
+| Pre-commit hook | on `git commit`, on the author's machine | the staged diff of any author and any tool, before it leaves the machine | `git commit --no-verify`, rebases and merges, a clone that never installed it; only added lines in tokenized file types |
+| CI step | on every pull request | the pull request's added lines regardless of how they were produced or bypassed | direct pushes to the default branch (branch protection's job); existing content; the advisory tier unless the word lists are shipped |
+
+Each file states in its own header what it does not cover; a green run at any layer is a
+measurement of what the tiers reach, not proof of compliance.
 
 ## Existing code
 

--- a/skills/code-locale/references/ci-step.md
+++ b/skills/code-locale/references/ci-step.md
@@ -35,8 +35,12 @@ jobs:
           echo "${CHECK_SHA256}  check-identifier-locale.py" | sha256sum -c -
 
       - name: Identifier locale on the lines this pull request adds
+        env:
+          PYTHONIOENCODING: utf-8:surrogateescape
         run: |
-          git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff - --no-english
+          set -o pipefail
+          git diff --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ origin/${{ github.base_ref }}...HEAD \
+            | python3 check-identifier-locale.py --diff - --no-english
 ```
 
 ## Why each line is there
@@ -46,8 +50,9 @@ jobs:
   nothing to measure. A gate that cannot measure must not approve, so it is not wired where it
   cannot run.
 - **`fetch-depth: 0`.** `git diff A...HEAD` measures from the merge base. The default depth of 1
-  leaves no base revision in the clone and the diff fails or measures the wrong thing; the
-  catalog's own `ci.yml` carries the same setting for the same reason.
+  leaves no base revision in the clone and `git diff` fails — which, with `pipefail` below, fails the
+  step instead of approving an empty diff; the catalog's own `ci.yml` carries the same setting for
+  the same reason.
 - **`persist-credentials: false`.** Nothing after the checkout needs the token; the default leaves
   it in `.git/config` for every later step.
 - **`permissions: contents: read`.** The job reads the repository and nothing else.
@@ -73,10 +78,29 @@ jobs:
   assumed. The gating tiers (`pt-verb`, `pt-noun`, `pt-morphology`, path) do not depend on those
   lists, so the exit code is identical with or without this flag. Want the advisory tier in CI?
   Download the three files beside the detector (same URL shape, same tag) and drop the flag.
-- **The pipe's exit code.** A `run:` block on Linux runs `bash -e {0}` **without** `pipefail`, so
-  the step's status is `python3`'s — exactly what is wanted: exit 1 on a gating finding, 0
-  otherwise. A `git diff` failure (no base revision) prints its error and the detector, reading an
-  empty diff, reports `findings: 0`; that is why `fetch-depth: 0` is not optional here.
+- **`set -o pipefail`.** The default shell of a `run:` block on Linux is `bash -e {0}` (GitHub's
+  workflow-syntax page; not probed on a runner here), and `-e` alone takes the pipe's status from its
+  **last** command. Without `pipefail` a failed `git diff` — a base ref that was not fetched, an empty
+  `github.base_ref`, a `fetch-depth` left at 1 — prints its error, the detector reads an empty
+  stream, prints `findings: 0`, and the step is green: measured on 2026-09-05 with the block verbatim
+  (`fatal: ambiguous argument 'origin/release/9...HEAD'` then `findings: 0`, exit 0). With `pipefail`
+  the same case exits 128. A gate that cannot measure must not approve, and this is the line that
+  makes the step obey its own rule. The same effect comes from declaring `shell: bash`, which the same
+  page documents as `bash --noprofile --norc -eo pipefail {0}`; the explicit line travels to other CI
+  systems unchanged.
+- **The four `git diff` flags.** They pin the diff's *shape*, so a runner's or a repository's git
+  config cannot change what the detector reads — the pre-commit hook passes the same four, for the
+  same measured reasons (its header, *WHAT IT DOES*): `--no-ext-diff` (a `diff.external` driver
+  replaces the unified diff with its own output — an empty stream and `findings: 0`), `--no-renames`
+  (with rename detection, git's default, `git mv orders.py relatorio.py` is a `rename to` header with
+  no `--- /dev/null`, and the detector never measures the new name; without it a rename is a delete
+  plus an add and the new path is measured), `--src-prefix=a/ --dst-prefix=b/` (`diff.mnemonicPrefix`
+  writes `+++ i/…`, and a path grandfathered in `.identifier-locale-allow` stops matching). A fresh
+  `ubuntu-latest` runner carries none of these settings; a self-hosted runner may.
+- **`PYTHONIOENCODING: utf-8:surrogateescape`.** A hunk carrying non-UTF-8 bytes — a latin-1 legacy
+  file, common in the codebases this skill targets — otherwise aborts the detector with
+  `UnicodeDecodeError` before any name is judged, and the step fails for the wrong reason. With the
+  handler the undecodable bytes pass through and only the names are measured.
 
 ## Reading a failure
 
@@ -95,7 +119,11 @@ guide: the skill's *Reviewing a diff* section.
   skipped, never as passing.
 - **Existing content.** Only added lines. A pull request that moves a legacy Portuguese name from
   one file to another adds it, and is reported — that is the migration policy meeting the gate, and
-  the waiver line is the answer when the move is deliberate.
+  the waiver line is the answer when the move is deliberate. With `--no-renames` a **renamed file** is
+  the same case: every line of the moved file is read as added, so renaming a legacy file whose
+  content still carries Portuguese names turns the pull request red at that moment (fix the names,
+  waive them, or grandfather the path). A pure rename of an English-clean file is silent; a rename
+  **to** a Portuguese name is reported on the path, which is why the flag is there.
 - **The advisory tier**, unless you ship the word lists and drop `--no-english`.
 - **Everything the detector's own `KNOWN LIMIT` list names** — words that are both English and
   Portuguese, abbreviations under the minimum segment length, identifiers built at runtime, Spanish

--- a/skills/code-locale/references/ci-step.md
+++ b/skills/code-locale/references/ci-step.md
@@ -1,0 +1,108 @@
+# CI step — the identifier-locale gate on every pull request
+
+One job, copy-paste. It downloads the detector the `code-locale` skill ships at a **tagged release**
+of `solvelab/ai-skills`, verifies its digest, and measures only the lines the pull request adds.
+No clone of the catalog, no assistant, no Python package: `python3` 3.9+ and `curl` are already on
+`ubuntu-latest`.
+
+```yaml
+name: identifier-locale
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  identifier-locale:
+    name: Identifier locale (added lines are English)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch the detector, pinned
+        env:
+          AI_SKILLS_TAG: v2.21.0
+          CHECK_SHA256: 4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2
+        run: |
+          curl -fsSL -o check-identifier-locale.py \
+            "https://raw.githubusercontent.com/solvelab/ai-skills/${AI_SKILLS_TAG}/skills/code-locale/references/check-identifier-locale.py"
+          echo "${CHECK_SHA256}  check-identifier-locale.py" | sha256sum -c -
+
+      - name: Identifier locale on the lines this pull request adds
+        run: |
+          git diff origin/${{ github.base_ref }}...HEAD | python3 check-identifier-locale.py --diff - --no-english
+```
+
+## Why each line is there
+
+- **`on: pull_request` only.** The command diffs the branch against its base, and `github.base_ref`
+  exists only on `pull_request` events — on `push` it is empty and `git diff origin/...HEAD` has
+  nothing to measure. A gate that cannot measure must not approve, so it is not wired where it
+  cannot run.
+- **`fetch-depth: 0`.** `git diff A...HEAD` measures from the merge base. The default depth of 1
+  leaves no base revision in the clone and the diff fails or measures the wrong thing; the
+  catalog's own `ci.yml` carries the same setting for the same reason.
+- **`persist-credentials: false`.** Nothing after the checkout needs the token; the default leaves
+  it in `.git/config` for every later step.
+- **`permissions: contents: read`.** The job reads the repository and nothing else.
+- **The pin.** `AI_SKILLS_TAG` is a release tag of `solvelab/ai-skills`, never `master`: a gate on
+  a moving branch fails your pull requests on someone else's release schedule. `CHECK_SHA256` is the
+  digest of the detector **at that tag** — `sha256sum -c` fails the step on any other content, so
+  the tag cannot drift under you and a compromised or mistyped URL cannot run. Bump the two
+  together:
+
+  ```bash
+  TAG=v2.22.0
+  curl -fsSL "https://raw.githubusercontent.com/solvelab/ai-skills/${TAG}/skills/code-locale/references/check-identifier-locale.py" | sha256sum
+  ```
+
+  The value shipped above (`4e72af47…3ff2`) is the detector at `v2.21.0`, measured on 2026-09-05.
+- **`--diff -`.** Added lines only. Whole-tree enforcement turns a legacy repository red on day one
+  and a gate that blocks every pipeline is switched off within a week — the detector's docstring
+  records this as the reason `--diff` exists. Existing names migrate by the skill's tiers
+  (`references/migration.md`), not by this step.
+- **`--no-english`.** The advisory "is this word English?" tier needs the three word-list files
+  that sit beside the detector in the catalog (`english-words.txt.gz`, `programming-words.txt`,
+  `not-english.txt`). Without them every segment would be reported as unknown — measured, not
+  assumed. The gating tiers (`pt-verb`, `pt-noun`, `pt-morphology`, path) do not depend on those
+  lists, so the exit code is identical with or without this flag. Want the advisory tier in CI?
+  Download the three files beside the detector (same URL shape, same tag) and drop the flag.
+- **The pipe's exit code.** A `run:` block on Linux runs `bash -e {0}` **without** `pipefail`, so
+  the step's status is `python3`'s — exactly what is wanted: exit 1 on a gating finding, 0
+  otherwise. A `git diff` failure (no base revision) prints its error and the detector, reading an
+  empty diff, reports `findings: 0`; that is why `fetch-depth: 0` is not optional here.
+
+## Reading a failure
+
+The detector prints `path:line:token [tier]` and the exact waiver line to add. The exits are the
+skill's, not this step's: `# locale-ok: <reason>` on the offending line or the one above it; the
+`.identifier-locale-allow` file for a file or directory name; and, for a term with no faithful
+English name, the change's glossary (`references/glossary-protocol.md`). Doctrine and the reading
+guide: the skill's *Reviewing a diff* section.
+
+## What this step does not cover
+
+- **Pushes to the default branch.** It runs on pull requests only. A repository that accepts direct
+  pushes has no gate on them here; branch protection is what closes that.
+- **Content outside the detector's `EXT_LANG`** (`.py .lua .js .jsx .mjs .cjs .ts .tsx .cs .sql .yml
+  .yaml .json .sh .bash`): the path of an added file is still measured; its content is reported as
+  skipped, never as passing.
+- **Existing content.** Only added lines. A pull request that moves a legacy Portuguese name from
+  one file to another adds it, and is reported — that is the migration policy meeting the gate, and
+  the waiver line is the answer when the move is deliberate.
+- **The advisory tier**, unless you ship the word lists and drop `--no-english`.
+- **Everything the detector's own `KNOWN LIMIT` list names** — words that are both English and
+  Portuguese, abbreviations under the minimum segment length, identifiers built at runtime, Spanish
+  and Italian. A green step is a measurement of what the tiers reach, not proof of compliance.
+- **Other CI systems.** The one-line command is the whole contract; the YAML around it is GitHub
+  Actions. On GitLab CI the base is `$CI_MERGE_REQUEST_TARGET_BRANCH_NAME` with `GIT_DEPTH: 0`; the
+  pin and the digest check are the same.
+
+For the layer that catches the name **before** it reaches a pull request — the human's own
+`git commit` — see `references/pre-commit-locale.sh`.

--- a/skills/code-locale/references/pre-commit-locale.sh
+++ b/skills/code-locale/references/pre-commit-locale.sh
@@ -3,9 +3,22 @@
 # identifier in the machine layer. Doctrine: the `code-locale` skill (solvelab/ai-skills).
 #
 # WHAT IT DOES
-#   git diff --cached --no-color | python3 check-identifier-locale.py --diff -
+#   git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ \
+#     | PYTHONIOENCODING=utf-8:surrogateescape python3 check-identifier-locale.py --diff -
 #   That is the whole check. The detector is the one the skill ships; this file only finds it,
 #   runs it on the staged diff, and explains a refusal. Exit 0 and silent when the diff is clean.
+#   The four diff flags pin the diff's SHAPE, so a repository's or a user's git config cannot change
+#   what the detector reads (measured 2026-09-05, each one a silent approval or a false refusal):
+#     --no-ext-diff    `diff.external` replaces the unified diff with a driver's output — an empty
+#                      stream, `findings: 0`, and the commit is approved unmeasured.
+#     --no-renames     with rename detection (git's default) `git mv orders.py relatorio.py` is a
+#                      `rename to` header with no `--- /dev/null`, and the new name is never measured.
+#                      Without it a rename is a delete plus an add: the new PATH is measured, and the
+#                      moved content is read as added lines (see DOES NOT COVER).
+#     --src/dst-prefix `diff.mnemonicPrefix` writes `+++ i/relatorio.txt`; the detector strips only
+#                      `b/`, so a path grandfathered in .identifier-locale-allow stops matching.
+#   PYTHONIOENCODING=utf-8:surrogateescape keeps a hunk with non-UTF-8 bytes (a latin-1 legacy file)
+#   from aborting the detector: undecodable bytes pass through, and only the names are judged.
 #   Exit 1 with the detector's findings when a gating tier (pt-verb, pt-noun, pt-morphology, path)
 #   reports — the same exit code the detector itself uses. The `en-unknown` tier stays advisory:
 #   it prints, and it never refuses a commit (the detector's --gate-unknown is deliberately not
@@ -33,7 +46,10 @@
 #      English word lists are absent, so the hook passes --no-english and says so on stderr. The
 #      gating tiers are identical in every mode; only the advisory tier is off here.
 #
-# THE PIN — bump the two together:
+# THE PIN — applies to source 3 only. Sources 1 and 2 run whatever file is at that path, with no
+# digest check: an explicit LOCALE_CHECK is your vendored copy, and the ~/ai-skills clone is at
+# whatever commit its owner last pulled — so a commit accepted locally and the CI step
+# (references/ci-step.md, always pinned) can run different detector versions. Bump the two together:
 #   LOCALE_CHECK_TAG     a release tag of solvelab/ai-skills (`git tag --list 'v*'` in the catalog,
 #                        or the Releases page). Never `master`: a gate on a moving branch fails
 #                        your commits on someone else's schedule.
@@ -68,12 +84,21 @@
 #   - Existing content. Only ADDED lines are read (`--diff`); a legacy name already in the tree is
 #     never reported, and renaming it is the skill's migration policy, not this hook's job. Partial
 #     staging (`git add -p`) is measured as staged: hunks left out of the commit are not read.
+#   - A rename is read as delete + add (--no-renames, above). The new path is measured — that is the
+#     point — and every line of the moved file is read as ADDED, so renaming a legacy file whose
+#     content still carries Portuguese names meets the gate at that moment: fix the names, waive
+#     them, or `--no-verify` and let CI record it. A pure rename of an English-clean file is silent.
+#   - A detector exit 1 counts as a refusal only when its output carries the `findings:` line the
+#     detector prints after a completed scan. Any other exit 1 — a traceback, a wrong LOCALE_CHECK —
+#     is reported as the detector failing, and the commit is still refused: nothing was measured.
 #   - The advisory English tier in download mode (see 3 above), and everything the detector's own
 #     docstring lists under KNOWN LIMIT — a curated word list is not a language model.
 #   - A missing python3 REFUSES the commit (exit 1, naming the bypass) instead of approving it: a
 #     gate that cannot measure must not approve. Install python3 (3.9+) or commit with --no-verify.
 #
-# Dependencies: bash, git, python3 (3.9+). curl only for the download fallback.
+# Dependencies: bash 3.2+ (macOS's stock /bin/bash included — every array expansion here is written
+# for `set -u` on bash < 4.4, where `"${empty[@]}"` is an unbound variable), git 2.x, python3 (3.9+).
+# curl only for the download fallback.
 
 set -u
 set -o pipefail
@@ -151,14 +176,23 @@ check_path="$(locate_check)" || refuse "could not locate the identifier-locale d
 # The English word lists live beside the detector. Absent (download mode, or a vendored copy of
 # the single file) every segment would be reported as unknown, so the advisory tier is switched
 # off and the switch is announced — the gating tiers do not depend on those lists.
-args=("${EXTRA_ARGS[@]}")
+# `${arr[@]+"${arr[@]}"}` is the expansion that survives `set -u` with an empty array on bash 3.2
+# and 4.3; the plain `"${arr[@]}"` aborts the hook there (measured on bash:3.2 and bash:4.3).
+args=(${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"})
 if [ ! -f "$(dirname "$check_path")/english-words.txt.gz" ]; then
   args+=(--no-english)
   log "advisory English tier off: english-words.txt.gz is not beside ${check_path} (gating tiers unaffected)"
 fi
 
-output="$(git diff --cached --no-color | python3 "$check_path" --diff - "${args[@]}" 2>&1)"
+output="$(git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ \
+  | PYTHONIOENCODING=utf-8:surrogateescape python3 "$check_path" --diff - ${args[@]+"${args[@]}"} 2>&1)"
 rc=$?
+
+# The detector prints `findings: N` only after a completed scan. Exit 1 without that line is a
+# crash (an uncaught exception also exits 1), not a measurement — and must not be explained as one.
+if [ "$rc" -eq 1 ] && ! printf '%s\n' "$output" | grep -q '^findings: '; then
+  rc=70
+fi
 
 case "$rc" in
   0)
@@ -178,6 +212,6 @@ case "$rc" in
     ;;
   *)
     printf '%s\n' "$output" >&2
-    refuse "the detector itself failed (exit ${rc}); nothing was measured, so nothing is approved"
+    refuse "the detector itself failed (exit ${rc}, no findings: line); nothing was measured, so nothing is approved"
     ;;
 esac

--- a/skills/code-locale/references/pre-commit-locale.sh
+++ b/skills/code-locale/references/pre-commit-locale.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# pre-commit-locale.sh — git pre-commit hook: the lines this commit ADDS carry no non-English
+# identifier in the machine layer. Doctrine: the `code-locale` skill (solvelab/ai-skills).
+#
+# WHAT IT DOES
+#   git diff --cached --no-color | python3 check-identifier-locale.py --diff -
+#   That is the whole check. The detector is the one the skill ships; this file only finds it,
+#   runs it on the staged diff, and explains a refusal. Exit 0 and silent when the diff is clean.
+#   Exit 1 with the detector's findings when a gating tier (pt-verb, pt-noun, pt-morphology, path)
+#   reports — the same exit code the detector itself uses. The `en-unknown` tier stays advisory:
+#   it prints, and it never refuses a commit (the detector's --gate-unknown is deliberately not
+#   passed here; add it to EXTRA_ARGS below once your repository has measured its own noise).
+#
+# INSTALL — one of:
+#   cp pre-commit-locale.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+#     (per clone; .git/ is never versioned)
+#   mkdir -p .githooks && cp pre-commit-locale.sh .githooks/pre-commit && chmod +x .githooks/pre-commit
+#   git config core.hooksPath .githooks
+#     (versioned hooks; the `git config` line runs once per clone — git never sets hooksPath
+#     from a repository file, on purpose)
+#   A repository that already has a pre-commit hook chains this one from it: `exec` or call
+#   `.githooks/pre-commit-locale.sh` at the end of the existing script and keep its exit code.
+#
+# WHERE THE DETECTOR COMES FROM — first match wins:
+#   1. $LOCALE_CHECK — an explicit path, for a repository that vendored the detector.
+#   2. $AI_SKILLS_HOME/skills/code-locale/references/check-identifier-locale.py, then the same path
+#      under ~/ai-skills — the clone the catalog's install.sh creates. The word lists sit beside
+#      the detector there, so the advisory English tier runs in full.
+#   3. Download, pinned: https://raw.githubusercontent.com/solvelab/ai-skills/<TAG>/skills/code-locale/references/check-identifier-locale.py
+#      fetched with `curl -fsSL`, its sha256 checked with python3 (hashlib — no sha256sum/shasum
+#      dependency), cached under `$(git rev-parse --git-dir)/locale-check/<TAG>/` so it is fetched
+#      once per tag and never enters the tree. Only the detector is downloaded: in this mode the
+#      English word lists are absent, so the hook passes --no-english and says so on stderr. The
+#      gating tiers are identical in every mode; only the advisory tier is off here.
+#
+# THE PIN — bump the two together:
+#   LOCALE_CHECK_TAG     a release tag of solvelab/ai-skills (`git tag --list 'v*'` in the catalog,
+#                        or the Releases page). Never `master`: a gate on a moving branch fails
+#                        your commits on someone else's schedule.
+#   LOCALE_CHECK_SHA256  sha256 of the detector AT THAT TAG:
+#                        curl -fsSL <raw url at the tag> | sha256sum
+#                        or, from a clone: git show <tag>:skills/code-locale/references/check-identifier-locale.py | sha256sum
+#   A tag changed without its hash fails loudly — a pin that accepts any content is not a pin.
+#   LOCALE_CHECK_SHA256=skip disables the digest check, in writing, for a tag-only pin.
+#   Both accept an environment override (`LOCALE_CHECK_TAG=v2.22.0 LOCALE_CHECK_SHA256=... git commit`).
+#
+# THE EXITS — every finding prints the exact line to add:
+#   # locale-ok: <why this term has no faithful English name>   on the offending line or the one
+#                                                                above it (the waiver covers its
+#                                                                own line and the next, nothing further)
+#   .identifier-locale-allow                                     one path or segment per line — the
+#                                                                only waiver a FILE NAME can carry
+#   git commit --no-verify                                       the deliberate bypass. Named, not
+#                                                                hidden: the rite informs, the author
+#                                                                decides — and the CI step
+#                                                                (references/ci-step.md) is the layer
+#                                                                that measures a bypassed commit.
+#
+# WHAT THIS HOOK DOES NOT COVER — a clean commit is not proof of compliance:
+#   - `git commit --no-verify`, and every path that never runs pre-commit: `git merge` with a
+#     conflict-free fast-forward, `git rebase`, `git cherry-pick`, `git commit --amend --no-verify`,
+#     pushes made by another machine or by a GUI with hooks disabled. The CI step is the layer
+#     that measures those.
+#   - Content outside the detector's EXT_LANG (.py .lua .js .jsx .mjs .cjs .ts .tsx .cs .sql .yml
+#     .yaml .json .sh .bash): the file's PATH is still measured when the diff adds the file, and
+#     its content is reported as skipped, never as passing. Markdown fences are not scanned here
+#     (that is the detector's --markdown-fences mode, for documentation repositories).
+#   - Existing content. Only ADDED lines are read (`--diff`); a legacy name already in the tree is
+#     never reported, and renaming it is the skill's migration policy, not this hook's job. Partial
+#     staging (`git add -p`) is measured as staged: hunks left out of the commit are not read.
+#   - The advisory English tier in download mode (see 3 above), and everything the detector's own
+#     docstring lists under KNOWN LIMIT — a curated word list is not a language model.
+#   - A missing python3 REFUSES the commit (exit 1, naming the bypass) instead of approving it: a
+#     gate that cannot measure must not approve. Install python3 (3.9+) or commit with --no-verify.
+#
+# Dependencies: bash, git, python3 (3.9+). curl only for the download fallback.
+
+set -u
+set -o pipefail
+
+LOCALE_CHECK_TAG="${LOCALE_CHECK_TAG:-v2.21.0}"
+LOCALE_CHECK_SHA256="${LOCALE_CHECK_SHA256:-4e72af47225d6259f6b69db638af6db6c586c7ee6800e401941e08c223413ff2}"
+# Extra detector flags for this repository, e.g. EXTRA_ARGS=(--gate-unknown) once measured.
+EXTRA_ARGS=()
+
+CHECK_REL="skills/code-locale/references/check-identifier-locale.py"
+RAW_URL="https://raw.githubusercontent.com/solvelab/ai-skills/${LOCALE_CHECK_TAG}/${CHECK_REL}"
+
+log() { printf '%s\n' "pre-commit-locale: $*" >&2; }
+
+refuse() {
+  log "$*"
+  log "bypass, if you mean it: git commit --no-verify"
+  exit 1
+}
+
+verify_digest() {
+  # $1 = file. Compares its sha256 with LOCALE_CHECK_SHA256 unless that is `skip`.
+  [ "$LOCALE_CHECK_SHA256" = "skip" ] && return 0
+  local actual
+  actual="$(python3 -c 'import hashlib, sys; print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())' "$1")" || return 1
+  if [ "$actual" != "$LOCALE_CHECK_SHA256" ]; then
+    log "digest mismatch for the detector at tag ${LOCALE_CHECK_TAG}"
+    log "  expected ${LOCALE_CHECK_SHA256}"
+    log "  got      ${actual}"
+    log "  bump LOCALE_CHECK_TAG and LOCALE_CHECK_SHA256 together (header: THE PIN), or set LOCALE_CHECK_SHA256=skip in writing"
+    return 1
+  fi
+}
+
+locate_check() {
+  # Prints the detector path on stdout; returns 1 when no source works.
+  if [ -n "${LOCALE_CHECK:-}" ]; then
+    if [ -f "$LOCALE_CHECK" ]; then printf '%s\n' "$LOCALE_CHECK"; return 0; fi
+    log "LOCALE_CHECK is set but is not a file: ${LOCALE_CHECK}"
+    return 1
+  fi
+  local candidate
+  for candidate in "${AI_SKILLS_HOME:-}/${CHECK_REL}" "${HOME}/ai-skills/${CHECK_REL}"; do
+    case "$candidate" in /"${CHECK_REL}") continue ;; esac   # AI_SKILLS_HOME unset
+    if [ -f "$candidate" ]; then printf '%s\n' "$candidate"; return 0; fi
+  done
+
+  local git_dir cache_dir cached tmp
+  git_dir="$(git rev-parse --git-dir)" || return 1
+  cache_dir="${git_dir}/locale-check/${LOCALE_CHECK_TAG}"
+  cached="${cache_dir}/check-identifier-locale.py"
+  if [ -f "$cached" ]; then
+    verify_digest "$cached" || return 1
+    printf '%s\n' "$cached"; return 0
+  fi
+  command -v curl >/dev/null 2>&1 || { log "no local detector and no curl to download it (header: WHERE THE DETECTOR COMES FROM)"; return 1; }
+  mkdir -p "$cache_dir" || return 1
+  tmp="${cached}.part"
+  log "downloading the detector once, pinned at ${LOCALE_CHECK_TAG}: ${RAW_URL}"
+  if ! curl -fsSL "$RAW_URL" -o "$tmp"; then
+    rm -f "$tmp"
+    log "download failed (is ${LOCALE_CHECK_TAG} a published tag of solvelab/ai-skills?)"
+    return 1
+  fi
+  verify_digest "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$cached" || return 1
+  printf '%s\n' "$cached"
+}
+
+command -v git >/dev/null 2>&1 || refuse "git not found on PATH"
+command -v python3 >/dev/null 2>&1 || refuse "python3 not found on PATH — the detector needs Python 3.9+, and a gate that cannot measure must not approve"
+
+check_path="$(locate_check)" || refuse "could not locate the identifier-locale detector"
+
+# The English word lists live beside the detector. Absent (download mode, or a vendored copy of
+# the single file) every segment would be reported as unknown, so the advisory tier is switched
+# off and the switch is announced — the gating tiers do not depend on those lists.
+args=("${EXTRA_ARGS[@]}")
+if [ ! -f "$(dirname "$check_path")/english-words.txt.gz" ]; then
+  args+=(--no-english)
+  log "advisory English tier off: english-words.txt.gz is not beside ${check_path} (gating tiers unaffected)"
+fi
+
+output="$(git diff --cached --no-color | python3 "$check_path" --diff - "${args[@]}" 2>&1)"
+rc=$?
+
+case "$rc" in
+  0)
+    # Clean. Advisory lines, when any, still deserve the author's eyes.
+    if [ -n "$output" ] && printf '%s\n' "$output" | grep -q 'advisory'; then
+      printf '%s\n' "$output" >&2
+    fi
+    exit 0
+    ;;
+  1)
+    printf '%s\n' "$output" >&2
+    log "refused: the staged diff adds a non-English name to the machine layer (code-locale)."
+    log "  waive one line:   # locale-ok: <why this term has no faithful English name>   (on the line, or the one above)"
+    log "  waive a path:     add it to .identifier-locale-allow (one path or segment per line)"
+    log "  bypass:           git commit --no-verify   — the deliberate exit; CI measures it anyway"
+    exit 1
+    ;;
+  *)
+    printf '%s\n' "$output" >&2
+    refuse "the detector itself failed (exit ${rc}); nothing was measured, so nothing is approved"
+    ;;
+esac


### PR DESCRIPTION
Closes #139

A regra "a camada de máquina é inglês" só era medida onde há um harness com o `settings.json` desta máquina (`locale-rite.py` em `PostToolUse`). Codex, Cursor, Copilot e um `git commit` digitado à mão não encontravam gate nenhum, e o único exemplo real de wiring era o `ci.yml` **deste** repositório. A skill `code-locale` passa a embarcar o meio de adoção por repositório — sem clonar o catálogo, sem assistente.

## O que muda

- **`skills/code-locale/references/pre-commit-locale.sh`**, novo — hook `pre-commit` em bash 3.2+ e python3. Localiza o detector (`$LOCALE_CHECK`, depois `$AI_SKILLS_HOME`/`~/ai-skills`, depois download pinado em `v2.21.0` com sha256 conferido por python3 e cache em `.git/locale-check/<TAG>/`) e roda `git diff --cached --no-color --no-ext-diff --no-renames --src-prefix=a/ --dst-prefix=b/ | PYTHONIOENCODING=utf-8:surrogateescape python3 <detector> --diff -`. Sai 1 com os achados e nomeia as três saídas (`# locale-ok:`, `.identifier-locale-allow`, `--no-verify`); `python3` ausente ou detector que não terminou o scan **recusam**, não aprovam. O cabeçalho declara instalação, a ordem das fontes (o pin vale só para o download), e o que não cobre.
- **`skills/code-locale/references/ci-step.md`**, novo — job de GitHub Actions copiável: `pull_request`, `permissions: contents: read`, `checkout@v5` com `fetch-depth: 0` e `persist-credentials: false`, `curl -fsSL` na tag + `sha256sum -c`, e um `run:` que abre com `set -o pipefail` e roda o mesmo `git diff` com os mesmos flags sobre `origin/${{ github.base_ref }}...HEAD`. Cada linha explicada com a medição que a justifica.
- **`skills/code-locale/SKILL.md`** — seção *Wire it in one minute* (dois links relativos + tabela das três camadas: hook de sessão / pre-commit / CI, o que cada uma pega e deixa passar). `metadata.version` `1.3.1 → 1.4.0`; wrappers regenerados (`plugins/` copia `references/` inteira).

## O que o review mediu e mudou

Nove observações reproduzidas contra a primeira versão **antes** de editar (`repro139.py before`: 7 de 10 casos fora do esperado), todas pelo `git commit` real:

| Caso | Antes | Depois |
|---|---|---|
| bash 3.2 / 4.3 (`/bin/bash` de fábrica do macOS) | `line 154: EXTRA_ARGS[@]: unbound variable`, **100 % dos commits recusados** | inglês rc=0, `buscar_cliente` rc=1 (containers `bash:3.2`, `bash:4.3`) |
| `diff.external` configurado | diff vazio, `findings: 0`, `buscar_cliente` **aprovado** | `--no-ext-diff` → recusado |
| `git mv orders.py relatorio.py` | `rename to`, sem `--- /dev/null`, **aprovado** | `--no-renames` → `relatorio.py [path-pt-noun]` rc=1 (hook e CI) |
| `diff.mnemonicPrefix` + allowlist | `i/relatorio.txt` recusado | prefixos fixados → rc=0 |
| hunk latin-1 + linha inglesa | `UnicodeDecodeError` e o rodapé "adds a non-English name" | `surrogateescape` → rc=0; com `buscar_cliente` → achado, rc=1 |
| detector que crasha (exit 1) | mesmo rodapé falso | "the detector itself failed (exit 70, no findings: line)" |
| step de CI com base ausente / `--depth 1` | `fatal: ambiguous argument` e **verde** (rc=0) | `set -o pipefail` → rc=128 |

## Simulação — saída observada

| Artefato | Expectativa | Casos | Resultado |
|---|---|---|---|
| hook, matriz completa em repo novo (`sim139_full.py`) | 9 recusas, 5 silêncios, 1 escape nomeado, CI 4 | 18/18 | `cases: 18 as expected: 18 unexpected: 0` |
| hook, achados do review (`repro139.py after`) | 3 config git recusam; allowlist aceita; latin-1 2; crash 1; trade-off 1 | 10/10 | antes 3/10 |
| hook em bash 3.2 e 4.3 (docker) | inglês aceito, PT recusado | 4/4 | antes 0/4 |
| step de CI, `run:` lido do próprio fence (`ci139.py`) | pt falha, en passa, rename-pt falha, latin-1 passa, base ausente e depth-1 **falham** | 8/8 | `cases: 8 as expected: 8` |
| escape conhecido | `--no-verify` fica mudo | 1/1 | rc=0 — e o CI pega (`calcular_frete`, rc=1) |

Declarado: `act` e `shellcheck` ausentes (o bloco `run:` roda sob `bash -e -c` com `origin/main`); o shell padrão do runner vem da doc do GitHub, por isso o `pipefail` está escrito no bloco. Comportamento novo deliberado: com `--no-renames`, renomear um arquivo legado com nomes em português relê o conteúdo e encontra o gate (D7).

## Evidência

| Verificação | Comando | Resultado |
|---|---|---|
| Wrappers em sincronia | `bash generate.sh && git status --porcelain` | vazio; espelhos de `plugins/` idênticos (`cmp`) |
| Skills | `python3 scripts/validate-skills.py` | `skills checked: 35 findings: 0` |
| Validador de referência | `agentskills validate skills/code-locale/` | `Valid skill` |
| Versão da skill | `validate-skill-version.py` (base master) | `0 findings`, 1.3.1 → 1.4.0 |
| Locale nos artefatos | detector sobre o hook e `--markdown-fences` sobre `ci-step.md`/`SKILL.md` | `findings: 0` |
| Sintaxe do hook | `bash -n` | rc=0 |
| Rito | `bash scripts/validate-rite.sh` | `rite gate OK` |
| Evidência do rito | `validate-rite-evidence.py` | 0 findings |
| OpenSpec estrito | `openspec validate add-locale-adoption-kit --strict` | `Change 'add-locale-adoption-kit' is valid` |
| Demais gates do `ci.yml` | selftests, secrets, hygiene, smoke, plugin validate | todos PASS |

## Rito

Spec-rite: add-locale-adoption-kit — capability `skills-catalog` (MODIFIED *Code locale has a canonical home*: a skill canônica embarca o meio de adoção por repositório; cenários *A repository adopts the gate without the assistant* e *A gate that cannot measure does not approve*).

## Known gaps

- O runner do Actions não foi exercitado (`act` ausente): `github.base_ref`, o checkout do merge commit e o shell padrão `bash -e {0}` vêm da doc e do precedente do `ci.yml`; o efeito do `pipefail` foi medido localmente.
- `shellcheck` ausente; o hook foi verificado com `bash -n` e rodando de ponta a ponta em bash 3.2, 4.3 e 5.2.
- As fontes 1 e 2 do hook (`LOCALE_CHECK`, clone `~/ai-skills`) rodam o arquivo que está lá, sem pin — declarado no cabeçalho e em D2; o CI é a camada pinada.
- Follow-ups fora desta issue (E.4): detector lendo o header `rename to`; `PYTHONIOENCODING` em `programming-words.txt` (hoje `en-unknown` consultivo).
- V.4 (archive) fica para um PR separado, como o repositório já faz.