### PR TITLE
📝 docs(documentation): pré-requisito colhido do manifesto, com valor que aprova e com egress

### DIFF
--- a/claude/skills/documentation/SKILL.md
+++ b/claude/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.3
+  version: 3.1.0
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/documentation.mdc
+++ b/cursor/rules/documentation.mdc
@@ -25,7 +25,13 @@ Never write a line of documentation before reading the code it describes.
 2. Read the entry point, the config module, the dependency manifest, and any existing docs.
 3. Identify: language, framework, how it is configured, how it is run, what it integrates with.
 4. **Extract the facts**, don't invent them: env vars from the config module, endpoints from the
-   router, commands from the manifest scripts / Makefile / CI, ports from the compose file.
+   router, commands from the manifest scripts / Makefile / CI, and — from the deployment manifest
+   (compose file, chart, Kubernetes manifest, systemd unit) — the ports, the compute and storage the
+   project asks for, the uid/gid it runs as, and the filesystem modes it needs. Prerequisites are
+   read from that file, never composed from memory: measured on a production repo, the setup guide
+   listed four prerequisites while the manifest two directories away carried the CPU and memory
+   requests and limits, the volume size, both node ports, the uid and the read-only root — none of
+   which reached the guide.
 
 Only document what you read. A fact that matters and could not be verified is written as an admitted
 gap ("Deployment target: not documented in this repo"), never guessed — the ladder for finding it and
@@ -74,6 +80,18 @@ the repo, and write them so it can:
 
 - **Repo paths are links**, not prose: `[app/main.py](app/main.py)`. A link is checkable; a sentence
   is not.
+- **A prerequisite states the value that passes**, not only the command that probes it. `kubectl
+  version` printing a JSON blob proves the reader has *a* cluster, and an expected result of "a JSON
+  block" is satisfied by every run — a step that cannot fail does not verify, it reassures, and that
+  costs the reader attention while returning nothing. Name the minimum, the range, or the exact
+  string. Where one command's results mean different failures with opposite fixes, map each result to
+  its meaning in a table; a single "expected" line can only describe success.
+- **What the software must reach is a prerequisite too.** Inbound ports get written down; outbound
+  destinations almost never do — and for anything that notifies, integrates, pulls an image or calls
+  an API, blocked egress fails *silently*: the process is healthy, the request never lands, and no
+  error surfaces where anyone looks. List the hostnames and ports the software must reach out to, and
+  say what the reader sees when it cannot. What the service should *do* while that dependency is
+  down is a different subject, and it belongs to `backend-resilience`.
 - **Directory trees show the real root.** Measured on a production repo: a README tree written without
   its `src/` prefix made every path in it unresolvable, and one entry had been renamed months earlier
   — 9 of 10 entries wrong in a block the reader trusts most.

--- a/openspec/changes/update-documentation-prerequisites/.openspec.yaml
+++ b/openspec/changes/update-documentation-prerequisites/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/update-documentation-prerequisites/design.md
+++ b/openspec/changes/update-documentation-prerequisites/design.md
@@ -1,0 +1,91 @@
+## Context
+
+A `documentation` foi endurecida em `2026-08-06-harden-documentation-skill` por medição, não por
+revisão, e a decisão `D3` daquele change escolheu a checabilidade como regra central: o braço revisado
+escreveu 131 afirmações checáveis contra 84 do controle. A `D7` mandou os esqueletos para
+`references/`, porque são lidos na hora de gerar e não na hora de escolher.
+
+Este change ataca o que aquela medição não cobriu: o **bloco de pré-requisitos** de um guia de
+instalação. A evidência de campo é `solvelab/feldt`, documentado com esta skill e com duas guardas de
+documentação em CI — ou seja, um caso onde a skill foi seguida e o buraco ficou mesmo assim.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Que a regra de colher fatos alcance a superfície de implantação, e não pare na porta do compose.
+- Que pré-requisito sondável carregue o valor que aprova, não só o comando.
+- Que o destino de saída seja categoria de primeira classe.
+- Que o catálogo ganhe o requisito autoral que o caso ensinou, sem duplicar doutrina.
+
+**Non-Goals**
+
+- Não prescrever números de hardware na skill. O requisito *Prescribed numbers carry the rule that
+  produces them* pede a regra, e a regra aqui é "leia do manifesto do projeto documentado".
+- Não escrever validador para o requisito novo. Ver `D3` abaixo.
+- Não consertar o feldt neste change. Ele é a prova, e a prova não se edita.
+- Não adotar o esqueleto do Good Docs como layout de arquivo — a `D2` do change de endurecimento já
+  decidiu que o `README`/`SETUP`/`TECHNICAL` fica.
+
+## Decisions
+
+**D1 — A superfície de implantação entra na lista de fontes, não numa regra nova.** A linha
+*Extract the facts* já enumera fonte por tipo de fato, e a porta do compose já está lá. Recursos,
+armazenamento, identidade e modo de filesystem são o mesmo tipo de fato lido do mesmo tipo de
+arquivo; separá-los numa regra própria criaria duas casas para uma doutrina só, contra o requisito
+*Single canonical home per rule*.
+
+**D2 — O valor que aprova é regra do `SKILL.md`, a lista de categorias é esqueleto do
+`references/`.** Pela `D7` do change de endurecimento: o que decide *se* e *por quê* fica na
+política, o que decide *o formato* fica no esqueleto. A lista de dez categorias é formato.
+
+**D3 — O requisito autoral novo entra sem validador, e isso é declarado.** Detectar "verificação sem
+critério de aprovação" exigiria decidir, sobre prosa, se um trecho de saída esperada é um critério.
+`# Esperado: um bloco JSON` e `# Esperado: v1.29 ou maior` têm a mesma forma e significados opostos.
+Um detector aqui produziria falso positivo, e o cenário *Partial coverage is declared, not implied*
+do `skills-authoring` manda declarar a condição e o que escapa dela em vez de presumir conformidade.
+A revisão é humana, e está escrito.
+
+**D4 — Egress é categoria própria, e não um subcaso de "rede".** Nenhuma das cinco fontes externas
+consultadas nomeia egress como pré-requisito: K3s, Grafana, Good Docs, Elastic ECK e Portainer
+documentam entrada, armazenamento, permissões e versões. A categoria é contribuição própria, paga por
+um defeito medido, e por isso entra com o defeito escrito ao lado — a doutrina deste repositório não
+aceita linha sem evidência.
+
+**D5 — A tabela de diagnóstico entra como forma prescrita.** O contra-modelo veio do próprio feldt:
+`deploy/standalone/README.md` §1 mede alcançabilidade e separa `qualquer HTTP`, `http=000` lento
+(firewall filtrando em silêncio) e `http=000` instantâneo (RST) — três leituras do mesmo comando com
+**remédios opostos**. Uma linha de "esperado" não consegue dizer isso; uma tabela consegue.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| De onde se lê cada tipo de fato ao documentar | `documentation` | already canonical — a lista de fontes ganha a superfície de implantação |
+| O que um bloco de pré-requisitos precisa cobrir | `documentation/references/templates.md` | establish here (new) — esqueleto, pela `D7` |
+| Pré-requisito carrega o valor que aprova | `documentation` | establish here (new) |
+| Egress como pré-requisito documentado | `documentation` | establish here (new) |
+| Como pesquisar um fato antes de afirmá-lo, e o relatório quando não se acha | `verify-before-claiming` | link (already canonical) — não repetir a escada aqui |
+| O que o serviço faz em runtime quando a dependência está fora | `backend-resilience` | link (already canonical) — este change documenta o pré-requisito, não o comportamento |
+| Verificação prescrita diz o que aprova | `openspec/specs/skills-authoring` | spec delta, não conteúdo de skill |
+
+## Risks / Trade-offs
+
+- [A lista de dez categorias vira formulário que alguém preenche com "N/A"] → cada categoria entra com
+  a fonte externa que a pede, e o esqueleto diz que categoria que não se aplica sai da lista em vez de
+  virar linha vazia — a mesma regra que a skill já aplica à tabela de decisão de documentos.
+- [O requisito autoral nasce sem enforcement e vira letra morta] → aceito e declarado na `D3`, com a
+  razão medida. A alternativa era um detector com falso positivo, que este repositório já mediu ser
+  pior: teste que reprova sem defeito é desligado.
+- [A `documentation` incha e perde a densidade que o `harden-documentation-skill` conquistou] → o
+  `SKILL.md` recebe três regras curtas; a lista vai para `references/`, que é onde o esqueleto mora e
+  onde o custo é lido só na hora de gerar.
+- [O egress é específico demais e não generaliza para software sem rede] → o esqueleto marca a
+  categoria como condicional ("quando o produto chama algo de fora"), na mesma forma condicional que
+  a tabela de decisão de documentos já usa.
+
+## Open Questions
+
+- Se a varredura registrada em E.4 achar outras skills prescrevendo verificação sem critério, elas
+  entram uma a uma ou numa varredura só? A `D1` do change de endurecimento preferiu a decisão por
+  caso; a resposta fica para o item que a varredura abrir.

