### PR TITLE
✨ feat(validate-skills): C5 exige o literal 'Probed on <data>' e normaliza o bloco antes de casar

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,8 +875,8 @@ A second gate checks the **content** of the skills themselves.
 [`scripts/validate-skills.py`](scripts/validate-skills.py) runs thirteen checks over every
 `skills/*/SKILL.md` and every `*.md` under its `references/`, recursively — referenced paths exist (C1), cross-skill references name a
 real skill (C2), code blocks parse (C3, bash/yaml/json/lua/python), the description states no policy
-the body contradicts (C4), every skill states what it was verified against — with the date it was
-probed — or that it does not depend on a tool version (C5), fence tags match their content
+the body contradicts (C4), every skill states what it was verified against — with a `Probed on
+<date>` line — or that it does not depend on a tool version (C5), fence tags match their content
 (C6), no generated wrapper is orphaned from a canonical source (C7), no meta section sits in a
 `SKILL.md` body where it cannot affect routing (C8), code examples use English identifiers (C9),
 the parsed `description` and `compatibility` stay within the Agent Skills limits (C10), every
@@ -911,7 +911,7 @@ as operational detail, never as a build failure.
 
 ```bash
 python3 scripts/validate-skills.py           # 0 findings expected
-python3 scripts/selftest-validate-skills.py  # 23/23 defect classes detected
+python3 scripts/selftest-validate-skills.py  # 24/24 defect classes detected
 python3 scripts/scan-secrets.py              # gate: no credentials in the working tree
 python3 scripts/scan-secrets.py --history    # audit: what the published history still contains
 ```

--- a/claude/skills/api-resilience-testing/SKILL.md
+++ b/claude/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing, nor for writing the service's own layout, envelope and handlers (that is `python-rest-api`).
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/claude/skills/svg-animation/SKILL.md
+++ b/claude/skills/svg-animation/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   the traps that break silently.
 metadata:
   author: solvelab
-  version: 1.1.3
+  version: 1.1.4
   category: frontend
 license: MIT
 compatibility: Works in any environment with filesystem access; verification steps need a Chrome binary.

--- a/cursor/rules/api-resilience-testing.mdc
+++ b/cursor/rules/api-resilience-testing.mdc
@@ -10,13 +10,13 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 # API Resilience Testing
 
 > **Verified against**: `fastapi 0.141.1` · `pydantic 2.13.4` · `starlette 1.6.0` · `httpx 0.28.1`
-> · `uvicorn 0.52.4`, re-measured on 2026-09-05 with a stock two-route service (a pydantic body
-> model, an `int` path parameter) under `TestClient` and under a real uvicorn server. Eight of the
-> nine baseline rows held; **one was corrected**: a body of nested brackets returns **400**
-> `{"detail":"There was an error parsing the body"}` at every depth from 990 to 10 000, closed or
-> unclosed, for model, `Any` and `dict` bodies — FastAPI's body parser catches the
-> `RecursionError`, and the **500** published here earlier did not reproduce. `curl` is the only
-> tool the checklist prescribes and no version-bound flag of it is used.
+> · `uvicorn 0.52.4`. Probed on 2026-09-05, re-measuring the nine baseline rows with a stock
+> two-route service (a pydantic body model, an `int` path parameter) under `TestClient` and under a
+> real uvicorn server. Eight of the nine baseline rows held; **one was corrected**: a body of
+> nested brackets returns **400** `{"detail":"There was an error parsing the body"}` at every depth
+> from 990 to 10 000, closed or unclosed, for model, `Any` and `dict` bodies — FastAPI's body
+> parser catches the `RecursionError`, and the **500** published here earlier did not reproduce.
+> `curl` is the only tool the checklist prescribes and no version-bound flag of it is used.
 
 Test a REST API so it survives the inputs nobody intended — invalid, malformed,
 out-of-contract, hostile — and fails **safely** instead of crashing, corrupting

--- a/cursor/rules/svg-animation.mdc
+++ b/cursor/rules/svg-animation.mdc
@@ -10,12 +10,14 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 # svg-animation — understand the object, then represent it
 
 > **Verified against**: `Google Chrome for Testing 151.0.7922.34` (`--headless=new`, 1280×720,
-> software rasterisation, WSL2), driven over CDP by [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs) on
-> 2026-08-30 and 2026-08-31 — every cost in `references/platform.md` comes from those two runs and
-> is recorded with its raw numbers in [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md). Not re-run on
-> 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS animation
-> semantics are specification-level and carry no tool version; the numbers do, and they expire with
-> that browser build.
+> software rasterisation, WSL2). Probed on 2026-08-30 and 2026-08-31, driven over CDP by
+> [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs)
+> — every cost in `references/platform.md` comes from those two runs and is recorded with its raw
+> numbers in
+> [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md).
+> Not re-run on 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS
+> animation semantics are specification-level and carry no tool version; the numbers do, and they
+> expire with that browser build.
 
 The failure this skill exists to prevent is not ugly output. It is **plausible** output: an animation
 whose every part is defensible and whose whole is wrong. Measured on 22 objects and 12 primitives

