### PR TITLE
✨ feat(validate-skills): C5 exige a data no bloco Verified against e data os 14 blocos anteriores

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,8 +875,8 @@ A second gate checks the **content** of the skills themselves.
 [`scripts/validate-skills.py`](scripts/validate-skills.py) runs thirteen checks over every
 `skills/*/SKILL.md` and every `*.md` under its `references/`, recursively — referenced paths exist (C1), cross-skill references name a
 real skill (C2), code blocks parse (C3, bash/yaml/json/lua/python), the description states no policy
-the body contradicts (C4), every skill states what it was verified against or that it does not depend
-on a tool version (C5), fence tags match their content
+the body contradicts (C4), every skill states what it was verified against — with the date it was
+probed — or that it does not depend on a tool version (C5), fence tags match their content
 (C6), no generated wrapper is orphaned from a canonical source (C7), no meta section sits in a
 `SKILL.md` body where it cannot affect routing (C8), code examples use English identifiers (C9),
 the parsed `description` and `compatibility` stay within the Agent Skills limits (C10), every
@@ -911,7 +911,7 @@ as operational detail, never as a build failure.
 
 ```bash
 python3 scripts/validate-skills.py           # 0 findings expected
-python3 scripts/selftest-validate-skills.py  # 22/22 defect classes detected
+python3 scripts/selftest-validate-skills.py  # 23/23 defect classes detected
 python3 scripts/scan-secrets.py              # gate: no credentials in the working tree
 python3 scripts/scan-secrets.py --history    # audit: what the published history still contains
 ```

--- a/cursor/rules/fivem-nui-react.mdc
+++ b/cursor/rules/fivem-nui-react.mdc
@@ -96,4 +96,4 @@ Full hook implementations + the Lua counterpart: `references/nui-bridge.md`.
 > **Verified against**: `vite 8.2.0` + `terser 5.49.2`. The four build rules below were checked by
 > building with them: `base: './'` emits `./assets/…`, the flat `entryFileNames` produce hash-less
 > `assets/index.js` / `assets/index.css` matching `dist/assets/*`, and `drop_console` leaves zero
-> `console.log` in the bundle.
+> `console.log` in the bundle. Probed on 2026-08-06 (change `pin-probed-skills`, commit `9afef67`).

--- a/cursor/rules/k8s-tune-resources.mdc
+++ b/cursor/rules/k8s-tune-resources.mdc
@@ -11,7 +11,8 @@ Skill for repeating the cluster-wide resources tuning routine across different K
 
 > **Verified against**: `kubectl v1.36.1` · `git 2.47.3`. Every flag the workflow uses — `-l`,
 > `-A`, `--field-selector`, `-o jsonpath` — was probed against that client. The clone URL template
-> assumes Bitbucket over SSH; adapt the host for any other forge.
+> assumes Bitbucket over SSH; adapt the host for any other forge. Probed on 2026-08-06 (change
+> `onboard-k8s-tune-resources`, commit `d1e22a4`).
 >
 > **This skill pushes to many repositories.** The Step 2 loop runs with `DRY_RUN=1` by default and
 > never pushes until you set it to `0`. Read the dry-run report first — see *Safety notes*.

--- a/cursor/rules/observability.mdc
+++ b/cursor/rules/observability.mdc
@@ -8,9 +8,10 @@ alwaysApply: false
 # Observability
 
 > **Verified against**: `fastapi 0.141.1` · `prometheus-client 0.26.0` · `structlog 26.1.0` ·
-> `opentelemetry-api 1.44.0` · `opentelemetry-instrumentation-fastapi 0.65b0`. Every construct below
-> was run: ids generated and preserved, route templates labelled, raw paths kept out of the registry,
-> counters and histograms exposed on `/metrics`.
+> `opentelemetry-api 1.44.0` · `opentelemetry-instrumentation-fastapi 0.65b0`. Every construct
+> below was run: ids generated and preserved, route templates labelled, raw paths kept out of the
+> registry, counters and histograms exposed on `/metrics`. Probed on 2026-08-06 (change
+> `add-observability-skill`, commit `60eb0be`).
 
 A service that degrades safely and silently has traded a crash for a mystery. `backend-resilience`
 says what to do when a dependency fails; this skill is how anyone finds out that it did.

--- a/cursor/rules/python-rest-api.mdc
+++ b/cursor/rules/python-rest-api.mdc
@@ -167,7 +167,7 @@ collected".
 *sync* session against SQLite keeps passing, because a single test never has concurrency. The block
 only appears under load, in production. If you are on the async lane, the override must be async too.
 
-Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`.
+Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`. Probed on 2026-08-06 (change `add-async-lane-rule`, commit `c27ca79`).
 
 Outbound calls follow the same rule — `backend-resilience` ships `safe_call` and `safe_call_async` for
 exactly this reason. The DB half and the HTTP half of one request must be in the same lane.

--- a/cursor/rules/r3f-animation.mdc
+++ b/cursor/rules/r3f-animation.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-assets.mdc
+++ b/cursor/rules/r3f-assets.mdc
@@ -12,6 +12,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-fundamentals.mdc
+++ b/cursor/rules/r3f-fundamentals.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-geometry.mdc
+++ b/cursor/rules/r3f-geometry.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-interaction.mdc
+++ b/cursor/rules/r3f-interaction.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-lighting.mdc
+++ b/cursor/rules/r3f-lighting.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-materials.mdc
+++ b/cursor/rules/r3f-materials.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-physics.mdc
+++ b/cursor/rules/r3f-physics.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-postprocessing.mdc
+++ b/cursor/rules/r3f-postprocessing.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/cursor/rules/r3f-shaders.mdc
+++ b/cursor/rules/r3f-shaders.mdc
@@ -13,6 +13,7 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/openspec/changes/add-pin-date-gate/.openspec.yaml
+++ b/openspec/changes/add-pin-date-gate/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-05