--- a/openspec/changes/update-documentation-prerequisites/proposal.md
+++ b/openspec/changes/update-documentation-prerequisites/proposal.md
@@ -1,0 +1,79 @@
+# Change: Pré-requisito colhido do manifesto, com valor que aprova e com egress
+
+## Why
+
+A `documentation` manda extrair fatos em vez de inventá-los e nomeia as fontes
+(`skills/documentation/SKILL.md:36-37`): env var do módulo de config, endpoint do router, comando do
+manifest, **porta do compose**. E manda verificar cada passo
+(`skills/documentation/references/templates.md:223-224`): "the command that confirms it worked and
+the output it should print".
+
+As duas regras param cedo, e o custo foi medido em `solvelab/feldt` — um serviço documentado com esta
+skill, com sete páginas e duas guardas de documentação em CI.
+
+**A lista de fontes não alcança a superfície de implantação.** O `docs/SETUP.md` §1 do feldt lista
+quatro pré-requisitos. O `deploy/feldt.yaml`, dois diretórios ao lado, carrega `cpu: 50m`/`200m`
+(`:155`,`:158`), `memory: 128Mi`/`256Mi` (`:156`,`:159`), `storage: 1Gi` (`:39`), `nodePort: 30080` e
+`30081` (`:63`,`:88`), `runAsUser`/`fsGroup: 65532` (`:113-114`) e `readOnlyRootFilesystem: true`
+(`:162`). Nenhum chegou ao §1. A regra cobre porta do compose e para ali, então requests, limits,
+tamanho de volume, uid e modo de filesystem não têm fonte nomeada — e o que não tem fonte é composto
+de memória.
+
+**Verificação sem valor de aprovação.** O mesmo §1 traz `kubectl version --output=json | head -5` com
+"Esperado: um bloco JSON com clientVersion e serverVersion". Isso prova que o `kubectl` fala com *um*
+cluster; não diz qual versão passa. `grep -rniE 'kubernetes 1\.|kubectl 1\.|versão mínima|minimum
+version'` no repositório inteiro do feldt devolve zero linhas. A regra do `templates.md` pede "the
+output it should print", e a saída que esse comando imprime **é** um bloco JSON — imprimir não é
+aprovar.
+
+**Egress não é pré-requisito em lugar nenhum.** Nenhuma das nove páginas do feldt declara que o
+cluster precisa alcançar `api.telegram.org`, `chat.googleapis.com` ou a URL de webhook. Porta de
+entrada se documenta; destino de saída não. O agravante é o sintoma: o feldt é um dead man's switch,
+e egress bloqueado produz silêncio — o estado que o produto existe para distinguir de saúde.
+
+## What Changes
+
+- `skills/documentation/SKILL.md`: a linha *Extract the facts* passa a nomear o manifesto de
+  implantação como fonte de recursos, armazenamento, portas, identidade e modo de filesystem; regra
+  nova de que pré-requisito sondável carrega o comando **e o valor que aprova**; regra nova de que
+  destino de saída é pré-requisito, com a razão de a falha dele ser silenciosa.
+- `skills/documentation/references/templates.md`: as convenções do `docs/SETUP.md` ganham a lista de
+  categorias de pré-requisito, cada uma com a fonte externa que a pede, e a forma de tabela de
+  diagnóstico para sintoma único com remédios opostos.
+- `metadata.version` da `documentation`: `3.0.3` -> `3.1.0`; árvores geradas regeneradas.
+- Delta em `skills-authoring`: requisito ADDED *A prescribed verification states what passes*,
+  generalizando o segundo defeito para todo o catálogo.
+
+## Deliberately not done
+
+- **Consertar o `docs/SETUP.md` do feldt.** Ele é a evidência de campo deste item; consertá-lo aqui
+  confundiria a prova com o conserto. Item próprio, no repositório dele.
+- **Validador para o requisito autoral novo.** Um detector de "verificação sem critério" sobre prosa
+  produziria falso positivo, que é o defeito que este repositório mais rejeita. A ausência é
+  declarada no `design.md`, conforme o cenário *Partial coverage is declared, not implied*.
+- **Números concretos de hardware na skill.** O requisito *Prescribed numbers carry the rule that
+  produces them* proíbe: o número certo é do projeto documentado, e a skill entrega a regra que o
+  produz.
+- **Varredura do catálogo por violações do requisito novo.** Achado registrado em E.4, não entrega
+  deste item.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `skills-authoring`: ADDED requirement — uma skill que prescreve um passo de verificação SHALL dizer
+  o valor que aprova, e não só o comando e a saída que ele imprime. Uma verificação sem critério de
+  aprovação não verifica; ela tranquiliza, que é pior que não verificar.
+
+## Impact
+
+- `skills/documentation/SKILL.md` e `skills/documentation/references/templates.md` — as duas skills
+  afetadas são uma só; nenhuma outra skill do catálogo muda.
+- `claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/` — regenerados por `generate.sh`.
+- Consumidores: projetos documentados com esta skill passam a receber pré-requisito colhido do
+  manifesto e com valor de aprovação. Não muda a composição do catálogo, então a descoberta por
+  `npx` fica intacta e nenhuma contagem publicada se move.