--- a/openspec/changes/require-probed-on-literal/.openspec.yaml
+++ b/openspec/changes/require-probed-on-literal/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-06

--- a/openspec/changes/require-probed-on-literal/design.md
+++ b/openspec/changes/require-probed-on-literal/design.md
@@ -1,0 +1,49 @@
+## Context
+
+`scripts/validate-skills.py:280-286` (read 2026-09-06, HEAD f1e4b02) isolates the block as raw text
+and searches `ISO_DATE` in it. Raw text keeps the `> ` prefixes and the line breaks the 97-column
+wrap introduced, so a phrase can straddle two lines. Measured: `assettoserver-csp-lua` and
+`react-api-client` carry `Probed on` at a line end and the date on the next line; `k8s-tune-resources`
+carries a second `>` paragraph after a bare `>` line, which normalises to an extra space.
+
+## Goals / Non-Goals
+
+**Goals:**
+- The date C5 proves is the probe's, named as such.
+- A correct block never fails because of where the wrap broke a line.
+
+**Non-Goals:**
+- Plausibility of the date; rewording blocks that already carry the literal.
+
+## Decisions
+
+1. **Normalise, then match.** Strip `^> ?` per line, join with a single space, run both date rules
+   on the result. Alternative — forbid the wrap from splitting the phrase — rejected: it moves a
+   gate's problem into every author's editor.
+2. **Two findings, not one.** "carries no date" (no ISO date at all) stays with its fragment, which
+   the existing `undated block` mutation asserts; "names no `Probed on <date>`" is added for a block
+   that has dates but not the literal. A reader of the finding knows which sentence to write.
+3. **Case-insensitive `[Pp]robed on`.** `verify-before-claiming` says "was probed on 2026-08-06";
+   the phrase is the same fact in running prose, and demanding the capital would edit a correct block
+   for the regex's sake.
+4. **Reword only the two blocks that lack the literal**, keeping their facts: `api-resilience-testing`
+   keeps "re-measuring", `svg-animation` keeps "Not re-run on 2026-09-05".
+5. **Patch bumps** on the two reworded skills: a block sentence changed, nothing else.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| The probe date is named with `Probed on <date>` | `skills-authoring` spec + C5 docstring | already canonical — blocks carry the sentence, not the rule |
+| Dated claims | `verify-before-claiming` | already canonical — nothing restated |
+
+## Risks / Trade-offs
+
+- [A block writes `Probed on <date>` for a run nobody made] → unchanged from every other C5 rule:
+  presence, not honesty; the review judges.
+- [Normalisation joins two paragraphs of a block] → harmless: the literal is searched anywhere in the
+  joined text; `k8s-tune-resources` is the measured case.
+
+## Open Questions
+
+None.

