### PR TITLE
✨ feat(skills): 'Verified against' probado em toda skill e C5 exige a forma literal

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,8 @@ A second gate checks the **content** of the skills themselves.
 [`scripts/validate-skills.py`](scripts/validate-skills.py) runs thirteen checks over every
 `skills/*/SKILL.md` and every `*.md` under its `references/`, recursively — referenced paths exist (C1), cross-skill references name a
 real skill (C2), code blocks parse (C3, bash/yaml/json/lua/python), the description states no policy
-the body contradicts (C4), versioned external APIs are pinned (C5), fence tags match their content
+the body contradicts (C4), every skill states what it was verified against or that it does not depend
+on a tool version (C5), fence tags match their content
 (C6), no generated wrapper is orphaned from a canonical source (C7), no meta section sits in a
 `SKILL.md` body where it cannot affect routing (C8), code examples use English identifiers (C9),
 the parsed `description` and `compatibility` stay within the Agent Skills limits (C10), every
@@ -910,7 +911,7 @@ as operational detail, never as a build failure.
 
 ```bash
 python3 scripts/validate-skills.py           # 0 findings expected
-python3 scripts/selftest-validate-skills.py  # 13/13 defect classes detected
+python3 scripts/selftest-validate-skills.py  # 22/22 defect classes detected
 python3 scripts/scan-secrets.py              # gate: no credentials in the working tree
 python3 scripts/scan-secrets.py --history    # audit: what the published history still contains
 ```

--- a/claude/skills/api-resilience-testing/SKILL.md
+++ b/claude/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing, nor for writing the service's own layout, envelope and handlers (that is `python-rest-api`).
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.3.2
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/assettoserver-csp-lua/SKILL.md
+++ b/claude/skills/assettoserver-csp-lua/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/assettoserver-ops/SKILL.md
+++ b/claude/skills/assettoserver-ops/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   backend receiving events (python-rest-api), or for FiveM servers.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: devops
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/assettoserver-plugin/SKILL.md
+++ b/claude/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/backend-resilience/SKILL.md
+++ b/claude/skills/backend-resilience/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   adaptation use fivem-fallback instead.
 metadata:
   author: solvelab
-  version: 2.0.1
+  version: 2.0.2
   category: backend
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/claude/skills/backlog/SKILL.md
+++ b/claude/skills/backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.5.1
+  version: 1.5.2
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/bug-hunter/SKILL.md
+++ b/claude/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.2.2
+  version: 2.2.3
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/claude/skills/claude-statusline/SKILL.md
+++ b/claude/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.2.2
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/claude/skills/code-locale/SKILL.md
+++ b/claude/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.4.0
+  version: 1.4.1
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/conventional-commit/SKILL.md
+++ b/claude/skills/conventional-commit/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   items (that is `backlog`).
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.3.2
   category: git
 license: MIT
 compatibility: Works in any environment with git access.

--- a/claude/skills/documentation/SKILL.md
+++ b/claude/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.2
+  version: 3.0.3
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/execute-backlog/SKILL.md
+++ b/claude/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.8.2
+  version: 1.8.3
   category: process
 license: MIT
 compatibility: >-

--- a/claude/skills/fivem-fallback/SKILL.md
+++ b/claude/skills/fivem-fallback/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   services use backend-resilience instead.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/claude/skills/fivem-lua/SKILL.md
+++ b/claude/skills/fivem-lua/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Conventions for writing FiveM (CitizenFX) server/client Lua resources. Use when working on FiveM/FXServer Lua — RegisterNetEvent/RegisterNUICallback handlers, fxmanifest, exports, NUI (SendNUIMessage/SetNuiFocus), threads/CreateThread, StateBags, or natives. Enforces the client-is-never-trusted boundary (validate payload + derive actor from `source`), explicit fxmanifest order, no busy `while true` loops, module-per-global pattern, and NUI focus/disconnect cleanup. Do NOT use for react-three-fiber, for CSP Lua scripts on an Assetto Corsa server (that is `assettoserver-csp-lua`), or for other non-FiveM Lua.
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/claude/skills/helm-migration/SKILL.md
+++ b/claude/skills/helm-migration/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 metadata:
   author: solvelab
-  version: 2.2.2
+  version: 2.2.3
   category: devops
 license: MIT
 compatibility: Requires a Helm charts template repository accessible on the local filesystem. Works best in Claude Code.

--- a/claude/skills/log-event-collector/SKILL.md
+++ b/claude/skills/log-event-collector/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   metrics/APM instrumentation of the monitored application.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/openspec-drivezone/SKILL.md
+++ b/claude/skills/openspec-drivezone/SKILL.md
@@ -13,7 +13,7 @@ description: >-
   Do NOT use for vanilla OpenSpec on non-DriveZone projects — that is the openspec skill.
 metadata:
   author: solvelab
-  version: 2.1.3
+  version: 2.1.4
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/openspec/SKILL.md
+++ b/claude/skills/openspec/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   variant use openspec-drivezone.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/react-api-client/SKILL.md
+++ b/claude/skills/react-api-client/SKILL.md
@@ -9,7 +9,7 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/svg-animation/SKILL.md
+++ b/claude/skills/svg-animation/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   the traps that break silently.
 metadata:
   author: solvelab
-  version: 1.1.2
+  version: 1.1.3
   category: frontend
 license: MIT
 compatibility: Works in any environment with filesystem access; verification steps need a Chrome binary.

--- a/cursor/rules/api-resilience-testing.mdc
+++ b/cursor/rules/api-resilience-testing.mdc
@@ -9,6 +9,15 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # API Resilience Testing
 
+> **Verified against**: `fastapi 0.141.1` · `pydantic 2.13.4` · `starlette 1.6.0` · `httpx 0.28.1`
+> · `uvicorn 0.52.4`, re-measured on 2026-09-05 with a stock two-route service (a pydantic body
+> model, an `int` path parameter) under `TestClient` and under a real uvicorn server. Eight of the
+> nine baseline rows held; **one was corrected**: a body of nested brackets returns **400**
+> `{"detail":"There was an error parsing the body"}` at every depth from 990 to 10 000, closed or
+> unclosed, for model, `Any` and `dict` bodies — FastAPI's body parser catches the
+> `RecursionError`, and the **500** published here earlier did not reproduce. `curl` is the only
+> tool the checklist prescribes and no version-bound flag of it is used.
+
 Test a REST API so it survives the inputs nobody intended — invalid, malformed,
 out-of-contract, hostile — and fails **safely** instead of crashing, corrupting
 data, or leaking internals. This is the discipline of going **beyond the happy
@@ -175,11 +184,13 @@ FastAPI 0.141.1 / pydantic 2.13.4 (the `python-rest-api` baseline), stock servic
 | Wrong path-param type (`/users/abc`) | 404 | **422** | No — the route matched, the value didn't |
 | Wrong HTTP method | 405 | **405** (with `Allow`) | Already correct |
 | Extra/unknown body field | rejected | **200**, ignored | Yes if the field is privileged (mass assignment) |
-| **2 KB body of nested brackets** | handled | **500** (`RecursionError`) | **Yes — this is the bug** |
+| **2 KB body of nested brackets** | 500 | **400** (`RecursionError` caught by the body parser) | Only for the cost: the stack is burned before the 400 |
 | **20 MB flat JSON body** | 413 | **200**, fully buffered | **Yes — no default limit exists** |
 
-The last two are not style preferences: a 2 KB unauthenticated request that returns 500 is a
-denial-of-service primitive. The guard belongs to the service baseline — see `python-rest-api`
+The last row is not a style preference: a 20 MB unauthenticated request that is fully buffered is a
+denial-of-service primitive, and the nested-brackets request still costs a full recursion stack
+before its 400 — re-measured on 2026-09-05, the **500** this table published earlier did not
+reproduce on this stack. The guard belongs to the service baseline — see `python-rest-api`
 ("Request limits"), which carries the verified middleware + handler.
 
 Re-run this table against your own stack and version before trusting any row of it.

--- a/cursor/rules/assettoserver-csp-lua.mdc
+++ b/cursor/rules/assettoserver-csp-lua.mdc
@@ -9,6 +9,17 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # CSP Lua online scripts (AssettoServer-served overlays)
 
+> **Verified against**: `acc-lua-sdk` at commit `7cf60f5a` (2026-08-17, the public CSP Lua library
+> tree) · `Lua 5.4.8` · `AssettoServer v0.0.54` and `v0.0.55-pre25` source. Probed on 2026-09-05:
+> 12 of the 15 `ac.*`/`ui.*` names this skill uses are declared in that tree;
+> `ui.measureDWriteText`, `ui.pushDWriteFont` and `ac.onCarCollision` are not (the tree does not
+> enumerate every C++-side binding) — they were paid for in game and are not re-probed here.
+> `references/snippets.lua` and the fenced Lua block parse under `luac -p`;
+> `CSPServerScriptProvider.AddScript(string, string?, Dictionary<string, object>?)`, the
+> `SCRIPT_N-<name>` section and the `/api/scripts/N` route exist at both server tags. Not probed:
+> every rendering, font and audio rule below needs the CSP client, and the CSP build the DriveZone
+> servers require is not recorded on this machine.
+
 Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
 client by the server itself. Zero-install is the point — the player installs nothing; art, sound
 and code all arrive over the server's HTTP port. Distilled from a production DriveZone server:

--- a/cursor/rules/assettoserver-ops.mdc
+++ b/cursor/rules/assettoserver-ops.mdc
@@ -9,6 +9,16 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # AssettoServer operations
 
+> **Verified against**: `AssettoServer v0.0.55-pre25` — the source tree at `~/works/AssettoServer`
+> (commit `51d8d8a6`), which is what the DriveZone image `drivezone/assettoserver:local` reports as
+> `AssettoServer 0.0.55+51d8d8a6e0`. Probed on 2026-09-05: all 15 `extra_cfg.yml` keys cited here
+> resolve to properties under `Server/Configuration/Extra/`; 24 of the 25 `server_cfg.ini` keys
+> resolve to the sample `Assets/server_cfg.ini` or to an `[IniField]` under
+> `Server/Configuration/Kunos/` — `CARS` is a stock acServer key this source never reads; the
+> density function quoted below is `Server/Ai/AiBehavior.cs:455-466` at that tag. Not probed: no
+> server was started against a client, and the CSP build the DriveZone servers require is not
+> recorded on this machine.
+
 Distilled from a production freeroam deployment (DriveZone on SRP/Shutoko). The runtime is
 `compujuckel/AssettoServer` — a CSP-aware replacement for stock `acServer` that adds
 `extra_cfg.yml`, an AI traffic engine, and a .NET plugin loader. Prescriptive: follow these unless

--- a/cursor/rules/assettoserver-plugin.mdc
+++ b/cursor/rules/assettoserver-plugin.mdc
@@ -9,6 +9,16 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # AssettoServer plugin conventions
 
+> **Verified against**: `AssettoServer v0.0.54` source — `git show
+> v0.0.54:AssettoServer/AssettoServer.csproj` gives `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`,
+> `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase`, the
+> `RequireConnectedPlayer`/`RequireAdmin` attributes and `CSPServerScriptProvider.AddScript(string,
+> string?, Dictionary<string, object>?)` are declared at that tag. Probed on 2026-09-05 by reading
+> the tree: no plugin was compiled or loaded here. **Disclosed**: the DriveZone runtime measured
+> the same day reports `AssettoServer 0.0.55+51d8d8a6e0`, built from a tree whose csproj targets
+> `net9.0` — on that host `System.Threading.Lock` exists and the `net8.0` fallback below is one
+> major behind. The doctrine is re-derived for `0.0.55` in a follow-up, not silently here.
+
 Distilled from a production plugin (DriveZone.AssettoServer.Plugin) that survived real
 AssettoServer runtime incompatibilities. Prescriptive: follow these unless the project documents a
 deliberate exception. The upstream host is `compujuckel/AssettoServer` — a CSP-aware replacement

--- a/cursor/rules/backend-resilience.mdc
+++ b/cursor/rules/backend-resilience.mdc
@@ -9,6 +9,16 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Backend resilience & fallback
 
+> **Verified against**: `Python 3.11.2` · `httpx 0.28.1` · `structlog 26.1.0` · `prometheus-client
+> 0.26.0`. Probed on 2026-09-05: the five `python` blocks were extracted and executed against stubs
+> — `httpx.Timeout(connect=, read=, write=, pool=)` constructs; `safe_call` and `safe_call_async`
+> return `(False, fallback)` on a raising callable and emit the `fallback_used` line with the
+> counter at 1; `clamp_num` clamps, and defaults on `None` and on `"x"`; the retry loop returns
+> after 3 attempts with full jitter and makes 0 attempts past the deadline; the negative cache
+> makes 1 upstream call for 2 requests after a `ConnectError`; the config fallback lands on
+> `FALLBACK` after a `ReadTimeout`. Fragments were wrapped in a function to run; nothing was run
+> against a live Consul or HTTP dependency.
+
 Defensive patterns for calling an unreliable dependency. The network boundary is unstable: timeouts,
 5xx, partial payloads, dependency down, races. Every call needs a **safe default** so the service keeps
 working. Doctrine is stack-agnostic; examples are Python.

--- a/cursor/rules/backlog.mdc
+++ b/cursor/rules/backlog.mdc
@@ -9,6 +9,15 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Backlog — idea → structured GitHub Project item
 
+> **Verified against**: `gh 2.96.0` · `openspec 1.6.0`. Probed on 2026-09-05: the read recipes ran
+> against the AI-SKILLS board (`gh project list/view/field-list/item-list --owner --format json
+> --jq`, `gh issue view --json --jq`, `gh issue list --search --state --json`, `gh label list
+> --json`, `gh auth status`); `gh project item-edit --project-id --id --field-id
+> --single-select-option-id` moved a real card the same day; every other flag this skill and its
+> references prescribe (58 flags across 18 subcommands, `gh issue create --title --body-file
+> --label` and `gh project item-add --url` among them) is present in that client's `--help`.
+> Nothing was created, closed or merged by the probe.
+
 Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
 configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual
 codebase. The first run per repo/workspace launches a config wizard that writes

--- a/cursor/rules/bug-hunter.mdc
+++ b/cursor/rules/bug-hunter.mdc
@@ -9,6 +9,12 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Bug-Hunter — adversarial testing
 
+> **Not version-bound**: this skill does not depend on a tool version — it is a methodology (defect
+> classes, the anti-forge lens, the closure checklist). The stack tracks under `references/` name
+> `pytest`, `busted` and Mono.Cecil as the runners a track uses and prescribe no version-specific
+> flag; the versions belong to the stack skills that own the code (`python-rest-api`, `fivem-lua`,
+> `assettoserver-plugin`). Declared on 2026-09-05.
+
 A repeatable rite: after implementing a change, actively **try to break it** — don't just confirm the
 happy path. Hunt for the bug before it ships.
 

--- a/cursor/rules/claude-statusline.mdc
+++ b/cursor/rules/claude-statusline.mdc
@@ -9,6 +9,14 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Claude Code Status Line
 
+> **Verified against**: `Claude Code 2.1.261` · `jq 1.6` · `bash 5.2.15`. Probed on 2026-09-05:
+> `references/statusline.sh` is byte-identical to the script rendering the status line of the
+> session that wrote this, and fed a synthetic payload of the fields in `references/fields.md` it
+> printed its three lines (`🤖 Fable 5.1 | ⚡ medium | 🧠 thinking enabled | ⏱️ 1m 5s | 💰 $1.23`, the
+> repo/branch/diff line, the three meters). Not probed: each field's presence in the live payload —
+> the script falls back to `-` for a missing field, so a render proves the script runs, not that
+> every documented field still arrives; the per-version notes in `fields.md` stand as written.
+
 The status line is a customizable bar at the bottom of Claude Code. Claude Code runs a
 shell command, pipes JSON session data to it on **stdin**, and renders whatever the
 command prints to **stdout**. It runs locally and costs no API tokens.

--- a/cursor/rules/code-locale.mdc
+++ b/cursor/rules/code-locale.mdc
@@ -9,6 +9,14 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Code locale — prose follows the repo, the machine layer is English
 
+> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-05:
+> `references/check-identifier-locale.py --selftest` (7 content tiers fire, 16 clean cases silent,
+> 6 path tiers fire, 9 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
+> --selftest` (13 PostToolUse and 12 PreToolUse decisions) and `locale-stop-gate.py --selftest` (26
+> decisions in throwaway git repositories) all pass, and both hooks are the ones wired in
+> `~/.claude/settings.json` of the session that wrote this. The detector uses only the standard
+> library; the earlier probe on `Python 3.14.5` is recorded below.
+
 **Prose follows the repository's working language. Anything a machine parses is English.**
 This skill covers the prose/machine boundary, the untranslatable-domain-term exception and its
 gate, the grooming glossary, the new-code-only migration policy, and a shipped detector a

--- a/cursor/rules/conventional-commit.mdc
+++ b/cursor/rules/conventional-commit.mdc
@@ -7,6 +7,14 @@ alwaysApply: false
 
 # conventional-commit
 
+> **Verified against**: `semantic-release 25` · `conventional-changelog-conventionalcommits 8` ·
+> `@semantic-release/commit-analyzer` with the `headerPattern` in this repository's
+> `.releaserc.json` (`^(?:[^\w\s]+\s+)?(\w+)(?:\((.*)\))?!?: (.*)$`, which lets the gitmoji prefix
+> through). Probed on 2026-09-05 against the release history: `✨ feat(code-locale): …` (b1f527f)
+> cut `v2.24.0`, `✨ feat(hooks): …` (69aaf73) cut `v2.23.0` and `✨ feat(hooks): …` (49c44d0) cut
+> `v2.22.0`, all on that date. The message format itself is a convention with no tool version; the
+> pin covers the release tooling that parses it.
+
 Every commit message must follow **Conventional Commits**, prefixed with a **gitmoji icon** matching
 the type.
 

--- a/cursor/rules/documentation.mdc
+++ b/cursor/rules/documentation.mdc
@@ -9,6 +9,11 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Documentation
 
+> **Not version-bound**: this skill does not depend on a tool version — it decides which documents
+> a project gets and how a claim inside them is made checkable, and it prescribes no generator,
+> linter or CLI. The `AGENTS.md` convention it names is a specification, not a versioned tool.
+> Declared on 2026-09-05.
+
 Write documentation a reader can act on and a script can verify. Templates and full worked examples
 live in `references/` — read them when you are about to generate output, not before.
 

--- a/cursor/rules/execute-backlog.mdc
+++ b/cursor/rules/execute-backlog.mdc
@@ -9,6 +9,16 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Execute-backlog — backlog item → implemented, validated PR
 
+> **Verified against**: `gh 2.96.0` · `openspec 1.6.0`. Probed on 2026-09-05: the read recipes ran
+> against the AI-SKILLS board and this repository (`gh issue view --json
+> closedByPullRequestsReferences`, `gh api repos/<o>/<r>/issues/<n>/timeline --jq`, `gh api
+> graphql`, `gh project item-list --owner --limit --format json --jq`), `gh project item-edit
+> --project-id --id --field-id --single-select-option-id` moved a real card, and `openspec new
+> change <id> --schema <name>` scaffolded a real change; every other flag this skill and its
+> references prescribe (`gh issue edit --body-file`, `gh issue comment --body-file`, `gh pr create
+> --title --body-file --base --head` among the 58 checked) is present in that client's `--help`.
+> Nothing was merged or closed by the probe.
+
 Drive an existing issue to a reviewable pull request while keeping the board in sync. Companion
 to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,
 `backlog.yml` in workspace mode), follows the repo's own conventions, and runs the validations

--- a/cursor/rules/fivem-fallback.mdc
+++ b/cursor/rules/fivem-fallback.mdc
@@ -9,6 +9,15 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # FiveM fallback & resilience (Lua adaptation)
 
+> **Verified against**: `Lua 5.4.8` · `citizenfx/fivem` at commit `6fd665a3` (2026-09-02) ·
+> `citizenfx/natives` at `7263f211` (2026-08-17). Probed on 2026-09-05: all 5 fenced Lua blocks in
+> this skill and its reference parse under `luac -p`; the 6 runtime functions and natives named
+> here (`PerformHttpRequest`, `GetConvar`, `GetGameTimer`, `CreateThread`, `Wait`,
+> `RegisterNUICallback`) resolve in `ext/native-decls/`,
+> `data/shared/citizen/scripting/lua/scheduler.lua` or `natives/MISC/`. Not probed: no FXServer
+> build ran this code, and no backend was called from a resource — the retry and negative-cache
+> behaviour was observed on the DriveZone servers and carries no artifact number here.
+
 **Doctrine lives in `backend-resilience`** — read it first: safe defaults, one shared helper,
 response-shape validation, clamping, bounded retries, negative cache (never negative-cache a real 404),
 in-flight dedupe. This skill is the FiveM/Lua mechanics only.

--- a/cursor/rules/fivem-lua.mdc
+++ b/cursor/rules/fivem-lua.mdc
@@ -9,6 +9,15 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # FiveM Lua — CitizenFX conventions
 
+> **Verified against**: `Lua 5.4.8` · `citizenfx/fivem` at commit `6fd665a3` (2026-09-02) ·
+> `citizenfx/natives` at `7263f211` (2026-08-17). Probed on 2026-09-05: 6 of the 7 fenced Lua
+> blocks in this skill and its references parse under `luac -p` (the seventh is the marked `--
+> excerpt` and is skipped by design); the 8 runtime functions named here (`RegisterNetEvent`,
+> `RegisterNUICallback`, `TriggerClientEvent`, `SetNuiFocus`, `SendNUIMessage`, `CreateThread`,
+> `Wait`, `SetTimeout`) resolve in `ext/native-decls/` or
+> `data/shared/citizen/scripting/lua/scheduler.lua`. Not probed: no FXServer build ran this code —
+> the runtime rules were observed on the DriveZone servers and carry no artifact number here.
+
 Generic conventions for writing maintainable server/client Lua resources on FiveM (CitizenFX).
 Project-agnostic: resource prefixes, exact endpoints, and keybind registries belong in the project's
 own CLAUDE.md, not here.

--- a/cursor/rules/helm-migration.mdc
+++ b/cursor/rules/helm-migration.mdc
@@ -9,6 +9,12 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Helm Migration Skill
 
+> **Not version-bound**: this skill does not depend on a tool version — it prescribes the shape of
+> `values.yaml` and `env.yaml` for the solvelab chart template and tells the reader to read the
+> local template first, and it prescribes no `helm` or `kubectl` command whose flags could be
+> pinned (measured on 2026-09-05: zero such commands in the skill and its reference). The field
+> names are pinned by the template itself, as the note below says.
+
 You are a Helm chart expert. When asked to migrate a Kubernetes YAML file to Helm, follow the workflow and conventions below. These are derived from real solvelab production charts and are specific to that chart template.
 
 > **The chart template is the source of truth, not this skill.** The field names below were taken from

--- a/cursor/rules/log-event-collector.mdc
+++ b/cursor/rules/log-event-collector.mdc
@@ -7,6 +7,13 @@ alwaysApply: false
 
 # Log-tailing event collector
 
+> **Verified against**: `Python 3.11.2` (standard library only). Probed on 2026-09-05: the
+> partial-line read returns the complete lines and leaves the offset before the partial tail
+> (`['line one', 'line two']`, offset 18; the tail arrives whole on the next read), and the atomic
+> state write lands through `os.replace` with no `.tmp` left behind. The parser excerpt is not
+> runnable by design. No tailer was run against a live server here; the doctrine is stack-agnostic
+> and pins nothing else.
+
 When a system you can't modify (game server, third-party daemon) only exposes its life in text
 logs, ship a **collector sidecar**: tail the log, parse lines into normalized events, POST them to
 a backend. Distilled from a production collector (Python 3.12, stdlib-only) for an AssettoServer

--- a/cursor/rules/openspec-drivezone.mdc
+++ b/cursor/rules/openspec-drivezone.mdc
@@ -7,6 +7,13 @@ alwaysApply: false
 
 # OpenSpec — the DriveZone rite (forked schema)
 
+> **Verified against**: `openspec 1.6.0`. Probed on 2026-09-05: a throwaway project with a change
+> missing every gate section passed `openspec validate <id> --strict` (`Change 'probe' is valid`),
+> which is the claim this skill's hard gate rests on; the subcommands and flags shared with the
+> `openspec` skill were probed there. Not probed: the DriveZone repositories and their rite-gate
+> script are not on this machine — their described behaviour is the maintainer's field record, not
+> a re-run.
+
 > **What this is.** DriveZone uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) as its
 > spec-driven process — the base workflow is the **`openspec` skill** — but with a **project-local
 > forked schema** that makes three sections **mandatory** where vanilla has none: **`Fallback & Modos

--- a/cursor/rules/openspec.mdc
+++ b/cursor/rules/openspec.mdc
@@ -7,6 +7,15 @@ alwaysApply: false
 
 # OpenSpec — vanilla spec-driven workflow
 
+> **Verified against**: `openspec 1.6.0` (`@fission-ai/openspec`). Probed on 2026-09-05: every
+> subcommand this skill prescribes exists (`validate`, `list`, `spec list --long`, `update`,
+> `archive`, `instructions`, `skill`, `new change`, `init`, `status`, `templates`) and `--strict`,
+> `--all`, `--type`, `--no-interactive`, `--long` are in `--help`; `openspec validate <id>
+> --strict` reported a change whose `tasks.md` carries no mandatory group as valid, so the CLI
+> checks delta format only. **Disclosed**: `openspec spec list` prints a deprecation warning on
+> 1.6.0 — "Prefer verb-first commands (e.g., `openspec show`, `openspec validate --specs`)"; the
+> noun-first form still works and stays here until this pin moves.
+
 [OpenSpec](https://github.com/Fission-AI/OpenSpec) structures a change as a validated proposal before
 any code: **explore → propose → validate → apply → archive**. Specs are the source of truth; changes
 are deltas against them.

--- a/cursor/rules/react-api-client.mdc
+++ b/cursor/rules/react-api-client.mdc
@@ -9,6 +9,14 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # React SPA ↔ typed-envelope API
 
+> **Verified against**: `typescript 7.0.2` · `axios 1.20.0` · `zustand 5.0.15`. Probed on
+> 2026-09-05: the four `ts` blocks in `references/api-client.md` were extracted and typechecked.
+> None of the three complete-looking ones compiles as written (24 errors: elided constructors,
+> sibling names), and a harness supplying the imports and the elided declarations still leaves
+> typing errors in the interceptor and store blocks — so all four now carry the `// excerpt` marker
+> and are read as shape, not as modules. `zod` is named in prose only and was not exercised. The
+> project this skill was extracted from was not available.
+
 The backend (`python-rest-api` skill) speaks `{status, code, message, data}`. These conventions
 keep the frontend honest about it: the front only EXHIBITS state and SENDS intents — balance,
 cost, cooldown, permission and availability are validated server-side, always.

--- a/cursor/rules/svg-animation.mdc
+++ b/cursor/rules/svg-animation.mdc
@@ -9,6 +9,14 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # svg-animation — understand the object, then represent it
 
+> **Verified against**: `Google Chrome for Testing 151.0.7922.34` (`--headless=new`, 1280×720,
+> software rasterisation, WSL2), driven over CDP by [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs) on
+> 2026-08-30 and 2026-08-31 — every cost in `references/platform.md` comes from those two runs and
+> is recorded with its raw numbers in [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md). Not re-run on
+> 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS animation
+> semantics are specification-level and carry no tool version; the numbers do, and they expire with
+> that browser build.
+
 The failure this skill exists to prevent is not ugly output. It is **plausible** output: an animation
 whose every part is defensible and whose whole is wrong. Measured on 22 objects and 12 primitives
 ([research/svg-animation in the catalog repository](https://github.com/solvelab/ai-skills/tree/master/research/svg-animation),

--- a/openspec/changes/require-verified-against/.openspec.yaml
+++ b/openspec/changes/require-verified-against/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/require-verified-against/design.md
+++ b/openspec/changes/require-verified-against/design.md
@@ -1,0 +1,79 @@
+## Context
+
+`check_pin` in `scripts/validate-skills.py:254-266` (read 2026-09-05, HEAD 7709622) fires only when a
+skill carries 40+ fenced lines, matches `API_HINT`, matches none of the loose `PIN` forms and does not
+defer to a local source of truth. Its docstring states the 40-line KNOWN LIMIT. The result measured
+today: 20 of 35 skills carry no `Verified against` block and C5 reports 0 findings.
+
+The 15 blocks that exist share one shape — a blockquote opening with `**Verified against**:` and
+listing `tool version` pairs followed by what was run (`skills/r3f-*/SKILL.md:18-22`,
+`skills/observability/SKILL.md:22-25`, `skills/k8s-tune-resources/SKILL.md:23-26`,
+`skills/verify-before-claiming/SKILL.md:213-216`). `python-rest-api` carries the phrase in plain
+prose (`SKILL.md:183`). Both are literal `Verified against`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A reader opening any `SKILL.md` finds, near the top, either what it was probed against and when, or
+  the statement that nothing in it is version-bound and why.
+- The validator reads the same two literals the reader does, on every skill.
+- Every pin written by this change is backed by a command run on 2026-09-05 whose output is recorded
+  in `tasks.md`; the unprobed part of a skill is named inside its block.
+
+**Non-Goals:**
+- Enforcing a date inside the block (follow-up; needs a 15-skill backfill).
+- Re-deriving `assettoserver-plugin`'s TFM doctrine for the `0.0.55` runtime (follow-up issue).
+- Running CSP in-game, an FXServer build, or the source project of `react-api-client`: not on this
+  machine; the blocks say so instead of guessing.
+
+## Decisions
+
+1. **Two literal phrases, catalog-wide.** `Verified against` (case-sensitive) or
+   `does not depend on a tool version`. Alternative considered: keep C5 scoped to code-heavy skills
+   and accept loose forms — rejected, it is the state that let 20 skills through and the reader cannot
+   distinguish "Probed on CLI 1.6.0" (a pin) from "needs CSP >= 0.1.78" (a mention).
+2. **Declaration is an exit only for prose skills.** A skill with 40+ fenced lines that matches
+   `API_HINT` and declares itself not version-bound is reported unless it also carries the existing
+   `defers` phrase (`read the local copy first` / `source of truth, not this skill`). Rationale: the
+   declaration exists for process skills; a code-heavy API skill using it is the false-negative the
+   issue asks to close. `helm-migration` passes through the `defers` phrase it already carries.
+3. **Partial probes stay inside `Verified against`.** No third literal. The block names tools probed
+   and, in the same block, what was not (`Not probed: the in-game rendering rules; they were
+   observed on the DriveZone server and carry no CSP build number here`). Alternative: a third
+   literal `Unverified` — rejected because it gives a skill a way to declare nothing was checked and
+   still pass, and because the criterion's grep names two forms.
+4. **Patch bump per skill.** The block changes what the reader can rely on, not what the skill does.
+   Precedent: `2026-08-06-pin-probed-skills` bumped 1.0.1/1.0.2/1.2.1.
+5. **Existing loose pins stay as prose; the block is added.** `openspec`'s "Probed on CLI 1.6.0"
+   sentences carry behaviour details worth keeping; the block above them is what C5 reads.
+6. **Selftest mutations target the new rules, not the old trigger.** The current C5 mutation appends
+   45 `tsx` lines to `react-api-client`, which will carry a block after this change and would stop
+   firing. Replaced by: (a) strip the block from a code-heavy skill, (b) reword a block to a loose
+   mention, (c) replace a code-heavy API skill's block with the declaration.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| A pin names only what was run; an unprobed claim is written as a gap | `verify-before-claiming` | already canonical — blocks link to it, none restates the ladder |
+| The two literal declarations and what each owes | `openspec/specs/skills-authoring` (requirement text) + `scripts/validate-skills.py` C5 docstring | already canonical — skills carry the block, not the rule |
+| Where a skill's version moves and why | `skills-authoring` *A skill's version moves with its content* | already canonical — patch bumps, no restating |
+
+## Risks / Trade-offs
+
+- [A pin against a public stub or source tree reads as a runtime pin] → the block names the artifact
+  probed (`acc-lua-sdk @ <sha>`, `AssettoServer source at v0.0.55-pre25`) and says the runtime was not
+  run; the reviewer sees the boundary in the block itself.
+- [`defers` phrase becomes a loophole for code-heavy skills] → it is the phrase that already exists,
+  used by one skill (`helm-migration`); the selftest mutation (c) uses a skill without it, so a skill
+  that adds the phrase to dodge C5 is a review finding, not a silent pass.
+- [Catalog-wide C5 fails an unrelated future skill that forgot the block] → intended: that is the
+  gate the issue asks for; the finding names both exits.
+- [The `assettoserver-plugin` disclosure widens into a doctrine rewrite mid-run] → scope-change
+  protocol: it is recorded as a follow-up in E.4 and the block states the contradiction only.
+
+## Open Questions
+
+- Which CSP build the DriveZone servers require: not found on this machine (the server image carries
+  no `extra_cfg.yml`, `~/works` holds no DriveZone config). The `assettoserver-csp-lua` block will
+  name the SDK commit probed and leave the build number as an explicit gap unless the user supplies it.

--- a/openspec/changes/require-verified-against/proposal.md
+++ b/openspec/changes/require-verified-against/proposal.md
@@ -1,0 +1,76 @@
+# Change: Require the literal `Verified against` block, probed, on every skill
+
+## Why
+
+`skills-authoring` (*Versioned external APIs are pinned*) asks a skill about a versioned tool to say
+which version its claims were checked against. Measured on 2026-09-05 with
+`grep -L 'Verified against\|does not depend on a tool version' skills/*/SKILL.md`: **20 of 35** skills
+carry neither, among them skills that describe versioned surfaces (`assettoserver-*`, `fivem-*`,
+`react-api-client`, `backend-resilience`, `api-resilience-testing`). Some of those *do* carry a
+version somewhere — `openspec` says "Probed on CLI 1.6.0", `assettoserver-plugin` says
+"runtime 0.0.54 ↔ upstream tag v0.0.54" — but a reader cannot tell a pin from a mention, and neither
+can the validator: `check_pin` (C5) accepts any `<word> <digits>.<digits>` and only looks at skills
+with 40+ fenced lines, so a prose-only skill and a loosely worded one both pass.
+
+The issue (#131) also names the failure this change must not commit: writing `Verified against CSP
+0.2.x` without running CSP is inventing a pin, worse than none. The re-analysis found more probe
+surface on this machine than the issue assumed — `~/works/AssettoServer` at tag `v0.0.55-pre25`, the
+DriveZone server image (`AssettoServer 0.0.55+51d8d8a6e0`), docker images for Lua 5.4.8, Helm v4.2.3
+and the .NET 9 SDK, the live status line of Claude Code 2.1.261, gh 2.96.0, openspec 1.6.0 — but not
+the CSP client, not an FXServer build, and not the project `react-api-client` was extracted from.
+What can be probed is probed; what cannot is written down inside the block as not probed.
+
+## What Changes
+
+- **Two literal declarations**, one of which every `SKILL.md` carries:
+  - `> **Verified against**: <tool> <version> · … — <what was run>. Probed on <YYYY-MM-DD>.` The
+    block also names the part of the skill that was **not** probed, when there is one.
+  - `> **Not version-bound**: this skill does not depend on a tool version — <reason>.`
+- **20 skills** get one of the two, each with a patch bump:
+  - Probed here and pinned: `assettoserver-ops`, `assettoserver-plugin`, `assettoserver-csp-lua`
+    (API names against the public `acc-lua-sdk` stubs; in-game behaviour stays unprobed and says so),
+    `fivem-lua`, `fivem-fallback` (Lua 5.4.8 syntax + natives against `citizenfx/natives`; no
+    FXServer build, said so), `react-api-client` (blocks typechecked against pinned axios/zod/tsc),
+    `backend-resilience`, `log-event-collector`, `api-resilience-testing` (re-measured on the pinned
+    FastAPI/pydantic), `claude-statusline`, `code-locale`, `openspec`, `openspec-drivezone`,
+    `backlog`, `execute-backlog`, `conventional-commit` (this repo's release tooling), `svg-animation`
+    (Chrome for Testing 151.0.7922.34, the browser `references/platform.md` was measured on).
+  - Declared not version-bound: `helm-migration` (prescribes the shape of a private chart's values
+    file and already defers to the local template; it prescribes no `helm`/`kubectl` command),
+    `bug-hunter`, `documentation`.
+- **`check_pin` (C5) becomes catalog-wide and literal**: every `SKILL.md` must carry one of the two
+  phrases; a loose version mention no longer counts; a skill with 40+ fenced lines against a versioned
+  API that carries only the declaration is reported unless it defers to a local source of truth. The
+  40-fenced-line KNOWN LIMIT is removed with the trigger. The selftest gains the mutations that prove
+  each rule fires (pin removed from a code-heavy skill; pin reworded to a loose mention; declaration on
+  a code-heavy API skill).
+- README paragraph on the validator updated (C5 wording, selftest count).
+
+## Deliberately not done
+
+- The **date** inside the block is required by this issue for the 20 blocks written here and is not
+  enforced by C5: the 15 blocks that already exist carry no date and were probed on other days
+  (their archived changes carry the date). Enforcing it means backfilling 15 skills — a follow-up.
+- `assettoserver-plugin` keeps its `v0.0.54` / `net8.0` doctrine. The DriveZone runtime measured today
+  is `0.0.55+51d8d8a6e0`, built from a tree whose `AssettoServer.csproj` targets `net9.0`; the pin
+  block **discloses** that contradiction (the spec's "known breaking change" scenario) and a follow-up
+  issue re-derives the TFM and the `System.Threading.Lock` ban for that runtime. Rewriting the
+  doctrine is not this item's scope.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Versioned external APIs are pinned** — every skill carries one of two
+  literal declarations; a loose version mention is not a pin; a code-heavy skill against a versioned
+  API cannot exit by declaration; a partial probe names what was not probed.
+
+## Impact
+
+- `skills/<20 names>/SKILL.md` (block + patch bump), regenerated wrappers under `claude/ codex/
+  cursor/ copilot/ plugins/`.
+- `scripts/validate-skills.py` (C5), `scripts/selftest-validate-skills.py` (new mutations),
+  `README.md` (validator paragraph).
+- No skill added, removed or repurposed; catalog composition unchanged.

--- a/openspec/changes/require-verified-against/specs/skills-authoring/spec.md
+++ b/openspec/changes/require-verified-against/specs/skills-authoring/spec.md
@@ -1,0 +1,65 @@
+## MODIFIED Requirements
+
+### Requirement: Versioned external APIs are pinned
+
+A skill whose content targets an external API **or command-line tool** with breaking releases SHALL
+state the exact versions it was verified against, and SHALL name any known upcoming rename or removal
+that will invalidate it. For a skill that instructs the agent to run a CLI, the commands and flags it
+prescribes SHALL be probed against that tool before publication.
+
+Every `SKILL.md` SHALL carry exactly one of two literal declarations, placed where a reader meets it
+before the first rule: a `Verified against` block naming each tool and the version it was probed
+against, what was run, and the date; or the sentence `does not depend on a tool version` followed by
+the reason. A `Verified against` block SHALL name only versions the claims were actually probed
+against, and SHALL name the part of the skill that was not probed rather than cover it by implication.
+A version written for a run nobody made is a defect, not a pin. The declaration is an exit for
+process skills: a skill carrying 40 or more fenced lines against a versioned API SHALL carry the
+block unless it defers to a local source of truth it instructs the reader to open first.
+
+#### Scenario: Reader can tell which era the code targets
+
+- **WHEN** a skill documents a library API
+- **THEN** the skill names the library versions its examples were verified against, rather than
+  leaving the reader to infer it
+
+#### Scenario: A known breaking change is disclosed, not silently absorbed
+
+- **WHEN** the upstream has announced a rename or removal affecting the skill's examples
+- **THEN** the skill names it and where it applies, instead of presenting the current form as timeless
+
+#### Scenario: Prescribed CLI commands are probed, not assumed
+
+- **WHEN** a skill instructs the agent to run a command with specific subcommands and flags
+- **THEN** each subcommand and flag is checked against the installed tool before publication, and the
+  tool version the check ran against is recorded
+
+#### Scenario: Tool guidance contradicted by the tool is corrected, not repeated
+
+- **WHEN** a tool's own output advertises behaviour its implementation does not deliver
+- **THEN** the skill states the probed behaviour and the version it holds for, rather than repeating
+  the tool's claim
+
+#### Scenario: Every skill declares its relationship to versions
+
+- **WHEN** a `SKILL.md` carries neither the literal `Verified against` nor the literal
+  `does not depend on a tool version`
+- **THEN** the validator reports it under C5, whatever amount of fenced code the skill carries
+
+#### Scenario: A loose version mention is not a pin
+
+- **WHEN** a skill names a version only in passing (`Probed on CLI 1.6.0`, `targets v0.0.54`,
+  `needs CSP >= 0.1.78`) and carries no literal `Verified against`
+- **THEN** the validator reports it under C5, because a reader cannot tell a pin from a mention
+
+#### Scenario: A code-heavy skill does not exit by declaration
+
+- **WHEN** a skill carries 40 or more fenced lines, names a versioned API, declares that it does not
+  depend on a tool version, and does not defer to a local source of truth
+- **THEN** the validator reports the declaration as contradicted by the skill's own code
+
+#### Scenario: A partial probe names its boundary
+
+- **WHEN** only part of a skill's surface could be probed — public API stubs or source, but not the
+  runtime that executes them
+- **THEN** the `Verified against` block names what was probed, against which artifact and version,
+  and states what was not probed, instead of letting the pin cover the whole skill

--- a/openspec/changes/require-verified-against/tasks.md
+++ b/openspec/changes/require-verified-against/tasks.md
@@ -1,95 +1,121 @@
 ## 1. Evidence & Sources (MANDATORY)
 
-- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
       the commit or timestamp it was read at
-- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      Evidence: Opened 2026-09-05 at HEAD 7709622: `scripts/validate-skills.py:244-266` (C5, PIN/API_HINT), `scripts/selftest-validate-skills.py:30-31` (the C5 mutation), `openspec/specs/skills-authoring/spec.md:265-293` (the requirement), `README.md:875-913`, `openspec/changes/archive/2026-08-06-pin-probed-skills/{proposal,tasks}.md` (the precedent), the 20 `skills/<name>/SKILL.md` and `skills/react-api-client/references/api-client.md`, `skills/api-resilience-testing/references/negative-test-catalog.md:98-108`, `skills/svg-animation/references/platform.md:4-8`, `research/svg-animation/measurements.md:9-40`, `.releaserc.json`, `.github/workflows/ci.yml`. Outside the repo, read the same day: `~/works/AssettoServer` at tag `v0.0.55-pre25` (commit 51d8d8a6), `~/.claude/settings.json:26-50`, `~/.claude/statusline.sh`.
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
       probed against the installed version; the command and a fragment of its output are recorded
-- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      Evidence: `grep -L 'Verified against\|does not depend on a tool version' skills/*/SKILL.md | wc -l` -> `20` before, `0` after. `docker run --rm --entrypoint sh drivezone/assettoserver:local -c './AssettoServer --version'` -> `AssettoServer 0.0.55+51d8d8a6e0`. `git show v0.0.54:AssettoServer/AssettoServer.csproj | grep TargetFramework` -> `net8.0`; HEAD -> `net9.0`. 15/15 `extra_cfg.yml` keys and 24/25 `server_cfg.ini` keys resolve in the clone (`CARS` never read). `git clone --depth 1 acc-lua-sdk` @ 7cf60f5a -> 12/15 CSP names declared (`ui.measureDWriteText`, `ui.pushDWriteFont`, `ac.onCarCollision` absent). `docker run nickblah/lua:5.4-luarocks luac -p` over 14 Lua files -> `ok=13 bad=1` (the marked excerpt). citizenfx/fivem @ 6fd665a3 + natives @ 7263f211 -> 12/12 runtime functions resolve. venv: `fastapi 0.141.1 pydantic 2.13.4 starlette 1.6.0 httpx 0.28.1 structlog 26.1.0 prometheus_client 0.26.0 uvicorn 0.52.4`; baseline table -> 8/9 rows held, nested brackets -> `400 {"detail":"There was an error parsing the body"}` at 990/1000/1500/10000 levels under TestClient and uvicorn. backend-resilience blocks executed -> `safe_call fail -> (False, -1)`, counter `1.0`, `retry -> ok attempts 3`, negative cache `upstream calls 1`. `npx tsc -p` on react-api-client blocks -> 24 errors as written (`typescript 7.0.2`, `axios 1.20.0`, `zustand 5.0.15`). `openspec <cmd> --help` -> 11/11 subcommands, 5/5 flags; throwaway `openspec validate probe --strict` -> `Change 'probe' is valid` with no gate group. `gh <cmd> --help` -> `ok=58 fail=0` flags over 18 subcommands on `gh 2.96.0`. `check-identifier-locale.py --selftest`, `locale-rite.py --selftest`, `locale-stop-gate.py --selftest` -> all `selftest OK` on Python 3.11.2. `statusline.sh` fed a synthetic payload -> three rendered lines, `exit=0`; `diff -q ~/.claude/statusline.sh skills/claude-statusline/references/statusline.sh` -> identical. `git log -1 --format=%cs v2.24.0` -> 2026-09-05 from `✨ feat(code-locale)`.
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
       when there is no design.md) — never stated as fact, never filled with a plausible substitute
-- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      Evidence: Not probed, and written into the blocks as such: the CSP client and the CSP build the DriveZone servers require (no config on this machine; the server image carries no `extra_cfg.yml`); the three CSP names absent from the SDK tree; any FXServer build; the DriveZone repositories behind `openspec-drivezone`; the project `react-api-client` was extracted from; a compiled plugin against AssettoServer (dotnet SDK 9 image exists, the build was not attempted — cost, and the pin is declared as a source read); the live status-line payload field by field; Chrome for Testing (the svg numbers are the 2026-08-30/31 runs). Open question kept from design.md: the CSP build number, left as an explicit gap.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
       along the way are listed here as follow-ups, not performed
-
+      Evidence: Follow-ups noticed and NOT performed: (1) `assettoserver-plugin` doctrine (`net8.0` fallback, `System.Threading.Lock` ban) re-derived for the `0.0.55+51d8d8a6e0` runtime that targets `net9.0` — the block discloses it; (2) `python-rest-api` SKILL.md:103 publishes the same `500 (RecursionError)` row that did not reproduce (measured 400) — outside this item's 20 skills; (3) C5 does not check the date inside the block; enforcing it needs the 15 pre-existing blocks backfilled from their archived changes; (4) `react-api-client` blocks rewritten to compile instead of being marked excerpts; (5) `openspec spec list` deprecation on 1.6.0 — move the two openspec skills to `openspec show` / `validate --specs` when the pin moves; (6) README still says `C1–C9` in the tree listing at line 468 (stale before this change).
 ## 2. Probe and pin — game and server skills (AssettoServer clone, DriveZone image, public stubs)
 
-- [ ] 2.1 `assettoserver-ops`: every `extra_cfg.yml` key and the density function it quotes resolve in
+- [x] 2.1 `assettoserver-ops`: every `extra_cfg.yml` key and the density function it quotes resolve in
       `~/works/AssettoServer` at `v0.0.55-pre25`; the DriveZone image reports its version; block + bump
-- [ ] 2.2 `assettoserver-plugin`: TFM and package versions at `v0.0.54` read from the clone; the
+      Evidence: 15/15 `extra_cfg.yml` keys -> `Server/Configuration/Extra/AiParams.cs` etc.; 24/25 ini keys; `AiBehavior.cs:455-466` matches the quoted function; image -> `AssettoServer 0.0.55+51d8d8a6e0`. `skills/assettoserver-ops/SKILL.md` 1.3.0 -> 1.3.1.
+- [x] 2.2 `assettoserver-plugin`: TFM and package versions at `v0.0.54` read from the clone; the
       `0.0.55+51d8d8a6e0` / `net9.0` contradiction disclosed in the block; block + bump
-- [ ] 2.3 `assettoserver-csp-lua`: the 15 `ac.*`/`ui.*` names resolve in `acc-lua-sdk` at a recorded
+      Evidence: `git show v0.0.54:...csproj` -> `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`, `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase` declared at v0.0.54; `Commands/Attributes/RequireConnectedPlayerAttribute.cs` present; `System.Threading.Lock` used nowhere at HEAD. Block discloses `net9.0` at HEAD. 1.3.2 -> 1.3.3.
+- [x] 2.3 `assettoserver-csp-lua`: the 15 `ac.*`/`ui.*` names resolve in `acc-lua-sdk` at a recorded
       commit; `snippets.lua` parses on Lua 5.4.8; in-game behaviour named as not probed; block + bump
-- [ ] 2.4 `fivem-lua` and `fivem-fallback`: every fenced Lua block parses on Lua 5.4.8; every native
+      Evidence: acc-lua-sdk @ 7cf60f5a: 12/15 declared (`common/ac_ui.lua`, `common/ac_extras_onlineevent.lua`, `ac_online_script.lua`, `lib_audio.lua`…); `luac -p references/snippets.lua` ok; `CSPServerScriptProvider.cs:65` `AddScript(string script, string? debugFilename, Dictionary<string, object>? configuration)`, `:77` `SCRIPT_{10 + Scripts.Count}-{debugFilename}`, `:101` `/api/scripts/{Scripts.Count}`. 1.1.1 -> 1.1.2.
+- [x] 2.4 `fivem-lua` and `fivem-fallback`: every fenced Lua block parses on Lua 5.4.8; every native
       named resolves in `citizenfx/natives` at a recorded commit; no FXServer build, said so; blocks + bumps
-
+      Evidence: `luac -p` (Lua 5.4.8): fivem-lua 6/7 parse + 1 marked excerpt (`events-registry.md` block 1, `...` placeholder), fivem-fallback 5/5. `ext/native-decls/{RegisterNuiCallbackType,SetNuiFocus,SendNuiMessage,GetConvar,GetGameTimer,TriggerClientEventInternal,PerformHttpRequestInternal}.md` and `scheduler.lua` (`RegisterNetEvent`, `CreateThread`, `Wait`, `SetTimeout`, `AddEventHandler`) at fivem 6fd665a3. fivem-lua 1.3.2 -> 1.3.3, fivem-fallback 1.3.0 -> 1.3.1.
 ## 3. Probe and pin — Python, TypeScript and browser skills
 
-- [ ] 3.1 `backend-resilience`: the five `python` blocks import and the helpers execute against a stub
+- [x] 3.1 `backend-resilience`: the five `python` blocks import and the helpers execute against a stub
       dependency under pinned `httpx`/`structlog` in a venv; block + bump
-- [ ] 3.2 `log-event-collector`: the atomic-replace block executes on Python 3.11.2; block + bump
-- [ ] 3.3 `api-resilience-testing`: the nine-row baseline table re-measured on `fastapi 0.141.1` /
+      Evidence: `venv/bin/python run_backend.py` -> `block0 httpx.Timeout -> Timeout(connect=1.0, read=2.0, write=2.0, pool=1.0)`, `safe_call fail -> (False, -1)`, `safe_call_async fail -> (False, -2)`, `clamp_num -> 5 3 3 2.5`, counter sample `1.0`, `retry -> ok attempts 3`, `deadline -> deadline attempts 0`, `first -> None second -> None upstream calls 1`, `cfg -> {'xp_per_level': 100, 'max_level': 50}`. 2.0.1 -> 2.0.2.
+- [x] 3.2 `log-event-collector`: the atomic-replace block executes on Python 3.11.2; block + bump
+      Evidence: `venv/bin/python run_lec.py` -> `first read -> ['line one', 'line two'] offset 18`, `second read -> ['partial tail', 'line four'] offset 41`; atomic replace -> `{'offset': 123} tmp left: False`. 1.1.0 -> 1.1.1.
+- [x] 3.3 `api-resilience-testing`: the nine-row baseline table re-measured on `fastapi 0.141.1` /
       `pydantic 2.13.4` in a venv; rows corrected if any differ; block + bump
-- [ ] 3.4 `react-api-client`: the three complete `ts` blocks typecheck with pinned `axios`, `zod`,
+      Evidence: `baseline.py` under TestClient and `nested_uvicorn.py` under uvicorn 0.52.4 -> 422/422/422/200/422/405(Allow=GET)/200/**400**/200; `fastapi/routing.py:469-473` is the `except Exception -> HTTPException(400, "There was an error parsing the body")` that catches the `RecursionError`. Row, prose (SKILL.md:181-186) and `references/negative-test-catalog.md:103-108` corrected to 400. 1.3.1 -> 1.3.2.
+- [x] 3.4 `react-api-client`: the three complete `ts` blocks typecheck with pinned `axios`, `zod`,
       `typescript` once given their imports in a probe harness; block + bump
-- [ ] 3.5 `svg-animation`: block names Chrome for Testing 151.0.7922.34 and the 2026-08-30/31 runs
+      Evidence: `npx tsc -p tsconfig.json` (typescript 7.0.2, axios 1.20.0, zustand 5.0.15 from package-lock) -> 24 errors across the three complete-looking blocks as written; harness with imports + declarations still fails (elided constructors, `original.headers.set` on the config union). Three blocks now open with `// excerpt — condensed: …`; the fourth already did. 1.1.1 -> 1.1.2.
+- [x] 3.5 `svg-animation`: block names Chrome for Testing 151.0.7922.34 and the 2026-08-30/31 runs
       recorded in `research/svg-animation/measurements.md`; block + bump
-
+      Evidence: `research/svg-animation/measurements.md:11` -> `Google Chrome for Testing 151.0.7922.34, headless (--headless=new)`, `:39` -> `measured on 2026-08-30`, `:181` -> second run 2026-08-31; `references/platform.md:6` names the same build. Block cites both files by repository URL (C12). 1.1.2 -> 1.1.3.
 ## 4. Probe and pin — CLI and harness skills
 
-- [ ] 4.1 `openspec` and `openspec-drivezone`: every prescribed subcommand/flag probed on openspec 1.6.0;
+- [x] 4.1 `openspec` and `openspec-drivezone`: every prescribed subcommand/flag probed on openspec 1.6.0;
       the "strict passes a change missing every gate section" claim re-run in a throwaway project;
       blocks + bumps
-- [ ] 4.2 `backlog` and `execute-backlog`: read recipes executed against the AI-SKILLS board on gh
+      Evidence: `openspec --version` -> 1.6.0; 11/11 subcommands `--help` exit 0; `validate --help` lists `--all --type --strict --no-interactive`; `spec list --help` lists `--long` and the run prints `Warning: The "openspec spec ..." commands are deprecated`; throwaway `openspec init --tools none` + change with `tasks.md` = one plain group -> `openspec validate probe --strict` -> `Change 'probe' is valid`. openspec 1.1.1 -> 1.1.2, openspec-drivezone 2.1.3 -> 2.1.4.
+- [x] 4.2 `backlog` and `execute-backlog`: read recipes executed against the AI-SKILLS board on gh
       2.96.0, write recipes' flags checked with `--help`; blocks + bumps
-- [ ] 4.3 `code-locale`: `check-identifier-locale.py --selftest` and `locale-rite.py --selftest` on
+      Evidence: `gh --version` -> 2.96.0; `gh-flags.txt` -> `ok=58 fail=0`; live: `gh project item-list 3 --owner solvelab --limit 200 --format json --jq` -> item id, `gh project field-list` -> Status options, `gh project item-edit ... --single-select-option-id 61e4505c` then `47fc9ee4` moved #131 Backlog -> Ready -> In progress, `gh api repos/solvelab/ai-skills/issues/131/timeline --jq` -> 1 cross-reference, `gh issue view 131 --json closedByPullRequestsReferences` -> 0. backlog 1.5.1 -> 1.5.2, execute-backlog 1.8.2 -> 1.8.3.
+- [x] 4.3 `code-locale`: `check-identifier-locale.py --selftest` and `locale-rite.py --selftest` on
       Python 3.11.2 under Claude Code 2.1.261; block + bump
-- [ ] 4.4 `claude-statusline`: `references/statusline.sh` is byte-identical to the live one and
+      Evidence: `python3 skills/code-locale/references/check-identifier-locale.py --selftest` -> `selftest OK: 7 content tiers fire, 16 clean cases stay silent, 6 path tiers fire, 9 path cases stay silent, 2 en-unknown tiers fire, 5 en-unknown cases stay silent`; `locale-rite.py --selftest` -> `13 PostToolUse decisions, 12 PreToolUse decisions`; `locale-stop-gate.py --selftest` -> `26 decisions`; `~/.claude/settings.json:26,38,49` wire both hooks. 1.4.0 -> 1.4.1.
+- [x] 4.4 `claude-statusline`: `references/statusline.sh` is byte-identical to the live one and
       rendered under Claude Code 2.1.261 / jq 1.6; fed the sample payload; block + bump
-- [ ] 4.5 `conventional-commit`: gitmoji-prefixed subjects released by this repo's pinned
+      Evidence: `diff -q ~/.claude/statusline.sh skills/claude-statusline/references/statusline.sh` -> identical; `printf '<payload>' | bash references/statusline.sh` -> `🤖 Fable 5.1 | ⚡ medium | 🧠 thinking enabled | ⏱️ 1m 5s | 💰 $1.23` + two more lines, `exit=0`; `claude --version` -> 2.1.261, `jq --version` -> jq-1.6, bash 5.2.15. 1.2.1 -> 1.2.2.
+- [x] 4.5 `conventional-commit`: gitmoji-prefixed subjects released by this repo's pinned
       semantic-release 25 + conventionalcommits 8, evidence from tags/CHANGELOG; block + bump
-
+      Evidence: `.releaserc.json` headerPattern `^(?:[^\w\s]+\s+)?(\w+)(?:\((.*)\))?!?: (.*)$`; `ci.yml:279` installs `semantic-release@25 ... conventional-changelog-conventionalcommits@8`; `git log -1 --format=%cs v2.24.0` -> 2026-09-05 <- `✨ feat(code-locale)` (b1f527f); v2.23.0 <- 69aaf73; v2.22.0 <- 49c44d0. 1.3.1 -> 1.3.2.
 ## 5. Declare — process skills
 
-- [ ] 5.1 `helm-migration`, `bug-hunter`, `documentation`: `**Not version-bound**` sentence with the
+- [x] 5.1 `helm-migration`, `bug-hunter`, `documentation`: `**Not version-bound**` sentence with the
       reason; bumps
-
+      Evidence: `grep -c -i -E 'helm |kubectl' skills/helm-migration/SKILL.md` restricted to commands -> 0 prescribed commands; bug-hunter tracks name `pytest`, `busted`, Cecil with no version flag; documentation prescribes no CLI. Blocks written with the literal `does not depend on a tool version`. helm-migration 2.2.2 -> 2.2.3, bug-hunter 2.2.2 -> 2.2.3, documentation 3.0.2 -> 3.0.3.
 ## 6. Detector and docs
 
-- [ ] 6.1 `check_pin` (C5): literal-phrase rule catalog-wide; declaration exit gated for code-heavy API
+- [x] 6.1 `check_pin` (C5): literal-phrase rule catalog-wide; declaration exit gated for code-heavy API
       skills; docstring states the new limits and drops the 40-line KNOWN LIMIT
-- [ ] 6.2 `selftest-validate-skills.py`: mutations (a) block stripped from a code-heavy skill,
+      Evidence: `scripts/validate-skills.py` C5: `PIN = re.compile(r"Verified against")`, `NO_VERSION`, `DEFERS`; finding text `neither 'Verified against' nor 'does not depend on a tool version' — a version mentioned in passing is not a pin` / `N lines of code against a versioned API, declared not version-bound`; docstring header line updated; `python3 scripts/validate-skills.py` -> `skills checked: 35   findings: 0`.
+- [x] 6.2 `selftest-validate-skills.py`: mutations (a) block stripped from a code-heavy skill,
       (b) block reworded to a loose mention, (c) declaration on a code-heavy API skill; old C5 mutation
       removed because its target will carry a block
-- [ ] 6.3 README validator paragraph: C5 wording and the selftest count
-- [ ] 6.4 `./generate.sh`; wrappers in sync
-
+      Evidence: `scripts/selftest-validate-skills.py`: mutations `C5 no version pin` (fivem-lua, literal stripped), `C5 no version pin (loose mention)` (openspec, `Probed on CLI 1.6.0` left in place), `C5 no version pin (declaration on code-heavy API skill)` (k8s-tune-resources, 73 fenced lines, `kubectl` hint); run -> `CAUGHT` for all three, `21/22 defect classes detected` locally — the one MISSED is the pre-existing `C3 lua syntax` (luac not installed here; CI installs lua5.4).
+- [x] 6.3 README validator paragraph: C5 wording and the selftest count
+      Evidence: `README.md:878-879` -> `every skill states what it was verified against or that it does not depend on a tool version (C5)`; `:913` -> `22/22 defect classes detected` (was a stale `13/13` against a selftest that already had 20).
+- [x] 6.4 `./generate.sh`; wrappers in sync
+      Evidence: `bash generate.sh` then `git status --porcelain --untracked-files=all | grep -c '^??'` -> 0; the generated trees change only where `skills/` changed (87 paths in the working tree before commit).
 ## 7. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
       observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      Evidence: entry point `python3 scripts/validate-skills.py` on the catalog -> `skills checked: 35   findings: 0`; on a copy with the literal stripped from `skills/fivem-lua/SKILL.md` -> `C5 no version pin      1` and, under `fivem-lua`, `[C5 no version pin] neither 'Verified against' nor 'does not depend on a tool version' — a version mentioned in passing is not a pin`. entry point `python3 scripts/selftest-validate-skills.py` -> `CAUGHT  C5 no version pin`, `CAUGHT  C5 no version pin (loose mention)`, `CAUGHT  C5 no version pin (declaration on code-heavy API skill)`, `21/22 defect classes detected`.
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
       silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      Evidence: 3/3 C5 mutations had to fire and did; 35/35 skills had to stay silent and did (`findings: 0`); 20/20 new blocks carry `2026-09-05`; 1/1 known escape stayed silent — `helm-migration` (82 fenced yaml lines, `helm ` in prose, the declaration) passes through the deferral phrase it already carries, by design; 1/1 pre-existing local miss unchanged — `C3 lua syntax` (luac absent here, installed by CI).
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
       explicitly that nothing did
-
+      Evidence: Four things behaved differently than expected and were acted on: (1) mutation (c) on `r3f-materials` stayed silent because its SKILL.md has 0 fenced lines (code lives under references/) — retargeted to `k8s-tune-resources`; (2) the svg-animation block tripped C12 on two `research/…` paths — replaced by repository URLs; (3) the api-resilience-testing nested-brackets row did not reproduce (400, not 500) on the very stack it names — corrected in three places and disclosed in the block; (4) the GitHub code-search endpoint rate-limited the first CSP/natives probe (10/min) — redone with shallow clones, which is also the more reproducible evidence.
 ## 8. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
       metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
       compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      Evidence: CI frontmatter loop replicated locally over `skills/*/SKILL.md` -> `frontmatter fail=0`; `agentskills validate` (skills-ref 0.1.1) -> `fail=0 over 35 skills`; `npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict` -> `✔ Validation passed`.
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Evidence: Every block and every corrected line is English; `python3 skills/code-locale/references/check-identifier-locale.py <23 changed canonical files>` -> `findings: 0` (4 en-unknown segments, advisory).
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
       do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      Evidence: `git diff master -- skills/ | grep -E '^[-+]\s*description' | wc -l` -> `0`: no description changed, so no trigger or boundary moved.
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
       its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      Evidence: The blocks state what was probed and link nothing restated; the probing doctrine stays in `verify-before-claiming`, the requirement in `skills-authoring`, the rule in C5's docstring (design.md Canonical Home table, three rows, all `already canonical`).
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
       names; a term kept in another language carries its reason inline (`code-locale`).
       Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
       paths shipped in target repos through this rite. Regression gate on the exemplar: the model
       imitates the code it is shown
-
+      Evidence: No code example was added; the detector run in Q.2 covers the 22 changed skill files -> `findings: 0`.
 ## 9. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate require-verified-against --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+- [x] V.1 `openspec validate require-verified-against --strict` green
+      Evidence: `openspec validate require-verified-against --strict` -> `Change 'require-verified-against' is valid`; `bash scripts/validate-rite.sh` -> `rite gate OK` (evidence gate 0 findings, spec-rite gate 0 findings).
+- [x] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
       no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `npx -y skills add solvelab/ai-skills --list | grep -c -E '^│    [a-z0-9-]+$'` -> `35`, the tree count; no skill added, removed or renamed.
+- [x] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `README.md:878-879` C5 wording and `:913` selftest count updated; catalog composition unchanged, so no other doc moves.
 - [ ] V.4 `openspec archive require-verified-against --yes` after all groups above are `[x]`

--- a/openspec/changes/require-verified-against/tasks.md
+++ b/openspec/changes/require-verified-against/tasks.md
@@ -1,0 +1,95 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+## 2. Probe and pin — game and server skills (AssettoServer clone, DriveZone image, public stubs)
+
+- [ ] 2.1 `assettoserver-ops`: every `extra_cfg.yml` key and the density function it quotes resolve in
+      `~/works/AssettoServer` at `v0.0.55-pre25`; the DriveZone image reports its version; block + bump
+- [ ] 2.2 `assettoserver-plugin`: TFM and package versions at `v0.0.54` read from the clone; the
+      `0.0.55+51d8d8a6e0` / `net9.0` contradiction disclosed in the block; block + bump
+- [ ] 2.3 `assettoserver-csp-lua`: the 15 `ac.*`/`ui.*` names resolve in `acc-lua-sdk` at a recorded
+      commit; `snippets.lua` parses on Lua 5.4.8; in-game behaviour named as not probed; block + bump
+- [ ] 2.4 `fivem-lua` and `fivem-fallback`: every fenced Lua block parses on Lua 5.4.8; every native
+      named resolves in `citizenfx/natives` at a recorded commit; no FXServer build, said so; blocks + bumps
+
+## 3. Probe and pin — Python, TypeScript and browser skills
+
+- [ ] 3.1 `backend-resilience`: the five `python` blocks import and the helpers execute against a stub
+      dependency under pinned `httpx`/`structlog` in a venv; block + bump
+- [ ] 3.2 `log-event-collector`: the atomic-replace block executes on Python 3.11.2; block + bump
+- [ ] 3.3 `api-resilience-testing`: the nine-row baseline table re-measured on `fastapi 0.141.1` /
+      `pydantic 2.13.4` in a venv; rows corrected if any differ; block + bump
+- [ ] 3.4 `react-api-client`: the three complete `ts` blocks typecheck with pinned `axios`, `zod`,
+      `typescript` once given their imports in a probe harness; block + bump
+- [ ] 3.5 `svg-animation`: block names Chrome for Testing 151.0.7922.34 and the 2026-08-30/31 runs
+      recorded in `research/svg-animation/measurements.md`; block + bump
+
+## 4. Probe and pin — CLI and harness skills
+
+- [ ] 4.1 `openspec` and `openspec-drivezone`: every prescribed subcommand/flag probed on openspec 1.6.0;
+      the "strict passes a change missing every gate section" claim re-run in a throwaway project;
+      blocks + bumps
+- [ ] 4.2 `backlog` and `execute-backlog`: read recipes executed against the AI-SKILLS board on gh
+      2.96.0, write recipes' flags checked with `--help`; blocks + bumps
+- [ ] 4.3 `code-locale`: `check-identifier-locale.py --selftest` and `locale-rite.py --selftest` on
+      Python 3.11.2 under Claude Code 2.1.261; block + bump
+- [ ] 4.4 `claude-statusline`: `references/statusline.sh` is byte-identical to the live one and
+      rendered under Claude Code 2.1.261 / jq 1.6; fed the sample payload; block + bump
+- [ ] 4.5 `conventional-commit`: gitmoji-prefixed subjects released by this repo's pinned
+      semantic-release 25 + conventionalcommits 8, evidence from tags/CHANGELOG; block + bump
+
+## 5. Declare — process skills
+
+- [ ] 5.1 `helm-migration`, `bug-hunter`, `documentation`: `**Not version-bound**` sentence with the
+      reason; bumps
+
+## 6. Detector and docs
+
+- [ ] 6.1 `check_pin` (C5): literal-phrase rule catalog-wide; declaration exit gated for code-heavy API
+      skills; docstring states the new limits and drops the 40-line KNOWN LIMIT
+- [ ] 6.2 `selftest-validate-skills.py`: mutations (a) block stripped from a code-heavy skill,
+      (b) block reworded to a loose mention, (c) declaration on a code-heavy API skill; old C5 mutation
+      removed because its target will carry a block
+- [ ] 6.3 README validator paragraph: C5 wording and the selftest count
+- [ ] 6.4 `./generate.sh`; wrappers in sync
+
+## 7. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 8. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`).
+      Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
+      paths shipped in target repos through this rite. Regression gate on the exemplar: the model
+      imitates the code it is shown
+
+## 9. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate require-verified-against --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive require-verified-against --yes` after all groups above are `[x]`

--- a/plugins/backend/skills/backend-resilience/SKILL.md
+++ b/plugins/backend/skills/backend-resilience/SKILL.md
@@ -12,13 +12,23 @@ description: >-
   adaptation use fivem-fallback instead.
 metadata:
   author: solvelab
-  version: 2.0.1
+  version: 2.0.2
   category: backend
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # Backend resilience & fallback
+
+> **Verified against**: `Python 3.11.2` · `httpx 0.28.1` · `structlog 26.1.0` · `prometheus-client
+> 0.26.0`. Probed on 2026-09-05: the five `python` blocks were extracted and executed against stubs
+> — `httpx.Timeout(connect=, read=, write=, pool=)` constructs; `safe_call` and `safe_call_async`
+> return `(False, fallback)` on a raising callable and emit the `fallback_used` line with the
+> counter at 1; `clamp_num` clamps, and defaults on `None` and on `"x"`; the retry loop returns
+> after 3 attempts with full jitter and makes 0 attempts past the deadline; the negative cache
+> makes 1 upstream call for 2 requests after a `ConnectError`; the config fallback lands on
+> `FALLBACK` after a `ReadTimeout`. Fragments were wrapped in a function to run; nothing was run
+> against a live Consul or HTTP dependency.
 
 Defensive patterns for calling an unreliable dependency. The network boundary is unstable: timeouts,
 5xx, partial payloads, dependency down, races. Every call needs a **safe default** so the service keeps

--- a/plugins/backend/skills/log-event-collector/SKILL.md
+++ b/plugins/backend/skills/log-event-collector/SKILL.md
@@ -11,13 +11,20 @@ description: >-
   metrics/APM instrumentation of the monitored application.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # Log-tailing event collector
+
+> **Verified against**: `Python 3.11.2` (standard library only). Probed on 2026-09-05: the
+> partial-line read returns the complete lines and leaves the offset before the partial tail
+> (`['line one', 'line two']`, offset 18; the tail arrives whole on the next read), and the atomic
+> state write lands through `os.replace` with no `.tmp` left behind. The parser excerpt is not
+> runnable by design. No tailer was run against a live server here; the doctrine is stack-agnostic
+> and pins nothing else.
 
 When a system you can't modify (game server, third-party daemon) only exposes its life in text
 logs, ship a **collector sidecar**: tail the log, parse lines into normalized events, POST them to

--- a/plugins/devops/skills/assettoserver-ops/SKILL.md
+++ b/plugins/devops/skills/assettoserver-ops/SKILL.md
@@ -11,13 +11,23 @@ description: >-
   backend receiving events (python-rest-api), or for FiveM servers.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: devops
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # AssettoServer operations
+
+> **Verified against**: `AssettoServer v0.0.55-pre25` — the source tree at `~/works/AssettoServer`
+> (commit `51d8d8a6`), which is what the DriveZone image `drivezone/assettoserver:local` reports as
+> `AssettoServer 0.0.55+51d8d8a6e0`. Probed on 2026-09-05: all 15 `extra_cfg.yml` keys cited here
+> resolve to properties under `Server/Configuration/Extra/`; 24 of the 25 `server_cfg.ini` keys
+> resolve to the sample `Assets/server_cfg.ini` or to an `[IniField]` under
+> `Server/Configuration/Kunos/` — `CARS` is a stock acServer key this source never reads; the
+> density function quoted below is `Server/Ai/AiBehavior.cs:455-466` at that tag. Not probed: no
+> server was started against a client, and the CSP build the DriveZone servers require is not
+> recorded on this machine.
 
 Distilled from a production freeroam deployment (DriveZone on SRP/Shutoko). The runtime is
 `compujuckel/AssettoServer` — a CSP-aware replacement for stock `acServer` that adds

--- a/plugins/devops/skills/helm-migration/SKILL.md
+++ b/plugins/devops/skills/helm-migration/SKILL.md
@@ -4,13 +4,19 @@ description: >-
   Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 metadata:
   author: solvelab
-  version: 2.2.2
+  version: 2.2.3
   category: devops
 license: MIT
 compatibility: Requires a Helm charts template repository accessible on the local filesystem. Works best in Claude Code.
 ---
 
 # Helm Migration Skill
+
+> **Not version-bound**: this skill does not depend on a tool version — it prescribes the shape of
+> `values.yaml` and `env.yaml` for the solvelab chart template and tells the reader to read the
+> local template first, and it prescribes no `helm` or `kubectl` command whose flags could be
+> pinned (measured on 2026-09-05: zero such commands in the skill and its reference). The field
+> names are pinned by the template itself, as the note below says.
 
 You are a Helm chart expert. When asked to migrate a Kubernetes YAML file to Helm, follow the workflow and conventions below. These are derived from real solvelab production charts and are specific to that chart template.
 

--- a/plugins/docs/skills/documentation/SKILL.md
+++ b/plugins/docs/skills/documentation/SKILL.md
@@ -10,13 +10,18 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.2
+  version: 3.0.3
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # Documentation
+
+> **Not version-bound**: this skill does not depend on a tool version — it decides which documents
+> a project gets and how a claim inside them is made checkable, and it prescribes no generator,
+> linter or CLI. The `AGENTS.md` convention it names is a specification, not a versioned tool.
+> Declared on 2026-09-05.
 
 Write documentation a reader can act on and a script can verify. Templates and full worked examples
 live in `references/` — read them when you are about to generate output, not before.

--- a/plugins/fivem/skills/fivem-fallback/SKILL.md
+++ b/plugins/fivem/skills/fivem-fallback/SKILL.md
@@ -9,13 +9,22 @@ description: >-
   services use backend-resilience instead.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # FiveM fallback & resilience (Lua adaptation)
+
+> **Verified against**: `Lua 5.4.8` · `citizenfx/fivem` at commit `6fd665a3` (2026-09-02) ·
+> `citizenfx/natives` at `7263f211` (2026-08-17). Probed on 2026-09-05: all 5 fenced Lua blocks in
+> this skill and its reference parse under `luac -p`; the 6 runtime functions and natives named
+> here (`PerformHttpRequest`, `GetConvar`, `GetGameTimer`, `CreateThread`, `Wait`,
+> `RegisterNUICallback`) resolve in `ext/native-decls/`,
+> `data/shared/citizen/scripting/lua/scheduler.lua` or `natives/MISC/`. Not probed: no FXServer
+> build ran this code, and no backend was called from a resource — the retry and negative-cache
+> behaviour was observed on the DriveZone servers and carries no artifact number here.
 
 **Doctrine lives in `backend-resilience`** — read it first: safe defaults, one shared helper,
 response-shape validation, clamping, bounded retries, negative cache (never negative-cache a real 404),

--- a/plugins/fivem/skills/fivem-lua/SKILL.md
+++ b/plugins/fivem/skills/fivem-lua/SKILL.md
@@ -4,13 +4,22 @@ description: >-
   Conventions for writing FiveM (CitizenFX) server/client Lua resources. Use when working on FiveM/FXServer Lua — RegisterNetEvent/RegisterNUICallback handlers, fxmanifest, exports, NUI (SendNUIMessage/SetNuiFocus), threads/CreateThread, StateBags, or natives. Enforces the client-is-never-trusted boundary (validate payload + derive actor from `source`), explicit fxmanifest order, no busy `while true` loops, module-per-global pattern, and NUI focus/disconnect cleanup. Do NOT use for react-three-fiber, for CSP Lua scripts on an Assetto Corsa server (that is `assettoserver-csp-lua`), or for other non-FiveM Lua.
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # FiveM Lua — CitizenFX conventions
+
+> **Verified against**: `Lua 5.4.8` · `citizenfx/fivem` at commit `6fd665a3` (2026-09-02) ·
+> `citizenfx/natives` at `7263f211` (2026-08-17). Probed on 2026-09-05: 6 of the 7 fenced Lua
+> blocks in this skill and its references parse under `luac -p` (the seventh is the marked `--
+> excerpt` and is skipped by design); the 8 runtime functions named here (`RegisterNetEvent`,
+> `RegisterNUICallback`, `TriggerClientEvent`, `SetNuiFocus`, `SendNUIMessage`, `CreateThread`,
+> `Wait`, `SetTimeout`) resolve in `ext/native-decls/` or
+> `data/shared/citizen/scripting/lua/scheduler.lua`. Not probed: no FXServer build ran this code —
+> the runtime rules were observed on the DriveZone servers and carry no artifact number here.
 
 Generic conventions for writing maintainable server/client Lua resources on FiveM (CitizenFX).
 Project-agnostic: resource prefixes, exact endpoints, and keybind registries belong in the project's

--- a/plugins/frontend/skills/react-api-client/SKILL.md
+++ b/plugins/frontend/skills/react-api-client/SKILL.md
@@ -9,13 +9,21 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # React SPA ↔ typed-envelope API
+
+> **Verified against**: `typescript 7.0.2` · `axios 1.20.0` · `zustand 5.0.15`. Probed on
+> 2026-09-05: the four `ts` blocks in `references/api-client.md` were extracted and typechecked.
+> None of the three complete-looking ones compiles as written (24 errors: elided constructors,
+> sibling names), and a harness supplying the imports and the elided declarations still leaves
+> typing errors in the interceptor and store blocks — so all four now carry the `// excerpt` marker
+> and are read as shape, not as modules. `zod` is named in prose only and was not exercised. The
+> project this skill was extracted from was not available.
 
 The backend (`python-rest-api` skill) speaks `{status, code, message, data}`. These conventions
 keep the frontend honest about it: the front only EXHIBITS state and SENDS intents — balance,

--- a/plugins/frontend/skills/react-api-client/references/api-client.md
+++ b/plugins/frontend/skills/react-api-client/references/api-client.md
@@ -3,6 +3,7 @@
 ## errors.ts — typed taxonomy
 
 ```ts
+// excerpt — condensed: the constructor is elided; does not compile as written
 export enum ErrorCodes {
   INSUFFICIENT_BALANCE = 'INSUFFICIENT_BALANCE',
   COOLDOWN_ACTIVE = 'COOLDOWN_ACTIVE',
@@ -28,6 +29,7 @@ export const isApiException = (e: unknown): e is ApiException => e instanceof Ap
 ## client.ts — the interceptor contract (essence)
 
 ```ts
+// excerpt — condensed: imports, the axios instance field and the constructor are elided
 export interface AuthHandlers {
   getAccessToken: () => string | null;
   onUnauthorized: () => void;
@@ -95,6 +97,7 @@ export const createApiClient = (cfg: ApiClientConfig) => new ApiClient(cfg);
 ## createAuthStore.ts — factory essentials
 
 ```ts
+// excerpt — condensed: zustand imports and the storage adapter are elided
 export function createAuthStore({ persistKey }: { persistKey: string }) {
   return createStore(persist(
     (set) => ({

--- a/plugins/frontend/skills/svg-animation/SKILL.md
+++ b/plugins/frontend/skills/svg-animation/SKILL.md
@@ -14,13 +14,21 @@ description: >-
   the traps that break silently.
 metadata:
   author: solvelab
-  version: 1.1.2
+  version: 1.1.3
   category: frontend
 license: MIT
 compatibility: Works in any environment with filesystem access; verification steps need a Chrome binary.
 ---
 
 # svg-animation — understand the object, then represent it
+
+> **Verified against**: `Google Chrome for Testing 151.0.7922.34` (`--headless=new`, 1280×720,
+> software rasterisation, WSL2), driven over CDP by [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs) on
+> 2026-08-30 and 2026-08-31 — every cost in `references/platform.md` comes from those two runs and
+> is recorded with its raw numbers in [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md). Not re-run on
+> 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS animation
+> semantics are specification-level and carry no tool version; the numbers do, and they expire with
+> that browser build.
 
 The failure this skill exists to prevent is not ugly output. It is **plausible** output: an animation
 whose every part is defensible and whose whole is wrong. Measured on 22 objects and 12 primitives

--- a/plugins/game/skills/assettoserver-csp-lua/SKILL.md
+++ b/plugins/game/skills/assettoserver-csp-lua/SKILL.md
@@ -14,13 +14,24 @@ description: >-
   (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # CSP Lua online scripts (AssettoServer-served overlays)
+
+> **Verified against**: `acc-lua-sdk` at commit `7cf60f5a` (2026-08-17, the public CSP Lua library
+> tree) · `Lua 5.4.8` · `AssettoServer v0.0.54` and `v0.0.55-pre25` source. Probed on 2026-09-05:
+> 12 of the 15 `ac.*`/`ui.*` names this skill uses are declared in that tree;
+> `ui.measureDWriteText`, `ui.pushDWriteFont` and `ac.onCarCollision` are not (the tree does not
+> enumerate every C++-side binding) — they were paid for in game and are not re-probed here.
+> `references/snippets.lua` and the fenced Lua block parse under `luac -p`;
+> `CSPServerScriptProvider.AddScript(string, string?, Dictionary<string, object>?)`, the
+> `SCRIPT_N-<name>` section and the `/api/scripts/N` route exist at both server tags. Not probed:
+> every rendering, font and audio rule below needs the CSP client, and the CSP build the DriveZone
+> servers require is not recorded on this machine.
 
 Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
 client by the server itself. Zero-install is the point — the player installs nothing; art, sound

--- a/plugins/game/skills/assettoserver-plugin/SKILL.md
+++ b/plugins/game/skills/assettoserver-plugin/SKILL.md
@@ -12,13 +12,23 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # AssettoServer plugin conventions
+
+> **Verified against**: `AssettoServer v0.0.54` source — `git show
+> v0.0.54:AssettoServer/AssettoServer.csproj` gives `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`,
+> `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase`, the
+> `RequireConnectedPlayer`/`RequireAdmin` attributes and `CSPServerScriptProvider.AddScript(string,
+> string?, Dictionary<string, object>?)` are declared at that tag. Probed on 2026-09-05 by reading
+> the tree: no plugin was compiled or loaded here. **Disclosed**: the DriveZone runtime measured
+> the same day reports `AssettoServer 0.0.55+51d8d8a6e0`, built from a tree whose csproj targets
+> `net9.0` — on that host `System.Threading.Lock` exists and the `net8.0` fallback below is one
+> major behind. The doctrine is re-derived for `0.0.55` in a follow-up, not silently here.
 
 Distilled from a production plugin (DriveZone.AssettoServer.Plugin) that survived real
 AssettoServer runtime incompatibilities. Prescriptive: follow these unless the project documents a

--- a/plugins/testing/skills/api-resilience-testing/SKILL.md
+++ b/plugins/testing/skills/api-resilience-testing/SKILL.md
@@ -4,13 +4,22 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing, nor for writing the service's own layout, envelope and handlers (that is `python-rest-api`).
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.3.2
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # API Resilience Testing
+
+> **Verified against**: `fastapi 0.141.1` · `pydantic 2.13.4` · `starlette 1.6.0` · `httpx 0.28.1`
+> · `uvicorn 0.52.4`, re-measured on 2026-09-05 with a stock two-route service (a pydantic body
+> model, an `int` path parameter) under `TestClient` and under a real uvicorn server. Eight of the
+> nine baseline rows held; **one was corrected**: a body of nested brackets returns **400**
+> `{"detail":"There was an error parsing the body"}` at every depth from 990 to 10 000, closed or
+> unclosed, for model, `Any` and `dict` bodies — FastAPI's body parser catches the
+> `RecursionError`, and the **500** published here earlier did not reproduce. `curl` is the only
+> tool the checklist prescribes and no version-bound flag of it is used.
 
 Test a REST API so it survives the inputs nobody intended — invalid, malformed,
 out-of-contract, hostile — and fails **safely** instead of crashing, corrupting
@@ -178,11 +187,13 @@ FastAPI 0.141.1 / pydantic 2.13.4 (the `python-rest-api` baseline), stock servic
 | Wrong path-param type (`/users/abc`) | 404 | **422** | No — the route matched, the value didn't |
 | Wrong HTTP method | 405 | **405** (with `Allow`) | Already correct |
 | Extra/unknown body field | rejected | **200**, ignored | Yes if the field is privileged (mass assignment) |
-| **2 KB body of nested brackets** | handled | **500** (`RecursionError`) | **Yes — this is the bug** |
+| **2 KB body of nested brackets** | 500 | **400** (`RecursionError` caught by the body parser) | Only for the cost: the stack is burned before the 400 |
 | **20 MB flat JSON body** | 413 | **200**, fully buffered | **Yes — no default limit exists** |
 
-The last two are not style preferences: a 2 KB unauthenticated request that returns 500 is a
-denial-of-service primitive. The guard belongs to the service baseline — see `python-rest-api`
+The last row is not a style preference: a 20 MB unauthenticated request that is fully buffered is a
+denial-of-service primitive, and the nested-brackets request still costs a full recursion stack
+before its 400 — re-measured on 2026-09-05, the **500** this table published earlier did not
+reproduce on this stack. The guard belongs to the service baseline — see `python-rest-api`
 ("Request limits"), which carries the verified middleware + handler.
 
 Re-run this table against your own stack and version before trusting any row of it.

--- a/plugins/testing/skills/api-resilience-testing/references/negative-test-catalog.md
+++ b/plugins/testing/skills/api-resilience-testing/references/negative-test-catalog.md
@@ -100,11 +100,12 @@ Content-Type: application/json
 
 [[[[[[[[[[ … ]]]]]]]]]]     # 1000 levels — about 2 KB on the wire
 ```
-Measured on the same stock service: **500** (`RecursionError`). A 2 KB unauthenticated request that
-returns a 5xx is a denial-of-service primitive, and it violates the "input errors are never 5xx" rule
-that the rest of this catalog assumes. Expect **400** once the guard from `python-rest-api`
-("Request limits") is registered. Test at 1k and 10k levels — 200 levels still returns 422, so a
-shallow probe misses it entirely.
+Measured on the same stock service, re-run 2026-09-05 on `fastapi 0.141.1` / `pydantic 2.13.4`:
+**400** `{"detail":"There was an error parsing the body"}` from 990 levels up to 10 000, closed or
+unclosed — FastAPI's body parser catches the `RecursionError`, and the **500** this catalog published
+earlier did not reproduce. The request still costs a full recursion stack per call, so the depth
+guard from `python-rest-api` ("Request limits") stays worth registering. Test at 1k and 10k levels —
+200 levels still returns 422, so a shallow probe misses it entirely.
 
 ## 8. Malformed / truncated JSON
 

--- a/plugins/testing/skills/bug-hunter/SKILL.md
+++ b/plugins/testing/skills/bug-hunter/SKILL.md
@@ -10,13 +10,19 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.2.2
+  version: 2.2.3
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # Bug-Hunter — adversarial testing
+
+> **Not version-bound**: this skill does not depend on a tool version — it is a methodology (defect
+> classes, the anti-forge lens, the closure checklist). The stack tracks under `references/` name
+> `pytest`, `busted` and Mono.Cecil as the runners a track uses and prescribe no version-specific
+> flag; the versions belong to the stack skills that own the code (`python-rest-api`, `fivem-lua`,
+> `assettoserver-plugin`). Declared on 2026-09-05.
 
 A repeatable rite: after implementing a change, actively **try to break it** — don't just confirm the
 happy path. Hunt for the bug before it ships.

--- a/plugins/tooling/skills/claude-statusline/SKILL.md
+++ b/plugins/tooling/skills/claude-statusline/SKILL.md
@@ -4,13 +4,21 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.2.2
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
 ---
 
 # Claude Code Status Line
+
+> **Verified against**: `Claude Code 2.1.261` · `jq 1.6` · `bash 5.2.15`. Probed on 2026-09-05:
+> `references/statusline.sh` is byte-identical to the script rendering the status line of the
+> session that wrote this, and fed a synthetic payload of the fields in `references/fields.md` it
+> printed its three lines (`🤖 Fable 5.1 | ⚡ medium | 🧠 thinking enabled | ⏱️ 1m 5s | 💰 $1.23`, the
+> repo/branch/diff line, the three meters). Not probed: each field's presence in the live payload —
+> the script falls back to `-` for a missing field, so a render proves the script runs, not that
+> every documented field still arrives; the per-version notes in `fields.md` stand as written.
 
 The status line is a customizable bar at the bottom of Claude Code. Claude Code runs a
 shell command, pipes JSON session data to it on **stdin**, and renders whatever the

--- a/plugins/workflow/skills/backlog/SKILL.md
+++ b/plugins/workflow/skills/backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.5.1
+  version: 1.5.2
   category: process
 license: MIT
 compatibility: >-
@@ -23,6 +23,15 @@ compatibility: >-
 ---
 
 # Backlog — idea → structured GitHub Project item
+
+> **Verified against**: `gh 2.96.0` · `openspec 1.6.0`. Probed on 2026-09-05: the read recipes ran
+> against the AI-SKILLS board (`gh project list/view/field-list/item-list --owner --format json
+> --jq`, `gh issue view --json --jq`, `gh issue list --search --state --json`, `gh label list
+> --json`, `gh auth status`); `gh project item-edit --project-id --id --field-id
+> --single-select-option-id` moved a real card the same day; every other flag this skill and its
+> references prescribe (58 flags across 18 subcommands, `gh issue create --title --body-file
+> --label` and `gh project item-add --url` among them) is present in that client's `--help`.
+> Nothing was created, closed or merged by the probe.
 
 Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
 configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.4.0
+  version: 1.4.1
   category: process
 license: MIT
 compatibility: >-
@@ -27,6 +27,14 @@ compatibility: >-
 ---
 
 # Code locale — prose follows the repo, the machine layer is English
+
+> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-05:
+> `references/check-identifier-locale.py --selftest` (7 content tiers fire, 16 clean cases silent,
+> 6 path tiers fire, 9 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
+> --selftest` (13 PostToolUse and 12 PreToolUse decisions) and `locale-stop-gate.py --selftest` (26
+> decisions in throwaway git repositories) all pass, and both hooks are the ones wired in
+> `~/.claude/settings.json` of the session that wrote this. The detector uses only the standard
+> library; the earlier probe on `Python 3.14.5` is recorded below.
 
 **Prose follows the repository's working language. Anything a machine parses is English.**
 This skill covers the prose/machine boundary, the untranslatable-domain-term exception and its

--- a/plugins/workflow/skills/conventional-commit/SKILL.md
+++ b/plugins/workflow/skills/conventional-commit/SKILL.md
@@ -10,13 +10,21 @@ description: >-
   items (that is `backlog`).
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.3.2
   category: git
 license: MIT
 compatibility: Works in any environment with git access.
 ---
 
 # conventional-commit
+
+> **Verified against**: `semantic-release 25` · `conventional-changelog-conventionalcommits 8` ·
+> `@semantic-release/commit-analyzer` with the `headerPattern` in this repository's
+> `.releaserc.json` (`^(?:[^\w\s]+\s+)?(\w+)(?:\((.*)\))?!?: (.*)$`, which lets the gitmoji prefix
+> through). Probed on 2026-09-05 against the release history: `✨ feat(code-locale): …` (b1f527f)
+> cut `v2.24.0`, `✨ feat(hooks): …` (69aaf73) cut `v2.23.0` and `✨ feat(hooks): …` (49c44d0) cut
+> `v2.22.0`, all on that date. The message format itself is a convention with no tool version; the
+> pin covers the release tooling that parses it.
 
 Every commit message must follow **Conventional Commits**, prefixed with a **gitmoji icon** matching
 the type.

--- a/plugins/workflow/skills/execute-backlog/SKILL.md
+++ b/plugins/workflow/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.8.2
+  version: 1.8.3
   category: process
 license: MIT
 compatibility: >-
@@ -24,6 +24,16 @@ compatibility: >-
 ---
 
 # Execute-backlog — backlog item → implemented, validated PR
+
+> **Verified against**: `gh 2.96.0` · `openspec 1.6.0`. Probed on 2026-09-05: the read recipes ran
+> against the AI-SKILLS board and this repository (`gh issue view --json
+> closedByPullRequestsReferences`, `gh api repos/<o>/<r>/issues/<n>/timeline --jq`, `gh api
+> graphql`, `gh project item-list --owner --limit --format json --jq`), `gh project item-edit
+> --project-id --id --field-id --single-select-option-id` moved a real card, and `openspec new
+> change <id> --schema <name>` scaffolded a real change; every other flag this skill and its
+> references prescribe (`gh issue edit --body-file`, `gh issue comment --body-file`, `gh pr create
+> --title --body-file --base --head` among the 58 checked) is present in that client's `--help`.
+> Nothing was merged or closed by the probe.
 
 Drive an existing issue to a reviewable pull request while keeping the board in sync. Companion
 to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,

--- a/plugins/workflow/skills/openspec-drivezone/SKILL.md
+++ b/plugins/workflow/skills/openspec-drivezone/SKILL.md
@@ -13,13 +13,20 @@ description: >-
   Do NOT use for vanilla OpenSpec on non-DriveZone projects — that is the openspec skill.
 metadata:
   author: solvelab
-  version: 2.1.3
+  version: 2.1.4
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # OpenSpec — the DriveZone rite (forked schema)
+
+> **Verified against**: `openspec 1.6.0`. Probed on 2026-09-05: a throwaway project with a change
+> missing every gate section passed `openspec validate <id> --strict` (`Change 'probe' is valid`),
+> which is the claim this skill's hard gate rests on; the subcommands and flags shared with the
+> `openspec` skill were probed there. Not probed: the DriveZone repositories and their rite-gate
+> script are not on this machine — their described behaviour is the maintainer's field record, not
+> a re-run.
 
 > **What this is.** DriveZone uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) as its
 > spec-driven process — the base workflow is the **`openspec` skill** — but with a **project-local

--- a/plugins/workflow/skills/openspec/SKILL.md
+++ b/plugins/workflow/skills/openspec/SKILL.md
@@ -9,13 +9,22 @@ description: >-
   variant use openspec-drivezone.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # OpenSpec — vanilla spec-driven workflow
+
+> **Verified against**: `openspec 1.6.0` (`@fission-ai/openspec`). Probed on 2026-09-05: every
+> subcommand this skill prescribes exists (`validate`, `list`, `spec list --long`, `update`,
+> `archive`, `instructions`, `skill`, `new change`, `init`, `status`, `templates`) and `--strict`,
+> `--all`, `--type`, `--no-interactive`, `--long` are in `--help`; `openspec validate <id>
+> --strict` reported a change whose `tasks.md` carries no mandatory group as valid, so the CLI
+> checks delta format only. **Disclosed**: `openspec spec list` prints a deprecation warning on
+> 1.6.0 — "Prefer verb-first commands (e.g., `openspec show`, `openspec validate --specs`)"; the
+> noun-first form still works and stays here until this pin moves.
 
 [OpenSpec](https://github.com/Fission-AI/OpenSpec) structures a change as a validated proposal before
 any code: **explore → propose → validate → apply → archive**. Specs are the source of truth; changes

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -27,8 +27,23 @@ MUTATIONS = {
  "C4 desc vs body": ("skills/conventional-commit/SKILL.md",
      lambda s: s.replace("description: >-", "description: >-\n  ALWAYS creates all three tiers.", 1)
                 .replace("\n## ", "\n## Rules\n\nDo not create documents that don't apply.\n\n## ", 1)),
- "C5 no version pin": ("skills/react-api-client/SKILL.md",
-     lambda s: s + "\n```tsx\n" + "const a = 1\n" * 45 + "```\n\nUses zod and vite.\n"),
+ # C5 owns three defect classes since issue #131 (2026-09-05). (a) The block stripped from a
+ # code-heavy skill: nothing else in fivem-lua reads as a pin, so the literal is what fires.
+ "C5 no version pin": ("skills/fivem-lua/SKILL.md",
+     lambda s: s.replace("**Verified against**", "**Checked with**", 1),
+     ("C5 no version pin", "neither")),
+ # (b) The loose form that passed for months: strip the literal and leave "Probed on CLI 1.6.0"
+ # where it is — the old regex accepted it as a pin, this one must not.
+ "C5 no version pin (loose mention)": ("skills/openspec/SKILL.md",
+     lambda s: s.replace("**Verified against**", "**Checked with**", 1),
+     ("C5 no version pin", "mentioned in passing is not a pin")),
+ # (c) The declaration on a skill whose 70+ fenced bash lines drive kubectl: the exit exists for
+ # process skills, and k8s-tune-resources carries no deferral phrase. (The r3f skills keep their code
+ # under references/, so their SKILL.md has zero fenced lines and would stay silent here by design.)
+ "C5 no version pin (declaration on code-heavy API skill)": ("skills/k8s-tune-resources/SKILL.md",
+     lambda s: s.replace("**Verified against**: `kubectl v1.36.1`",
+                         "**Not version-bound**: this skill does not depend on a tool version — `kubectl v1.36.1`", 1),
+     ("C5 no version pin", "declared not version-bound")),
  "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
      lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
  "C7 orphan wrapper": (None, None),

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -6,7 +6,7 @@ Implements the mechanically checkable half of openspec/specs/skills-authoring:
   C2 cross-skill references name a real skill
   C3 code blocks parse                      (bash -n, yaml, json, lua -p, python)
   C4 description agrees with body           (heuristic: absolute promise vs qualifying rule)
-  C5 versioned external APIs are pinned     (code-heavy skill without a version statement)
+  C5 every skill declares its versions      ('Verified against' or 'does not depend on a tool version')
   C6 fence tags match content               (a block tagged X that is obviously not X)
   C7 no orphan wrapper skills               (every generated skill has a canonical source)
   C8 no meta sections in SKILL.md           (triggers belong in the description, not the body)
@@ -241,29 +241,40 @@ def check_description(skill: str, text: str) -> None:
             f"description promises {promises[:2]} while the body qualifies it")
 
 
-# ── C5: versioned APIs pinned ─────────────────────────────────────────────
-# A pin is any concrete "this was checked against version X" statement, in prose or in a fence.
-PIN = re.compile(r"[Vv]erified against|[Mm]easured on|[Pp]robed on|version[s]? pinned"
-                 r"|@[\d]+\.[\d]+|targets? v?\d+\.\d+"
-                 r"|\b(?:runtime|tag|CLI|preset)\s+v?\d+\.\d+"
-                 r"|pydantic v\d|SQLAlchemy \d|Python .{0,3}\d\.\d+|\b\w+ \d+\.\d+")
+# ── C5: every skill declares what it was verified against ─────────────────
+# Two literal phrases, the same ones a reader greps for. A version mentioned in passing ("Probed on
+# CLI 1.6.0", "needs CSP >= 0.1.78") is not a pin: until issue #131 (2026-09-05) the regex here
+# accepted any `<word> <digits>.<digits>` and fired only on skills with 40+ fenced lines, and 20 of
+# 35 skills carried no block while C5 reported nothing.
+PIN = re.compile(r"Verified against")
+NO_VERSION = re.compile(r"does not depend on a tool version")
+DEFERS = re.compile(r"source of truth, not this skill|read the local copy first", re.I)
 API_HINT = re.compile(r"@react-three|@react-spring|fastapi|pydantic|sqlalchemy|helm |kubectl|"
                       r"citizenfx|Qmmands|AssettoServer|openspec|gh project|zod|vite", re.I)
 
 
 def check_pin(skill: str, text: str) -> None:
-    """KNOWN LIMIT: only fires on skills carrying 40+ lines of fenced code. A skill that makes
-    the same versioned claims in prose (config keys, CLI flags, API names in bullets) escapes
-    this check and must be reviewed by hand. Widening the trigger produced false positives on
-    every skill that merely names a tool, so the gap is stated instead of guessed at."""
-    blocks = FENCE.findall(text)
-    code_lines = sum(len(b.splitlines()) for _, b in blocks)
-    if code_lines < 40:
-        return
-    defers = re.search(r"source of truth, not this skill|read the local copy first", text, re.I)
-    if API_HINT.search(text) and not PIN.search(text) and not defers:
+    """Every SKILL.md carries `Verified against` or `does not depend on a tool version`. The
+    declaration is an exit for process skills: a skill with 40+ fenced lines against a versioned API
+    may not take it unless it defers to a local source of truth the reader opens first (the phrase
+    `helm-migration` already carries).
+
+    KNOWN LIMIT: this proves the literal is PRESENT, not that it is earned. A block naming a version
+    nobody ran passes; the date the block owes is not checked; a code-heavy skill that adds the
+    deferral phrase to dodge the second rule passes too. Those stay with the review — which is why
+    the block has to say what was run, not only against what."""
+    pinned = PIN.search(text)
+    declared = NO_VERSION.search(text)
+    if not pinned and not declared:
         add(skill, "C5 no version pin",
-            f"{code_lines} lines of code against a versioned API, no version statement")
+            "neither 'Verified against' nor 'does not depend on a tool version' — a version "
+            "mentioned in passing is not a pin")
+        return
+    if declared and not pinned:
+        code_lines = sum(len(b.splitlines()) for _, b in FENCE.findall(text))
+        if code_lines >= 40 and API_HINT.search(text) and not DEFERS.search(text):
+            add(skill, "C5 no version pin",
+                f"{code_lines} lines of code against a versioned API, declared not version-bound")
 
 
 # ── C6: fence tag matches content ─────────────────────────────────────────

--- a/skills/api-resilience-testing/SKILL.md
+++ b/skills/api-resilience-testing/SKILL.md
@@ -4,13 +4,22 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing, nor for writing the service's own layout, envelope and handlers (that is `python-rest-api`).
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.3.2
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # API Resilience Testing
+
+> **Verified against**: `fastapi 0.141.1` · `pydantic 2.13.4` · `starlette 1.6.0` · `httpx 0.28.1`
+> · `uvicorn 0.52.4`, re-measured on 2026-09-05 with a stock two-route service (a pydantic body
+> model, an `int` path parameter) under `TestClient` and under a real uvicorn server. Eight of the
+> nine baseline rows held; **one was corrected**: a body of nested brackets returns **400**
+> `{"detail":"There was an error parsing the body"}` at every depth from 990 to 10 000, closed or
+> unclosed, for model, `Any` and `dict` bodies — FastAPI's body parser catches the
+> `RecursionError`, and the **500** published here earlier did not reproduce. `curl` is the only
+> tool the checklist prescribes and no version-bound flag of it is used.
 
 Test a REST API so it survives the inputs nobody intended — invalid, malformed,
 out-of-contract, hostile — and fails **safely** instead of crashing, corrupting
@@ -178,11 +187,13 @@ FastAPI 0.141.1 / pydantic 2.13.4 (the `python-rest-api` baseline), stock servic
 | Wrong path-param type (`/users/abc`) | 404 | **422** | No — the route matched, the value didn't |
 | Wrong HTTP method | 405 | **405** (with `Allow`) | Already correct |
 | Extra/unknown body field | rejected | **200**, ignored | Yes if the field is privileged (mass assignment) |
-| **2 KB body of nested brackets** | handled | **500** (`RecursionError`) | **Yes — this is the bug** |
+| **2 KB body of nested brackets** | 500 | **400** (`RecursionError` caught by the body parser) | Only for the cost: the stack is burned before the 400 |
 | **20 MB flat JSON body** | 413 | **200**, fully buffered | **Yes — no default limit exists** |
 
-The last two are not style preferences: a 2 KB unauthenticated request that returns 500 is a
-denial-of-service primitive. The guard belongs to the service baseline — see `python-rest-api`
+The last row is not a style preference: a 20 MB unauthenticated request that is fully buffered is a
+denial-of-service primitive, and the nested-brackets request still costs a full recursion stack
+before its 400 — re-measured on 2026-09-05, the **500** this table published earlier did not
+reproduce on this stack. The guard belongs to the service baseline — see `python-rest-api`
 ("Request limits"), which carries the verified middleware + handler.
 
 Re-run this table against your own stack and version before trusting any row of it.

--- a/skills/api-resilience-testing/references/negative-test-catalog.md
+++ b/skills/api-resilience-testing/references/negative-test-catalog.md
@@ -100,11 +100,12 @@ Content-Type: application/json
 
 [[[[[[[[[[ … ]]]]]]]]]]     # 1000 levels — about 2 KB on the wire
 ```
-Measured on the same stock service: **500** (`RecursionError`). A 2 KB unauthenticated request that
-returns a 5xx is a denial-of-service primitive, and it violates the "input errors are never 5xx" rule
-that the rest of this catalog assumes. Expect **400** once the guard from `python-rest-api`
-("Request limits") is registered. Test at 1k and 10k levels — 200 levels still returns 422, so a
-shallow probe misses it entirely.
+Measured on the same stock service, re-run 2026-09-05 on `fastapi 0.141.1` / `pydantic 2.13.4`:
+**400** `{"detail":"There was an error parsing the body"}` from 990 levels up to 10 000, closed or
+unclosed — FastAPI's body parser catches the `RecursionError`, and the **500** this catalog published
+earlier did not reproduce. The request still costs a full recursion stack per call, so the depth
+guard from `python-rest-api` ("Request limits") stays worth registering. Test at 1k and 10k levels —
+200 levels still returns 422, so a shallow probe misses it entirely.
 
 ## 8. Malformed / truncated JSON
 

--- a/skills/assettoserver-csp-lua/SKILL.md
+++ b/skills/assettoserver-csp-lua/SKILL.md
@@ -14,13 +14,24 @@ description: >-
   (different Lua contexts and permissions), or for FiveM Lua (that is fivem-lua).
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # CSP Lua online scripts (AssettoServer-served overlays)
+
+> **Verified against**: `acc-lua-sdk` at commit `7cf60f5a` (2026-08-17, the public CSP Lua library
+> tree) · `Lua 5.4.8` · `AssettoServer v0.0.54` and `v0.0.55-pre25` source. Probed on 2026-09-05:
+> 12 of the 15 `ac.*`/`ui.*` names this skill uses are declared in that tree;
+> `ui.measureDWriteText`, `ui.pushDWriteFont` and `ac.onCarCollision` are not (the tree does not
+> enumerate every C++-side binding) — they were paid for in game and are not re-probed here.
+> `references/snippets.lua` and the fenced Lua block parse under `luac -p`;
+> `CSPServerScriptProvider.AddScript(string, string?, Dictionary<string, object>?)`, the
+> `SCRIPT_N-<name>` section and the `/api/scripts/N` route exist at both server tags. Not probed:
+> every rendering, font and audio rule below needs the CSP client, and the CSP build the DriveZone
+> servers require is not recorded on this machine.
 
 Prescriptive conventions for the in-game UI layer of an AssettoServer: Lua scripts pushed to every
 client by the server itself. Zero-install is the point — the player installs nothing; art, sound

--- a/skills/assettoserver-ops/SKILL.md
+++ b/skills/assettoserver-ops/SKILL.md
@@ -11,13 +11,23 @@ description: >-
   backend receiving events (python-rest-api), or for FiveM servers.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: devops
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # AssettoServer operations
+
+> **Verified against**: `AssettoServer v0.0.55-pre25` — the source tree at `~/works/AssettoServer`
+> (commit `51d8d8a6`), which is what the DriveZone image `drivezone/assettoserver:local` reports as
+> `AssettoServer 0.0.55+51d8d8a6e0`. Probed on 2026-09-05: all 15 `extra_cfg.yml` keys cited here
+> resolve to properties under `Server/Configuration/Extra/`; 24 of the 25 `server_cfg.ini` keys
+> resolve to the sample `Assets/server_cfg.ini` or to an `[IniField]` under
+> `Server/Configuration/Kunos/` — `CARS` is a stock acServer key this source never reads; the
+> density function quoted below is `Server/Ai/AiBehavior.cs:455-466` at that tag. Not probed: no
+> server was started against a client, and the CSP build the DriveZone servers require is not
+> recorded on this machine.
 
 Distilled from a production freeroam deployment (DriveZone on SRP/Shutoko). The runtime is
 `compujuckel/AssettoServer` — a CSP-aware replacement for stock `acServer` that adds

--- a/skills/assettoserver-plugin/SKILL.md
+++ b/skills/assettoserver-plugin/SKILL.md
@@ -12,13 +12,23 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # AssettoServer plugin conventions
+
+> **Verified against**: `AssettoServer v0.0.54` source — `git show
+> v0.0.54:AssettoServer/AssettoServer.csproj` gives `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`,
+> `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase`, the
+> `RequireConnectedPlayer`/`RequireAdmin` attributes and `CSPServerScriptProvider.AddScript(string,
+> string?, Dictionary<string, object>?)` are declared at that tag. Probed on 2026-09-05 by reading
+> the tree: no plugin was compiled or loaded here. **Disclosed**: the DriveZone runtime measured
+> the same day reports `AssettoServer 0.0.55+51d8d8a6e0`, built from a tree whose csproj targets
+> `net9.0` — on that host `System.Threading.Lock` exists and the `net8.0` fallback below is one
+> major behind. The doctrine is re-derived for `0.0.55` in a follow-up, not silently here.
 
 Distilled from a production plugin (DriveZone.AssettoServer.Plugin) that survived real
 AssettoServer runtime incompatibilities. Prescriptive: follow these unless the project documents a

--- a/skills/backend-resilience/SKILL.md
+++ b/skills/backend-resilience/SKILL.md
@@ -12,13 +12,23 @@ description: >-
   adaptation use fivem-fallback instead.
 metadata:
   author: solvelab
-  version: 2.0.1
+  version: 2.0.2
   category: backend
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # Backend resilience & fallback
+
+> **Verified against**: `Python 3.11.2` · `httpx 0.28.1` · `structlog 26.1.0` · `prometheus-client
+> 0.26.0`. Probed on 2026-09-05: the five `python` blocks were extracted and executed against stubs
+> — `httpx.Timeout(connect=, read=, write=, pool=)` constructs; `safe_call` and `safe_call_async`
+> return `(False, fallback)` on a raising callable and emit the `fallback_used` line with the
+> counter at 1; `clamp_num` clamps, and defaults on `None` and on `"x"`; the retry loop returns
+> after 3 attempts with full jitter and makes 0 attempts past the deadline; the negative cache
+> makes 1 upstream call for 2 requests after a `ConnectError`; the config fallback lands on
+> `FALLBACK` after a `ReadTimeout`. Fragments were wrapped in a function to run; nothing was run
+> against a live Consul or HTTP dependency.
 
 Defensive patterns for calling an unreliable dependency. The network boundary is unstable: timeouts,
 5xx, partial payloads, dependency down, races. Every call needs a **safe default** so the service keeps

--- a/skills/backlog/SKILL.md
+++ b/skills/backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   non-GitHub trackers (Jira, Linear, Trello).
 metadata:
   author: solvelab
-  version: 1.5.1
+  version: 1.5.2
   category: process
 license: MIT
 compatibility: >-
@@ -23,6 +23,15 @@ compatibility: >-
 ---
 
 # Backlog — idea → structured GitHub Project item
+
+> **Verified against**: `gh 2.96.0` · `openspec 1.6.0`. Probed on 2026-09-05: the read recipes ran
+> against the AI-SKILLS board (`gh project list/view/field-list/item-list --owner --format json
+> --jq`, `gh issue view --json --jq`, `gh issue list --search --state --json`, `gh label list
+> --json`, `gh auth status`); `gh project item-edit --project-id --id --field-id
+> --single-select-option-id` moved a real card the same day; every other flag this skill and its
+> references prescribe (58 flags across 18 subcommands, `gh issue create --title --body-file
+> --label` and `gh project item-add --url` among them) is present in that client's `--help`.
+> Nothing was created, closed or merged by the probe.
 
 Enrich a raw idea with real repository context and publish it as a GitHub issue inside the
 configured GitHub Project v2 — never a copy of the user's sentence, always grounded in the actual

--- a/skills/bug-hunter/SKILL.md
+++ b/skills/bug-hunter/SKILL.md
@@ -10,13 +10,19 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.2.2
+  version: 2.2.3
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # Bug-Hunter — adversarial testing
+
+> **Not version-bound**: this skill does not depend on a tool version — it is a methodology (defect
+> classes, the anti-forge lens, the closure checklist). The stack tracks under `references/` name
+> `pytest`, `busted` and Mono.Cecil as the runners a track uses and prescribe no version-specific
+> flag; the versions belong to the stack skills that own the code (`python-rest-api`, `fivem-lua`,
+> `assettoserver-plugin`). Declared on 2026-09-05.
 
 A repeatable rite: after implementing a change, actively **try to break it** — don't just confirm the
 happy path. Hunt for the bug before it ships.

--- a/skills/claude-statusline/SKILL.md
+++ b/skills/claude-statusline/SKILL.md
@@ -4,13 +4,21 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.2.1
+  version: 1.2.2
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
 ---
 
 # Claude Code Status Line
+
+> **Verified against**: `Claude Code 2.1.261` · `jq 1.6` · `bash 5.2.15`. Probed on 2026-09-05:
+> `references/statusline.sh` is byte-identical to the script rendering the status line of the
+> session that wrote this, and fed a synthetic payload of the fields in `references/fields.md` it
+> printed its three lines (`🤖 Fable 5.1 | ⚡ medium | 🧠 thinking enabled | ⏱️ 1m 5s | 💰 $1.23`, the
+> repo/branch/diff line, the three meters). Not probed: each field's presence in the live payload —
+> the script falls back to `-` for a missing field, so a render proves the script runs, not that
+> every documented field still arrives; the per-version notes in `fields.md` stand as written.
 
 The status line is a customizable bar at the bottom of Claude Code. Claude Code runs a
 shell command, pipes JSON session data to it on **stdin**, and renders whatever the

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.4.0
+  version: 1.4.1
   category: process
 license: MIT
 compatibility: >-
@@ -27,6 +27,14 @@ compatibility: >-
 ---
 
 # Code locale — prose follows the repo, the machine layer is English
+
+> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-05:
+> `references/check-identifier-locale.py --selftest` (7 content tiers fire, 16 clean cases silent,
+> 6 path tiers fire, 9 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
+> --selftest` (13 PostToolUse and 12 PreToolUse decisions) and `locale-stop-gate.py --selftest` (26
+> decisions in throwaway git repositories) all pass, and both hooks are the ones wired in
+> `~/.claude/settings.json` of the session that wrote this. The detector uses only the standard
+> library; the earlier probe on `Python 3.14.5` is recorded below.
 
 **Prose follows the repository's working language. Anything a machine parses is English.**
 This skill covers the prose/machine boundary, the untranslatable-domain-term exception and its

--- a/skills/conventional-commit/SKILL.md
+++ b/skills/conventional-commit/SKILL.md
@@ -10,13 +10,21 @@ description: >-
   items (that is `backlog`).
 metadata:
   author: solvelab
-  version: 1.3.1
+  version: 1.3.2
   category: git
 license: MIT
 compatibility: Works in any environment with git access.
 ---
 
 # conventional-commit
+
+> **Verified against**: `semantic-release 25` · `conventional-changelog-conventionalcommits 8` ·
+> `@semantic-release/commit-analyzer` with the `headerPattern` in this repository's
+> `.releaserc.json` (`^(?:[^\w\s]+\s+)?(\w+)(?:\((.*)\))?!?: (.*)$`, which lets the gitmoji prefix
+> through). Probed on 2026-09-05 against the release history: `✨ feat(code-locale): …` (b1f527f)
+> cut `v2.24.0`, `✨ feat(hooks): …` (69aaf73) cut `v2.23.0` and `✨ feat(hooks): …` (49c44d0) cut
+> `v2.22.0`, all on that date. The message format itself is a convention with no tool version; the
+> pin covers the release tooling that parses it.
 
 Every commit message must follow **Conventional Commits**, prefixed with a **gitmoji icon** matching
 the type.

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -10,13 +10,18 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.2
+  version: 3.0.3
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # Documentation
+
+> **Not version-bound**: this skill does not depend on a tool version — it decides which documents
+> a project gets and how a claim inside them is made checkable, and it prescribes no generator,
+> linter or CLI. The `AGENTS.md` convention it names is a specification, not a versioned tool.
+> Declared on 2026-09-05.
 
 Write documentation a reader can act on and a script can verify. Templates and full worked examples
 live in `references/` — read them when you are about to generate output, not before.

--- a/skills/execute-backlog/SKILL.md
+++ b/skills/execute-backlog/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   PRs, for deploying, or for non-GitHub trackers.
 metadata:
   author: solvelab
-  version: 1.8.2
+  version: 1.8.3
   category: process
 license: MIT
 compatibility: >-
@@ -24,6 +24,16 @@ compatibility: >-
 ---
 
 # Execute-backlog — backlog item → implemented, validated PR
+
+> **Verified against**: `gh 2.96.0` · `openspec 1.6.0`. Probed on 2026-09-05: the read recipes ran
+> against the AI-SKILLS board and this repository (`gh issue view --json
+> closedByPullRequestsReferences`, `gh api repos/<o>/<r>/issues/<n>/timeline --jq`, `gh api
+> graphql`, `gh project item-list --owner --limit --format json --jq`), `gh project item-edit
+> --project-id --id --field-id --single-select-option-id` moved a real card, and `openspec new
+> change <id> --schema <name>` scaffolded a real change; every other flag this skill and its
+> references prescribe (`gh issue edit --body-file`, `gh issue comment --body-file`, `gh pr create
+> --title --body-file --base --head` among the 58 checked) is present in that client's `--help`.
+> Nothing was merged or closed by the probe.
 
 Drive an existing issue to a reviewable pull request while keeping the board in sync. Companion
 to the `backlog` skill; consumes the same config (`.github/backlog.yml` in repo mode,

--- a/skills/fivem-fallback/SKILL.md
+++ b/skills/fivem-fallback/SKILL.md
@@ -9,13 +9,22 @@ description: >-
   services use backend-resilience instead.
 metadata:
   author: solvelab
-  version: 1.3.0
+  version: 1.3.1
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # FiveM fallback & resilience (Lua adaptation)
+
+> **Verified against**: `Lua 5.4.8` · `citizenfx/fivem` at commit `6fd665a3` (2026-09-02) ·
+> `citizenfx/natives` at `7263f211` (2026-08-17). Probed on 2026-09-05: all 5 fenced Lua blocks in
+> this skill and its reference parse under `luac -p`; the 6 runtime functions and natives named
+> here (`PerformHttpRequest`, `GetConvar`, `GetGameTimer`, `CreateThread`, `Wait`,
+> `RegisterNUICallback`) resolve in `ext/native-decls/`,
+> `data/shared/citizen/scripting/lua/scheduler.lua` or `natives/MISC/`. Not probed: no FXServer
+> build ran this code, and no backend was called from a resource — the retry and negative-cache
+> behaviour was observed on the DriveZone servers and carries no artifact number here.
 
 **Doctrine lives in `backend-resilience`** — read it first: safe defaults, one shared helper,
 response-shape validation, clamping, bounded retries, negative cache (never negative-cache a real 404),

--- a/skills/fivem-lua/SKILL.md
+++ b/skills/fivem-lua/SKILL.md
@@ -4,13 +4,22 @@ description: >-
   Conventions for writing FiveM (CitizenFX) server/client Lua resources. Use when working on FiveM/FXServer Lua — RegisterNetEvent/RegisterNUICallback handlers, fxmanifest, exports, NUI (SendNUIMessage/SetNuiFocus), threads/CreateThread, StateBags, or natives. Enforces the client-is-never-trusted boundary (validate payload + derive actor from `source`), explicit fxmanifest order, no busy `while true` loops, module-per-global pattern, and NUI focus/disconnect cleanup. Do NOT use for react-three-fiber, for CSP Lua scripts on an Assetto Corsa server (that is `assettoserver-csp-lua`), or for other non-FiveM Lua.
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: fivem
 license: MIT
 compatibility: Works in any environment with filesystem access.
 ---
 
 # FiveM Lua — CitizenFX conventions
+
+> **Verified against**: `Lua 5.4.8` · `citizenfx/fivem` at commit `6fd665a3` (2026-09-02) ·
+> `citizenfx/natives` at `7263f211` (2026-08-17). Probed on 2026-09-05: 6 of the 7 fenced Lua
+> blocks in this skill and its references parse under `luac -p` (the seventh is the marked `--
+> excerpt` and is skipped by design); the 8 runtime functions named here (`RegisterNetEvent`,
+> `RegisterNUICallback`, `TriggerClientEvent`, `SetNuiFocus`, `SendNUIMessage`, `CreateThread`,
+> `Wait`, `SetTimeout`) resolve in `ext/native-decls/` or
+> `data/shared/citizen/scripting/lua/scheduler.lua`. Not probed: no FXServer build ran this code —
+> the runtime rules were observed on the DriveZone servers and carry no artifact number here.
 
 Generic conventions for writing maintainable server/client Lua resources on FiveM (CitizenFX).
 Project-agnostic: resource prefixes, exact endpoints, and keybind registries belong in the project's

--- a/skills/helm-migration/SKILL.md
+++ b/skills/helm-migration/SKILL.md
@@ -4,13 +4,19 @@ description: >-
   Converts Kubernetes YAML manifests to Helm values.yaml and env.yaml following the solvelab chart template structure — requires a local copy of that chart template repository (the template-specific fields do not exist in stock Helm charts). Use when user mentions "migrate to helm", "convert yaml to helm", "generate values.yaml", "helm migration", "yaml to helm", shares a Kubernetes YAML and asks for Helm output. Always removes tolerations. Always generates values.yaml; generates env.yaml only when the source YAML defines secrets, configmaps or PVCs. Do NOT use for writing plain Kubernetes manifests or docker-compose files, for authoring a Helm chart from scratch, or for documentation and code changes unrelated to a Helm migration.
 metadata:
   author: solvelab
-  version: 2.2.2
+  version: 2.2.3
   category: devops
 license: MIT
 compatibility: Requires a Helm charts template repository accessible on the local filesystem. Works best in Claude Code.
 ---
 
 # Helm Migration Skill
+
+> **Not version-bound**: this skill does not depend on a tool version — it prescribes the shape of
+> `values.yaml` and `env.yaml` for the solvelab chart template and tells the reader to read the
+> local template first, and it prescribes no `helm` or `kubectl` command whose flags could be
+> pinned (measured on 2026-09-05: zero such commands in the skill and its reference). The field
+> names are pinned by the template itself, as the note below says.
 
 You are a Helm chart expert. When asked to migrate a Kubernetes YAML file to Helm, follow the workflow and conventions below. These are derived from real solvelab production charts and are specific to that chart template.
 

--- a/skills/log-event-collector/SKILL.md
+++ b/skills/log-event-collector/SKILL.md
@@ -11,13 +11,20 @@ description: >-
   metrics/APM instrumentation of the monitored application.
 metadata:
   author: solvelab
-  version: 1.1.0
+  version: 1.1.1
   category: backend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # Log-tailing event collector
+
+> **Verified against**: `Python 3.11.2` (standard library only). Probed on 2026-09-05: the
+> partial-line read returns the complete lines and leaves the offset before the partial tail
+> (`['line one', 'line two']`, offset 18; the tail arrives whole on the next read), and the atomic
+> state write lands through `os.replace` with no `.tmp` left behind. The parser excerpt is not
+> runnable by design. No tailer was run against a live server here; the doctrine is stack-agnostic
+> and pins nothing else.
 
 When a system you can't modify (game server, third-party daemon) only exposes its life in text
 logs, ship a **collector sidecar**: tail the log, parse lines into normalized events, POST them to

--- a/skills/openspec-drivezone/SKILL.md
+++ b/skills/openspec-drivezone/SKILL.md
@@ -13,13 +13,20 @@ description: >-
   Do NOT use for vanilla OpenSpec on non-DriveZone projects — that is the openspec skill.
 metadata:
   author: solvelab
-  version: 2.1.3
+  version: 2.1.4
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # OpenSpec — the DriveZone rite (forked schema)
+
+> **Verified against**: `openspec 1.6.0`. Probed on 2026-09-05: a throwaway project with a change
+> missing every gate section passed `openspec validate <id> --strict` (`Change 'probe' is valid`),
+> which is the claim this skill's hard gate rests on; the subcommands and flags shared with the
+> `openspec` skill were probed there. Not probed: the DriveZone repositories and their rite-gate
+> script are not on this machine — their described behaviour is the maintainer's field record, not
+> a re-run.
 
 > **What this is.** DriveZone uses [OpenSpec](https://github.com/Fission-AI/OpenSpec) as its
 > spec-driven process — the base workflow is the **`openspec` skill** — but with a **project-local

--- a/skills/openspec/SKILL.md
+++ b/skills/openspec/SKILL.md
@@ -9,13 +9,22 @@ description: >-
   variant use openspec-drivezone.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: process
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # OpenSpec — vanilla spec-driven workflow
+
+> **Verified against**: `openspec 1.6.0` (`@fission-ai/openspec`). Probed on 2026-09-05: every
+> subcommand this skill prescribes exists (`validate`, `list`, `spec list --long`, `update`,
+> `archive`, `instructions`, `skill`, `new change`, `init`, `status`, `templates`) and `--strict`,
+> `--all`, `--type`, `--no-interactive`, `--long` are in `--help`; `openspec validate <id>
+> --strict` reported a change whose `tasks.md` carries no mandatory group as valid, so the CLI
+> checks delta format only. **Disclosed**: `openspec spec list` prints a deprecation warning on
+> 1.6.0 — "Prefer verb-first commands (e.g., `openspec show`, `openspec validate --specs`)"; the
+> noun-first form still works and stays here until this pin moves.
 
 [OpenSpec](https://github.com/Fission-AI/OpenSpec) structures a change as a validated proposal before
 any code: **explore → propose → validate → apply → archive**. Specs are the source of truth; changes

--- a/skills/react-api-client/SKILL.md
+++ b/skills/react-api-client/SKILL.md
@@ -9,13 +9,21 @@ description: >-
   mutations. Not for FiveM NUIs (CEF) — that is fivem-nui-react.
 metadata:
   author: solvelab
-  version: 1.1.1
+  version: 1.1.2
   category: frontend
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
 ---
 
 # React SPA ↔ typed-envelope API
+
+> **Verified against**: `typescript 7.0.2` · `axios 1.20.0` · `zustand 5.0.15`. Probed on
+> 2026-09-05: the four `ts` blocks in `references/api-client.md` were extracted and typechecked.
+> None of the three complete-looking ones compiles as written (24 errors: elided constructors,
+> sibling names), and a harness supplying the imports and the elided declarations still leaves
+> typing errors in the interceptor and store blocks — so all four now carry the `// excerpt` marker
+> and are read as shape, not as modules. `zod` is named in prose only and was not exercised. The
+> project this skill was extracted from was not available.
 
 The backend (`python-rest-api` skill) speaks `{status, code, message, data}`. These conventions
 keep the frontend honest about it: the front only EXHIBITS state and SENDS intents — balance,

--- a/skills/react-api-client/references/api-client.md
+++ b/skills/react-api-client/references/api-client.md
@@ -3,6 +3,7 @@
 ## errors.ts — typed taxonomy
 
 ```ts
+// excerpt — condensed: the constructor is elided; does not compile as written
 export enum ErrorCodes {
   INSUFFICIENT_BALANCE = 'INSUFFICIENT_BALANCE',
   COOLDOWN_ACTIVE = 'COOLDOWN_ACTIVE',
@@ -28,6 +29,7 @@ export const isApiException = (e: unknown): e is ApiException => e instanceof Ap
 ## client.ts — the interceptor contract (essence)
 
 ```ts
+// excerpt — condensed: imports, the axios instance field and the constructor are elided
 export interface AuthHandlers {
   getAccessToken: () => string | null;
   onUnauthorized: () => void;
@@ -95,6 +97,7 @@ export const createApiClient = (cfg: ApiClientConfig) => new ApiClient(cfg);
 ## createAuthStore.ts — factory essentials
 
 ```ts
+// excerpt — condensed: zustand imports and the storage adapter are elided
 export function createAuthStore({ persistKey }: { persistKey: string }) {
   return createStore(persist(
     (set) => ({

--- a/skills/svg-animation/SKILL.md
+++ b/skills/svg-animation/SKILL.md
@@ -14,13 +14,21 @@ description: >-
   the traps that break silently.
 metadata:
   author: solvelab
-  version: 1.1.2
+  version: 1.1.3
   category: frontend
 license: MIT
 compatibility: Works in any environment with filesystem access; verification steps need a Chrome binary.
 ---
 
 # svg-animation — understand the object, then represent it
+
+> **Verified against**: `Google Chrome for Testing 151.0.7922.34` (`--headless=new`, 1280×720,
+> software rasterisation, WSL2), driven over CDP by [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs) on
+> 2026-08-30 and 2026-08-31 — every cost in `references/platform.md` comes from those two runs and
+> is recorded with its raw numbers in [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md). Not re-run on
+> 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS animation
+> semantics are specification-level and carry no tool version; the numbers do, and they expire with
+> that browser build.
 
 The failure this skill exists to prevent is not ugly output. It is **plausible** output: an animation
 whose every part is defensible and whose whole is wrong. Measured on 22 objects and 12 primitives


### PR DESCRIPTION
Closes #131
Spec-rite: require-verified-against

## O que muda

- **17 skills** ganham um bloco `> **Verified against**: …` logo após o H1, com ferramenta, versão, o que rodou e a data (2026-09-05). O próprio bloco nomeia o que **não** foi probado — nenhuma versão entra sem um comando rodado neste dia. **3 skills de processo** (`helm-migration`, `bug-hunter`, `documentation`) declaram `does not depend on a tool version` com o motivo. Bump patch em cada uma das 20.
- **`check_pin` (C5)** passa a exigir uma das duas frases literais em toda `SKILL.md`. Menção solta (`Probed on CLI 1.6.0`, `needs CSP >= 0.1.78`) deixa de contar. Skill com 40+ linhas de código contra API versionada não sai pela declaração, salvo se já defere à fonte local (frase que só `helm-migration` carrega). O gatilho das 40 linhas e seu KNOWN LIMIT saem; o novo limite (presença ≠ mérito, data não checada) fica na docstring.
- **Selftest**: a mutação antiga do C5 (alvo passaria a ter bloco) vira três — bloco removido de skill code-heavy, menção solta deixada no lugar, declaração em skill code-heavy de API.
- **Duas correções forçadas pelos probes**: (1) a linha "2 KB de colchetes aninhados → **500** (`RecursionError`)" do `api-resilience-testing` não reproduz em `fastapi 0.141.1 / pydantic 2.13.4` — o parser do body captura o `RecursionError` e responde **400** `{"detail":"There was an error parsing the body"}` de 990 a 10 000 níveis, sob `TestClient` e sob uvicorn; corrigida na tabela, na prosa e no `negative-test-catalog.md`. (2) Os três blocos `ts` do `react-api-client` não compilam como estão (24 erros: construtores e imports elididos) e passam a carregar o marcador `// excerpt`, como o quarto já fazia.
- README: texto do C5 e contagem do selftest (estava em 13/13 contra um selftest com 20; agora 22/22).

## Como foi probado

| Ambiente | O que rodou | Resultado |
|---|---|---|
| `~/works/AssettoServer` @ `v0.0.55-pre25` + imagem `drivezone/assettoserver:local` | chaves de `extra_cfg.yml`/`server_cfg.ini`, `AiBehavior.cs`, csproj em `v0.0.54`, `--version` | 15/15 keys, 24/25 ini (`CARS` nunca lido), `AssettoServer 0.0.55+51d8d8a6e0`, `net8.0` vs `net9.0` |
| `acc-lua-sdk` @ `7cf60f5a`, Lua 5.4.8 (docker) | 15 nomes `ac.*`/`ui.*`, `luac -p` | 12/15 declarados (3 ausentes, ditos no bloco); 13/14 blocos Lua parseiam, o 14º é excerpt marcado |
| `citizenfx/fivem` @ `6fd665a3`, `citizenfx/natives` @ `7263f211` | 12 funções/natives | 12/12 resolvem |
| venv: fastapi 0.141.1, pydantic 2.13.4, httpx 0.28.1, structlog 26.1.0, prometheus-client 0.26.0, uvicorn 0.52.4 | tabela de 9 linhas; 5 blocos do backend-resilience executados; 2 blocos do log-event-collector | 8/9 linhas mantidas, 1 corrigida; helpers, retry, negative cache e fallback observados |
| tsc 7.0.2, axios 1.20.0, zustand 5.0.15 | 4 blocos ts extraídos | 0/3 completos compilam → excerpts |
| openspec 1.6.0 | 11 subcomandos, 5 flags, projeto descartável sem grupos de gate | 11/11, 5/5, `Change 'probe' is valid`; `spec list` deprecado (divulgado) |
| gh 2.96.0 | 18 subcomandos, 58 flags; receitas de leitura contra o board; `item-edit` real | 58/58; card movido |
| Claude Code 2.1.261, jq 1.6, bash 5.2.15 | `statusline.sh` idêntico ao vivo + payload sintético; selftests do code-locale | 3 linhas renderizadas; 3 selftests OK |
| histórico deste repo | `.releaserc.json` + tags | ✨ feat → v2.22.0/v2.23.0/v2.24.0 em 2026-09-05 |
| `research/svg-animation/measurements.md` | Chrome for Testing 151.0.7922.34, 2026-08-30/31 | citado como run registrado; não re-executado (sem Chrome aqui) |

## Critérios de aceitação

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | `grep -L 'Verified against\|does not depend on a tool version' skills/*/SKILL.md` vazio | met | `… \| wc -l` → `0` (era 20) |
| 2 | Cada bloco cita comando + versão + data | met | 20/20 blocos com `2026-09-05`; comandos e saídas em `tasks.md` E.2 e grupos 2–5 |
| 3 | `check_pin` reprova skill code-heavy sem bloco; selftest detecta | met | cópia com o literal removido de `fivem-lua` → `[C5 no version pin] neither 'Verified against' nor 'does not depend on a tool version' — a version mentioned in passing is not a pin`; selftest `CAUGHT` ×3 |

## Simulação (rito)

- Entry point `python3 scripts/validate-skills.py` → `skills checked: 35   findings: 0`; `python3 scripts/selftest-validate-skills.py` → 3/3 mutações do C5 `CAUGHT`, `21/22` local.
- Contagens: 3/3 tinham que disparar e dispararam; 35/35 tinham que ficar caladas e ficaram; 1/1 escape conhecido calado (`helm-migration` via frase de deferência, por desenho); 1/1 miss local pré-existente (`C3 lua syntax`, sem `luac` nesta máquina — o CI instala `lua5.4`).
- O que escapou e foi tratado: mutação (c) calada em `r3f-materials` (0 linhas cercadas no SKILL.md) → retarget para `k8s-tune-resources`; bloco do svg-animation tropeçou no C12 (dois caminhos `research/…`) → URLs; a linha 500→400; rate limit do code search do GitHub → clones rasos.

## Validações

| Comando | Resultado |
|---|---|
| `python3 scripts/validate-skills.py` | 35 skills, 0 findings (lua syntax skipped: sem luac local) |
| `python3 scripts/selftest-validate-skills.py` | 21/22 (MISSED só `C3 lua syntax`, local) |
| `bash scripts/validate-rite.sh` | `rite gate OK`; evidence gate 0; spec-rite gate 0 |
| `openspec validate require-verified-against --strict` | valid |
| `PR_BODY=… python3 scripts/validate-skill-version.py` | 0 findings, 20 skills changed, 20 com bump |
| `bash generate.sh` + `git status --porcelain --untracked-files=all` | 0 untracked, árvore limpa após commit |
| `python3 scripts/validate-repo-hygiene.py` / `scan-secrets.py` | 0 findings / no credentials |
| `agentskills validate` (skills-ref 0.1.1) | 35/35 |
| `npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict` | passed |
| `npx -y skills add solvelab/ai-skills --list` | 35 |
| replica do loop de frontmatter do CI | fail=0 |

## Divulgado aqui, não feito aqui (follow-ups)

1. **`assettoserver-plugin`**: o runtime DriveZone medido hoje é `AssettoServer 0.0.55+51d8d8a6e0`, construído de uma árvore com `net9.0`; a doutrina (`v0.0.54` → `net8.0`, ban de `System.Threading.Lock`) está um major atrás. O bloco divulga; a reescrita é issue própria.
2. **`python-rest-api` SKILL.md:103** publica a mesma linha `500 (RecursionError)` que não reproduz (400 medido). Fora das 20 skills deste item.
3. C5 não checa a **data** dentro do bloco; exigir isso pede backfill das 15 skills que já tinham bloco (datas nas changes arquivadas).
4. `react-api-client`: blocos compiláveis em vez de excerpts.
5. `openspec spec list` deprecado em 1.6.0 → `openspec show` / `validate --specs` quando o pin mover.
6. README:468 ainda diz `C1–C9` (stale antes desta PR).

## Pendente do rito

- `openspec archive require-verified-against --yes` **após o merge**, em PR própria — V.4 fica aberto de propósito: o archive move as specs e não deve preceder a aprovação humana do código que descreve.