--- a/openspec/changes/update-documentation-prerequisites/specs/skills-authoring/spec.md
+++ b/openspec/changes/update-documentation-prerequisites/specs/skills-authoring/spec.md
@@ -1,0 +1,40 @@
+## ADDED Requirements
+
+### Requirement: A prescribed verification states what passes
+
+A skill that tells the reader to verify a step SHALL state the value that passes, not only the
+command and the output it prints. A verification whose expected result is satisfied by any run of the
+command does not verify; it reassures, which is worse than no verification because it consumes the
+reader's attention and returns nothing.
+
+Where one command's output distinguishes failures that need opposite remedies, the skill SHALL
+prescribe a table mapping each observable result to its meaning, rather than a single "expected"
+line that can only describe the success case.
+
+#### Scenario: A version probe names the version that passes
+
+- **WHEN** a skill prescribes a command whose purpose is to establish that a dependency is present at
+  a supported version
+- **THEN** the prescribed step states the minimum or the range that passes, so that a reader running
+  it against an unsupported version fails the step instead of continuing
+
+#### Scenario: An expected output that any run satisfies is a defect
+
+- **WHEN** the expected result of a prescribed verification is a shape the command prints regardless
+  of whether the underlying condition holds
+- **THEN** it is treated as a missing criterion and rewritten to name the passing value, because the
+  step as written cannot fail
+
+#### Scenario: Opposite remedies get a table, not a line
+
+- **WHEN** one prescribed command has results that mean different failures and call for different
+  fixes
+- **THEN** the skill maps each result to its meaning and its remedy in a table, instead of naming
+  only the success case and leaving the reader to guess which failure they hit
+
+#### Scenario: The criterion is reviewed by hand, and that is declared
+
+- **WHEN** a skill adds or edits a prescribed verification
+- **THEN** the criterion is reviewed by a human, and the skill's change records that no validator
+  covers this rule, because distinguishing a criterion from a shape description in prose is a
+  judgement a checker would get wrong in both directions