--- a/openspec/changes/require-probed-on-literal/proposal.md
+++ b/openspec/changes/require-probed-on-literal/proposal.md
@@ -1,0 +1,48 @@
+# Change: Require the literal `Probed on <date>` in every `Verified against` block, matched on the normalised block
+
+## Why
+
+Since #153, C5 requires an ISO date inside the `Verified against` block — any ISO date. The block of
+`fivem-lua` dates the citizenfx commits it names (`(2026-09-02)`, `(2026-08-17)`) and would pass
+with its own probe date removed; the selftest mutation had to move to `observability` for that
+reason (recorded in `2026-09-06-add-pin-date-gate/tasks.md`, S.3). The date the gate proves present
+is therefore not necessarily the date of the probe.
+
+Measured on 2026-09-06 over the 32 blocks, normalised (leading `> ` stripped, lines joined by a
+space): 30 carry `Probed on YYYY-MM-DD` or `probed on YYYY-MM-DD`; 2 do not —
+`api-resilience-testing` ("re-measured on 2026-09-05") and `svg-animation` ("driven … on 2026-08-30
+and 2026-08-31 … Not re-run on 2026-09-05"). Matched on the raw text instead, two correct blocks
+would fail: the 97-column wrap leaves `Probed on` at the end of one line and the date at the start
+of the next in `assettoserver-csp-lua/SKILL.md:26-27` and `react-api-client/SKILL.md:18-19`.
+
+## What Changes
+
+- **C5 normalises the block** — `" ".join(re.sub(r"^> ?", "", l) for l in block.splitlines())` —
+  before both date rules, and adds a second rule: a block with a date but no
+  `[Pp]robed on YYYY-MM-DD` is reported as naming no probe date. The "carries no date" finding stays
+  for blocks with no date at all. Docstring names the normalisation and why (the wrap).
+- **Selftest**: mutation `C5 no version pin (date but no Probed on)` on `observability`
+  (`Probed on 2026-08-06` → `Dated 2026-08-06`); the `undated block` mutation stays.
+- **Two blocks reworded**, patch bump each: `api-resilience-testing` ("Probed on 2026-09-05,
+  re-measuring the nine rows …") and `svg-animation` ("Probed on 2026-08-30 and 2026-08-31 …
+  Not re-run on 2026-09-05"). `verify-before-claiming` already matches (`probed on 2026-08-06`).
+- **README**: C5 sentence names the `Probed on <date>` line; selftest count 23 → 24.
+
+## Deliberately not done
+
+- Date plausibility; a date on the declaration form; rewording the 30 blocks that already match.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Versioned external APIs are pinned** — the probe date is named
+  with the literal `Probed on YYYY-MM-DD`; other dates in the block do not stand in for it.
+
+## Impact
+
+- `scripts/validate-skills.py`, `scripts/selftest-validate-skills.py`, `README.md`,
+  `skills/api-resilience-testing/SKILL.md`, `skills/svg-animation/SKILL.md`, regenerated wrappers.
+- No skill added, removed or repurposed; no description changes.

--- a/openspec/changes/require-probed-on-literal/specs/skills-authoring/spec.md
+++ b/openspec/changes/require-probed-on-literal/specs/skills-authoring/spec.md
@@ -1,0 +1,86 @@
+## MODIFIED Requirements
+
+### Requirement: Versioned external APIs are pinned
+
+A skill whose content targets an external API **or command-line tool** with breaking releases SHALL
+state the exact versions it was verified against, and SHALL name any known upcoming rename or removal
+that will invalidate it. For a skill that instructs the agent to run a CLI, the commands and flags it
+prescribes SHALL be probed against that tool before publication.
+
+Every `SKILL.md` SHALL carry exactly one of two literal declarations, placed where a reader meets it
+before the first rule: a `Verified against` block naming each tool and the version it was probed
+against, what was run, and the probe date written as the literal `Probed on YYYY-MM-DD`; or the sentence `does not depend on a tool
+version` followed by the reason. The date MAY be the recorded probe's when the block names the change
+or commit that recorded it. A `Verified against` block SHALL name only versions the claims were actually probed
+against, and SHALL name the part of the skill that was not probed rather than cover it by implication.
+A version written for a run nobody made is a defect, not a pin. The declaration is an exit for
+process skills: a skill carrying 40 or more fenced lines against a versioned API SHALL carry the
+block unless it defers to a local source of truth it instructs the reader to open first.
+
+#### Scenario: Reader can tell which era the code targets
+
+- **WHEN** a skill documents a library API
+- **THEN** the skill names the library versions its examples were verified against, rather than
+  leaving the reader to infer it
+
+#### Scenario: A known breaking change is disclosed, not silently absorbed
+
+- **WHEN** the upstream has announced a rename or removal affecting the skill's examples
+- **THEN** the skill names it and where it applies, instead of presenting the current form as timeless
+
+#### Scenario: Prescribed CLI commands are probed, not assumed
+
+- **WHEN** a skill instructs the agent to run a command with specific subcommands and flags
+- **THEN** each subcommand and flag is checked against the installed tool before publication, and the
+  tool version the check ran against is recorded
+
+#### Scenario: Tool guidance contradicted by the tool is corrected, not repeated
+
+- **WHEN** a tool's own output advertises behaviour its implementation does not deliver
+- **THEN** the skill states the probed behaviour and the version it holds for, rather than repeating
+  the tool's claim
+
+#### Scenario: Every skill declares its relationship to versions
+
+- **WHEN** a `SKILL.md` carries neither the literal `Verified against` nor the literal
+  `does not depend on a tool version`
+- **THEN** the validator reports it under C5, whatever amount of fenced code the skill carries
+
+#### Scenario: A loose version mention is not a pin
+
+- **WHEN** a skill names a version only in passing (`Probed on CLI 1.6.0`, `targets v0.0.54`,
+  `needs CSP >= 0.1.78`) and carries no literal `Verified against`
+- **THEN** the validator reports it under C5, because a reader cannot tell a pin from a mention
+
+#### Scenario: A code-heavy skill does not exit by declaration
+
+- **WHEN** a skill carries 40 or more fenced lines, names a versioned API, declares that it does not
+  depend on a tool version, and does not defer to a local source of truth
+- **THEN** the validator reports the declaration as contradicted by the skill's own code
+
+#### Scenario: A partial probe names its boundary
+
+- **WHEN** only part of a skill's surface could be probed — public API stubs or source, but not the
+  runtime that executes them
+- **THEN** the `Verified against` block names what was probed, against which artifact and version,
+  and states what was not probed, instead of letting the pin cover the whole skill
+
+#### Scenario: A pin carries the date it was probed
+
+- **WHEN** a `Verified against` block — the text from that line to the next blank line — carries no
+  ISO date (`YYYY-MM-DD`)
+- **THEN** the validator reports it under C5, because a pin with no date does not say when it
+  stopped being trustworthy
+
+#### Scenario: The probe date is named as such
+
+- **WHEN** a `Verified against` block — normalised by stripping the blockquote prefix and joining
+  its lines — carries ISO dates but no `Probed on YYYY-MM-DD` (or `probed on YYYY-MM-DD`)
+- **THEN** the validator reports it under C5, because a date of a commit or a release the block
+  cites does not stand in for the date the probe ran
+
+#### Scenario: A line wrap does not fail a correct block
+
+- **WHEN** the wrap leaves `Probed on` at the end of one blockquote line and the date at the start of
+  the next
+- **THEN** the validator, matching on the normalised block, stays silent

--- a/openspec/changes/require-probed-on-literal/tasks.md
+++ b/openspec/changes/require-probed-on-literal/tasks.md
@@ -1,0 +1,56 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+## 2. Gate
+
+- [ ] 2.1 C5 normalises the block and requires `[Pp]robed on YYYY-MM-DD`; "carries no date" kept for
+      blocks with no date; docstring names the normalisation and the wrap it exists for
+- [ ] 2.2 Selftest mutation `C5 no version pin (date but no Probed on)` on `observability`
+
+## 3. Blocks and docs
+
+- [ ] 3.1 `api-resilience-testing` and `svg-animation` blocks reworded to carry the literal, facts kept;
+      patch bumps
+- [ ] 3.2 README C5 sentence and selftest count (23 → 24)
+- [ ] 3.3 `./generate.sh`; wrappers in sync
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 5. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`).
+      Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
+      paths shipped in target repos through this rite. Regression gate on the exemplar: the model
+      imitates the code it is shown
+
+## 6. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate require-probed-on-literal --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive require-probed-on-literal --yes` after all groups above are `[x]`

--- a/openspec/changes/require-probed-on-literal/tasks.md
+++ b/openspec/changes/require-probed-on-literal/tasks.md
@@ -1,56 +1,71 @@
 ## 1. Evidence & Sources (MANDATORY)
 
-- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
       the commit or timestamp it was read at
-- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      Evidence: Opened 2026-09-06 at HEAD f1e4b02: `scripts/validate-skills.py:244-296` (C5 block, `ISO_DATE`, `check_pin`), `scripts/selftest-validate-skills.py:30-55`, `README.md:875-913`, `openspec/specs/skills-authoring/spec.md` (requirement copied whole into the MODIFIED delta), the 32 `Verified against` blocks (measured programmatically), `skills/api-resilience-testing/SKILL.md:23-30`, `skills/svg-animation/SKILL.md:25-31`, `openspec/changes/archive/2026-09-06-add-pin-date-gate/tasks.md` (S.3, the fivem-lua escape).
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
       probed against the installed version; the command and a fragment of its output are recorded
-- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      Evidence: Normalised measurement script (`block = text[m.start():].split('\n\n',1)[0]; norm = ' '.join(re.sub(r'^> ?','',l) for l in block.splitlines())`) -> `blocks: 32 with literal: 30 declarations: 3`, `missing literal: [('api-resilience-testing', ['2026-09-05']), ('svg-animation', ['2026-08-30','2026-08-31','2026-09-05'])]`; raw-vs-normalised on the wrap cases -> `assettoserver-csp-lua raw=False normalised=True`, `react-api-client raw=False normalised=True`, `k8s-tune-resources raw=True normalised=True paragraphs=2`. After the rewrites -> `missing literal: []`. `python3 scripts/validate-skills.py` -> `skills checked: 35   findings: 0`.
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
       when there is no design.md) — never stated as fact, never filled with a plausible substitute
-- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      Evidence: Nothing this change asserts was unprobeable: every count comes from the measurement script over this clone and every finding text from a run of the validator. What the gate still cannot tell — a `Probed on <date>` written for a run nobody made, or an implausible date — stays in the C5 docstring as the remaining KNOWN LIMIT.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
       along the way are listed here as follow-ups, not performed
-
+      Evidence: Follow-ups noticed and NOT performed: (1) date plausibility (future or decades-old dates pass); (2) the declaration form carries a date by convention only; (3) README:468 still says `C1–C9` in the tree listing (noted three times now); (4) `verify-before-claiming` writes the literal in lower case inside running prose — accepted by design, not reworded.
 ## 2. Gate
 
-- [ ] 2.1 C5 normalises the block and requires `[Pp]robed on YYYY-MM-DD`; "carries no date" kept for
+- [x] 2.1 C5 normalises the block and requires `[Pp]robed on YYYY-MM-DD`; "carries no date" kept for
       blocks with no date; docstring names the normalisation and the wrap it exists for
-- [ ] 2.2 Selftest mutation `C5 no version pin (date but no Probed on)` on `observability`
-
+      Evidence: `scripts/validate-skills.py`: `PROBED_ON = re.compile(r"\b[Pp]robed on 20\d\d-\d\d-\d\d\b")`; `block = " ".join(re.sub(r"^> ?", "", line) for line in block.splitlines())` before both rules; new finding `'Verified against' block names no \`Probed on <date>\` — a date of a commit or release the block cites does not stand in for the date the probe ran`; docstring names the normalisation and the two wrap cases.
+- [x] 2.2 Selftest mutation `C5 no version pin (date but no Probed on)` on `observability`
+      Evidence: `scripts/selftest-validate-skills.py`: mutation `C5 no version pin (date but no Probed on)` on `skills/observability/SKILL.md` (`Probed on 2026-08-06` -> `Dated 2026-08-06`, fragment `names no`) -> `CAUGHT`; run -> `23/24 defect classes detected` locally (MISSED only `C3 lua syntax`, luac absent).
 ## 3. Blocks and docs
 
-- [ ] 3.1 `api-resilience-testing` and `svg-animation` blocks reworded to carry the literal, facts kept;
+- [x] 3.1 `api-resilience-testing` and `svg-animation` blocks reworded to carry the literal, facts kept;
       patch bumps
-- [ ] 3.2 README C5 sentence and selftest count (23 → 24)
-- [ ] 3.3 `./generate.sh`; wrappers in sync
-
+      Evidence: `api-resilience-testing` 1.3.2 -> 1.3.3: `… \`uvicorn 0.52.4\`. Probed on 2026-09-05, re-measuring the nine baseline rows with a stock two-route service …`; `svg-animation` 1.1.3 -> 1.1.4: `… WSL2). Probed on 2026-08-30 and 2026-08-31, driven over CDP by measure.mjs — …`, `Not re-run on 2026-09-05` kept. Rewrite script asserted the old sentence present before replacing.
+- [x] 3.2 README C5 sentence and selftest count (23 → 24)
+      Evidence: `README.md:878-879` -> `with a \`Probed on <date>\` line`; `:913` -> `24/24 defect classes detected`.
+- [x] 3.3 `./generate.sh`; wrappers in sync
+      Evidence: `bash generate.sh` -> `git status --porcelain --untracked-files=all | grep -c '^??'` -> 0; 11 paths changed before commit.
 ## 4. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
       observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      Evidence: entry point `python3 scripts/validate-skills.py` -> `skills checked: 35   findings: 0`; on a copy with observability's `Probed on` -> `Dated` -> `[C5 no version pin] 'Verified against' block names no \`Probed on <date>\` — a date of a commit or release the block cites does not stand in for the date the probe ran`; the same copy restored -> `assettoserver-csp-lua`, `react-api-client`, `k8s-tune-resources` absent from the findings (wrap-split and two-paragraph blocks silent); entry point `python3 scripts/selftest-validate-skills.py` -> `CAUGHT  C5 no version pin (date but no Probed on)`.
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
       silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      Evidence: 1/1 dated-but-unnamed block had to fire and did; 35/35 skills silent after the two rewrites; 2/2 wrap-split blocks silent without edits; 1/1 two-paragraph block silent; 2/2 reworded blocks keep their facts; 1/1 lower-case `probed on` block (verify-before-claiming) silent by design; 1/1 pre-existing local miss unchanged (`C3 lua syntax`).
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
       explicitly that nothing did
-
+      Evidence: Nothing escaped or behaved differently than expected: the raw-vs-normalised measurement predicted exactly the two rewrites and the two wrap cases, and the validator confirmed both.
 ## 5. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
       metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
       compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      Evidence: Frontmatter loop replicated over `skills/*/SKILL.md` -> `frontmatter fail=0`; `agentskills validate` -> `fail=0` over 35; `npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict` -> `✔ Validation passed`.
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Evidence: All added text is English; `check-identifier-locale.py` over the changed `skills/`, `scripts/` and `README.md` -> `findings: 0`.
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
       do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      Evidence: `git diff master -- skills/ | grep -c -E '^[-+]\s*description'` -> `0`; no trigger moved.
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
       its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      Evidence: The rule lives in the `skills-authoring` requirement and the C5 docstring; the two blocks carry the sentence only (design.md Canonical Home, two rows, `already canonical`).
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
       names; a term kept in another language carries its reason inline (`code-locale`).
       Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
       paths shipped in target repos through this rite. Regression gate on the exemplar: the model
       imitates the code it is shown
-
+      Evidence: No code example touched; detector -> `findings: 0`.
 ## 6. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate require-probed-on-literal --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+- [x] V.1 `openspec validate require-probed-on-literal --strict` green
+      Evidence: `openspec validate require-probed-on-literal --strict` -> `Change 'require-probed-on-literal' is valid`; `bash scripts/validate-rite.sh` -> `rite gate OK` (evidence gate 0, spec-rite gate 0).
+- [x] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
       no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `npx -y skills add solvelab/ai-skills --list | grep -c -E '^│    [a-z0-9-]+$'` -> `35`; nothing added, removed or renamed.
+- [x] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `README.md` C5 sentence and selftest count updated; catalog composition unchanged.
 - [ ] V.4 `openspec archive require-probed-on-literal --yes` after all groups above are `[x]`

--- a/plugins/frontend/skills/svg-animation/SKILL.md
+++ b/plugins/frontend/skills/svg-animation/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   the traps that break silently.
 metadata:
   author: solvelab
-  version: 1.1.3
+  version: 1.1.4
   category: frontend
 license: MIT
 compatibility: Works in any environment with filesystem access; verification steps need a Chrome binary.
@@ -23,12 +23,14 @@ compatibility: Works in any environment with filesystem access; verification ste
 # svg-animation — understand the object, then represent it
 
 > **Verified against**: `Google Chrome for Testing 151.0.7922.34` (`--headless=new`, 1280×720,
-> software rasterisation, WSL2), driven over CDP by [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs) on
-> 2026-08-30 and 2026-08-31 — every cost in `references/platform.md` comes from those two runs and
-> is recorded with its raw numbers in [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md). Not re-run on
-> 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS animation
-> semantics are specification-level and carry no tool version; the numbers do, and they expire with
-> that browser build.
+> software rasterisation, WSL2). Probed on 2026-08-30 and 2026-08-31, driven over CDP by
+> [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs)
+> — every cost in `references/platform.md` comes from those two runs and is recorded with its raw
+> numbers in
+> [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md).
+> Not re-run on 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS
+> animation semantics are specification-level and carry no tool version; the numbers do, and they
+> expire with that browser build.
 
 The failure this skill exists to prevent is not ugly output. It is **plausible** output: an animation
 whose every part is defensible and whose whole is wrong. Measured on 22 objects and 12 primitives

