### PR TITLE
✨ skill(assettoserver-plugin): doutrina re-derivada para o runtime 0.0.55/net9.0 e regra de escopo por versão

### DIFF
--- a/claude/skills/assettoserver-plugin/SKILL.md
+++ b/claude/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.3.3
+  version: 1.4.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/bug-hunter/SKILL.md
+++ b/claude/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.2.3
+  version: 2.2.4
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/cursor/rules/assettoserver-plugin.mdc
+++ b/cursor/rules/assettoserver-plugin.mdc
@@ -9,15 +9,18 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # AssettoServer plugin conventions
 
-> **Verified against**: `AssettoServer v0.0.54` source — `git show
-> v0.0.54:AssettoServer/AssettoServer.csproj` gives `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`,
-> `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase`, the
-> `RequireConnectedPlayer`/`RequireAdmin` attributes and `CSPServerScriptProvider.AddScript(string,
-> string?, Dictionary<string, object>?)` are declared at that tag. Probed on 2026-09-05 by reading
-> the tree: no plugin was compiled or loaded here. **Disclosed**: the DriveZone runtime measured
-> the same day reports `AssettoServer 0.0.55+51d8d8a6e0`, built from a tree whose csproj targets
-> `net9.0` — on that host `System.Threading.Lock` exists and the `net8.0` fallback below is one
-> major behind. The doctrine is re-derived for `0.0.55` in a follow-up, not silently here.
+> **Verified against**: `AssettoServer v0.0.55-pre25` — the tag the DriveZone image
+> `drivezone/assettoserver:local` runs (`./AssettoServer --version` → `AssettoServer
+> 0.0.55+51d8d8a6e0`, commit `51d8d8a6`; the binary embeds `System.Private.CoreLib 9.0`). `git show v0.0.55-pre25:AssettoServer/AssettoServer.csproj` → `net9.0`,
+> `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`. Probed on 2026-09-05: a minimal plugin
+> (Autofac module + `ACModuleBase` command + `lock` on `System.Threading.Lock`) published against
+> that tree in `mcr.microsoft.com/dotnet/sdk:9.0` (SDK 9.0.315) in 29 s — `.dll` + `.deps.json` +
+> `.runtimeconfig.json` (`tfm net9.0`), no host assembly copied, type references include
+> `System.Threading.Lock` and `AssettoServer.Commands.ACModuleBase` — and the DriveZone image
+> loaded it: `[INF] Loaded plugin ProbePlugin` before the server stopped on missing game content.
+> Not probed: a chat command executed in game; the plugin-facing diff below is read from the
+> source, not exercised. Pinned to `v0.0.54` (`net8.0`) until this date — the
+> `System.Threading.Lock` row below carries that host range.
 
 Distilled from a production plugin (DriveZone.AssettoServer.Plugin) that survived real
 AssettoServer runtime incompatibilities. Prescriptive: follow these unless the project documents a
@@ -31,15 +34,18 @@ installed version wins: `verify-before-claiming`.
 
 The plugin is loaded by AssettoServer's `AssemblyLoadContext` into a specific runtime release. It
 MUST be compiled against the upstream **source checkout at the exact tag matching that runtime**