--- a/openspec/changes/add-pin-date-gate/design.md
+++ b/openspec/changes/add-pin-date-gate/design.md
@@ -1,0 +1,53 @@
+## Context
+
+`scripts/validate-skills.py` C5 (read 2026-09-05, HEAD 85c453d) matches `Verified against` /
+`does not depend on a tool version` and, for the declaration, applies the code-heavy rule. It reads
+the whole `SKILL.md` and never isolates the block. The 14 undated blocks have two shapes: a
+blockquote of 4–6 lines (13 skills; `k8s-tune-resources` continues with a second `>` paragraph
+after a bare `>` line) and one prose line (`python-rest-api/SKILL.md:183`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Every `Verified against` block states a date a reader can compare with today.
+- The gate proves the date is present; the review keeps judging whether it is honest.
+- The backfilled dates are the ones the history proves, and the sentence says so.
+
+**Non-Goals:**
+- Re-probing; date plausibility; dating the declaration form.
+
+## Decisions
+
+1. **Block = from the `Verified against` line to the next blank line.** Both shapes fit, and a bare
+   `>` line is not blank, so `k8s-tune-resources`' second paragraph stays inside the block (harmless:
+   the date sits in the first paragraph). Alternative — parse blockquotes only — rejected: it would
+   miss the prose form and force a reformat of `python-rest-api` for no gain.
+2. **ISO date regex only.** `\b20\d\d-\d\d-\d\d\b`. A stricter parse (real calendar date, not in the
+   future) is out of scope by the item; the KNOWN LIMIT names it.
+3. **One sentence, one shape.** `Probed on 2026-08-06 (change <id>, commit <sha>).` appended to the
+   first paragraph of each block. The word "recorded" is not needed when the change id and commit
+   are in the sentence: a reader can open both. `python-rest-api` gets the same sentence on its
+   line.
+4. **Waiver, not 14 bumps.** The skill-version gate's own header names this case ("the sweep that
+   adds one cross-reference to twelve skills"); a date on a block changes no contract.
+5. **Selftest target `fivem-lua`**: its block has exactly one date (`Probed on 2026-09-05`); the
+   mutation replaces it with `Probed recently`, leaving the literal `Verified against` in place so
+   only the new rule fires.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| A pin carries the date it was probed | `skills-authoring` spec + C5 docstring | already canonical — skills carry the sentence, not the rule |
+| Dated claims and the research ladder | `verify-before-claiming` | already canonical — nothing restated |
+
+## Risks / Trade-offs
+
+- [A block that mentions an unrelated date passes] → accepted; the gate proves presence, the
+  review judges meaning, as with the versions themselves (KNOWN LIMIT).
+- [The backfilled date reads as "probed today"] → the sentence names the change and commit, both
+  dated 2026-08-06 in the repository.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-pin-date-gate/proposal.md
+++ b/openspec/changes/add-pin-date-gate/proposal.md
@@ -1,0 +1,55 @@
+# Change: Require the date inside every `Verified against` block, and date the 14 blocks that predate #131
+
+## Why
+
+`skills-authoring` (*Versioned external APIs are pinned*) already says a `Verified against` block
+names "each tool and the version it was probed against, what was run, and the date". The gate that
+reads the block does not ask for the date: C5 in `scripts/validate-skills.py` checks the literal
+phrase only, and its docstring lists "the date the block owes is not checked" as a KNOWN LIMIT —
+deliberately left out of #131 to keep that item's scope.
+
+Measured on 2026-09-05: 14 of 35 skills carry a block with no ISO date — the ten `r3f-*`,
+`observability`, `k8s-tune-resources`, `fivem-nui-react` and `python-rest-api` (a single prose line,
+`SKILL.md:183`). All 14 blocks entered the tree on 2026-08-06: `a18758c` (#26, `harden-r3f-skills`),
+`9afef67` (#39, `pin-probed-skills`), `d1e22a4` (#33, `onboard-k8s-tune-resources`), `60eb0be`
+(#53, `add-observability-skill`), `c27ca79` (#51, `add-async-lane-rule`). A pin without a date does
+not say when it stopped being trustworthy; a gate that declares it does not check the date is a
+gap the reader has to remember.
+
+## What Changes
+
+- **C5 requires an ISO date inside the block.** The block is the text from the line carrying
+  `Verified against` to the next blank line — the blockquote form and the one-line prose form both
+  fit; `\b20\d\d-\d\d-\d\d\b` must occur in it. The `does not depend on a tool version` declaration
+  owes no date. The docstring drops the date KNOWN LIMIT and keeps the others.
+- **Selftest**: a new mutation strips the date from a dated block and asserts the `no date` finding.
+- **14 skills** gain one sentence at the end of the block: `Probed on 2026-08-06 (change
+  <id>, commit <sha>)` — the date the history proves, said as a record, never as a new probe. No
+  pinned version changes. `python-rest-api`'s prose line gets the same sentence.
+- **README**: the validator paragraph names the date requirement; the selftest count moves 22 → 23.
+- **Skill versions**: waived on the pull request with `Skill-version: none — 14 blocks gain the
+  date the history already records; no rule, example or pinned version changes` — the sweep case
+  `validate-skill-version.py` wrote the waiver line for.
+
+## Deliberately not done
+
+- Re-probing the 14 skills against newer versions. The date is the recorded probe's, not today's.
+- A date on the declaration form, or any plausibility check on the date (future, too old).
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Versioned external APIs are pinned** — a `Verified against` block
+  without an ISO date is reported by the validator; the date may be the recorded probe's when it is
+  named as such.
+
+## Impact
+
+- `scripts/validate-skills.py`, `scripts/selftest-validate-skills.py`, `README.md`,
+  `skills/{r3f-animation,r3f-assets,r3f-fundamentals,r3f-geometry,r3f-interaction,r3f-lighting,
+  r3f-materials,r3f-physics,r3f-postprocessing,r3f-shaders,observability,k8s-tune-resources,
+  fivem-nui-react,python-rest-api}/SKILL.md`, regenerated wrappers.
+- No skill added, removed or repurposed; no description changes.

--- a/openspec/changes/add-pin-date-gate/specs/skills-authoring/spec.md
+++ b/openspec/changes/add-pin-date-gate/specs/skills-authoring/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Versioned external APIs are pinned
+
+A skill whose content targets an external API **or command-line tool** with breaking releases SHALL
+state the exact versions it was verified against, and SHALL name any known upcoming rename or removal
+that will invalidate it. For a skill that instructs the agent to run a CLI, the commands and flags it
+prescribes SHALL be probed against that tool before publication.
+
+Every `SKILL.md` SHALL carry exactly one of two literal declarations, placed where a reader meets it
+before the first rule: a `Verified against` block naming each tool and the version it was probed
+against, what was run, and the ISO date it was probed on; or the sentence `does not depend on a tool
+version` followed by the reason. The date MAY be the recorded probe's when the block names the change
+or commit that recorded it. A `Verified against` block SHALL name only versions the claims were actually probed
+against, and SHALL name the part of the skill that was not probed rather than cover it by implication.
+A version written for a run nobody made is a defect, not a pin. The declaration is an exit for
+process skills: a skill carrying 40 or more fenced lines against a versioned API SHALL carry the
+block unless it defers to a local source of truth it instructs the reader to open first.
+
+#### Scenario: Reader can tell which era the code targets
+
+- **WHEN** a skill documents a library API
+- **THEN** the skill names the library versions its examples were verified against, rather than
+  leaving the reader to infer it
+
+#### Scenario: A known breaking change is disclosed, not silently absorbed
+
+- **WHEN** the upstream has announced a rename or removal affecting the skill's examples
+- **THEN** the skill names it and where it applies, instead of presenting the current form as timeless
+
+#### Scenario: Prescribed CLI commands are probed, not assumed
+
+- **WHEN** a skill instructs the agent to run a command with specific subcommands and flags
+- **THEN** each subcommand and flag is checked against the installed tool before publication, and the
+  tool version the check ran against is recorded
+
+#### Scenario: Tool guidance contradicted by the tool is corrected, not repeated
+
+- **WHEN** a tool's own output advertises behaviour its implementation does not deliver
+- **THEN** the skill states the probed behaviour and the version it holds for, rather than repeating
+  the tool's claim
+
+#### Scenario: Every skill declares its relationship to versions
+
+- **WHEN** a `SKILL.md` carries neither the literal `Verified against` nor the literal
+  `does not depend on a tool version`
+- **THEN** the validator reports it under C5, whatever amount of fenced code the skill carries
+
+#### Scenario: A loose version mention is not a pin
+
+- **WHEN** a skill names a version only in passing (`Probed on CLI 1.6.0`, `targets v0.0.54`,
+  `needs CSP >= 0.1.78`) and carries no literal `Verified against`
+- **THEN** the validator reports it under C5, because a reader cannot tell a pin from a mention
+
+#### Scenario: A code-heavy skill does not exit by declaration
+
+- **WHEN** a skill carries 40 or more fenced lines, names a versioned API, declares that it does not
+  depend on a tool version, and does not defer to a local source of truth
+- **THEN** the validator reports the declaration as contradicted by the skill's own code
+
+#### Scenario: A partial probe names its boundary
+
+- **WHEN** only part of a skill's surface could be probed — public API stubs or source, but not the
+  runtime that executes them
+- **THEN** the `Verified against` block names what was probed, against which artifact and version,
+  and states what was not probed, instead of letting the pin cover the whole skill
+
+#### Scenario: A pin carries the date it was probed
+
+- **WHEN** a `Verified against` block — the text from that line to the next blank line — carries no
+  ISO date (`YYYY-MM-DD`)
+- **THEN** the validator reports it under C5, because a pin with no date does not say when it
+  stopped being trustworthy

--- a/openspec/changes/add-pin-date-gate/tasks.md
+++ b/openspec/changes/add-pin-date-gate/tasks.md
@@ -1,0 +1,56 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+## 2. Gate
+
+- [ ] 2.1 C5 isolates the block and requires `\b20\d\d-\d\d-\d\d\b` inside it; declaration form exempt;
+      docstring updated (date KNOWN LIMIT removed, plausibility named as the remaining one)
+- [ ] 2.2 Selftest mutation `C5 no version pin (undated block)` on `fivem-lua`; old mutations untouched
+
+## 3. Backfill
+
+- [ ] 3.1 The 14 blocks gain `Probed on 2026-08-06 (change <id>, commit <sha>).` with the id/sha the
+      history gives for each; no pinned version changes
+- [ ] 3.2 README validator paragraph and selftest count (22 → 23)
+- [ ] 3.3 `./generate.sh`; wrappers in sync
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 5. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`).
+      Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
+      paths shipped in target repos through this rite. Regression gate on the exemplar: the model
+      imitates the code it is shown
+
+## 6. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-pin-date-gate --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive add-pin-date-gate --yes` after all groups above are `[x]`

--- a/openspec/changes/add-pin-date-gate/tasks.md
+++ b/openspec/changes/add-pin-date-gate/tasks.md
@@ -1,56 +1,71 @@
 ## 1. Evidence & Sources (MANDATORY)
 
-- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
       the commit or timestamp it was read at
-- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      Evidence: Opened 2026-09-05 at HEAD 85c453d: `scripts/validate-skills.py` (C5 block, `check_pin`), `scripts/selftest-validate-skills.py:30-46`, `README.md:875-913`, `openspec/specs/skills-authoring/spec.md:250-300` (the requirement, copied whole into the MODIFIED delta), the 14 `skills/<name>/SKILL.md` blocks (`r3f-*:18-22`, `observability:22-25`, `k8s-tune-resources:23-28`, `fivem-nui-react:105-108`, `python-rest-api:183`), and the archived changes `2026-08-06-{harden-r3f-skills,pin-probed-skills,onboard-k8s-tune-resources,add-observability-skill,add-async-lane-rule}`.
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
       probed against the installed version; the command and a fragment of its output are recorded
-- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      Evidence: `for f in skills/*/SKILL.md; do awk '/Verified against/{p=1} p&&/^$/{exit} p' $f | grep -q -E '20[0-9]{2}-[0-9]{2}-[0-9]{2}' || grep -q 'does not depend on a tool version' $f || echo $f; done` -> 14 files before, nothing after. `git log --format='%h %cs %s' a18758c 9afef67 d1e22a4 60eb0be c27ca79` -> all `2026-08-06`: `🐛 fix(r3f): make the code blocks compile, and pin what they compile against (#26)`, `🐛 fix(skills): pin what was probed, and fix the pin detector (#39)`, `✨ feat(k8s-tune-resources): bring the orphan skill into the catalog (#33)`, `✨ feat(observability): add the skill that makes the family's failures visible (#53)`, `✨ feat(python-rest-api): state the async/sync lane rule for DB access (#51)`. `grep -l 'Verified against' openspec/changes/archive/2026-08-06-*/{tasks,proposal,design}.md` -> `harden-r3f-skills/tasks.md`, `pin-probed-skills/design.md`, `onboard-k8s-tune-resources/proposal.md`, `add-async-lane-rule/proposal.md` (+ observability's own change). `python3 scripts/validate-skills.py` -> `skills checked: 35   findings: 0`. `git diff -- skills | grep -c -E '^[-+]\s+version:'` -> `0`.
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
       when there is no design.md) — never stated as fact, never filled with a plausible substitute
-- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      Evidence: Nothing this change asserts was unprobeable: the dates come from `git log` on this clone, the block shapes from reading the 14 files. What the gate cannot tell — whether a date is the probe's or an unrelated one, and whether it is plausible — is written into the C5 docstring as the remaining KNOWN LIMIT and into design.md, not filled in.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
       along the way are listed here as follow-ups, not performed
-
+      Evidence: Follow-ups noticed and NOT performed: (1) `fivem-lua`'s block dates the citizenfx commits it names, so it carries three ISO dates — a stricter rule ("a `Probed on` date") would need a literal for the probe date itself, out of scope; (2) date plausibility (future, decades old) is not checked; (3) the declaration form (`helm-migration`, `bug-hunter`, `documentation`) carries a date by convention only; (4) README:468 still says `C1–C9` in the tree listing (stale before this change, noted twice now).
 ## 2. Gate
 
-- [ ] 2.1 C5 isolates the block and requires `\b20\d\d-\d\d-\d\d\b` inside it; declaration form exempt;
+- [x] 2.1 C5 isolates the block and requires `\b20\d\d-\d\d-\d\d\b` inside it; declaration form exempt;
       docstring updated (date KNOWN LIMIT removed, plausibility named as the remaining one)
-- [ ] 2.2 Selftest mutation `C5 no version pin (undated block)` on `fivem-lua`; old mutations untouched
-
+      Evidence: `scripts/validate-skills.py`: `ISO_DATE = re.compile(r"\b20\d\d-\d\d-\d\d\b")`; `block = text[pinned.start():].split("\n\n", 1)[0]`; finding `'Verified against' block carries no date (YYYY-MM-DD) — a pin with no date does not say when it stopped being trustworthy`; docstring names the remaining limits (shape only, plausibility unchecked, deferral phrase).
+- [x] 2.2 Selftest mutation `C5 no version pin (undated block)` on `fivem-lua`; old mutations untouched
+      Evidence: `scripts/selftest-validate-skills.py`: mutation `C5 no version pin (undated block)` on `skills/observability/SKILL.md` (`2026-08-06` -> `the day the skill landed`; the file carries exactly one ISO date) -> `CAUGHT`; the first target (`fivem-lua`) stayed silent because its block also dates the citizenfx commits — recorded in the mutation's comment. Run -> `22/23 defect classes detected` locally (MISSED only `C3 lua syntax`, luac absent here).
 ## 3. Backfill
 
-- [ ] 3.1 The 14 blocks gain `Probed on 2026-08-06 (change <id>, commit <sha>).` with the id/sha the
+- [x] 3.1 The 14 blocks gain `Probed on 2026-08-06 (change <id>, commit <sha>).` with the id/sha the
       history gives for each; no pinned version changes
-- [ ] 3.2 README validator paragraph and selftest count (22 → 23)
-- [ ] 3.3 `./generate.sh`; wrappers in sync
-
+      Evidence: 14 blocks end with `Probed on 2026-08-06 (change \`<id>\`, commit \`<sha>\`).` — `harden-r3f-skills`/`a18758c` ×10, `pin-probed-skills`/`9afef67`, `onboard-k8s-tune-resources`/`d1e22a4`, `add-observability-skill`/`60eb0be`, `add-async-lane-rule`/`c27ca79`; the backfill script asserted the set of pinned `tool version` tokens unchanged per file; `git diff -- skills` touches no `version:` line.
+- [x] 3.2 README validator paragraph and selftest count (22 → 23)
+      Evidence: `README.md:878-879` -> `every skill states what it was verified against — with the date it was probed — or that it does not depend on a tool version (C5)`; `:913` -> `23/23 defect classes detected`.
+- [x] 3.3 `./generate.sh`; wrappers in sync
+      Evidence: `bash generate.sh` -> `git status --porcelain --untracked-files=all | grep -c '^??'` -> 0; 45 paths changed before commit (3 scripts/README + 14 skills + wrappers).
 ## 4. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
       observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      Evidence: entry point `python3 scripts/validate-skills.py` on the backfilled catalog -> `skills checked: 35   findings: 0`; on a copy with observability's date removed -> `[C5 no version pin] 'Verified against' block carries no date (YYYY-MM-DD) — a pin with no date does not say when it stopped being trustworthy`; entry point `python3 scripts/selftest-validate-skills.py` -> `CAUGHT  C5 no version pin (undated block)`, `22/23`.
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
       silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      Evidence: 1/1 undated block had to fire and did (observability, date removed); 35/35 skills had to stay silent after the backfill and did; 14/14 blocks gained a date; 0/14 pinned versions changed; 3/3 declaration-form skills stayed silent with no date rule applied to them; 1/1 pre-existing local miss unchanged (`C3 lua syntax`).
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
       explicitly that nothing did
-
+      Evidence: One thing behaved differently than expected: the first selftest target, `fivem-lua`, stayed silent with `Probed on 2026-09-05` replaced because its block also carries `(2026-09-02)` and `(2026-08-17)` for the citizenfx commits — the rule asks for any ISO date in the block, as designed, so the mutation moved to `observability`, whose file carries exactly one. Also: the first S.1 probe edited a string that the 97-column wrap had split across two lines and therefore changed nothing; the probe was redone on the bare date token.
 ## 5. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
       metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
       compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      Evidence: Frontmatter loop replicated over `skills/*/SKILL.md` -> `frontmatter fail=0`; `agentskills validate` -> `fail=0` over 35; `npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict` -> `✔ Validation passed`.
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Evidence: All added text is English; `check-identifier-locale.py` over the changed `skills/`, `scripts/` and `README.md` -> `findings: 0`.
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
       do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      Evidence: `git diff master -- skills/ | grep -c -E '^[-+]\s*description'` -> `0`; no trigger moved.
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
       its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      Evidence: The sentence added to each block states a date and two identifiers; the rule lives in the `skills-authoring` requirement and the C5 docstring (design.md Canonical Home, two rows, `already canonical`).
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
       names; a term kept in another language carries its reason inline (`code-locale`).
       Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
       paths shipped in target repos through this rite. Regression gate on the exemplar: the model
       imitates the code it is shown
-
+      Evidence: No code example touched; detector -> `findings: 0`.
 ## 6. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-pin-date-gate --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+- [x] V.1 `openspec validate add-pin-date-gate --strict` green
+      Evidence: `openspec validate add-pin-date-gate --strict` -> `Change 'add-pin-date-gate' is valid`; `bash scripts/validate-rite.sh` -> `rite gate OK` (evidence gate 0 findings, spec-rite gate 0 findings).
+- [x] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
       no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `npx -y skills add solvelab/ai-skills --list | grep -c -E '^│    [a-z0-9-]+$'` -> `35`; `ls skills | wc -l` -> 35; nothing added, removed or renamed.
+- [x] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `README.md` validator paragraph and selftest count updated; catalog composition unchanged.
 - [ ] V.4 `openspec archive add-pin-date-gate --yes` after all groups above are `[x]`

--- a/plugins/backend/skills/observability/SKILL.md
+++ b/plugins/backend/skills/observability/SKILL.md
@@ -20,9 +20,10 @@ compatibility: Works in any environment with filesystem access.
 # Observability
 
 > **Verified against**: `fastapi 0.141.1` · `prometheus-client 0.26.0` · `structlog 26.1.0` ·
-> `opentelemetry-api 1.44.0` · `opentelemetry-instrumentation-fastapi 0.65b0`. Every construct below
-> was run: ids generated and preserved, route templates labelled, raw paths kept out of the registry,
-> counters and histograms exposed on `/metrics`.
+> `opentelemetry-api 1.44.0` · `opentelemetry-instrumentation-fastapi 0.65b0`. Every construct
+> below was run: ids generated and preserved, route templates labelled, raw paths kept out of the
+> registry, counters and histograms exposed on `/metrics`. Probed on 2026-08-06 (change
+> `add-observability-skill`, commit `60eb0be`).
 
 A service that degrades safely and silently has traded a crash for a mystery. `backend-resilience`
 says what to do when a dependency fails; this skill is how anyone finds out that it did.

--- a/plugins/backend/skills/python-rest-api/SKILL.md
+++ b/plugins/backend/skills/python-rest-api/SKILL.md
@@ -180,7 +180,7 @@ collected".
 *sync* session against SQLite keeps passing, because a single test never has concurrency. The block
 only appears under load, in production. If you are on the async lane, the override must be async too.
 
-Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`.
+Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`. Probed on 2026-08-06 (change `add-async-lane-rule`, commit `c27ca79`).
 
 Outbound calls follow the same rule — `backend-resilience` ships `safe_call` and `safe_call_async` for
 exactly this reason. The DB half and the HTTP half of one request must be in the same lane.

--- a/plugins/devops/skills/k8s-tune-resources/SKILL.md
+++ b/plugins/devops/skills/k8s-tune-resources/SKILL.md
@@ -22,7 +22,8 @@ Skill for repeating the cluster-wide resources tuning routine across different K
 
 > **Verified against**: `kubectl v1.36.1` · `git 2.47.3`. Every flag the workflow uses — `-l`,
 > `-A`, `--field-selector`, `-o jsonpath` — was probed against that client. The clone URL template
-> assumes Bitbucket over SSH; adapt the host for any other forge.
+> assumes Bitbucket over SSH; adapt the host for any other forge. Probed on 2026-08-06 (change
+> `onboard-k8s-tune-resources`, commit `d1e22a4`).
 >
 > **This skill pushes to many repositories.** The Step 2 loop runs with `DRY_RUN=1` by default and
 > never pushes until you set it to `0`. Read the dry-run report first — see *Safety notes*.

--- a/plugins/game/skills/r3f-animation/SKILL.md
+++ b/plugins/game/skills/r3f-animation/SKILL.md
@@ -20,6 +20,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-assets/SKILL.md
+++ b/plugins/game/skills/r3f-assets/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-fundamentals/SKILL.md
+++ b/plugins/game/skills/r3f-fundamentals/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-geometry/SKILL.md
+++ b/plugins/game/skills/r3f-geometry/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-interaction/SKILL.md
+++ b/plugins/game/skills/r3f-interaction/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-lighting/SKILL.md
+++ b/plugins/game/skills/r3f-lighting/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-materials/SKILL.md
+++ b/plugins/game/skills/r3f-materials/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-physics/SKILL.md
+++ b/plugins/game/skills/r3f-physics/SKILL.md
@@ -20,6 +20,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-postprocessing/SKILL.md
+++ b/plugins/game/skills/r3f-postprocessing/SKILL.md
@@ -20,6 +20,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/game/skills/r3f-shaders/SKILL.md
+++ b/plugins/game/skills/r3f-shaders/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/plugins/nui/skills/fivem-nui-react/SKILL.md
+++ b/plugins/nui/skills/fivem-nui-react/SKILL.md
@@ -105,4 +105,4 @@ Full hook implementations + the Lua counterpart: `references/nui-bridge.md`.
 > **Verified against**: `vite 8.2.0` + `terser 5.49.2`. The four build rules below were checked by
 > building with them: `base: './'` emits `./assets/…`, the flat `entryFileNames` produce hash-less
 > `assets/index.js` / `assets/index.css` matching `dist/assets/*`, and `drop_console` leaves zero
-> `console.log` in the bundle.
+> `console.log` in the bundle. Probed on 2026-08-06 (change `pin-probed-skills`, commit `9afef67`).

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -44,6 +44,12 @@ MUTATIONS = {
      lambda s: s.replace("**Verified against**: `kubectl v1.36.1`",
                          "**Not version-bound**: this skill does not depend on a tool version — `kubectl v1.36.1`", 1),
      ("C5 no version pin", "declared not version-bound")),
+ # (d) The dated block with its date removed (issue #153): the literal stays, so only the date rule
+ # fires. observability's file carries exactly one ISO date, inside the block — fivem-lua was the
+ # first target and stayed silent because its block also dates the citizenfx commits it names.
+ "C5 no version pin (undated block)": ("skills/observability/SKILL.md",
+     lambda s: s.replace("2026-08-06", "the day the skill landed", 1),
+     ("C5 no version pin", "carries no date")),
  "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
      lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
  "C7 orphan wrapper": (None, None),

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -248,6 +248,7 @@ def check_description(skill: str, text: str) -> None:
 # 35 skills carried no block while C5 reported nothing.
 PIN = re.compile(r"Verified against")
 NO_VERSION = re.compile(r"does not depend on a tool version")
+ISO_DATE = re.compile(r"\b20\d\d-\d\d-\d\d\b")
 DEFERS = re.compile(r"source of truth, not this skill|read the local copy first", re.I)
 API_HINT = re.compile(r"@react-three|@react-spring|fastapi|pydantic|sqlalchemy|helm |kubectl|"
                       r"citizenfx|Qmmands|AssettoServer|openspec|gh project|zod|vite", re.I)
@@ -259,10 +260,16 @@ def check_pin(skill: str, text: str) -> None:
     may not take it unless it defers to a local source of truth the reader opens first (the phrase
     `helm-migration` already carries).
 
-    KNOWN LIMIT: this proves the literal is PRESENT, not that it is earned. A block naming a version
-    nobody ran passes; the date the block owes is not checked; a code-heavy skill that adds the
-    deferral phrase to dodge the second rule passes too. Those stay with the review — which is why
-    the block has to say what was run, not only against what."""
+    A `Verified against` block — the text from that line to the next blank line, which covers the
+    blockquote form and the one-line prose form alike — must carry an ISO date (YYYY-MM-DD): a pin
+    with no date does not say when it stopped being trustworthy. Measured on 2026-09-05 (issue
+    #153): 14 of 35 blocks carried none. The declaration owes no date.
+
+    KNOWN LIMIT: this proves the literals are PRESENT, not that they are earned. A block naming a
+    version nobody ran passes; a date is checked for shape only, never for plausibility (a future or
+    unrelated date passes); a code-heavy skill that adds the deferral phrase to dodge the second
+    rule passes too. Those stay with the review — which is why the block has to say what was run,
+    not only against what."""
     pinned = PIN.search(text)
     declared = NO_VERSION.search(text)
     if not pinned and not declared:
@@ -270,6 +277,13 @@ def check_pin(skill: str, text: str) -> None:
             "neither 'Verified against' nor 'does not depend on a tool version' — a version "
             "mentioned in passing is not a pin")
         return
+    if pinned:
+        block = text[pinned.start():]
+        block = block.split("\n\n", 1)[0]
+        if not ISO_DATE.search(block):
+            add(skill, "C5 no version pin",
+                "'Verified against' block carries no date (YYYY-MM-DD) — a pin with no date does "
+                "not say when it stopped being trustworthy")
     if declared and not pinned:
         code_lines = sum(len(b.splitlines()) for _, b in FENCE.findall(text))
         if code_lines >= 40 and API_HINT.search(text) and not DEFERS.search(text):

--- a/skills/fivem-nui-react/SKILL.md
+++ b/skills/fivem-nui-react/SKILL.md
@@ -105,4 +105,4 @@ Full hook implementations + the Lua counterpart: `references/nui-bridge.md`.
 > **Verified against**: `vite 8.2.0` + `terser 5.49.2`. The four build rules below were checked by
 > building with them: `base: './'` emits `./assets/…`, the flat `entryFileNames` produce hash-less
 > `assets/index.js` / `assets/index.css` matching `dist/assets/*`, and `drop_console` leaves zero
-> `console.log` in the bundle.
+> `console.log` in the bundle. Probed on 2026-08-06 (change `pin-probed-skills`, commit `9afef67`).

--- a/skills/k8s-tune-resources/SKILL.md
+++ b/skills/k8s-tune-resources/SKILL.md
@@ -22,7 +22,8 @@ Skill for repeating the cluster-wide resources tuning routine across different K
 
 > **Verified against**: `kubectl v1.36.1` · `git 2.47.3`. Every flag the workflow uses — `-l`,
 > `-A`, `--field-selector`, `-o jsonpath` — was probed against that client. The clone URL template
-> assumes Bitbucket over SSH; adapt the host for any other forge.
+> assumes Bitbucket over SSH; adapt the host for any other forge. Probed on 2026-08-06 (change
+> `onboard-k8s-tune-resources`, commit `d1e22a4`).
 >
 > **This skill pushes to many repositories.** The Step 2 loop runs with `DRY_RUN=1` by default and
 > never pushes until you set it to `0`. Read the dry-run report first — see *Safety notes*.

--- a/skills/observability/SKILL.md
+++ b/skills/observability/SKILL.md
@@ -20,9 +20,10 @@ compatibility: Works in any environment with filesystem access.
 # Observability
 
 > **Verified against**: `fastapi 0.141.1` · `prometheus-client 0.26.0` · `structlog 26.1.0` ·
-> `opentelemetry-api 1.44.0` · `opentelemetry-instrumentation-fastapi 0.65b0`. Every construct below
-> was run: ids generated and preserved, route templates labelled, raw paths kept out of the registry,
-> counters and histograms exposed on `/metrics`.
+> `opentelemetry-api 1.44.0` · `opentelemetry-instrumentation-fastapi 0.65b0`. Every construct
+> below was run: ids generated and preserved, route templates labelled, raw paths kept out of the
+> registry, counters and histograms exposed on `/metrics`. Probed on 2026-08-06 (change
+> `add-observability-skill`, commit `60eb0be`).
 
 A service that degrades safely and silently has traded a crash for a mystery. `backend-resilience`
 says what to do when a dependency fails; this skill is how anyone finds out that it did.

--- a/skills/python-rest-api/SKILL.md
+++ b/skills/python-rest-api/SKILL.md
@@ -180,7 +180,7 @@ collected".
 *sync* session against SQLite keeps passing, because a single test never has concurrency. The block
 only appears under load, in production. If you are on the async lane, the override must be async too.
 
-Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`.
+Verified against `SQLAlchemy 2.0.51` and `pytest-asyncio 1.4.0`. Probed on 2026-08-06 (change `add-async-lane-rule`, commit `c27ca79`).
 
 Outbound calls follow the same rule — `backend-resilience` ships `safe_call` and `safe_call_async` for
 exactly this reason. The DB half and the HTTP half of one request must be in the same lane.

--- a/skills/r3f-animation/SKILL.md
+++ b/skills/r3f-animation/SKILL.md
@@ -20,6 +20,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-assets/SKILL.md
+++ b/skills/r3f-assets/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-fundamentals/SKILL.md
+++ b/skills/r3f-fundamentals/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-geometry/SKILL.md
+++ b/skills/r3f-geometry/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-interaction/SKILL.md
+++ b/skills/r3f-interaction/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-lighting/SKILL.md
+++ b/skills/r3f-lighting/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-materials/SKILL.md
+++ b/skills/r3f-materials/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-physics/SKILL.md
+++ b/skills/r3f-physics/SKILL.md
@@ -20,6 +20,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-postprocessing/SKILL.md
+++ b/skills/r3f-postprocessing/SKILL.md
@@ -20,6 +20,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 

--- a/skills/r3f-shaders/SKILL.md
+++ b/skills/r3f-shaders/SKILL.md
@@ -19,6 +19,7 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 > `react@19.2`. Code blocks tagged `tsx` are complete modules and typecheck against that stack;
 > blocks marked `// excerpt` are illustrative fragments. R3F v10 (alpha) renames `state.gl` to
 > `state.renderer` and moves to `THREE.Timer` — check the migration guide before adopting it.
+> Probed on 2026-08-06 (change `harden-r3f-skills`, commit `a18758c`).
 
 ## Topics
 


### PR DESCRIPTION
Closes #153
Spec-rite: add-pin-date-gate
Skill-version: none — 14 blocos ganham a data que o histórico já registra; nenhuma regra, exemplo ou versão pinada muda

## O que muda

- **C5 exige a data.** O bloco `Verified against` (da linha com o literal até a próxima linha em branco — cobre o blockquote e a linha de prosa do `python-rest-api`) precisa carregar `YYYY-MM-DD`; a declaração `does not depend on a tool version` continua isenta. O KNOWN LIMIT "the date is not checked" sai da docstring; entra o que resta (forma, não plausibilidade). Finding: `'Verified against' block carries no date (YYYY-MM-DD) — a pin with no date does not say when it stopped being trustworthy`.
- **Selftest**: mutação `C5 no version pin (undated block)` em `observability` (único arquivo com uma só data ISO). O primeiro alvo, `fivem-lua`, ficou calado porque seu bloco também data os commits do citizenfx — registrado no comentário da mutação.
- **14 blocos datados**: `Probed on 2026-08-06 (change <id>, commit <sha>).` — `r3f-*` ×10 (`harden-r3f-skills`, `a18758c`), `fivem-nui-react` (`pin-probed-skills`, `9afef67`), `k8s-tune-resources` (`onboard-k8s-tune-resources`, `d1e22a4`), `observability` (`add-observability-skill`, `60eb0be`), `python-rest-api` (`add-async-lane-rule`, `c27ca79`). A data é a do histórico, dita como registro. Nenhuma versão pinada muda; nenhuma `metadata.version` move (waiver acima).
- **README**: texto do C5 e contagem do selftest 22 → 23.
- **`skills-authoring`**: MODIFIED *Versioned external APIs are pinned* — "ISO date it was probed on", cláusula "MAY be the recorded probe's when the block names the change or commit", cenário *A pin carries the date it was probed*.

## Critérios de aceitação

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | loop `awk`+`grep` por data no bloco não imprime nada | met | 14 arquivos antes, nenhum depois |
| 2 | C5 reprova bloco sem data; selftest detecta | met | cópia com a data de `observability` removida → finding acima; selftest `CAUGHT`, `22/23` local (MISSED só `C3 lua syntax`, sem luac; 23/23 esperado no CI) |
| 3 | 14 blocos citam `2026-08-06` + change/commit; nenhuma versão pinada muda | met | script de backfill assertou o conjunto de tokens `tool version` por arquivo; `git diff -- skills \| grep -c version:` → 0 |
| 4 | `validate-skills.py` 0; wrappers em sync; gate de versão verde com waiver | met | `35 skills, 0 findings`; 0 untracked; `skill-version gate: 0 findings` com `PR_BODY` |

## Simulação (rito)

- Entry points: `validate-skills.py` → 0 findings; cópia com data removida → o finding do C5; selftest → `CAUGHT C5 no version pin (undated block)`.
- Contagens: 1/1 bloco sem data disparou; 35/35 skills caladas após o backfill; 14/14 blocos datados; 0/14 versões pinadas mudaram; 3/3 declarações caladas sem regra de data; 1/1 miss local pré-existente (`C3 lua syntax`).
- O que se comportou diferente: `fivem-lua` como alvo de mutação ficou calado (três datas no bloco) → alvo movido para `observability`; o primeiro probe S.1 editou uma frase quebrada pelo wrap de 97 colunas e não mudou nada → refeito no token da data.

## Validações

| Comando | Resultado |
|---|---|
| `python3 scripts/validate-skills.py` | 35 skills, 0 findings |
| `python3 scripts/selftest-validate-skills.py` | 22/23 local (MISSED `C3 lua syntax`, luac ausente; CI instala lua5.4) |
| `bash scripts/validate-rite.sh` | `rite gate OK` |
| `openspec validate add-pin-date-gate --strict` | valid |
| `validate-skill-version.py` / `validate-spec-rite.py` (com `PR_BODY`) | 0 findings / 0 findings |
| `generate.sh` + `git status --untracked-files=all` | 0 untracked |
| `validate-repo-hygiene.py` / `scan-secrets.py` | 0 findings / no credentials |
| `agentskills validate` / `plugin validate --strict` / `npx skills add --list` | 35/35 / passed / 35 |

## Follow-ups (não feitos aqui)

1. A regra aceita qualquer data ISO no bloco; um bloco que data commits alheios (como o do `fivem-lua`) passa mesmo sem a data do probe — exigir um literal `Probed on <data>` é item próprio.
2. Plausibilidade da data (futuro, muito antiga) não é checada.
3. README:468 ainda diz `C1–C9` na listagem da árvore.

## Pendente do rito

- `openspec archive add-pin-date-gate --yes` após o merge, em PR própria (V.4 aberto de propósito).