--- a/plugins/testing/skills/api-resilience-testing/SKILL.md
+++ b/plugins/testing/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing, nor for writing the service's own layout, envelope and handlers (that is `python-rest-api`).
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -13,13 +13,13 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 # API Resilience Testing
 
 > **Verified against**: `fastapi 0.141.1` · `pydantic 2.13.4` · `starlette 1.6.0` · `httpx 0.28.1`
-> · `uvicorn 0.52.4`, re-measured on 2026-09-05 with a stock two-route service (a pydantic body
-> model, an `int` path parameter) under `TestClient` and under a real uvicorn server. Eight of the
-> nine baseline rows held; **one was corrected**: a body of nested brackets returns **400**
-> `{"detail":"There was an error parsing the body"}` at every depth from 990 to 10 000, closed or
-> unclosed, for model, `Any` and `dict` bodies — FastAPI's body parser catches the
-> `RecursionError`, and the **500** published here earlier did not reproduce. `curl` is the only
-> tool the checklist prescribes and no version-bound flag of it is used.
+> · `uvicorn 0.52.4`. Probed on 2026-09-05, re-measuring the nine baseline rows with a stock
+> two-route service (a pydantic body model, an `int` path parameter) under `TestClient` and under a
+> real uvicorn server. Eight of the nine baseline rows held; **one was corrected**: a body of
+> nested brackets returns **400** `{"detail":"There was an error parsing the body"}` at every depth
+> from 990 to 10 000, closed or unclosed, for model, `Any` and `dict` bodies — FastAPI's body
+> parser catches the `RecursionError`, and the **500** published here earlier did not reproduce.
+> `curl` is the only tool the checklist prescribes and no version-bound flag of it is used.
 
 Test a REST API so it survives the inputs nobody intended — invalid, malformed,
 out-of-contract, hostile — and fails **safely** instead of crashing, corrupting

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -50,6 +50,10 @@ MUTATIONS = {
  "C5 no version pin (undated block)": ("skills/observability/SKILL.md",
      lambda s: s.replace("2026-08-06", "the day the skill landed", 1),
      ("C5 no version pin", "carries no date")),
+ # (e) A dated block whose date is not the probe's (issue #157): the ISO date stays, the literal goes.
+ "C5 no version pin (date but no Probed on)": ("skills/observability/SKILL.md",
+     lambda s: s.replace("Probed on 2026-08-06", "Dated 2026-08-06", 1),
+     ("C5 no version pin", "names no")),
  "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
      lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
  "C7 orphan wrapper": (None, None),

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -249,6 +249,7 @@ def check_description(skill: str, text: str) -> None:
 PIN = re.compile(r"Verified against")
 NO_VERSION = re.compile(r"does not depend on a tool version")
 ISO_DATE = re.compile(r"\b20\d\d-\d\d-\d\d\b")
+PROBED_ON = re.compile(r"\b[Pp]robed on 20\d\d-\d\d-\d\d\b")
 DEFERS = re.compile(r"source of truth, not this skill|read the local copy first", re.I)
 API_HINT = re.compile(r"@react-three|@react-spring|fastapi|pydantic|sqlalchemy|helm |kubectl|"
                       r"citizenfx|Qmmands|AssettoServer|openspec|gh project|zod|vite", re.I)
@@ -261,9 +262,14 @@ def check_pin(skill: str, text: str) -> None:
     `helm-migration` already carries).
 
     A `Verified against` block — the text from that line to the next blank line, which covers the