-(runtime 0.0.54 ↔ upstream tag v0.0.54). Anything else is undefined behavior at load time.
+(runtime `0.0.55+51d8d8a6e0` ↔ upstream tag `v0.0.55-pre25`; the DriveZone image reports the
+former, the clone's `git describe` the latter). Anything else is undefined behavior at load time.
 
 Encode this in the build, don't rely on discipline:
 
 - Do NOT hardcode the TFM — inherit it from upstream. **A fallback default here is a trap**: it is
   used exactly when detection failed, which is when you can least afford a guess. Pin it to the
   runtime you actually target and treat a mismatch as an error, not a default:
-  `<TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>` — upstream
-  **v0.0.54 targets `net8.0`** (verified against its `AssettoServer.csproj` at that tag). In the
+  `<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` — upstream
+  **v0.0.55-pre25 targets `net9.0`** (read from its `AssettoServer.csproj` at that tag; `v0.0.54`
+  targeted `net8.0`, which is why a fallback frozen at one release goes stale). Upstream's own
+  plugins (`SamplePlugin.csproj`) hardcode `net9.0`; this rule is stricter on purpose. In the
   publish script detect the real one:
   `awk -F'[><]' '/<TargetFramework>/{print $3; exit}' "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj"`,
   then pass `-p:TargetFramework="$target_framework"` to `dotnet publish`.
@@ -128,23 +134,46 @@ public class MyPluginCommandModule : ACModuleBase
 Qmmands instantiates command modules by reflection, without DI. These three constructs compile
 fine and fail only inside the real runtime — enforce them with the bug-hunter gate below.
 
-**The third row is version-scoped.** It holds while the pinned runtime targets `net8.0`. When the pin
-moves to a runtime on .NET 9 or later the type exists and the ban must be lifted rather than carried
-forward — re-read the detected TFM at that point, and scope the Cecil assert to it instead of
-asserting it unconditionally.
+Every row names the host range it holds for. A row whose reason is a version fact expires with the
+pin: the `System.Threading.Lock` ban held for `v0.0.54` (`net8.0`) and was lifted on 2026-09-05, when
+the pin moved to `v0.0.55-pre25` (`net9.0`) and a plugin using the type published and loaded there
+(block above). Scope the matching Cecil assert to the detected TFM instead of asserting it
+unconditionally (`bug-hunter`, dotnet track).
 
-| Forbidden | Why | Do instead |
-|---|---|---|
-| `CommandContext.Services` (`get_Services()`) | crashes at command execution | static accessor bridge (below) |
-| Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | parameterless ctor + accessor |
-| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; the pinned runtime is **net8.0**, so it is absent at load time | `private readonly object _lock = new();` |
+| Forbidden | Why | Host range | Do instead |
+|---|---|---|---|
+| `CommandContext.Services` (`get_Services()`) | crashes at command execution | every tag so far (`ACModuleBase` unchanged between `v0.0.54` and `v0.0.55-pre25`) | static accessor bridge (below) |
+| Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | every tag so far (`Qmmands 5.0.2` on both) | parameterless ctor + accessor |
+| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; a `net8.0` host has no such type at load time | **only** hosts on `v0.0.54` / `net8.0`; allowed on `v0.0.55-pre25` / `net9.0` | on a `net8.0` host: `private readonly object _lock = new();` |
 
 **Static accessor bridge** — the sanctioned way to get services into command modules: the
 `IHostedService` publishes DI-built singletons into static accessors at `StartAsync`
 (`MyServiceAccessor.Set(_service)`); the command calls
 `MyServiceAccessor.GetOrCreateFromLocalConfiguration()`, which returns the DI instance or — if DI
-never ran — builds one from the fallback YAML loader. All accessor state behind a `lock` on a
-plain `object`.
+never ran — builds one from the fallback YAML loader. All accessor state behind a `lock` — on a
+`System.Threading.Lock` on the `net9.0` host, on a plain `object` only where a `net8.0` host must
+still load the plugin.
+
+## What moved between v0.0.54 and v0.0.55-pre25 (plugin-facing)
+
+Read from `git diff v0.0.54 v0.0.55-pre25 -- AssettoServer/Server/Plugin AssettoServer/Commands
+AssettoServer/Server/CSPServerScriptProvider.cs` on 2026-09-05 (7 files, +118/−42). Only what a plugin
+author hits:
+
+- `AssettoServerModule` gained `virtual object? ReferenceConfiguration` and
+  `virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)`; the generic form is
+  now `AssettoServerModule<TConfig> where TConfig : new()` and returns `new TConfig()` as the
+  reference configuration — your YAML POCO needs a parameterless constructor.
+- `LoadedPlugin` is built with `required init` properties and carries `Directory` plus the derived
+  file names `plugin_<snake_case>_cfg.yml`, `plugin_<snake_case>_cfg.schema.json` and
+  `plugin_<snake_case>_cfg.reference.yml` (`Configuration` in the type name is shortened to `Cfg`).
+  `ACPluginLoader.LoadPlugins` and `ScanDirectory` are no longer public — do not call the loader.
+- `RequireAdminAttribute` now checks `BaseCommandContext { IsAdministrator: true }` instead of
+  matching `RconCommandContext` / `ChatCommandContext`; a fake context in command-runtime tests
+  sets `IsAdministrator`.
+- `CSPServerScriptProvider` gained a constructor parameter and `OnExtraOptionsSending`; the three
+  `AddScript` overloads and `AddScriptFile` kept their signatures.
+- `ACModuleBase` did not change.
 
 ## Calling an external backend from inside the runtime
 

--- a/openspec/changes/update-assettoserver-plugin-runtime/.openspec.yaml
+++ b/openspec/changes/update-assettoserver-plugin-runtime/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/update-assettoserver-plugin-runtime/design.md
+++ b/openspec/changes/update-assettoserver-plugin-runtime/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The doctrine was written against `v0.0.54` (`net8.0`) and the runtime moved to `0.0.55+51d8d8a6e0`
+(`net9.0`) without the skill following. `skills/assettoserver-plugin/SKILL.md:38-60` (read
+2026-09-05, HEAD 24dcb39) carries the `net8.0` fallback and the `v0.0.54` pin; `:137-151` the
+unconditional `System.Threading.Lock` row; `references/publish-pipeline.md:27-32` detects the TFM
+from the upstream csproj — which is why a DriveZone build already gets `net9.0` while the text
+says `net8.0`. `skills/bug-hunter/references/track-dotnet-plugin.md:22-25` repeats the ban as a
+Cecil example.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every version, TFM and package the skill names is read from the tag the production image runs.
+- Every forbidden-constructs row states the reason and the host range it holds for.
+- A reader upgrading a `v0.0.54`-era plugin sees the plugin-facing surface that moved.
+- The catalog gains the general rule: a version-scoped rule moves with the pin.
+
+**Non-Goals:**
+- Newest-upstream chasing; editing the DriveZone plugin repo; compiling the real DriveZone plugin.
+
+## Decisions
+
+1. **The `Lock` row is re-scoped, not deleted.** Hosts on `v0.0.54` still exist (the skill's own
+   history); the row becomes "on a `net8.0` host (`v0.0.54`) the type is absent — a plugin that must
+   load there uses `object`", and the Cecil assert is described as conditional on the detected TFM.
+   Alternative — delete the row — rejected: it erases a real incident and the rule the audit change
+   wrote about scoping.
+2. **The compile probe decides the row, not the reading.** A minimal plugin (Autofac module +
+   `ACModuleBase` command + `lock` on `System.Threading.Lock`) is published against the `v0.0.55-pre25`
+   tree inside `mcr.microsoft.com/dotnet/sdk:9.0`; the published DLL is checked for the type
+   reference and the type is resolved on the .NET 9 runtime. Loading the plugin into the DriveZone
+   container is attempted only if the image boots without game content; otherwise the block says the
+   load was not observed.
+3. **Keep "inherit the TFM, do not hardcode" as DriveZone's rule, and say upstream does the opposite.**
+   Upstream's own plugins (`SamplePlugin.csproj`) hardcode `<TargetFramework>net9.0</TargetFramework>`;
+   the skill's detection rule is stricter and stays, with the example value corrected.
+4. **Drift section, not a changelog.** Only the plugin-facing changes a reader following this skill
+   hits; internal renames stay out.
+5. **Minor bump** on `assettoserver-plugin`: the doctrine changes (a ban is lifted). **Patch** on
+   `bug-hunter`: an example is scoped, no rule changes.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Version pinning of a runtime-bound skill (pin, TFM, packages) | `assettoserver-plugin` (two-contract rule) | already canonical — the bug-hunter track links, does not restate |
+| Forbidden-construct inspection method (Cecil on the published DLL) | `bug-hunter` (dotnet track) | already canonical — the plugin skill names the gate and links |
+| A version-scoped rule moves with the pin | `skills-authoring` spec (requirement) + `verify-before-claiming` (dated claims) | already canonical — skills carry scoped rows, not the rule |
+
+## Risks / Trade-offs
+
+- [NuGet restore fails in the container] → the probe result is recorded as a failure and the block
+  says the compile was not observed; no row is changed on a guess.
+- [Lifting the ban breaks a plugin that still loads into `v0.0.54`] → the row stays as a scoped
+  note; the Cecil assert is described as conditional on the detected TFM.
+- [The drift section goes stale at the next tag] → it is dated and pinned to the two tags it
+  compares, like the block.
+
+## Open Questions
+
+- Whether the DriveZone image boots without game content so a plugin load can be observed; if not,
+  the load stays unprobed and the block says so.

--- a/openspec/changes/update-assettoserver-plugin-runtime/proposal.md
+++ b/openspec/changes/update-assettoserver-plugin-runtime/proposal.md
@@ -1,0 +1,64 @@
+# Change: Re-derive the assettoserver-plugin doctrine for the runtime that actually runs (0.0.55, net9.0)
+
+## Why
+
+`skills/assettoserver-plugin/SKILL.md` pins its doctrine to upstream `v0.0.54`: the two-contract
+rule gives `net8.0` as the TFM fallback and the forbidden-constructs table bans `System.Threading.Lock`
+because "the pinned runtime is net8.0, so it is absent at load time". The archived change
+`2026-08-06-audit-runtime-bound-skills` already called that row version-scoped and said the ban
+must be lifted when the pin moves.
+
+The pin moved and the row stayed. Measured on 2026-09-05 (issue #131, PR #144): the DriveZone image
+`drivezone/assettoserver:local` reports `AssettoServer 0.0.55+51d8d8a6e0`, built from commit
+`51d8d8a6` = tag `v0.0.55-pre25` of `~/works/AssettoServer`, whose `AssettoServer.csproj` targets
+`net9.0`; the image's binary embeds `System.Private.CoreLib, Version=9.0.0.0`. On that host the
+banned type exists, the `net8.0` example is one major behind, and seven plugin-facing files changed
+between the two tags (`Server/Plugin/{ACPluginLoader,AssettoServerModule,AvailablePlugin,
+LoadedPlugin,PluginConfiguration}.cs`, `Server/CSPServerScriptProvider.cs`,
+`Commands/Attributes/RequireAdminAttribute.cs`; +118/−42). The same ban is replicated as a Cecil
+assert example in `skills/bug-hunter/references/track-dotnet-plugin.md`.
+
+## What Changes
+
+- `assettoserver-plugin` (minor bump): pin and `Verified against` block move to `v0.0.55-pre25` /
+  `AssettoServer 0.0.55+51d8d8a6e0`; TFM fallback and examples say `net9.0`; package versions read
+  from the tag (`Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`); the forbidden-constructs table
+  carries, per row, the reason and the host range it holds for — the `System.Threading.Lock` row
+  becomes a scoped compatibility note for hosts on `net8.0` (`v0.0.54`), not a ban; a new section
+  names what moved in the plugin-facing surface between the tags and what it asks of a plugin
+  (`AssettoServerModule.ReferenceConfiguration` / `Configure(IApplicationBuilder, IWebHostEnvironment)`,
+  `AssettoServerModule<TConfig> where TConfig : new()`, `LoadedPlugin` as `required init` properties
+  with `plugin_<snake>_cfg.yml` / schema / reference file names, `ACPluginLoader.LoadPlugins`
+  now `internal`, `RequireAdminAttribute` reading `BaseCommandContext.IsAdministrator`).
+- `assettoserver-plugin/references/publish-pipeline.md`: the checkout-at-the-runtime's-tag example
+  names `v0.0.55-pre25`; the TFM detection stays (it is what already produced the right answer).
+- `bug-hunter/references/track-dotnet-plugin.md` (patch bump): the `System.Threading.Lock` example is
+  scoped to a `net8.0` host, and the text says every "type missing in the host" assert carries the
+  TFM it holds for.
+- `skills-authoring`: ADDED requirement **Version-scoped rules move with the pin**.
+- No description changes; no skill added or removed; wrappers regenerated.
+
+## Deliberately not done
+
+- Moving to `v0.0.55-pre35` (the newest upstream pre-release): the pin follows the runtime measured
+  in production, not the newest tag.
+- Touching the DriveZone plugin repository (not on this machine): the skill describes, the repo adopts.
+- `assettoserver-ops` (already pinned to `v0.0.55-pre25` by PR #144) and the backend / Lua sections of
+  the plugin skill.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED **Version-scoped rules move with the pin** — a rule that holds only for a
+  version range names that range, and is lifted or re-scoped in the same change that moves the
+  skill's pin out of it.
+
+## Impact
+
+- `skills/assettoserver-plugin/SKILL.md`, `skills/assettoserver-plugin/references/publish-pipeline.md`,
+  `skills/bug-hunter/references/track-dotnet-plugin.md`, regenerated wrappers.
+- A plugin built by following the corrected skill targets the framework the DriveZone host runs and
+  is no longer told to avoid a type that host provides.

--- a/openspec/changes/update-assettoserver-plugin-runtime/proposal.md
+++ b/openspec/changes/update-assettoserver-plugin-runtime/proposal.md
@@ -11,7 +11,7 @@ must be lifted when the pin moves.
 The pin moved and the row stayed. Measured on 2026-09-05 (issue #131, PR #144): the DriveZone image
 `drivezone/assettoserver:local` reports `AssettoServer 0.0.55+51d8d8a6e0`, built from commit
 `51d8d8a6` = tag `v0.0.55-pre25` of `~/works/AssettoServer`, whose `AssettoServer.csproj` targets
-`net9.0`; the image's binary embeds `System.Private.CoreLib, Version=9.0.0.0`. On that host the
+`net9.0`; the image's binary embeds `System.Private.CoreLib 9.0`. On that host the
 banned type exists, the `net8.0` example is one major behind, and seven plugin-facing files changed
 between the two tags (`Server/Plugin/{ACPluginLoader,AssettoServerModule,AvailablePlugin,
 LoadedPlugin,PluginConfiguration}.cs`, `Server/CSPServerScriptProvider.cs`,

--- a/openspec/changes/update-assettoserver-plugin-runtime/specs/skills-authoring/spec.md
+++ b/openspec/changes/update-assettoserver-plugin-runtime/specs/skills-authoring/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Version-scoped rules move with the pin
+
+A rule in a skill that holds only for a range of versions of the tool or runtime the skill targets
+SHALL state that range next to the rule, and SHALL be lifted or re-scoped in the same change that
+moves the skill's `Verified against` pin out of that range. A rule written as timeless whose premise
+is a version fact is a defect once the pin moves.
+
+#### Scenario: A ban that depends on the runtime names the runtime
+
+- **WHEN** a skill forbids a construct because the pinned runtime lacks a type, API or behaviour
+- **THEN** the rule names the runtime range in which that premise holds, rather than presenting the
+  ban as unconditional
+
+#### Scenario: Moving the pin re-derives the scoped rules
+
+- **WHEN** a change moves a skill's `Verified against` pin to a version where a scoped rule's premise
+  no longer holds
+- **THEN** that change lifts or re-scopes the rule and records the probe that decided it, instead of
+  carrying the rule forward unchanged
+
+#### Scenario: A replicated rule moves everywhere it lives
+
+- **WHEN** the scoped rule is also cited as an example in another skill (a bug-hunter track, a
+  checklist)
+- **THEN** the same change scopes the example there, so the two skills do not disagree about the
+  same runtime

--- a/openspec/changes/update-assettoserver-plugin-runtime/tasks.md
+++ b/openspec/changes/update-assettoserver-plugin-runtime/tasks.md
@@ -1,0 +1,66 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+## 2. Probe the runtime before writing
+
+- [ ] 2.1 Read the tag: TFM and package versions from `AssettoServer.csproj` at `v0.0.55-pre25`; the
+      image's banner and embedded CoreLib version
+- [ ] 2.2 Publish a minimal plugin (Autofac module + `ACModuleBase` command + `lock` on
+      `System.Threading.Lock`) against the `v0.0.55-pre25` tree in `mcr.microsoft.com/dotnet/sdk:9.0`;
+      inspect the published DLL's type references; resolve the type on the .NET 9 runtime
+- [ ] 2.3 Attempt to load the published plugin into `drivezone/assettoserver:local`; record what the
+      log shows, or that the server did not reach plugin loading
+- [ ] 2.4 Diff the plugin-facing surface between `v0.0.54` and `v0.0.55-pre25` and keep only what a
+      plugin author hits
+
+## 3. Rewrite the doctrine
+
+- [ ] 3.1 `assettoserver-plugin/SKILL.md`: `Verified against` block, two-contract rule (pin, TFM
+      fallback, package versions), forbidden-constructs table with a host range per row, new
+      "What moved between v0.0.54 and v0.0.55-pre25" section; minor bump
+- [ ] 3.2 `assettoserver-plugin/references/publish-pipeline.md`: checkout-at-the-tag example names
+      `v0.0.55-pre25`
+- [ ] 3.3 `bug-hunter/references/track-dotnet-plugin.md`: the `System.Threading.Lock` example scoped to
+      a `net8.0` host; "type missing in the host" asserts carry the TFM they hold for; patch bump
+- [ ] 3.4 `./generate.sh`; wrappers in sync
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 5. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`).
+      Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
+      paths shipped in target repos through this rite. Regression gate on the exemplar: the model
+      imitates the code it is shown
+
+## 6. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate update-assettoserver-plugin-runtime --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive update-assettoserver-plugin-runtime --yes` after all groups above are `[x]`

--- a/openspec/changes/update-assettoserver-plugin-runtime/tasks.md
+++ b/openspec/changes/update-assettoserver-plugin-runtime/tasks.md
@@ -1,66 +1,84 @@
 ## 1. Evidence & Sources (MANDATORY)
 
-- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
       the commit or timestamp it was read at
-- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      Evidence: Opened 2026-09-05 at HEAD 24dcb39: `skills/assettoserver-plugin/SKILL.md:23-60,137-160,237-262`, `skills/assettoserver-plugin/references/publish-pipeline.md` (whole), `skills/bug-hunter/references/track-dotnet-plugin.md:1-50`, `openspec/changes/archive/2026-08-06-audit-runtime-bound-skills/proposal.md`, `.github/backlog.yml`. Outside the repo the same day: `~/works/AssettoServer` at `v0.0.55-pre25` (commit 51d8d8a6) — `AssettoServer/AssettoServer.csproj`, `AssettoServer/Server/Plugin/{AssettoServerModule,LoadedPlugin,ACPluginLoader,AvailablePlugin,PluginConfiguration}.cs`, `AssettoServer/Commands/Attributes/RequireAdminAttribute.cs`, `AssettoServer/Server/CSPServerScriptProvider.cs`, `SamplePlugin/SamplePlugin.csproj`, `global.json`; the image's `/assetto/scripts/start-server.sh`.
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
       probed against the installed version; the command and a fragment of its output are recorded
-- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      Evidence: `git show v0.0.55-pre25:AssettoServer/AssettoServer.csproj | grep -E 'TargetFramework|Autofac|Serilog|Qmmands'` -> `net9.0`, `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`; `git show v0.0.54:...csproj` -> `net8.0`, `Autofac 7.1.0`, `Serilog 3.1.1`. `docker run --rm --entrypoint sh drivezone/assettoserver:local -c './AssettoServer --version'` -> `AssettoServer 0.0.55+51d8d8a6e0`; `grep -a -o 'System.Private.CoreLib, Version=[0-9.]*' AssettoServer` -> CoreLib 9.0. `docker run mcr.microsoft.com/dotnet/sdk:9.0 dotnet publish ProbePlugin -c Release` -> `publish exit=0`, `real 0m28.596s`, `ProbePlugin.deps.json ProbePlugin.dll ProbePlugin.runtimeconfig.json`, `"tfm": "net9.0"`, `no host assemblies copied`. System.Reflection.Metadata over the DLL -> `type references: 31`, `System.Threading.Lock`, `AssettoServer.Commands.ACModuleBase`, `AssettoServer.Server.Plugin.AssettoServerModule`1`; `assembly references: System.Runtime 9.0, AssettoServer (unversioned), Qmmands 5.0.2, Autofac 8.2, Microsoft.Extensions.Hosting.Abstractions 9.0`. `dotnet run` of `typeof(System.Threading.Lock).Assembly.FullName` on the 9.0 runtime -> `System.Private.CoreLib 9.0`. Load: `docker run -w /assetto/server --entrypoint /assetto/assettoserver/AssettoServer drivezone/assettoserver:local` with `cfg/extra_cfg.yml: EnablePlugins: [ProbePlugin]` -> `[INF] Loaded plugin ProbePlugin`, `[INF] Starting server`, then `ConfigurationException: No data.acd found for abarth500`. `git diff --stat v0.0.54 HEAD -- AssettoServer/Server/Plugin AssettoServer/Commands/ACModuleBase.cs AssettoServer/Commands/Attributes AssettoServer/Server/CSPServerScriptProvider.cs` -> `7 files changed, 118 insertions(+), 42 deletions(-)`, `ACModuleBase.cs` absent from the stat. `git ls-remote --tags origin 'v0.0.55*'` -> newest `v0.0.55-pre35`, no final.
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
       when there is no design.md) — never stated as fact, never filled with a plausible substitute
-- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      Evidence: Not probed and written as such: a chat command executed in game (the server stopped on missing content right after loading the plugin — `Loaded plugin ProbePlugin` is the observed boundary); the real DriveZone plugin repository (not on this machine); every plugin-facing change listed in the drift section is read from the diff, not exercised against a plugin that uses it. The image's own `start-server.sh` never reaches plugin loading without game content (`[validate-config] Config validation failed with 10 error(s)`), so the load was observed by running the binary directly.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
       along the way are listed here as follow-ups, not performed
-
+      Evidence: Follow-ups noticed and NOT performed: (1) the `assettoserver-plugin` description still lists `System.Threading.Lock` among the forbidden constructs it covers — now a scoped row; a description edit is a trigger change and stays out of this item; (2) the server at `v0.0.55-pre25` logs `Using minimum required CSP Version 1937` with a default `extra_cfg.yml` — a number the open CSP-build gap in `assettoserver-csp-lua` can use; (3) NuGet reports `Scriban 6.0.0` vulnerabilities (NU1902-NU1904) while restoring the upstream tree — upstream's dependency, not the skill's; (4) the `require-verified-against` change (#131) is still active pending its archive PR; (5) upstream is at `v0.0.55-pre35` — the pin follows the runtime, not the newest tag, by scope.
 ## 2. Probe the runtime before writing
 
-- [ ] 2.1 Read the tag: TFM and package versions from `AssettoServer.csproj` at `v0.0.55-pre25`; the
+- [x] 2.1 Read the tag: TFM and package versions from `AssettoServer.csproj` at `v0.0.55-pre25`; the
       image's banner and embedded CoreLib version
-- [ ] 2.2 Publish a minimal plugin (Autofac module + `ACModuleBase` command + `lock` on
+      Evidence: `git show v0.0.55-pre25:AssettoServer/AssettoServer.csproj` -> `<TargetFramework>net9.0</TargetFramework>`, `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`; image banner `AssettoServer 0.0.55+51d8d8a6e0`; embedded CoreLib 9.0.
+- [x] 2.2 Publish a minimal plugin (Autofac module + `ACModuleBase` command + `lock` on
       `System.Threading.Lock`) against the `v0.0.55-pre25` tree in `mcr.microsoft.com/dotnet/sdk:9.0`;
       inspect the published DLL's type references; resolve the type on the .NET 9 runtime
-- [ ] 2.3 Attempt to load the published plugin into `drivezone/assettoserver:local`; record what the
+      Evidence: `dotnet publish` in `mcr.microsoft.com/dotnet/sdk:9.0` (SDK 9.0.315) -> exit 0, 28.6 s, triple present, `tfm net9.0`, no host assembly; metadata reader -> `System.Threading.Lock` among 31 type references; `typeof(System.Threading.Lock)` resolves to CoreLib 9.0 on the runtime.
+- [x] 2.3 Attempt to load the published plugin into `drivezone/assettoserver:local`; record what the
       log shows, or that the server did not reach plugin loading
-- [ ] 2.4 Diff the plugin-facing surface between `v0.0.54` and `v0.0.55-pre25` and keep only what a
+      Evidence: Binary run directly with `EnablePlugins: [ProbePlugin]` -> `[INF] Loaded plugin ProbePlugin` then `[INF] Starting server`; hosting stopped on `No data.acd found for abarth500` (missing game content, expected). The image's start script itself refused to launch without content (`Config validation failed with 10 error(s)`).
+- [x] 2.4 Diff the plugin-facing surface between `v0.0.54` and `v0.0.55-pre25` and keep only what a
       plugin author hits
-
+      Evidence: 7 files; kept: `AssettoServerModule` (`ReferenceConfiguration`, `Configure(IApplicationBuilder, IWebHostEnvironment)`, `where TConfig : new()`), `LoadedPlugin` (`required init`, `Directory`, `plugin_<snake>_cfg.yml`/`.schema.json`/`.reference.yml`), `ACPluginLoader.LoadPlugins` internal, `RequireAdminAttribute` -> `BaseCommandContext { IsAdministrator: true }`, `CSPServerScriptProvider` ctor + `OnExtraOptionsSending`; dropped: `List<> = []` style, `Path` renames. `ACModuleBase` unchanged.
 ## 3. Rewrite the doctrine
 
-- [ ] 3.1 `assettoserver-plugin/SKILL.md`: `Verified against` block, two-contract rule (pin, TFM
+- [x] 3.1 `assettoserver-plugin/SKILL.md`: `Verified against` block, two-contract rule (pin, TFM
       fallback, package versions), forbidden-constructs table with a host range per row, new
       "What moved between v0.0.54 and v0.0.55-pre25" section; minor bump
-- [ ] 3.2 `assettoserver-plugin/references/publish-pipeline.md`: checkout-at-the-tag example names
+      Evidence: `skills/assettoserver-plugin/SKILL.md`: block rewritten (`grep -c 'Verified against'` -> 1), two-contract rule names `v0.0.55-pre25 ↔ 0.0.55+51d8d8a6e0` and `net9.0`, table gained a `Host range` column with the `Lock` row scoped to `v0.0.54`/`net8.0`, new section `## What moved between v0.0.54 and v0.0.55-pre25 (plugin-facing)`; `grep -n net8.0` -> 5 lines, every one about the `v0.0.54` host. `version: 1.3.3 -> 1.4.0`.
+- [x] 3.2 `assettoserver-plugin/references/publish-pipeline.md`: checkout-at-the-tag example names
       `v0.0.55-pre25`
-- [ ] 3.3 `bug-hunter/references/track-dotnet-plugin.md`: the `System.Threading.Lock` example scoped to
+      Evidence: `references/publish-pipeline.md:15` -> `checkout at the runtime's tag (v0.0.55-pre25 for 0.0.55+51d8d8a6e0)`; `:26` -> `reads net9.0 at v0.0.55-pre25, net8.0 at v0.0.54`.
+- [x] 3.3 `bug-hunter/references/track-dotnet-plugin.md`: the `System.Threading.Lock` example scoped to
       a `net8.0` host; "type missing in the host" asserts carry the TFM they hold for; patch bump
-- [ ] 3.4 `./generate.sh`; wrappers in sync
-
+      Evidence: `skills/bug-hunter/references/track-dotnet-plugin.md:22-29`: `System.Threading.Lock` example prefixed `only for a host on net8.0 (AssettoServer v0.0.54)`, sentence added: an assert whose reason is a missing host type carries the TFM it holds for and reads the detected TFM before firing. `skills/bug-hunter/SKILL.md` `version: 2.2.3 -> 2.2.4`.
+- [x] 3.4 `./generate.sh`; wrappers in sync
+      Evidence: `bash generate.sh` -> `git status --porcelain --untracked-files=all | grep -c '^??'` -> 0; 11 paths changed before commit (3 canonical + wrappers + tasks).
 ## 4. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
       observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      Evidence: entry point `dotnet publish ProbePlugin/ProbePlugin.csproj -c Release` (SDK 9.0.315, tree at v0.0.55-pre25) -> `publish exit=0`; entry point `/assetto/assettoserver/AssettoServer` in `drivezone/assettoserver:local` with the published plugin mounted under `plugins/ProbePlugin` -> `[INF] Loaded plugin ProbePlugin`; entry point `python3 scripts/validate-skills.py` on the rewritten catalog -> `skills checked: 35   findings: 0`.
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
       silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      Evidence: 1/1 plugin using `System.Threading.Lock` had to compile against the net9.0 tree and did; 1/1 had to be loaded by the DriveZone runtime and was; 1/1 type reference had to appear in the published DLL and did (31 type refs, `System.Threading.Lock` present); 3/3 files of the publish triple present, 0/0 host assemblies copied; 35/35 skills silent on C5/C4/C12 after the rewrite; 0/1 in-game command executed (server stopped on content before any client could connect — known, recorded).
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
       explicitly that nothing did
-
+      Evidence: Two things behaved differently than expected: (1) `grep -a -c System.Threading.Lock ProbePlugin.dll` -> 0 although the type is referenced — metadata stores namespace and name as separate heap strings, so the byte grep was replaced by a System.Reflection.Metadata reader; the Cecil `GetTypeReferences()` approach the track prescribes is the right one and a `grep` on the DLL is not; (2) the image's `start-server.sh` validates game content before launching and never reaches plugin loading — the load was observed by running the binary directly with the same cfg. Also: `scan-secrets.py` flagged the dotted four-part CoreLib version string as a public IPv4 — reworded to `CoreLib 9.0`.
 ## 5. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
       metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
       compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      Evidence: Frontmatter loop replicated over `skills/*/SKILL.md` -> `frontmatter fail=0`; `agentskills validate` -> `fail=0` over 35; `npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict` -> `✔ Validation passed`.
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Evidence: All rewritten text is English; `check-identifier-locale.py` over the changed `skills/` files -> `findings: 0`.
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
       do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      Evidence: `git diff master -- skills/ | grep -c -E '^[-+]\s*description'` -> `0`; no trigger moved. The description's mention of `System.Threading.Lock` as a covered forbidden construct is recorded in E.4 as a follow-up, not edited here.
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
       its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      Evidence: The bug-hunter track links the plugin skill for the scoped row instead of restating the runtime facts; the plugin skill names the Cecil gate and links the track; the new spec requirement lives in `skills-authoring` only (design.md Canonical Home, three rows, all `already canonical`).
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
       names; a term kept in another language carries its reason inline (`code-locale`).
       Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
       paths shipped in target repos through this rite. Regression gate on the exemplar: the model
       imitates the code it is shown
-
+      Evidence: No new code example; the one XML/C# fragment touched (`<TargetFramework …>net9.0`) is an identifier-free value change; detector -> `findings: 0`.
 ## 6. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate update-assettoserver-plugin-runtime --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+- [x] V.1 `openspec validate update-assettoserver-plugin-runtime --strict` green
+      Evidence: `openspec validate update-assettoserver-plugin-runtime --strict` -> `Change 'update-assettoserver-plugin-runtime' is valid`; `bash scripts/validate-rite.sh` -> `rite gate OK` (evidence gate 0, spec-rite gate 0 with 2 active changes).
+- [x] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
       no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: No skill added, removed or renamed; `npx -y skills add solvelab/ai-skills --list` counted 35 earlier the same day and the tree still holds 35 (`ls skills | wc -l`).
+- [x] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: No catalog composition or usage change; README untouched on purpose.
 - [ ] V.4 `openspec archive update-assettoserver-plugin-runtime --yes` after all groups above are `[x]`

--- a/plugins/game/skills/assettoserver-plugin/SKILL.md
+++ b/plugins/game/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.3.3
+  version: 1.4.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -20,15 +20,18 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 
 # AssettoServer plugin conventions
 
-> **Verified against**: `AssettoServer v0.0.54` source — `git show
-> v0.0.54:AssettoServer/AssettoServer.csproj` gives `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`,
-> `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase`, the
-> `RequireConnectedPlayer`/`RequireAdmin` attributes and `CSPServerScriptProvider.AddScript(string,
-> string?, Dictionary<string, object>?)` are declared at that tag. Probed on 2026-09-05 by reading
-> the tree: no plugin was compiled or loaded here. **Disclosed**: the DriveZone runtime measured
-> the same day reports `AssettoServer 0.0.55+51d8d8a6e0`, built from a tree whose csproj targets
-> `net9.0` — on that host `System.Threading.Lock` exists and the `net8.0` fallback below is one
-> major behind. The doctrine is re-derived for `0.0.55` in a follow-up, not silently here.
+> **Verified against**: `AssettoServer v0.0.55-pre25` — the tag the DriveZone image
+> `drivezone/assettoserver:local` runs (`./AssettoServer --version` → `AssettoServer
+> 0.0.55+51d8d8a6e0`, commit `51d8d8a6`; the binary embeds `System.Private.CoreLib 9.0`). `git show v0.0.55-pre25:AssettoServer/AssettoServer.csproj` → `net9.0`,
+> `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`. Probed on 2026-09-05: a minimal plugin
+> (Autofac module + `ACModuleBase` command + `lock` on `System.Threading.Lock`) published against
+> that tree in `mcr.microsoft.com/dotnet/sdk:9.0` (SDK 9.0.315) in 29 s — `.dll` + `.deps.json` +
+> `.runtimeconfig.json` (`tfm net9.0`), no host assembly copied, type references include
+> `System.Threading.Lock` and `AssettoServer.Commands.ACModuleBase` — and the DriveZone image
+> loaded it: `[INF] Loaded plugin ProbePlugin` before the server stopped on missing game content.
+> Not probed: a chat command executed in game; the plugin-facing diff below is read from the
+> source, not exercised. Pinned to `v0.0.54` (`net8.0`) until this date — the
+> `System.Threading.Lock` row below carries that host range.
 
 Distilled from a production plugin (DriveZone.AssettoServer.Plugin) that survived real
 AssettoServer runtime incompatibilities. Prescriptive: follow these unless the project documents a
@@ -42,15 +45,18 @@ installed version wins: `verify-before-claiming`.
 
 The plugin is loaded by AssettoServer's `AssemblyLoadContext` into a specific runtime release. It
 MUST be compiled against the upstream **source checkout at the exact tag matching that runtime**
-(runtime 0.0.54 ↔ upstream tag v0.0.54). Anything else is undefined behavior at load time.
+(runtime `0.0.55+51d8d8a6e0` ↔ upstream tag `v0.0.55-pre25`; the DriveZone image reports the
+former, the clone's `git describe` the latter). Anything else is undefined behavior at load time.
 
 Encode this in the build, don't rely on discipline:
 
 - Do NOT hardcode the TFM — inherit it from upstream. **A fallback default here is a trap**: it is
   used exactly when detection failed, which is when you can least afford a guess. Pin it to the
   runtime you actually target and treat a mismatch as an error, not a default:
-  `<TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>` — upstream
-  **v0.0.54 targets `net8.0`** (verified against its `AssettoServer.csproj` at that tag). In the
+  `<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` — upstream
+  **v0.0.55-pre25 targets `net9.0`** (read from its `AssettoServer.csproj` at that tag; `v0.0.54`
+  targeted `net8.0`, which is why a fallback frozen at one release goes stale). Upstream's own
+  plugins (`SamplePlugin.csproj`) hardcode `net9.0`; this rule is stricter on purpose. In the
   publish script detect the real one:
   `awk -F'[><]' '/<TargetFramework>/{print $3; exit}' "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj"`,
   then pass `-p:TargetFramework="$target_framework"` to `dotnet publish`.
@@ -139,23 +145,46 @@ public class MyPluginCommandModule : ACModuleBase
 Qmmands instantiates command modules by reflection, without DI. These three constructs compile
 fine and fail only inside the real runtime — enforce them with the bug-hunter gate below.
 
-**The third row is version-scoped.** It holds while the pinned runtime targets `net8.0`. When the pin
-moves to a runtime on .NET 9 or later the type exists and the ban must be lifted rather than carried
-forward — re-read the detected TFM at that point, and scope the Cecil assert to it instead of
-asserting it unconditionally.
+Every row names the host range it holds for. A row whose reason is a version fact expires with the
+pin: the `System.Threading.Lock` ban held for `v0.0.54` (`net8.0`) and was lifted on 2026-09-05, when
+the pin moved to `v0.0.55-pre25` (`net9.0`) and a plugin using the type published and loaded there
+(block above). Scope the matching Cecil assert to the detected TFM instead of asserting it
+unconditionally (`bug-hunter`, dotnet track).
 
-| Forbidden | Why | Do instead |
-|---|---|---|
-| `CommandContext.Services` (`get_Services()`) | crashes at command execution | static accessor bridge (below) |
-| Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | parameterless ctor + accessor |
-| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; the pinned runtime is **net8.0**, so it is absent at load time | `private readonly object _lock = new();` |
+| Forbidden | Why | Host range | Do instead |
+|---|---|---|---|
+| `CommandContext.Services` (`get_Services()`) | crashes at command execution | every tag so far (`ACModuleBase` unchanged between `v0.0.54` and `v0.0.55-pre25`) | static accessor bridge (below) |
+| Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | every tag so far (`Qmmands 5.0.2` on both) | parameterless ctor + accessor |
+| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; a `net8.0` host has no such type at load time | **only** hosts on `v0.0.54` / `net8.0`; allowed on `v0.0.55-pre25` / `net9.0` | on a `net8.0` host: `private readonly object _lock = new();` |
 
 **Static accessor bridge** — the sanctioned way to get services into command modules: the
 `IHostedService` publishes DI-built singletons into static accessors at `StartAsync`
 (`MyServiceAccessor.Set(_service)`); the command calls
 `MyServiceAccessor.GetOrCreateFromLocalConfiguration()`, which returns the DI instance or — if DI
-never ran — builds one from the fallback YAML loader. All accessor state behind a `lock` on a
-plain `object`.
+never ran — builds one from the fallback YAML loader. All accessor state behind a `lock` — on a
+`System.Threading.Lock` on the `net9.0` host, on a plain `object` only where a `net8.0` host must
+still load the plugin.
+
+## What moved between v0.0.54 and v0.0.55-pre25 (plugin-facing)
+
+Read from `git diff v0.0.54 v0.0.55-pre25 -- AssettoServer/Server/Plugin AssettoServer/Commands
+AssettoServer/Server/CSPServerScriptProvider.cs` on 2026-09-05 (7 files, +118/−42). Only what a plugin
+author hits:
+
+- `AssettoServerModule` gained `virtual object? ReferenceConfiguration` and
+  `virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)`; the generic form is
+  now `AssettoServerModule<TConfig> where TConfig : new()` and returns `new TConfig()` as the
+  reference configuration — your YAML POCO needs a parameterless constructor.
+- `LoadedPlugin` is built with `required init` properties and carries `Directory` plus the derived
+  file names `plugin_<snake_case>_cfg.yml`, `plugin_<snake_case>_cfg.schema.json` and
+  `plugin_<snake_case>_cfg.reference.yml` (`Configuration` in the type name is shortened to `Cfg`).
+  `ACPluginLoader.LoadPlugins` and `ScanDirectory` are no longer public — do not call the loader.
+- `RequireAdminAttribute` now checks `BaseCommandContext { IsAdministrator: true }` instead of
+  matching `RconCommandContext` / `ChatCommandContext`; a fake context in command-runtime tests
+  sets `IsAdministrator`.
+- `CSPServerScriptProvider` gained a constructor parameter and `OnExtraOptionsSending`; the three
+  `AddScript` overloads and `AddScriptFile` kept their signatures.
+- `ACModuleBase` did not change.
 
 ## Calling an external backend from inside the runtime
 

--- a/plugins/game/skills/assettoserver-plugin/references/publish-pipeline.md
+++ b/plugins/game/skills/assettoserver-plugin/references/publish-pipeline.md
@@ -10,7 +10,7 @@ dispatch when already containerized.
 git status --short --branch                      # know your tree before editing
 bash -n tooling/scripts/*.sh                     # 1. shell syntax gate
 tooling/scripts/run-plugin-tests.sh              # 2. unit tests (host-free)
-export ASSETTOSERVER_SOURCE_DIR=~/src/AssettoServer   # checkout at the runtime's tag!
+export ASSETTOSERVER_SOURCE_DIR=~/src/AssettoServer   # checkout at the runtime's tag (v0.0.55-pre25 for 0.0.55+51d8d8a6e0)!
 tooling/scripts/build-drivezone-plugin.sh        # 3. compile against upstream
 tooling/scripts/publish-drivezone-plugin.sh      # 4. publish (docker by default)
 tooling/scripts/run-bug-hunter.sh                # 5. Cecil inspection of the published DLL
@@ -23,7 +23,7 @@ script checks for the rite proof (below) before copying.
 ## Publish script essentials
 
 ```bash
-# TFM comes from upstream, never hardcoded:
+# TFM comes from upstream, never hardcoded (reads net9.0 at v0.0.55-pre25, net8.0 at v0.0.54):
 target_framework="$(awk -F'[><]' '/<TargetFramework>/{print $3; exit}' \
   "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj")"
 

--- a/plugins/testing/skills/bug-hunter/SKILL.md
+++ b/plugins/testing/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.2.3
+  version: 2.2.4
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/plugins/testing/skills/bug-hunter/references/track-dotnet-plugin.md
+++ b/plugins/testing/skills/bug-hunter/references/track-dotnet-plugin.md
@@ -21,8 +21,12 @@ the **host's instantiation path**, not just your logic.
 
   Known examples from a production AssettoServer plugin: `CommandContext.get_Services()` (crashes
   at command time), non-parameterless command-module constructors (host instantiates by
-  reflection, DI never runs), `System.Threading.Lock` type references (missing in the host
-  runtime — checked via `GetTypeReferences()`). Every new runtime crash earns a new Cecil assert.
+  reflection, DI never runs), and — **only for a host on `net8.0`** (`AssettoServer v0.0.54`) —
+  `System.Threading.Lock` type references, checked via `GetTypeReferences()`. An assert whose
+  reason is "the type is missing in the host runtime" carries the TFM it holds for and reads the
+  detected TFM before firing: on `v0.0.55-pre25` (`net9.0`) the type exists and a plugin using it
+  loaded (`assettoserver-plugin`, block and forbidden-constructs table, 2026-09-05). Every new
+  runtime crash earns a new Cecil assert; every version-scoped assert names its range.
 - **Publish-shape check**: the artifact triple exists next to the DLL (`.deps.json`,
   `.runtimeconfig.json`); no host assemblies were copied into the plugin output.
 - **Host-instantiation test**: drive the plugin through the host's real reflection path (e.g. a

--- a/skills/assettoserver-plugin/SKILL.md
+++ b/skills/assettoserver-plugin/SKILL.md
@@ -12,7 +12,7 @@ description: >-
   fivem-lua), or general .NET services.
 metadata:
   author: solvelab
-  version: 1.3.3
+  version: 1.4.0
   category: game
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -20,15 +20,18 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 
 # AssettoServer plugin conventions
 
-> **Verified against**: `AssettoServer v0.0.54` source — `git show
-> v0.0.54:AssettoServer/AssettoServer.csproj` gives `net8.0`, `Qmmands 5.0.2`, `Autofac 7.1.0`,
-> `Serilog 3.1.1`; `AssettoServerModule`, `ACModuleBase`, the
-> `RequireConnectedPlayer`/`RequireAdmin` attributes and `CSPServerScriptProvider.AddScript(string,
-> string?, Dictionary<string, object>?)` are declared at that tag. Probed on 2026-09-05 by reading
-> the tree: no plugin was compiled or loaded here. **Disclosed**: the DriveZone runtime measured
-> the same day reports `AssettoServer 0.0.55+51d8d8a6e0`, built from a tree whose csproj targets
-> `net9.0` — on that host `System.Threading.Lock` exists and the `net8.0` fallback below is one
-> major behind. The doctrine is re-derived for `0.0.55` in a follow-up, not silently here.
+> **Verified against**: `AssettoServer v0.0.55-pre25` — the tag the DriveZone image
+> `drivezone/assettoserver:local` runs (`./AssettoServer --version` → `AssettoServer
+> 0.0.55+51d8d8a6e0`, commit `51d8d8a6`; the binary embeds `System.Private.CoreLib 9.0`). `git show v0.0.55-pre25:AssettoServer/AssettoServer.csproj` → `net9.0`,
+> `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`. Probed on 2026-09-05: a minimal plugin
+> (Autofac module + `ACModuleBase` command + `lock` on `System.Threading.Lock`) published against
+> that tree in `mcr.microsoft.com/dotnet/sdk:9.0` (SDK 9.0.315) in 29 s — `.dll` + `.deps.json` +
+> `.runtimeconfig.json` (`tfm net9.0`), no host assembly copied, type references include
+> `System.Threading.Lock` and `AssettoServer.Commands.ACModuleBase` — and the DriveZone image
+> loaded it: `[INF] Loaded plugin ProbePlugin` before the server stopped on missing game content.
+> Not probed: a chat command executed in game; the plugin-facing diff below is read from the
+> source, not exercised. Pinned to `v0.0.54` (`net8.0`) until this date — the
+> `System.Threading.Lock` row below carries that host range.
 
 Distilled from a production plugin (DriveZone.AssettoServer.Plugin) that survived real
 AssettoServer runtime incompatibilities. Prescriptive: follow these unless the project documents a
@@ -42,15 +45,18 @@ installed version wins: `verify-before-claiming`.
 
 The plugin is loaded by AssettoServer's `AssemblyLoadContext` into a specific runtime release. It
 MUST be compiled against the upstream **source checkout at the exact tag matching that runtime**
-(runtime 0.0.54 ↔ upstream tag v0.0.54). Anything else is undefined behavior at load time.
+(runtime `0.0.55+51d8d8a6e0` ↔ upstream tag `v0.0.55-pre25`; the DriveZone image reports the
+former, the clone's `git describe` the latter). Anything else is undefined behavior at load time.
 
 Encode this in the build, don't rely on discipline:
 
 - Do NOT hardcode the TFM — inherit it from upstream. **A fallback default here is a trap**: it is
   used exactly when detection failed, which is when you can least afford a guess. Pin it to the
   runtime you actually target and treat a mismatch as an error, not a default:
-  `<TargetFramework Condition="'$(TargetFramework)' == ''">net8.0</TargetFramework>` — upstream
-  **v0.0.54 targets `net8.0`** (verified against its `AssettoServer.csproj` at that tag). In the
+  `<TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>` — upstream
+  **v0.0.55-pre25 targets `net9.0`** (read from its `AssettoServer.csproj` at that tag; `v0.0.54`
+  targeted `net8.0`, which is why a fallback frozen at one release goes stale). Upstream's own
+  plugins (`SamplePlugin.csproj`) hardcode `net9.0`; this rule is stricter on purpose. In the
   publish script detect the real one:
   `awk -F'[><]' '/<TargetFramework>/{print $3; exit}' "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj"`,
   then pass `-p:TargetFramework="$target_framework"` to `dotnet publish`.
@@ -139,23 +145,46 @@ public class MyPluginCommandModule : ACModuleBase
 Qmmands instantiates command modules by reflection, without DI. These three constructs compile
 fine and fail only inside the real runtime — enforce them with the bug-hunter gate below.
 
-**The third row is version-scoped.** It holds while the pinned runtime targets `net8.0`. When the pin
-moves to a runtime on .NET 9 or later the type exists and the ban must be lifted rather than carried
-forward — re-read the detected TFM at that point, and scope the Cecil assert to it instead of
-asserting it unconditionally.
+Every row names the host range it holds for. A row whose reason is a version fact expires with the
+pin: the `System.Threading.Lock` ban held for `v0.0.54` (`net8.0`) and was lifted on 2026-09-05, when
+the pin moved to `v0.0.55-pre25` (`net9.0`) and a plugin using the type published and loaded there
+(block above). Scope the matching Cecil assert to the detected TFM instead of asserting it
+unconditionally (`bug-hunter`, dotnet track).
 
-| Forbidden | Why | Do instead |
-|---|---|---|
-| `CommandContext.Services` (`get_Services()`) | crashes at command execution | static accessor bridge (below) |
-| Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | parameterless ctor + accessor |
-| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; the pinned runtime is **net8.0**, so it is absent at load time | `private readonly object _lock = new();` |
+| Forbidden | Why | Host range | Do instead |
+|---|---|---|---|
+| `CommandContext.Services` (`get_Services()`) | crashes at command execution | every tag so far (`ACModuleBase` unchanged between `v0.0.54` and `v0.0.55-pre25`) | static accessor bridge (below) |
+| Command-module constructor with parameters | Qmmands reflects a parameterless ctor; DI never runs | every tag so far (`Qmmands 5.0.2` on both) | parameterless ctor + accessor |
+| `System.Threading.Lock` (C# 13 `lock` on `Lock`) | the type ships in **.NET 9**; a `net8.0` host has no such type at load time | **only** hosts on `v0.0.54` / `net8.0`; allowed on `v0.0.55-pre25` / `net9.0` | on a `net8.0` host: `private readonly object _lock = new();` |
 
 **Static accessor bridge** — the sanctioned way to get services into command modules: the
 `IHostedService` publishes DI-built singletons into static accessors at `StartAsync`
 (`MyServiceAccessor.Set(_service)`); the command calls
 `MyServiceAccessor.GetOrCreateFromLocalConfiguration()`, which returns the DI instance or — if DI
-never ran — builds one from the fallback YAML loader. All accessor state behind a `lock` on a
-plain `object`.
+never ran — builds one from the fallback YAML loader. All accessor state behind a `lock` — on a
+`System.Threading.Lock` on the `net9.0` host, on a plain `object` only where a `net8.0` host must
+still load the plugin.
+
+## What moved between v0.0.54 and v0.0.55-pre25 (plugin-facing)
+
+Read from `git diff v0.0.54 v0.0.55-pre25 -- AssettoServer/Server/Plugin AssettoServer/Commands
+AssettoServer/Server/CSPServerScriptProvider.cs` on 2026-09-05 (7 files, +118/−42). Only what a plugin
+author hits:
+
+- `AssettoServerModule` gained `virtual object? ReferenceConfiguration` and
+  `virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)`; the generic form is
+  now `AssettoServerModule<TConfig> where TConfig : new()` and returns `new TConfig()` as the
+  reference configuration — your YAML POCO needs a parameterless constructor.
+- `LoadedPlugin` is built with `required init` properties and carries `Directory` plus the derived
+  file names `plugin_<snake_case>_cfg.yml`, `plugin_<snake_case>_cfg.schema.json` and
+  `plugin_<snake_case>_cfg.reference.yml` (`Configuration` in the type name is shortened to `Cfg`).
+  `ACPluginLoader.LoadPlugins` and `ScanDirectory` are no longer public — do not call the loader.
+- `RequireAdminAttribute` now checks `BaseCommandContext { IsAdministrator: true }` instead of
+  matching `RconCommandContext` / `ChatCommandContext`; a fake context in command-runtime tests
+  sets `IsAdministrator`.
+- `CSPServerScriptProvider` gained a constructor parameter and `OnExtraOptionsSending`; the three
+  `AddScript` overloads and `AddScriptFile` kept their signatures.
+- `ACModuleBase` did not change.
 
 ## Calling an external backend from inside the runtime
 

--- a/skills/assettoserver-plugin/references/publish-pipeline.md
+++ b/skills/assettoserver-plugin/references/publish-pipeline.md
@@ -10,7 +10,7 @@ dispatch when already containerized.
 git status --short --branch                      # know your tree before editing
 bash -n tooling/scripts/*.sh                     # 1. shell syntax gate
 tooling/scripts/run-plugin-tests.sh              # 2. unit tests (host-free)
-export ASSETTOSERVER_SOURCE_DIR=~/src/AssettoServer   # checkout at the runtime's tag!
+export ASSETTOSERVER_SOURCE_DIR=~/src/AssettoServer   # checkout at the runtime's tag (v0.0.55-pre25 for 0.0.55+51d8d8a6e0)!
 tooling/scripts/build-drivezone-plugin.sh        # 3. compile against upstream
 tooling/scripts/publish-drivezone-plugin.sh      # 4. publish (docker by default)
 tooling/scripts/run-bug-hunter.sh                # 5. Cecil inspection of the published DLL
@@ -23,7 +23,7 @@ script checks for the rite proof (below) before copying.
 ## Publish script essentials
 
 ```bash
-# TFM comes from upstream, never hardcoded:
+# TFM comes from upstream, never hardcoded (reads net9.0 at v0.0.55-pre25, net8.0 at v0.0.54):
 target_framework="$(awk -F'[><]' '/<TargetFramework>/{print $3; exit}' \
   "$ASSETTOSERVER_SOURCE_DIR/AssettoServer/AssettoServer.csproj")"
 

--- a/skills/bug-hunter/SKILL.md
+++ b/skills/bug-hunter/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   api-resilience-testing.
 metadata:
   author: solvelab
-  version: 2.2.3
+  version: 2.2.4
   category: testing
 license: MIT
 compatibility: Works in any environment with filesystem access.

--- a/skills/bug-hunter/references/track-dotnet-plugin.md
+++ b/skills/bug-hunter/references/track-dotnet-plugin.md
@@ -21,8 +21,12 @@ the **host's instantiation path**, not just your logic.
 
   Known examples from a production AssettoServer plugin: `CommandContext.get_Services()` (crashes
   at command time), non-parameterless command-module constructors (host instantiates by
-  reflection, DI never runs), `System.Threading.Lock` type references (missing in the host
-  runtime — checked via `GetTypeReferences()`). Every new runtime crash earns a new Cecil assert.
+  reflection, DI never runs), and — **only for a host on `net8.0`** (`AssettoServer v0.0.54`) —
+  `System.Threading.Lock` type references, checked via `GetTypeReferences()`. An assert whose
+  reason is "the type is missing in the host runtime" carries the TFM it holds for and reads the
+  detected TFM before firing: on `v0.0.55-pre25` (`net9.0`) the type exists and a plugin using it
+  loaded (`assettoserver-plugin`, block and forbidden-constructs table, 2026-09-05). Every new
+  runtime crash earns a new Cecil assert; every version-scoped assert names its range.
 - **Publish-shape check**: the artifact triple exists next to the DLL (`.deps.json`,
   `.runtimeconfig.json`); no host assemblies were copied into the plugin output.
 - **Host-instantiation test**: drive the plugin through the host's real reflection path (e.g. a


### PR DESCRIPTION
Closes #147
Spec-rite: update-assettoserver-plugin-runtime

## O que muda

- **`assettoserver-plugin` 1.3.3 → 1.4.0**: o pin sai de `v0.0.54`/`net8.0` para o que a imagem DriveZone roda — `AssettoServer 0.0.55+51d8d8a6e0`, tag `v0.0.55-pre25`, csproj `net9.0`, `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2`. A two-contract rule troca o exemplo de fallback para `net9.0` e diz por que um fallback congelado num release envelhece. A tabela de construções proibidas ganha a coluna **Host range**: as duas linhas Qmmands valem em todo tag (`ACModuleBase` não mudou); a linha `System.Threading.Lock` deixa de ser proibição e vira nota escopada a hosts `net8.0` (`v0.0.54`). Nova seção *What moved between v0.0.54 and v0.0.55-pre25 (plugin-facing)* com o que o autor de plugin encontra (7 arquivos, +118/−42).
- **`references/publish-pipeline.md`**: exemplo de checkout cita `v0.0.55-pre25`; detecção de TFM inalterada (é o que já produzia a resposta certa).
- **`bug-hunter` 2.2.3 → 2.2.4**: o exemplo de assert Cecil do `System.Threading.Lock` fica escopado a host `net8.0`, e o track diz que todo assert de "tipo ausente no host" carrega o TFM em que vale e lê o TFM detectado antes de disparar.
- **`skills-authoring`** ADDED *Version-scoped rules move with the pin* (3 cenários).

## Como foi probado (antes de qualquer edição)

| Probe | Observado |
|---|---|
| `git show v0.0.55-pre25:AssettoServer/AssettoServer.csproj` | `net9.0`, `Autofac 8.2.0`, `Serilog 4.2.0`, `Qmmands 5.0.2` (em `v0.0.54`: `net8.0`, 7.1.0, 3.1.1) |
| `./AssettoServer --version` na imagem `drivezone/assettoserver:local` | `AssettoServer 0.0.55+51d8d8a6e0`; binário embute CoreLib 9.0 |
| `dotnet publish` (SDK 9.0.315, `mcr.microsoft.com/dotnet/sdk:9.0`) de plugin mínimo com `lock` sobre `System.Threading.Lock` contra a árvore `v0.0.55-pre25` | exit 0 em 28,6 s; `.dll` + `.deps.json` + `.runtimeconfig.json` (`tfm net9.0`); nenhum assembly do host copiado |
| Leitura de metadados do DLL (System.Reflection.Metadata) | 31 type refs, entre elas `System.Threading.Lock`, `AssettoServer.Commands.ACModuleBase`; assembly refs `System.Runtime 9.0`, `Autofac 8.2`, `Qmmands 5.0.2` |
| Load no container DriveZone (binário direto, `EnablePlugins: [ProbePlugin]`) | `[INF] Loaded plugin ProbePlugin` → `[INF] Starting server` → parada posterior por `No data.acd found for abarth500` (conteúdo ausente, esperado) |
| `git diff v0.0.54 v0.0.55-pre25` na superfície plugin-facing | 7 arquivos: `AssettoServerModule` (`ReferenceConfiguration`, `Configure(IApplicationBuilder, IWebHostEnvironment)`, `where TConfig : new()`), `LoadedPlugin` (`required init`, `plugin_<snake>_cfg.yml`/schema/reference), `ACPluginLoader.LoadPlugins` internal, `RequireAdmin` → `BaseCommandContext.IsAdministrator`, `CSPServerScriptProvider` + `OnExtraOptionsSending`; `ACModuleBase` inalterado |

Não probado, e dito no bloco: comando de chat executado em jogo; o drift é lido do diff, não exercitado contra um plugin que o use.

## Critérios de aceitação

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | `grep net8.0` só em linhas sobre o host `v0.0.54` | met | 5 linhas em SKILL.md + 1 em publish-pipeline.md, todas nomeiam `v0.0.54`/host `net8.0` |
| 2 | Linha do `Lock` version-scoped nos dois lugares | met | `SKILL.md` tabela, coluna *Host range*; `track-dotnet-plugin.md:22-29` |
| 3 | Bloco cita tag, banner, TFM, pacotes, comando do probe, saída e data | met | `SKILL.md:23-35`, datado 2026-09-05 |
| 4 | Drift plugin-facing nomeado (7 arquivos) | met | seção *What moved between v0.0.54 and v0.0.55-pre25* |
| 5 | strict verde; `validate-skills.py` 0; selftest inalterado | met | `Change 'update-assettoserver-plugin-runtime' is valid`; `35 skills, 0 findings`; `21/22` (mesmo MISSED local `C3 lua syntax`, sem luac) |
| 6 | Identificadores conforme Glossary | met | nenhum identificador novo; detector de locale `findings: 0` |

## Simulação (rito)

- Entry points: `dotnet publish` → exit 0; binário do servidor na imagem → `Loaded plugin ProbePlugin`; `validate-skills.py` → 0 findings.
- Contagens: 1/1 plugin com `Lock` compilou; 1/1 foi carregado pelo runtime; 1/1 type ref presente no DLL; 3/3 arquivos da tripla; 0/0 assemblies do host copiados; 35/35 skills caladas nos checks; 0/1 comando em jogo (servidor parou no conteúdo, registrado).
- O que se comportou diferente: `grep -a` no DLL não acha o nome do tipo (namespace e nome ficam em strings separadas no heap) → leitor de metadados; o `start-server.sh` da imagem valida conteúdo antes de subir e não chega ao load → binário direto; o scan de segredos leu a versão de 4 partes da CoreLib como IPv4 → reescrita.

## Validações

| Comando | Resultado |
|---|---|
| `python3 scripts/validate-skills.py` | 35 skills, 0 findings |
| `python3 scripts/selftest-validate-skills.py` | 21/22 (MISSED só `C3 lua syntax`, local) |
| `bash scripts/validate-rite.sh` | `rite gate OK` (2 changes ativas: esta e `require-verified-against`, que aguarda o archive do #131) |
| `openspec validate update-assettoserver-plugin-runtime --strict` | valid |
| `PR_BODY=… validate-skill-version.py` / `validate-spec-rite.py` | 0 findings, 2 skills com bump / 0 findings |
| `generate.sh` + `git status --untracked-files=all` | 0 untracked, árvore limpa |
| `validate-repo-hygiene.py` / `scan-secrets.py` | 0 findings / no credentials |
| `agentskills validate` (skills-ref 0.1.1) / `plugin validate --strict` (2.1.246) | 35/35 / passed |

## Follow-ups (não feitos aqui)

1. A **description** do `assettoserver-plugin` ainda lista `System.Threading.Lock` entre as construções proibidas que cobre; agora é uma linha escopada. Mudar description é mudar trigger — item próprio.
2. O servidor em `v0.0.55-pre25` loga `Using minimum required CSP Version 1937` com `extra_cfg.yml` padrão — número útil para a lacuna aberta do `assettoserver-csp-lua`.
3. NuGet reporta vulnerabilidades em `Scriban 6.0.0` (NU1902–NU1904) ao restaurar a árvore upstream — dependência do upstream.
4. Archive do `require-verified-against` (#131) segue pendente em PR própria.

## Pendente do rito

- `openspec archive update-assettoserver-plugin-runtime --yes` após o merge, em PR própria (V.4 aberto de propósito).