--- a/openspec/changes/update-documentation-prerequisites/tasks.md
+++ b/openspec/changes/update-documentation-prerequisites/tasks.md
@@ -1,0 +1,180 @@
+## 1. Evidence & Sources (MANDATORY)
+
+<!-- Sempre o PRIMEIRO grupo: sondar antes de escrever. Registrar o COMANDO e um fragmento da SAÍDA
+     CRUA, nunca uma conclusão. -->
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      No `solvelab/ai-skills`, lidos em `85c453d` (topo de `master`, 2026-09-05):
+
+      - `skills/documentation/SKILL.md` — 185 linhas; `metadata.version: 3.0.3` na linha 13; a linha
+        *Extract the facts* em `:36-37`, enumerando env var, endpoint, comando e porta do compose.
+      - `skills/documentation/references/templates.md` — 366 linhas; *Setup guide conventions* em
+        `:219-230`, com "Prerequisites as `- [ ]` checkboxes" em `:222` e "Verify after every step…
+        the output it should print" em `:223-224`.
+      - `openspec/config.yaml` — `schema: skills-rite`; a regra "Never write a doctrine line whose
+        evidence is not recorded in the Evidence & Sources group".
+      - `openspec/specs/skills-authoring/spec.md` — 16 requisitos; *Single canonical home per rule*
+        (`:11`), *Prescribed numbers carry the rule that produces them* (`:146`), *Checklists are
+        scored against field defects* (`:349`).
+      - `scripts/validate-rite.sh` e `scripts/validate-rite-evidence.py` — as quatro posições
+        obrigatórias e as formas E.1-E.4 / S.1-S.3.
+      - `openspec/changes/archive/2026-08-06-harden-documentation-skill/design.md` — decisões `D3`
+        (checabilidade) e `D7` (esqueletos para `references/`).
+
+      No `solvelab/feldt`, lidos em `1975ada` (topo de `main`, 2026-09-05):
+
+      - `docs/SETUP.md` — §1 *Pré-requisitos* com quatro caixas e o bloco `### Confira o cluster`.
+      - `deploy/feldt.yaml` — `storage: 1Gi` (`:39`), `nodePort: 30080` (`:63`) e `30081` (`:88`),
+        `runAsUser`/`fsGroup: 65532` (`:113-114`), `cpu: 50m`/`memory: 128Mi` (`:155-156`),
+        `limits` `200m`/`256Mi` (`:158-159`), `readOnlyRootFilesystem: true` (`:162`).
+      - `deploy/standalone/README.md` — §1, com a tabela de três leituras do mesmo `curl`.
+
+- [x] E.2 Ferramentas e fontes externas sondadas: comando -> fragmento da saída
+
+      - `grep -rniE 'kubernetes 1\.|k8s 1\.|kubectl 1\.|versão mínima|minimum version' docs/ README.md deploy/ AGENTS.md`
+        no feldt -> nenhuma linha (saída vazia; o `echo '(fim)'` seguinte foi a única coisa impressa).
+      - `sed -n '/^## 1\. Pré-requisitos/,/^## 2\./p' docs/SETUP.md` ->
+        `# Esperado: um bloco JSON com clientVersion e serverVersion`.
+      - `grep -nE 'resources|memory|cpu|requests|limits|containerPort|nodePort|fsGroup|runAsUser' deploy/feldt.yaml`
+        -> `155:              cpu: 50m` e `156:              memory: 128Mi`.
+      - `openspec --version` -> `1.6.0`.
+      - `openspec validate update-documentation-prerequisites --strict` ->
+        `Change 'update-documentation-prerequisites' is valid`.
+      - Fontes externas, por requisição: `https://docs.k3s.io/installation/requirements` -> seções
+        *Architecture*, *Operating Systems*, *Hardware* (`"2 cores"` e `"2 GB"` para server, `"1 core"`
+        e `"512 MB"` para agent) e *Networking* (`"port 6443"`, `"8472"`, `"51820/51821"`).
+      - `https://grafana.com/docs/grafana/latest/setup-grafana/installation/` -> mínimos
+        `"512 MB"` de memória, `"1 core"` de CPU, disco de 10-50 GB por porte; SO suportados;
+        bancos `"SQLite 3"`, `"MySQL 8.0+"`, `"PostgreSQL 12+"`; navegadores Chrome, Firefox, Safari,
+        Edge, com "JavaScript must be enabled".
+      - `https://www.thegooddocsproject.dev/template/installation-guide` -> a seção *Before you begin*
+        pede `"Necessary dependencies or packages"`, `"Required version for your system or other
+        system requirements"` e `"Specialist knowledge or skills"`.
+      - `https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/required-rbac-permissions` e
+        `https://docs.portainer.io/start/install-ce/server/kubernetes/baremetal` -> permissões RBAC e
+        StorageClass default como pré-requisitos declarados.
+
+- [x] E.3 O que não deu para sondar
+
+      Não foi possível abrir o `didevlab/housek8s`, que guarda o manifesto vivo do feldt: o
+      repositório não está clonado nesta máquina e o acesso não foi testado. Isso não afeta a doutrina
+      deste change — os números vêm do espelho `deploy/feldt.yaml`, que o CI do feldt exige idêntico
+      ao vivo, byte a byte, no step *Atualizar a tag nos dois manifestos*. Também não foi sondado
+      nenhum cluster: as afirmações sobre StorageClass e RBAC vêm das fontes externas citadas em E.2,
+      não de medição própria, e entram no esqueleto como categoria a documentar, nunca como número.
+
+- [x] E.4 Escopo e desdobramentos
+
+      Dois desdobramentos ficam registrados e fora deste change. **Primeiro:** o `docs/SETUP.md` §1 do
+      feldt continua com as nove lacunas medidas; corrigi-lo aqui confundiria a prova com o conserto,
+      então vira item no repositório dele. **Segundo:** o requisito autoral novo provavelmente tem
+      violações em outras skills do catálogo — a varredura por "verificação prescrita sem valor de
+      aprovação" nas 35 skills não foi feita, e abre item próprio se achar mais de um caso.
+
+## 2. Doutrina no SKILL.md
+
+- [x] 2.1 A linha *Extract the facts* passa a nomear o manifesto de implantação como fonte de
+      recursos, armazenamento, portas, identidade e modo de filesystem
+- [x] 2.2 Regra do valor que aprova, com a razão de uma verificação sem critério não verificar
+- [x] 2.3 Regra do egress como pré-requisito, com a razão de a falha dele ser silenciosa
+- [x] 2.4 `metadata.version` `3.0.3` -> `3.1.0`
+
+## 3. Esqueleto no references/templates.md
+
+- [x] 3.1 Lista de categorias de pré-requisito nas convenções do `docs/SETUP.md`, cada uma com a
+      fonte externa que a pede e marcada como condicional quando não se aplica a todo produto
+- [x] 3.2 Forma de tabela de diagnóstico para sintoma único com remédios opostos
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 O artefato foi exercitado pelo seu ponto de entrada real; o comando e um fragmento da saída
+      observada estão registrados
+
+      O artefato é doutrina, e o ponto de entrada dela é alguém aplicando a doutrina a um repositório
+      real. Aplicada em rascunho ao `solvelab/feldt` em `1975ada`, **sem commitar nada lá**:
+
+      - entry point: as dez categorias do esqueleto novo caminhadas contra `docs/SETUP.md` §1, com
+        `re.search` por categoria e fronteira de palavra -> `categorias cobertas: 1/10   ausentes: 9/10`
+      - entry point: as mesmas categorias cruzadas com `deploy/feldt.yaml` -> `Compute NÃO` com
+        `cpu: 50m, memory: 128Mi, limits`; `Storage NÃO` com `storage: 1Gi`;
+        `Identity and permissions NÃO` com `runAsUser: 65532, fsGroup: 65532`
+      - entry point: `bash generate.sh` -> `Generated wrappers for 35 skills:` e
+        `Generated 10 category plugins in plugins/`
+      - entry point: `python3 scripts/validate-skills.py` -> `skills checked: 35   findings: 0`
+      - entry point: `bash scripts/validate-rite.sh` -> `rite gate OK`
+
+- [x] S.2 Matriz de casos medida, como contagens
+
+      Doutrina contra o campo: 10/10 categorias caminhadas; 1/10 coberta pelo `docs/SETUP.md` §1 do
+      feldt (Dependencies); 9/10 ausentes — e 3 delas com o dado já escrito no `deploy/feldt.yaml`,
+      dois diretórios ao lado. As nove batem, uma a uma, com as nove lacunas medidas antes de a regra
+      existir: a regra reproduz o achado em vez de inventar outro.
+
+      Regra do valor que aprova: 12 verificações prescritas com `# Esperado:` em `docs/SETUP.md`;
+      1/12 confirmada sem valor de aprovação (`um bloco JSON com clientVersion e serverVersion`);
+      3/4 marcações da heurística derrubadas na conferência à mão (ver S.3); 8/12 não marcadas.
+
+      Portões do repositório: 35/35 skills sem achado; 22/22 classes de defeito detectadas pelo
+      selftest do validador; 4/4 pelo selftest de higiene; 12/12 padrões de segredo; 17/17 casos do
+      smoke de distribuição; 6/6 links externos novos em `200`; 0/1 change ativa com achado no rito.
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Duas coisas, e as duas são o mesmo defeito que este change corrige — um instrumento cujo
+      resultado esperado é satisfeito por algo que não é o fato medido.
+
+      **Primeira:** a primeira rodada da simulação devolveu `Compute SIM`, contradizendo o que já se
+      sabia. O marcador `RAM` casava dentro de **Tele*gram***, na linha do destino de alerta. Com
+      fronteira de palavra a categoria volta a `NÃO`, e a contagem passa de `2/10` para `1/10`. O
+      número que não fechava era do instrumento, não do campo.
+
+      **Segunda:** a heurística que procura verificação sem valor de aprovação marcou 4 linhas e 3
+      caíram na conferência à mão — `qualquer código HTTP, rápido — um 404 já prova o caminho` **é**
+      um critério; `uma linha "kind":"lost" … "kind":"recovered"` nomeia strings exatas; `uma linha
+      com a senha` aprova pela existência da linha. Sobra 1 defeito real em 12. Isso é medição direta
+      da decisão `D3` do `design.md`: um detector sobre prosa erra nos dois sentidos, e é por isso que
+      o requisito autoral novo entra declaradamente sem validador.
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado
+      Evidência: o loop do `ci.yml` replicado sobre `skills/*/SKILL.md` -> `frontmatter fail=0 sobre
+      35 skills`; `metadata.version: 3.1.0` na `documentation`, semver, `author: solvelab`,
+      `category: docs` no conjunto controlado, `license: MIT`, `compatibility` presente,
+      `name` == diretório, description em `>-`.
+- [x] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
+      Evidência: as três regras novas do `SKILL.md` e o bloco novo do `templates.md` são inglês;
+      `python3 skills/code-locale/references/check-identifier-locale.py --selftest` -> `selftest OK: 7
+      content tiers fire, 16 clean cases stay silent`; `python3 scripts/validate-skills.py` ->
+      `skills checked: 35   findings: 0`, que inclui a checagem de locale do catálogo.
+- [x] Q.3 Gatilhos da description testáveis e sem colisão com skill irmã
+      Evidência: `git diff master -- skills/documentation/SKILL.md | grep -cE '^[-+] *description'` ->
+      `0`; nenhum gatilho se moveu, e a description já dispara em "SETUP" e "install". A cláusula
+      "Do NOT use for non-software documentation tasks" continua no lugar.
+- [x] Q.4 Sem doutrina duplicada
+      Evidência: a regra do egress termina apontando `backend-resilience` para o comportamento em
+      runtime, em vez de repeti-lo; a escada de pesquisa continua só em `verify-before-claiming`; a
+      tabela Canonical Home do `design.md` tem sete linhas, três `establish here (new)`, duas
+      `link (already canonical)`, uma `already canonical` e uma `spec delta`.
+- [x] Q.5 Todo exemplo de código em skill tocada usa identificador em inglês
+      Evidência: o único bloco novo é a tabela de diagnóstico do `templates.md`, em markdown, com
+      `--max-time` e códigos HTTP — sem identificador de código; detector de locale -> `findings: 0`.
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate --strict` verde e `validate-rite.sh` verde
+      Evidência: `openspec validate update-documentation-prerequisites --strict` ->
+      `Change 'update-documentation-prerequisites' is valid`; `bash scripts/validate-rite.sh` ->
+      `rite gate OK`.
+- [x] V.2 Descoberta do catálogo intacta
+      Evidência: `ls -d skills/*/ | wc -l` -> `35`, o mesmo de antes; nenhuma skill criada, removida
+      ou renomeada; `bash generate.sh` -> `Generated wrappers for 35 skills` e `10 category plugins`;
+      `python3 scripts/validate-repo-hygiene.py` -> `repo hygiene: 0 findings`, que inclui a coerência
+      das contagens publicadas.
+- [x] V.3 README e docs atualizados onde o change altera composição ou uso
+      Evidência: o change não altera composição nem uso do catálogo — nenhuma skill entra, sai ou muda
+      de nome, e nenhuma contagem publicada se move. `README.md` intocado de propósito;
+      `python3 scripts/validate-repo-hygiene.py --selftest` -> `4/4 defect classes detected`, e o
+      check H2 é justamente o que reprovaria uma contagem defasada.
+- [ ] V.4 `openspec archive update-documentation-prerequisites --yes` depois do merge do PR

--- a/plugins/docs/skills/documentation/SKILL.md
+++ b/plugins/docs/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.3
+  version: 3.1.0
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -34,7 +34,13 @@ Never write a line of documentation before reading the code it describes.
 2. Read the entry point, the config module, the dependency manifest, and any existing docs.
 3. Identify: language, framework, how it is configured, how it is run, what it integrates with.
 4. **Extract the facts**, don't invent them: env vars from the config module, endpoints from the
-   router, commands from the manifest scripts / Makefile / CI, ports from the compose file.
+   router, commands from the manifest scripts / Makefile / CI, and — from the deployment manifest
+   (compose file, chart, Kubernetes manifest, systemd unit) — the ports, the compute and storage the
+   project asks for, the uid/gid it runs as, and the filesystem modes it needs. Prerequisites are
+   read from that file, never composed from memory: measured on a production repo, the setup guide
+   listed four prerequisites while the manifest two directories away carried the CPU and memory
+   requests and limits, the volume size, both node ports, the uid and the read-only root — none of
+   which reached the guide.
 
 Only document what you read. A fact that matters and could not be verified is written as an admitted
 gap ("Deployment target: not documented in this repo"), never guessed — the ladder for finding it and
@@ -83,6 +89,18 @@ the repo, and write them so it can:
 
 - **Repo paths are links**, not prose: `[app/main.py](app/main.py)`. A link is checkable; a sentence
   is not.
+- **A prerequisite states the value that passes**, not only the command that probes it. `kubectl
+  version` printing a JSON blob proves the reader has *a* cluster, and an expected result of "a JSON
+  block" is satisfied by every run — a step that cannot fail does not verify, it reassures, and that
+  costs the reader attention while returning nothing. Name the minimum, the range, or the exact
+  string. Where one command's results mean different failures with opposite fixes, map each result to
+  its meaning in a table; a single "expected" line can only describe success.
+- **What the software must reach is a prerequisite too.** Inbound ports get written down; outbound
+  destinations almost never do — and for anything that notifies, integrates, pulls an image or calls
+  an API, blocked egress fails *silently*: the process is healthy, the request never lands, and no
+  error surfaces where anyone looks. List the hostnames and ports the software must reach out to, and
+  say what the reader sees when it cannot. What the service should *do* while that dependency is
+  down is a different subject, and it belongs to `backend-resilience`.
 - **Directory trees show the real root.** Measured on a production repo: a README tree written without
   its `src/` prefix made every path in it unresolvable, and one entry had been renamed months earlier
   — 9 of 10 entries wrong in a block the reader trusts most.

--- a/plugins/docs/skills/documentation/references/templates.md
+++ b/plugins/docs/skills/documentation/references/templates.md
@@ -219,7 +219,8 @@ curl http://localhost:8000/api/v1/health
 ### Setup guide conventions
 
 - Numbered sections with a table of contents at the top, anchors matching the numbers.
-- Prerequisites as `- [ ]` checkboxes so a reader can track them.
+- Prerequisites as `- [ ]` checkboxes so a reader can track them, and each one carries the command
+  that proves it **and the value that passes** — see the prerequisite categories below.
 - **Verify after every step.** Each action is followed by the command that confirms it worked and the
   output it should print. A setup guide with no verification is a list of hopes.
 - Group the environment template by feature area with comment dividers (`# ====`), matching the order
@@ -228,6 +229,46 @@ curl http://localhost:8000/api/v1/health
   messages and error paths in the code, not from a generic list, and add one whenever a reader hits a
   new one.
 - End with a `- [ ]` Next Steps checklist for what comes after "it runs".
+
+#### Prerequisite categories
+
+Walk this list and keep the rows this project earns — a category that does not apply is dropped, not
+filled with "N/A". Every value is read from the project's own manifests, never carried over from the
+sources that name the category.
+
+| Category | Covers | Documented as a prerequisite by |
+|---|---|---|
+| Compute | CPU, memory, and the disk the install needs | [K3s](https://docs.k3s.io/installation/requirements) (2 cores / 2 GB server, 1 core / 512 MB agent); [Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) (1 core, 512 MB, 10-50 GB) |
+| Platform | architecture and operating systems supported | K3s (x86_64, armhf, arm64); Grafana (five OS families) |
+| Versions | the supported range of the platform and of every dependency | [The Good Docs Project](https://www.thegooddocsproject.dev/template/installation-guide) ("Required version for your system"); Grafana (SQLite 3, MySQL 8.0+, PostgreSQL 12+) |
+| Dependencies | packages, runtimes and CLIs the steps invoke | The Good Docs Project ("Necessary dependencies or packages") |
+| Inbound network | the ports and hostnames that must be free and reachable | K3s (6443, 8472/UDP, 51820-51821) |
+| **Outbound network** | the hostnames and ports the software must *reach* | — not named by any of these sources; add it anyway, see below |
+| Storage | persistent volumes, and the provisioner or class they need | [Portainer](https://docs.portainer.io/start/install-ce/server/kubernetes/baremetal), [Kubernetes StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) |
+| Identity and permissions | the uid/gid the process runs as, filesystem modes, RBAC, accounts, tokens, licences | [Elastic ECK](https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/required-rbac-permissions) |
+| Client | browser and client-side requirements, when the product ships a web UI | Grafana (Chrome, Firefox, Safari, Edge; "JavaScript must be enabled") |
+| Operator knowledge | the skills the steps assume the reader already has | The Good Docs Project ("Specialist knowledge or skills") |
+
+**Outbound network is the row the sources leave out, and the one that fails quietest.** None of the
+five above names it. Its absence was measured on a production watchdog: the guide never said the
+cluster had to reach the alerting provider, and blocked egress there produces a healthy process, a
+green board, and no alert — the exact state the product existed to distinguish from health.
+
+#### Diagnostic tables, when one result has opposite remedies
+
+An "expected output" line can only describe success. When the same command's failures need different
+fixes, map every observable result:
+
+```markdown
+| Result | Means | Do |
+|---|---|---|
+| any HTTP code, fast | reachable — a `404` already proves the path | continue |
+| `000` after the full `--max-time` | timeout: a firewall is dropping silently | open the path |
+| `000` immediately | RST: host up, port closed | start the service |
+```
+
+Without the second and third rows a reader who sees `000` cannot tell which of two opposite actions
+they need, and the fastest wrong guess is the one they take.
 
 ---
 

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.0.3
+  version: 3.1.0
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -34,7 +34,13 @@ Never write a line of documentation before reading the code it describes.
 2. Read the entry point, the config module, the dependency manifest, and any existing docs.
 3. Identify: language, framework, how it is configured, how it is run, what it integrates with.
 4. **Extract the facts**, don't invent them: env vars from the config module, endpoints from the
-   router, commands from the manifest scripts / Makefile / CI, ports from the compose file.
+   router, commands from the manifest scripts / Makefile / CI, and — from the deployment manifest
+   (compose file, chart, Kubernetes manifest, systemd unit) — the ports, the compute and storage the
+   project asks for, the uid/gid it runs as, and the filesystem modes it needs. Prerequisites are
+   read from that file, never composed from memory: measured on a production repo, the setup guide
+   listed four prerequisites while the manifest two directories away carried the CPU and memory
+   requests and limits, the volume size, both node ports, the uid and the read-only root — none of
+   which reached the guide.
 
 Only document what you read. A fact that matters and could not be verified is written as an admitted
 gap ("Deployment target: not documented in this repo"), never guessed — the ladder for finding it and
@@ -83,6 +89,18 @@ the repo, and write them so it can:
 
 - **Repo paths are links**, not prose: `[app/main.py](app/main.py)`. A link is checkable; a sentence
   is not.
+- **A prerequisite states the value that passes**, not only the command that probes it. `kubectl
+  version` printing a JSON blob proves the reader has *a* cluster, and an expected result of "a JSON
+  block" is satisfied by every run — a step that cannot fail does not verify, it reassures, and that
+  costs the reader attention while returning nothing. Name the minimum, the range, or the exact
+  string. Where one command's results mean different failures with opposite fixes, map each result to
+  its meaning in a table; a single "expected" line can only describe success.
+- **What the software must reach is a prerequisite too.** Inbound ports get written down; outbound
+  destinations almost never do — and for anything that notifies, integrates, pulls an image or calls
+  an API, blocked egress fails *silently*: the process is healthy, the request never lands, and no
+  error surfaces where anyone looks. List the hostnames and ports the software must reach out to, and
+  say what the reader sees when it cannot. What the service should *do* while that dependency is
+  down is a different subject, and it belongs to `backend-resilience`.
 - **Directory trees show the real root.** Measured on a production repo: a README tree written without
   its `src/` prefix made every path in it unresolvable, and one entry had been renamed months earlier
   — 9 of 10 entries wrong in a block the reader trusts most.

--- a/skills/documentation/references/templates.md
+++ b/skills/documentation/references/templates.md
@@ -219,7 +219,8 @@ curl http://localhost:8000/api/v1/health
 ### Setup guide conventions
 
 - Numbered sections with a table of contents at the top, anchors matching the numbers.
-- Prerequisites as `- [ ]` checkboxes so a reader can track them.
+- Prerequisites as `- [ ]` checkboxes so a reader can track them, and each one carries the command
+  that proves it **and the value that passes** — see the prerequisite categories below.
 - **Verify after every step.** Each action is followed by the command that confirms it worked and the
   output it should print. A setup guide with no verification is a list of hopes.
 - Group the environment template by feature area with comment dividers (`# ====`), matching the order
@@ -228,6 +229,46 @@ curl http://localhost:8000/api/v1/health
   messages and error paths in the code, not from a generic list, and add one whenever a reader hits a
   new one.
 - End with a `- [ ]` Next Steps checklist for what comes after "it runs".
+
+#### Prerequisite categories
+
+Walk this list and keep the rows this project earns — a category that does not apply is dropped, not
+filled with "N/A". Every value is read from the project's own manifests, never carried over from the
+sources that name the category.
+
+| Category | Covers | Documented as a prerequisite by |
+|---|---|---|
+| Compute | CPU, memory, and the disk the install needs | [K3s](https://docs.k3s.io/installation/requirements) (2 cores / 2 GB server, 1 core / 512 MB agent); [Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/installation/) (1 core, 512 MB, 10-50 GB) |
+| Platform | architecture and operating systems supported | K3s (x86_64, armhf, arm64); Grafana (five OS families) |
+| Versions | the supported range of the platform and of every dependency | [The Good Docs Project](https://www.thegooddocsproject.dev/template/installation-guide) ("Required version for your system"); Grafana (SQLite 3, MySQL 8.0+, PostgreSQL 12+) |
+| Dependencies | packages, runtimes and CLIs the steps invoke | The Good Docs Project ("Necessary dependencies or packages") |
+| Inbound network | the ports and hostnames that must be free and reachable | K3s (6443, 8472/UDP, 51820-51821) |
+| **Outbound network** | the hostnames and ports the software must *reach* | — not named by any of these sources; add it anyway, see below |
+| Storage | persistent volumes, and the provisioner or class they need | [Portainer](https://docs.portainer.io/start/install-ce/server/kubernetes/baremetal), [Kubernetes StorageClass](https://kubernetes.io/docs/concepts/storage/storage-classes/) |
+| Identity and permissions | the uid/gid the process runs as, filesystem modes, RBAC, accounts, tokens, licences | [Elastic ECK](https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s/required-rbac-permissions) |
+| Client | browser and client-side requirements, when the product ships a web UI | Grafana (Chrome, Firefox, Safari, Edge; "JavaScript must be enabled") |
+| Operator knowledge | the skills the steps assume the reader already has | The Good Docs Project ("Specialist knowledge or skills") |
+
+**Outbound network is the row the sources leave out, and the one that fails quietest.** None of the
+five above names it. Its absence was measured on a production watchdog: the guide never said the
+cluster had to reach the alerting provider, and blocked egress there produces a healthy process, a
+green board, and no alert — the exact state the product existed to distinguish from health.
+
+#### Diagnostic tables, when one result has opposite remedies
+
+An "expected output" line can only describe success. When the same command's failures need different
+fixes, map every observable result:
+
+```markdown
+| Result | Means | Do |
+|---|---|---|
+| any HTTP code, fast | reachable — a `404` already proves the path | continue |
+| `000` after the full `--max-time` | timeout: a firewall is dropping silently | open the path |
+| `000` immediately | RST: host up, port closed | start the service |
+```
+
+Without the second and third rows a reader who sees `000` cannot tell which of two opposite actions
+they need, and the fastest wrong guess is the one they take.
 
 ---
 


### PR DESCRIPTION
Closes #152

A `documentation` manda extrair fatos em vez de inventá-los e **nomeia as fontes** — env var do
módulo de config, endpoint do router, comando do manifest, porta do compose. E manda verificar cada
passo, com *"the command that confirms it worked and the output it should print"*.

As duas regras param cedo. O custo foi medido em `solvelab/feldt`: um serviço documentado com esta
skill, com sete páginas e **duas guardas de documentação em CI** — ou seja, um caso onde a skill foi
seguida e o buraco ficou mesmo assim.

## Os três defeitos que pagaram a doutrina

**1. A lista de fontes não alcança a superfície de implantação.** O `docs/SETUP.md` §1 do feldt lista
quatro pré-requisitos. O `deploy/feldt.yaml`, dois diretórios ao lado, carrega `cpu: 50m`/`200m`,
`memory: 128Mi`/`256Mi`, `storage: 1Gi`, `nodePort: 30080` e `30081`, `runAsUser`/`fsGroup: 65532` e
`readOnlyRootFilesystem: true`. Nenhum chegou ao guia — a regra cobre porta do compose e para ali.

**2. Verificação sem valor de aprovação.** O mesmo §1 roda `kubectl version --output=json` esperando
*"um bloco JSON com clientVersion e serverVersion"*. Prova que existe **um** cluster; nunca diz qual
versão passa. `grep` por versão mínima no repositório inteiro do feldt: **zero linhas**. A saída
esperada é satisfeita por toda execução, então o passo **não pode reprovar** — e um passo que não
reprova não verifica, tranquiliza.

**3. Egress não é pré-requisito em nenhuma das nove páginas.** Nenhuma das cinco fontes externas
consultadas nomeia a categoria. Ela entra mesmo assim, porque a falha dela é silenciosa: processo
saudável, requisição que não chega, quadro verde. Num dead man's switch, esse é exatamente o estado
que o produto existe para negar.

## O que muda

| Arquivo | O quê |
|---|---|
| `skills/documentation/SKILL.md` | a linha *Extract the facts* nomeia o manifesto de implantação; regra do valor que aprova; regra do egress; `3.0.3` -> **`3.1.0`** |
| `skills/documentation/references/templates.md` | dez categorias de pré-requisito com a fonte de cada uma; forma de tabela de diagnóstico |
| `specs/skills-authoring` (delta) | ADDED *A prescribed verification states what passes*, com quatro cenários |
| árvores geradas | `claude/`, `cursor/`, `plugins/` regeneradas por `generate.sh` |

## A prova de campo

Doutrina nova aplicada **em rascunho** ao feldt, sem commitar nada lá:

```
categorias cobertas: 1/10   ausentes: 9/10
Compute                     NÃO    cpu: 50m, memory: 128Mi, limits
Storage                     NÃO    storage: 1Gi
Identity and permissions    NÃO    runAsUser: 65532, fsGroup: 65532
```

As nove batem, uma a uma, com as nove lacunas medidas **antes** de a regra existir. A regra reproduz
o achado em vez de inventar outro — que é o teste que importa.

## Duas vezes o instrumento mentiu, e as duas viraram evidência

**A primeira rodada devolveu `Compute SIM`**, contradizendo o que já se sabia. O marcador `RAM`
casava dentro de **Tele*gram***. Com fronteira de palavra a contagem cai de `2/10` para `1/10`.

**A heurística que procura verificação sem critério marcou 4 linhas e 3 caíram** na conferência à
mão: `qualquer código HTTP, rápido — um 404 já prova o caminho` **é** um critério; `uma linha
"kind":"lost" … "kind":"recovered"` nomeia strings exatas. Sobra **1 defeito real em 12**.

Isso é medição direta da decisão `D3` do `design.md`: **um detector sobre prosa erra nos dois
sentidos**, e é por isso que o requisito autoral novo entra declaradamente **sem validador**, na
forma que o cenário *Partial coverage is declared, not implied* do `skills-authoring` exige.

## Portões

| Portão | Resultado |
|---|---|
| `openspec validate --strict` | `Change 'update-documentation-prerequisites' is valid` |
| `scripts/validate-rite.sh` | `rite gate OK` |
| `scripts/validate-spec-rite.py` | `0 findings (11 changed paths, 1 active change)` |
| `scripts/validate-skill-version.py` | `0 findings (1 skill changed, 1 with content changes)` |
| `+ --selftest` | `7/7 defect classes, 11/11 false-positive cases silent` |
| `generate.sh` + `git diff` sobre árvore commitada | wrappers em dia, nenhum untracked |
| `scripts/validate-skills.py` | `skills checked: 35   findings: 0` |
| `selftest-validate-skills.py` | `22/22 defect classes detected` |
| `check-identifier-locale.py --selftest` | `7 content tiers fire, 16 clean cases silent` |
| 4 hooks `--selftest` | 13+12, 26, 16, 12 decisões |
| `scan-secrets.py` (+selftest) | `no credentials found` · `12/12 patterns` |
| `validate-repo-hygiene.py` (+selftest) | `0 findings` · `4/4 defect classes` |
| `smoke-install-scripts.sh` | `17/17 cases passed` |
| frontmatter (loop do `ci.yml`) | `fail=0` sobre 35 skills |
| 6 links externos novos | `200` em 6/6 |

Os 16 critérios do item estão marcados.

## Deliberadamente fora

- **Consertar o `docs/SETUP.md` do feldt.** Ele é a prova; consertá-lo aqui confundiria a prova com o
  conserto. Item próprio, no repositório dele.
- **Validador para o requisito autoral novo** — a razão está medida acima e escrita na `D3`.
- **Números de hardware na skill** — o requisito *Prescribed numbers carry the rule that produces
  them* proíbe; o número certo é do projeto documentado.
- **Varredura do catálogo** por outras violações do requisito novo — registrada em `E.4`, abre item
  se achar mais de um caso.

Spec-rite: update-documentation-prerequisites