-    blockquote form and the one-line prose form alike — must carry an ISO date (YYYY-MM-DD): a pin
-    with no date does not say when it stopped being trustworthy. Measured on 2026-09-05 (issue
-    #153): 14 of 35 blocks carried none. The declaration owes no date.
+    blockquote form and the one-line prose form alike — must carry the probe date as the literal
+    `Probed on YYYY-MM-DD` (or `probed on`): a pin with no date does not say when it stopped being
+    trustworthy, and a date of a commit or release the block cites does not stand in for the
+    probe's (measured on 2026-09-06, issue #157: fivem-lua's block dates two citizenfx commits).
+    Both rules run on the NORMALISED block — blockquote prefix stripped, lines joined by a space —
+    because the 97-column wrap can leave `Probed on` at one line's end and the date at the next
+    line's start (assettoserver-csp-lua, react-api-client), and a gate must not fail a correct
+    block for where the wrap broke it. The declaration owes no date.
 
     KNOWN LIMIT: this proves the literals are PRESENT, not that they are earned. A block naming a
     version nobody ran passes; a date is checked for shape only, never for plausibility (a future or
@@ -278,12 +284,16 @@ def check_pin(skill: str, text: str) -> None:
             "mentioned in passing is not a pin")
         return
     if pinned:
-        block = text[pinned.start():]
-        block = block.split("\n\n", 1)[0]
+        block = text[pinned.start():].split("\n\n", 1)[0]
+        block = " ".join(re.sub(r"^> ?", "", line) for line in block.splitlines())
         if not ISO_DATE.search(block):
             add(skill, "C5 no version pin",
                 "'Verified against' block carries no date (YYYY-MM-DD) — a pin with no date does "
                 "not say when it stopped being trustworthy")
