### PR TITLE
📝 docs(readme): árvore de scripts/ cita C1–C13 e os dois scripts que faltavam

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,9 +465,11 @@ ai-skills/
 ├── update.sh                                 # Sync + regenerate
 ├── scripts/
 │   ├── set-version.sh                        # Version propagation (called by semantic-release)
-│   ├── validate-skills.py                    # Skill content checks (C1–C9) + selftest-validate-skills.py
+│   ├── validate-skills.py                    # Skill content checks (C1–C13, list in its docstring) + selftest-validate-skills.py
 │   ├── validate-repo-hygiene.py              # Compiled artifacts, published counts
 │   ├── validate-rite.sh                      # OpenSpec rite gate (+ validate-rite-evidence.py, validate-spec-rite.py)
+│   ├── validate-skill-version.py             # Skill version gate (an edited skill moves its metadata.version, or the PR body waives it)
+│   ├── smoke-install-scripts.sh              # install.sh + update.sh under a temporary HOME, against a local bare clone
 │   └── scan-secrets.py                       # Credential scan (working tree gates, history reports)
 ├── .releaserc.json                           # semantic-release config (auto-versioning from commits)
 └── README.md


### PR DESCRIPTION
Closes #161
Spec-rite: none — uma linha de comentário e duas entradas ausentes na árvore de arquivos do README; nenhum requisito, gate ou skill muda

## O que muda

Três linhas na árvore de arquivos de `README.md` (`scripts/`):

- `validate-skills.py` → "Skill content checks (C1–C13, list in its docstring)" (dizia `C1–C9`; o script tem treze checks e README:875 já dizia "thirteen").
- `validate-skill-version.py` → nova entrada: "Skill version gate (an edited skill moves its metadata.version, or the PR body waives it)".
- `smoke-install-scripts.sh` → nova entrada: "install.sh + update.sh under a temporary HOME, against a local bare clone" (texto do `ci.yml`).

Correção de fato em relação à issue: `scripts/` tem dez arquivos, não sete; a árvore já citava oito (alguns dentro de comentários) e omitia exatamente estes dois.

## Critérios de aceitação

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | `grep -c 'C1–C9' README.md` → 0; linha cita `C1–C13` | met | `0`; README:468 |
| 2 | todo arquivo de `ls scripts` aparece no README | met | loop `for f in $(ls scripts); grep -q "$f" README.md` → nada impresso (10/10) |
| 3 | `validate-repo-hygiene.py` 0 findings; demais gates verdes | met | `repo hygiene: 0 findings`; `no credentials found`; `rite gate OK` com o waiver via `PR_BODY`; `skill-version gate: 0 findings (0 skills changed)`; `generate.sh` → 0 untracked, nada gerado muda |

Sem artefato de runtime tocado; sem change OpenSpec (waiver acima, re-checado contra o diff: só `README.md`).