+        elif not PROBED_ON.search(block):
+            add(skill, "C5 no version pin",
+                "'Verified against' block names no `Probed on <date>` — a date of a commit or "
+                "release the block cites does not stand in for the date the probe ran")
     if declared and not pinned:
         code_lines = sum(len(b.splitlines()) for _, b in FENCE.findall(text))
         if code_lines >= 40 and API_HINT.search(text) and not DEFERS.search(text):

--- a/skills/api-resilience-testing/SKILL.md
+++ b/skills/api-resilience-testing/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Tests REST/HTTP APIs beyond the happy path — negative, fuzz, contract, and security testing — to find critical failures before production. Use this skill whenever the work involves a REST API: adding or changing an endpoint, reviewing an API PR or diff, writing API tests, designing request/response schemas, or when the user says "test/harden/break/audit/review the API", "negative testing", "fuzz", "API robustness", "API security", "validate payloads", or asks about invalid inputs, status codes, error handling, auth/authz, or OpenAPI/Swagger contract validation. Produces an endpoint map, positive + negative scenarios, suggested automated tests, and a resilience checklist. Do NOT use for non-API or pure happy-path unit testing, nor for writing the service's own layout, envelope and handlers (that is `python-rest-api`).
 metadata:
   author: solvelab
-  version: 1.3.2
+  version: 1.3.3
   category: testing
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.
@@ -13,13 +13,13 @@ compatibility: Works in Claude Code, Claude.ai, and any environment with filesys
 # API Resilience Testing
 
 > **Verified against**: `fastapi 0.141.1` · `pydantic 2.13.4` · `starlette 1.6.0` · `httpx 0.28.1`
-> · `uvicorn 0.52.4`, re-measured on 2026-09-05 with a stock two-route service (a pydantic body
-> model, an `int` path parameter) under `TestClient` and under a real uvicorn server. Eight of the
-> nine baseline rows held; **one was corrected**: a body of nested brackets returns **400**
-> `{"detail":"There was an error parsing the body"}` at every depth from 990 to 10 000, closed or
-> unclosed, for model, `Any` and `dict` bodies — FastAPI's body parser catches the
-> `RecursionError`, and the **500** published here earlier did not reproduce. `curl` is the only
-> tool the checklist prescribes and no version-bound flag of it is used.
+> · `uvicorn 0.52.4`. Probed on 2026-09-05, re-measuring the nine baseline rows with a stock
+> two-route service (a pydantic body model, an `int` path parameter) under `TestClient` and under a
+> real uvicorn server. Eight of the nine baseline rows held; **one was corrected**: a body of
+> nested brackets returns **400** `{"detail":"There was an error parsing the body"}` at every depth
+> from 990 to 10 000, closed or unclosed, for model, `Any` and `dict` bodies — FastAPI's body
+> parser catches the `RecursionError`, and the **500** published here earlier did not reproduce.
+> `curl` is the only tool the checklist prescribes and no version-bound flag of it is used.
 
 Test a REST API so it survives the inputs nobody intended — invalid, malformed,
 out-of-contract, hostile — and fails **safely** instead of crashing, corrupting

--- a/skills/svg-animation/SKILL.md
+++ b/skills/svg-animation/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   the traps that break silently.
 metadata:
   author: solvelab
-  version: 1.1.3
+  version: 1.1.4
   category: frontend
 license: MIT
 compatibility: Works in any environment with filesystem access; verification steps need a Chrome binary.
@@ -23,12 +23,14 @@ compatibility: Works in any environment with filesystem access; verification ste
 # svg-animation — understand the object, then represent it
 
 > **Verified against**: `Google Chrome for Testing 151.0.7922.34` (`--headless=new`, 1280×720,
-> software rasterisation, WSL2), driven over CDP by [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs) on
-> 2026-08-30 and 2026-08-31 — every cost in `references/platform.md` comes from those two runs and
-> is recorded with its raw numbers in [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md). Not re-run on
-> 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS animation
-> semantics are specification-level and carry no tool version; the numbers do, and they expire with
-> that browser build.
+> software rasterisation, WSL2). Probed on 2026-08-30 and 2026-08-31, driven over CDP by
+> [`measure.mjs`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measure.mjs)
+> — every cost in `references/platform.md` comes from those two runs and is recorded with its raw
+> numbers in
+> [`measurements.md`](https://github.com/solvelab/ai-skills/blob/master/research/svg-animation/measurements.md).
+> Not re-run on 2026-09-05: no Chrome binary on the machine that wrote this pin. SVG, SMIL and CSS
+> animation semantics are specification-level and carry no tool version; the numbers do, and they
+> expire with that browser build.
 
 The failure this skill exists to prevent is not ugly output. It is **plausible** output: an animation
 whose every part is defensible and whose whole is wrong. Measured on 22 objects and 12 primitives


### PR DESCRIPTION
Closes #157
Spec-rite: require-probed-on-literal

## O que muda

- **C5 normaliza o bloco e exige o literal.** O bloco `Verified against` tem o prefixo `> ` removido e as linhas unidas antes das duas regras de data; além de "carries no date" (sem data alguma), um bloco com data mas sem `[Pp]robed on YYYY-MM-DD` recebe `'Verified against' block names no `Probed on <date>` — a date of a commit or release the block cites does not stand in for the date the probe ran`. A normalização existe porque o wrap de 97 colunas deixa `Probed on` no fim de uma linha e a data no início da seguinte em `assettoserver-csp-lua` e `react-api-client` — ambos passam sem edição.
- **Selftest**: mutação `C5 no version pin (date but no Probed on)` em `observability` (`Probed on 2026-08-06` → `Dated 2026-08-06`).
- **Dois blocos reescritos**, bump patch: `api-resilience-testing` 1.3.2 → 1.3.3 ("Probed on 2026-09-05, re-measuring the nine baseline rows…") e `svg-animation` 1.1.3 → 1.1.4 ("Probed on 2026-08-30 and 2026-08-31, driven over CDP…", mantendo "Not re-run on 2026-09-05"). `verify-before-claiming` já casa com `probed on` em minúsculo.
- **README**: frase do C5 e contagem 23 → 24.
- **`skills-authoring`**: MODIFIED *Versioned external APIs are pinned* — "the probe date written as the literal `Probed on YYYY-MM-DD`", cenários *The probe date is named as such* e *A line wrap does not fail a correct block*.

## Critérios de aceitação

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | 32 blocos normalizados casam `[Pp]robed on <data>`; 3 declarações fora | met | script de medição → `blocks: 32 missing literal: []`, `declarations: 3` |
| 2 | C5 reprova data-sem-literal; selftest detecta | met | cópia de `observability` com `Dated` → finding acima; selftest `CAUGHT`, `23/24` local (MISSED só `C3 lua syntax`, sem luac; 24/24 esperado no CI) |
| 3 | `assettoserver-csp-lua` e `react-api-client` passam sem edição | met | raw=False / normalised=True medido; ausentes dos findings na cópia |
| 4 | `validate-skills.py` 0; wrappers em sync; gate de versão verde (2 bumps) | met | `35 skills, 0 findings`; 0 untracked; `skill-version gate: 0 findings (2 skills changed)` |

## Simulação (rito)

- Entry points: `validate-skills.py` → 0 findings; cópia com `Dated` → o finding novo; cópia intacta → `assettoserver-csp-lua`, `react-api-client`, `k8s-tune-resources` ausentes dos findings; selftest → `CAUGHT`.
- Contagens: 1/1 bloco data-sem-literal disparou; 35/35 skills caladas; 2/2 blocos partidos pelo wrap calados sem edição; 1/1 bloco de dois parágrafos calado; 2/2 blocos reescritos com fatos mantidos; 1/1 `probed on` minúsculo calado por desenho; 1/1 miss local pré-existente.
- Nada escapou: a medição raw-vs-normalizada previu exatamente as duas reescritas e os dois casos de wrap.

## Validações

| Comando | Resultado |
|---|---|
| `python3 scripts/validate-skills.py` | 35 skills, 0 findings |
| `python3 scripts/selftest-validate-skills.py` | 23/24 local (MISSED `C3 lua syntax`, luac ausente; CI instala lua5.4) |
| `bash scripts/validate-rite.sh` | `rite gate OK` |
| `openspec validate require-probed-on-literal --strict` | valid |
| `validate-skill-version.py` / `validate-spec-rite.py` (com `PR_BODY`) | 0 findings / 0 findings |
| `generate.sh` + `git status --untracked-files=all` | 0 untracked |
| `validate-repo-hygiene.py` / `scan-secrets.py` | 0 findings / no credentials |
| `agentskills validate` / `plugin validate --strict` / `npx skills add --list` | 35/35 / passed / 35 |

## Follow-ups (não feitos aqui)

1. Plausibilidade da data (futuro, muito antiga) não é checada.
2. README:468 ainda diz `C1–C9` na listagem da árvore.

## Pendente do rito

- `openspec archive require-probed-on-literal --yes` após o merge, em PR própria (V.4 aberto de propósito).
