### PR TITLE
✨ feat(validate-skills): C5 valida a plausibilidade da data do probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,7 +878,8 @@ A second gate checks the **content** of the skills themselves.
 `skills/*/SKILL.md` and every `*.md` under its `references/`, recursively — referenced paths exist (C1), cross-skill references name a
 real skill (C2), code blocks parse (C3, bash/yaml/json/lua/python), the description states no policy
 the body contradicts (C4), every skill states what it was verified against — with a `Probed on
-<date>` line — or that it does not depend on a tool version (C5), fence tags match their content
+<date>` line whose date could actually be true — or that it does not depend on a tool version (C5),
+fence tags match their content
 (C6), no generated wrapper is orphaned from a canonical source (C7), no meta section sits in a
 `SKILL.md` body where it cannot affect routing (C8), code examples use English identifiers (C9),
 the parsed `description` and `compatibility` stay within the Agent Skills limits (C10), every
@@ -913,7 +914,7 @@ as operational detail, never as a build failure.
 
 ```bash
 python3 scripts/validate-skills.py           # 0 findings expected
-python3 scripts/selftest-validate-skills.py  # 24/24 defect classes detected
+python3 scripts/selftest-validate-skills.py  # 27/27 defect classes detected
 python3 scripts/scan-secrets.py              # gate: no credentials in the working tree
 python3 scripts/scan-secrets.py --history    # audit: what the published history still contains
 ```

--- a/openspec/changes/add-probe-date-plausibility/.openspec.yaml
+++ b/openspec/changes/add-probe-date-plausibility/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-06

--- a/openspec/changes/add-probe-date-plausibility/design.md
+++ b/openspec/changes/add-probe-date-plausibility/design.md
@@ -1,0 +1,61 @@
+## Context
+
+`scripts/validate-skills.py` C5 (read 2026-09-06, HEAD c8f55f9) normalises the block and searches
+`PROBED_ON = re.compile(r"\b[Pp]robed on 20\d\d-\d\d-\d\d\b")`. The module imports `json`, `re`,
+`shutil`, `subprocess`, `sys`, `tempfile` and `pathlib.Path` — no `datetime`, and no git access of
+any kind. The selftest already carries two mutations on `observability` and five C5 entries in
+total, so a third and fourth on the same file follow an established shape.
+
+Measured on the 32 blocks: `svg-animation` writes "Probed on 2026-08-30 and 2026-08-31" — one
+literal, two dates, of which the capture takes the first; `fivem-lua` and `assettoserver-csp-lua`
+carry cited commit dates (`2026-09-02`, `2026-08-17`) that must stay outside the rule.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A probe date that cannot be true is reported, naming which rule it broke.
+- The rule reads only what follows the literal, so cited dates stay untouched.
+- The remaining KNOWN LIMIT is written down rather than implied.
+
+**Non-Goals:**
+- Age reporting or expiry; git access inside the validator; validating cited dates.
+
+## Decisions
+
+1. **Three findings, not one.** Each rule names itself in the message. A single "implausible date"
+   finding would make the author guess which of three things is wrong.
+2. **`REPO_INCEPTION` as a constant with its command in the comment.** Alternatives: run
+   `git log --reverse` at check time (the validator shells out for `bash -n`/`luac -p` already, but
+   a shallow CI clone — `fetch-depth: 0` today, not guaranteed forever — would return nothing and
+   the gate would silently lose P3); or drop P3 entirely (then `2020-01-01` passes and the typo
+   class that P3 exists for survives). The constant is the honest trade: it is wrong only if the
+   history is rewritten, and the comment says how to re-measure it.
+3. **UTC and `<=` for P2.** The CI runner is UTC and the maintainer is UTC-3: a probe run late in
+   the evening locally is already "tomorrow" in UTC. Comparing in UTC with `<=` means a date written
+   for today never fails, and only a genuinely future date does.
+4. **Capture per literal occurrence.** `PROBE_DATE.findall(block)` returns one date per
+   `Probed on` — `svg-animation`'s second date (`2026-08-31`) is prose, not a second claim of a
+   probe date, and demanding a literal for it would edit a correct block for the regex's sake.
+5. **No backfill.** The dry run found zero implausible dates, so the change is gate-only. A change
+   that edits nothing in `skills/` is the honest outcome, not a sign the rule is useless — it is a
+   trap set for the next typo.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| What a `Verified against` block owes (literal, date, plausibility) | `skills-authoring` spec + C5 docstring | already canonical — skills carry the sentence, not the rule |
+| A claim is dated and its date is checkable | `verify-before-claiming` | already canonical — nothing restated |
+
+## Risks / Trade-offs
+
+- [A plausible date for a probe nobody ran still passes] → unchanged and stated in the docstring;
+  presence and possibility are machine-checkable, honesty is the review's job.
+- [`REPO_INCEPTION` drifts if the history is rewritten] → the comment carries the command that
+  re-measures it in one line.
+- [Timezone edge] → UTC plus `<=`, documented in the docstring and exercised by no mutation (a
+  "today" date is what every current block carries).
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-probe-date-plausibility/proposal.md
+++ b/openspec/changes/add-probe-date-plausibility/proposal.md
@@ -1,0 +1,58 @@
+# Change: Validate the `Probed on` date, not only its shape
+
+## Why
+
+Since #157 the C5 check requires the literal `Probed on YYYY-MM-DD` inside the normalised
+`Verified against` block. It matches a **shape**, never a value: `Probed on 2026-13-45` (no such
+month), `Probed on 2099-01-01` (the future) and `Probed on 2020-01-01` (six years before the
+repository existed) all pass today. The check's own docstring says so — "a date is checked for
+shape only, never for plausibility (a future or unrelated date passes)" — and #153 and #157 both
+recorded it as the follow-up they were deliberately not doing.
+
+A typo in the probe date is indistinguishable from a correct one, which defeats the reason the date
+is there: telling the reader how old the pin is.
+
+Measured on 2026-09-06 across the 32 blocks: three distinct probe dates (`2026-08-06`, `2026-08-30`,
+`2026-09-05`), each a real calendar date, none in the future, none before the repository's first
+commit `1e95262` of 2026-03-13 (`git log --reverse --format='%cs %h' | head -1`). Dry-running the
+three rules over the catalogue reports **no** implausible date, so no skill needs editing — this
+change adds the gate, not a backfill.
+
+## What Changes
+
+- **C5 validates each captured probe date** — every `[Pp]robed on (20\d\d-\d\d-\d\d)` in the
+  normalised block — against three rules, each with its own finding:
+  - **P1 calendar**: `date.fromisoformat` parses it, else `Probed on 2026-13-45 is not a calendar date`.
+  - **P2 not future**: `<= datetime.now(timezone.utc).date()`, else `… is in the future`.
+  - **P3 not before the repository**: `>= REPO_INCEPTION`, else `… predates the repository (first commit 2026-03-13)`.
+  `REPO_INCEPTION = date(2026, 3, 13)` is a constant carrying the command that measured it: the
+  validator imports no git, and a shallow clone would not have the history to derive it.
+  Dates in the block that do **not** follow `Probed on` (commits and releases the block cites) are
+  untouched.
+- **Selftest**: three mutations on `observability`, one per rule.
+- **Docstring**: the plausibility half of the KNOWN LIMIT is removed; what remains is stated (a
+  plausible date for a probe nobody ran still passes).
+- **README**: the C5 sentence says the date is plausible; the selftest count moves 24 → 27.
+- **No skill changes**: all 32 probe dates already satisfy the three rules.
+
+## Deliberately not done
+
+- An age report or expiry policy for pins (how many days since the probe) — a different decision,
+  out of scope by the item.
+- Validating the block's other dates (cited commits and releases).
+- Deriving the inception date from git at runtime.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED **Versioned external APIs are pinned** — the probe date is a real
+  calendar date, not in the future and not before the repository existed; an impossible date is a
+  defect the validator reports.
+
+## Impact
+
+- `scripts/validate-skills.py`, `scripts/selftest-validate-skills.py`, `README.md`.
+- No `skills/` file changes; no wrapper changes; catalog composition untouched.

--- a/openspec/changes/add-probe-date-plausibility/specs/skills-authoring/spec.md
+++ b/openspec/changes/add-probe-date-plausibility/specs/skills-authoring/spec.md
@@ -1,0 +1,101 @@
+## MODIFIED Requirements
+
+### Requirement: Versioned external APIs are pinned
+
+A skill whose content targets an external API **or command-line tool** with breaking releases SHALL
+state the exact versions it was verified against, and SHALL name any known upcoming rename or removal
+that will invalidate it. For a skill that instructs the agent to run a CLI, the commands and flags it
+prescribes SHALL be probed against that tool before publication.
+
+Every `SKILL.md` SHALL carry exactly one of two literal declarations, placed where a reader meets it
+before the first rule: a `Verified against` block naming each tool and the version it was probed
+against, what was run, and the probe date written as the literal `Probed on YYYY-MM-DD`, which
+SHALL be a real calendar date that is neither in the future nor earlier than the repository's first
+commit; or the sentence `does not depend on a tool
+version` followed by the reason. The date MAY be the recorded probe's when the block names the change
+or commit that recorded it. A `Verified against` block SHALL name only versions the claims were actually probed
+against, and SHALL name the part of the skill that was not probed rather than cover it by implication.
+A version written for a run nobody made is a defect, not a pin. The declaration is an exit for
+process skills: a skill carrying 40 or more fenced lines against a versioned API SHALL carry the
+block unless it defers to a local source of truth it instructs the reader to open first.
+
+#### Scenario: Reader can tell which era the code targets
+
+- **WHEN** a skill documents a library API
+- **THEN** the skill names the library versions its examples were verified against, rather than
+  leaving the reader to infer it
+
+#### Scenario: A known breaking change is disclosed, not silently absorbed
+
+- **WHEN** the upstream has announced a rename or removal affecting the skill's examples
+- **THEN** the skill names it and where it applies, instead of presenting the current form as timeless
+
+#### Scenario: Prescribed CLI commands are probed, not assumed
+
+- **WHEN** a skill instructs the agent to run a command with specific subcommands and flags
+- **THEN** each subcommand and flag is checked against the installed tool before publication, and the
+  tool version the check ran against is recorded
+
+#### Scenario: Tool guidance contradicted by the tool is corrected, not repeated
+
+- **WHEN** a tool's own output advertises behaviour its implementation does not deliver
+- **THEN** the skill states the probed behaviour and the version it holds for, rather than repeating
+  the tool's claim
+
+#### Scenario: Every skill declares its relationship to versions
+
+- **WHEN** a `SKILL.md` carries neither the literal `Verified against` nor the literal
+  `does not depend on a tool version`
+- **THEN** the validator reports it under C5, whatever amount of fenced code the skill carries
+
+#### Scenario: A loose version mention is not a pin
+
+- **WHEN** a skill names a version only in passing (`Probed on CLI 1.6.0`, `targets v0.0.54`,
+  `needs CSP >= 0.1.78`) and carries no literal `Verified against`
+- **THEN** the validator reports it under C5, because a reader cannot tell a pin from a mention
+
+#### Scenario: A code-heavy skill does not exit by declaration
+
+- **WHEN** a skill carries 40 or more fenced lines, names a versioned API, declares that it does not
+  depend on a tool version, and does not defer to a local source of truth
+- **THEN** the validator reports the declaration as contradicted by the skill's own code
+
+#### Scenario: A partial probe names its boundary
+
+- **WHEN** only part of a skill's surface could be probed — public API stubs or source, but not the
+  runtime that executes them
+- **THEN** the `Verified against` block names what was probed, against which artifact and version,
+  and states what was not probed, instead of letting the pin cover the whole skill
+
+#### Scenario: A pin carries the date it was probed
+
+- **WHEN** a `Verified against` block — the text from that line to the next blank line — carries no
+  ISO date (`YYYY-MM-DD`)
+- **THEN** the validator reports it under C5, because a pin with no date does not say when it
+  stopped being trustworthy
+
+#### Scenario: The probe date is named as such
+
+- **WHEN** a `Verified against` block — normalised by stripping the blockquote prefix and joining
+  its lines — carries ISO dates but no `Probed on YYYY-MM-DD` (or `probed on YYYY-MM-DD`)
+- **THEN** the validator reports it under C5, because a date of a commit or a release the block
+  cites does not stand in for the date the probe ran
+
+#### Scenario: A line wrap does not fail a correct block
+
+- **WHEN** the wrap leaves `Probed on` at the end of one blockquote line and the date at the start of
+  the next
+- **THEN** the validator, matching on the normalised block, stays silent
+
+#### Scenario: An impossible probe date is a defect
+
+- **WHEN** the date following `Probed on` is not a calendar date, is later than the day of the check
+  (UTC), or is earlier than the repository's first commit
+- **THEN** the validator reports it under C5 naming the rule it broke, because a date that cannot be
+  true tells the reader nothing about how old the pin is
+
+#### Scenario: Dates the block merely cites are not probe dates
+
+- **WHEN** the block names the date of a commit, release or measurement run it cites, outside the
+  `Probed on` literal
+- **THEN** the validator leaves that date alone, judging only what the block claims as its probe date

--- a/openspec/changes/add-probe-date-plausibility/tasks.md
+++ b/openspec/changes/add-probe-date-plausibility/tasks.md
@@ -1,55 +1,70 @@
 ## 1. Evidence & Sources (MANDATORY)
 
-- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
       the commit or timestamp it was read at
-- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      Evidence: Opened 2026-09-06 at HEAD c8f55f9: `scripts/validate-skills.py` (module docstring, the C5 region 249-300, the import block, `add()`), `scripts/selftest-validate-skills.py` (24 MUTATIONS entries, the runner's `expect`/`fragment` contract), `README.md:880-881` and `:916`, `openspec/specs/skills-authoring/spec.md` (requirement copied whole into the MODIFIED delta), the 32 `Verified against` blocks (read programmatically), `openspec/changes/archive/2026-09-06-require-probed-on-literal/tasks.md` (the KNOWN LIMIT this change closes).
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
       probed against the installed version; the command and a fragment of its output are recorded
-- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      Evidence: `git log --reverse --format='%cs %h' | head -1` -> `2026-03-13 1e95262` (the P3 floor). `date -u +%F` -> `2026-09-06`. `python3 -c "datetime.date.fromisoformat('2026-13-45')"` -> `ValueError: month must be in 1..12`. Dry run of the three rules over the catalogue before any edit -> `implausible probe dates today: []`, probe dates `['2026-08-06', '2026-08-30', '2026-09-05']`. Capture check -> `svg-animation captures=['2026-08-30'] all_iso=['2026-08-30','2026-08-31','2026-09-05']`, `fivem-lua captures=['2026-09-05'] all_iso=['2026-09-02','2026-08-17','2026-09-05']` (cited commit dates stay outside the rule). `python3 scripts/validate-skills.py` after the edit -> `skills checked: 35   findings: 0`. `git status --porcelain` -> only `README.md`, `scripts/selftest-validate-skills.py`, `scripts/validate-skills.py`; `git diff --stat master -- skills` -> empty.
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
       when there is no design.md) — never stated as fact, never filled with a plausible substitute
-- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      Evidence: Nothing this change asserts was unprobeable: every rule was exercised through the validator's own entry point and every count comes from a script over this clone. What the gate still cannot tell — a plausible date written for a probe that never ran — is stated in the C5 docstring as the remaining KNOWN LIMIT, not filled in.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
       along the way are listed here as follow-ups, not performed
-
+      Evidence: Follow-ups noticed and NOT performed: (1) an age report per pin (days since the probe) and any expiry policy — excluded by the item on the user's choice; (2) dates the block cites outside the literal are still unvalidated, by design; (3) `REPO_INCEPTION` is a constant, so a rewritten history would need it re-measured — the command is in the comment beside it; (4) the two active changes from another session (`add-lean-code-research`, `update-documentation-prerequisites`) were left untouched.
 ## 2. Gate
 
-- [ ] 2.1 C5 validates every captured probe date: P1 calendar (`date.fromisoformat`), P2 not after
+- [x] 2.1 C5 validates every captured probe date: P1 calendar (`date.fromisoformat`), P2 not after
       today in UTC, P3 not before `REPO_INCEPTION`; one finding per rule; cited dates untouched
-- [ ] 2.2 Docstring: plausibility leaves the KNOWN LIMIT, what remains is written, UTC choice stated
-
+      Evidence: `scripts/validate-skills.py`: `PROBE_DATE = re.compile(r"[Pp]robed on (20\d\d-\d\d-\d\d)")`, `REPO_INCEPTION = date(2026, 3, 13)` with the re-measure command in the comment, and a loop over `PROBE_DATE.findall(block)` raising one finding per rule under the check name `C5 implausible probe date`: `is not a calendar date` (ValueError from `date.fromisoformat`), `is in the future (checked <today> UTC)`, `predates the repository (first commit 2026-03-13)`. Dates outside the literal are never read.
+- [x] 2.2 Docstring: plausibility leaves the KNOWN LIMIT, what remains is written, UTC choice stated
+      Evidence: Docstring: the paragraph 'Each captured probe date is also checked for POSSIBILITY (issue #165)…' states the three rules, the UTC + `<=` choice and why (CI is UTC, the maintainer is UTC-3), and that cited dates are left alone; the KNOWN LIMIT now reads 'proves the literals are PRESENT and the probe date is POSSIBLE, not that either is earned… a plausible date for a probe that never happened' passes.
 ## 3. Selftest and docs
 
-- [ ] 3.1 Three mutations on `observability` (month 13, year 2099, year 2020), one per rule
-- [ ] 3.2 README: C5 sentence says the date is plausible; selftest count 24 → 27
-- [ ] 3.3 `./generate.sh`; wrappers in sync (nothing generated changes)
-
+- [x] 3.1 Three mutations on `observability` (month 13, year 2099, year 2020), one per rule
+      Evidence: `scripts/selftest-validate-skills.py`: `C5 implausible probe date (not a calendar date)` / `(future)` / `(predates the repository)` on `skills/observability/SKILL.md`, replacing `Probed on 2026-08-06` with `2026-13-45` / `2099-01-01` / `2020-01-01`; run -> all three `CAUGHT`, `26/27 defect classes detected` locally (MISSED only `C3 lua syntax`, luac absent here).
+- [x] 3.2 README: C5 sentence says the date is plausible; selftest count 24 → 27
+      Evidence: `README.md:880-882` -> `with a \`Probed on <date>\` line whose date could actually be true`; `:916` -> `27/27 defect classes detected`. The module docstring's C5 line also names the possible date.
+- [x] 3.3 `./generate.sh`; wrappers in sync (nothing generated changes)
+      Evidence: `bash generate.sh` -> `git status --porcelain --untracked-files=all | grep -c '^??'` -> 0, and the working tree still shows only the three edited files: nothing generated changed, because no `skills/` file was touched.
 ## 4. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
       observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      Evidence: entry point `python3 scripts/validate-skills.py` on the catalogue -> `skills checked: 35   findings: 0`. Four temporary copies, each with observability's probe date replaced, run through the same entry point: `2026-13-45` -> `[C5 implausible probe date] Probed on 2026-13-45 is not a calendar date`; `2099-01-01` -> `… is in the future (checked 2026-09-06 UTC)`; `2020-01-01` -> `… predates the repository (first commit 2026-03-13)`; `2026-09-06` (today in UTC, the P2 boundary) -> `<silent>`. entry point `python3 scripts/selftest-validate-skills.py` -> three `CAUGHT`, `26/27`.
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
       silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      Evidence: 3/3 rules had to fire and did, each with its own message; 1/1 boundary case (a date equal to today in UTC) had to stay silent and did; 35/35 skills silent with no edit; 32/32 probe dates plausible in the dry run; 2/2 blocks carrying cited commit dates (`fivem-lua`, `assettoserver-csp-lua`) silent, so the rule reads only what follows the literal; 1/1 block with two dates after one literal (`svg-animation`) silent; 0 files under `skills/` changed; 1/1 pre-existing local miss unchanged (`C3 lua syntax`, luac absent — CI installs lua5.4).
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
       explicitly that nothing did
-
+      Evidence: Nothing escaped or behaved differently than expected. One deliberate design choice worth naming: the three findings are filed under a NEW check label, `C5 implausible probe date`, instead of the existing `C5 no version pin` — the summary groups findings by label, and a run that says 'implausible probe date 1' points at the defect directly. It stays inside C5's family and the README's C1–C13 list is unaffected.
 ## 5. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
       metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
       compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      Evidence: No SKILL.md was touched (`git diff --stat master -- skills` empty); the frontmatter loop was replicated anyway over `skills/*/SKILL.md` -> `frontmatter fail=0`; `agentskills validate` -> `fail=0` over 35; `npx -y @anthropic-ai/claude-code@2.1.246 plugin validate . --strict` -> `✔ Validation passed`.
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Evidence: All added text is English; `check-identifier-locale.py` over the three changed files -> `findings: 0`.
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
       do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      Evidence: No description changed (no skill file touched), so no trigger moved.
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
       its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      Evidence: The rule lives in the `skills-authoring` requirement and the C5 docstring; no skill restates it (design.md Canonical Home, two rows, `already canonical`).
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
       names; a term kept in another language carries its reason inline (`code-locale`).
       Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
       paths shipped in target repos through this rite. Regression gate on the exemplar: the model
       imitates the code it is shown
-
+      Evidence: No code example touched; detector -> `findings: 0`.
 ## 6. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate add-probe-date-plausibility --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+- [x] V.1 `openspec validate add-probe-date-plausibility --strict` green
+      Evidence: `openspec validate add-probe-date-plausibility --strict` -> `Change 'add-probe-date-plausibility' is valid`; `bash scripts/validate-rite.sh` -> `rite gate OK` (evidence gate 0 findings, spec-rite gate 0 findings, 3 active changes — two belong to another session and were not touched).
+- [x] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
       no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `npx -y skills add solvelab/ai-skills --list | grep -c -E '^│    [a-z0-9-]+$'` -> `35`; nothing added, removed or renamed.
+- [x] V.3 README / docs updated where the change alters catalog composition or usage
+      Evidence: `README.md` C5 sentence and selftest count updated; catalog composition unchanged.
 - [ ] V.4 `openspec archive add-probe-date-plausibility --yes` after all groups above are `[x]`

--- a/openspec/changes/add-probe-date-plausibility/tasks.md
+++ b/openspec/changes/add-probe-date-plausibility/tasks.md
@@ -1,0 +1,55 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [ ] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+- [ ] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+- [ ] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+- [ ] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+## 2. Gate
+
+- [ ] 2.1 C5 validates every captured probe date: P1 calendar (`date.fromisoformat`), P2 not after
+      today in UTC, P3 not before `REPO_INCEPTION`; one finding per rule; cited dates untouched
+- [ ] 2.2 Docstring: plausibility leaves the KNOWN LIMIT, what remains is written, UTC choice stated
+
+## 3. Selftest and docs
+
+- [ ] 3.1 Three mutations on `observability` (month 13, year 2099, year 2020), one per rule
+- [ ] 3.2 README: C5 sentence says the date is plausible; selftest count 24 → 27
+- [ ] 3.3 `./generate.sh`; wrappers in sync (nothing generated changes)
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 5. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`).
+      Provenance: maintainer field report 2026-08-14 (issue #76) — Portuguese identifiers and route
+      paths shipped in target repos through this rite. Regression gate on the exemplar: the model
+      imitates the code it is shown
+
+## 6. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate add-probe-date-plausibility --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive add-probe-date-plausibility --yes` after all groups above are `[x]`

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -54,6 +54,17 @@ MUTATIONS = {
  "C5 no version pin (date but no Probed on)": ("skills/observability/SKILL.md",
      lambda s: s.replace("Probed on 2026-08-06", "Dated 2026-08-06", 1),
      ("C5 no version pin", "names no")),
+ # (f) Issue #165: the date's VALUE, one mutation per rule. observability carries exactly one probe
+ # date, so each replacement leaves the literal in place and only the plausibility rule fires.
+ "C5 implausible probe date (not a calendar date)": ("skills/observability/SKILL.md",
+     lambda s: s.replace("Probed on 2026-08-06", "Probed on 2026-13-45", 1),
+     ("C5 implausible probe date", "is not a calendar date")),
+ "C5 implausible probe date (future)": ("skills/observability/SKILL.md",
+     lambda s: s.replace("Probed on 2026-08-06", "Probed on 2099-01-01", 1),
+     ("C5 implausible probe date", "is in the future")),
+ "C5 implausible probe date (predates the repository)": ("skills/observability/SKILL.md",
+     lambda s: s.replace("Probed on 2026-08-06", "Probed on 2020-01-01", 1),
+     ("C5 implausible probe date", "predates the repository")),
  "C6 wrong tag": ("skills/r3f-materials/SKILL.md",
      lambda s: s + "\n```tsx\nvarying vec2 vUv;\nvoid main() {}\n```\n"),
  "C7 orphan wrapper": (None, None),

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -6,7 +6,8 @@ Implements the mechanically checkable half of openspec/specs/skills-authoring:
   C2 cross-skill references name a real skill
   C3 code blocks parse                      (bash -n, yaml, json, lua -p, python)
   C4 description agrees with body           (heuristic: absolute promise vs qualifying rule)
-  C5 every skill declares its versions      ('Verified against' or 'does not depend on a tool version')
+  C5 every skill declares its versions      ('Verified against' + a possible `Probed on <date>`, or
+                                             'does not depend on a tool version')
   C6 fence tags match content               (a block tagged X that is obviously not X)
   C7 no orphan wrapper skills               (every generated skill has a canonical source)
   C8 no meta sections in SKILL.md           (triggers belong in the description, not the body)
@@ -26,6 +27,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 ROOT = Path.cwd()
@@ -250,6 +252,12 @@ PIN = re.compile(r"Verified against")
 NO_VERSION = re.compile(r"does not depend on a tool version")
 ISO_DATE = re.compile(r"\b20\d\d-\d\d-\d\d\b")
 PROBED_ON = re.compile(r"\b[Pp]robed on 20\d\d-\d\d-\d\d\b")
+PROBE_DATE = re.compile(r"[Pp]robed on (20\d\d-\d\d-\d\d)")
+# The first commit of this repository, so a probe cannot predate it. Hardcoded on purpose: the
+# validator shells out for `bash -n` and `luac -p` but never for git, and a shallow clone would
+# have no history to derive this from — losing the rule in silence. Re-measure with
+# `git log --reverse --format='%cs %h' | head -1` (2026-09-06: 2026-03-13 1e95262).
+REPO_INCEPTION = date(2026, 3, 13)
 DEFERS = re.compile(r"source of truth, not this skill|read the local copy first", re.I)
 API_HINT = re.compile(r"@react-three|@react-spring|fastapi|pydantic|sqlalchemy|helm |kubectl|"
                       r"citizenfx|Qmmands|AssettoServer|openspec|gh project|zod|vite", re.I)
@@ -271,9 +279,16 @@ def check_pin(skill: str, text: str) -> None:
     line's start (assettoserver-csp-lua, react-api-client), and a gate must not fail a correct
     block for where the wrap broke it. The declaration owes no date.
 
-    KNOWN LIMIT: this proves the literals are PRESENT, not that they are earned. A block naming a
-    version nobody ran passes; a date is checked for shape only, never for plausibility (a future or
-    unrelated date passes); a code-heavy skill that adds the deferral phrase to dodge the second
+    Each captured probe date is also checked for POSSIBILITY (issue #165): it parses as a calendar
+    date, it is not after today, and it is not before this repository existed. The comparison runs
+    in UTC with `<=`, because CI runs in UTC while the maintainer is UTC-3 — a probe run late in the
+    evening locally is already tomorrow in UTC, and a date written for today must never fail. Dates
+    the block merely cites (a commit, a release, a measurement run) are left alone: only what
+    follows the literal is a claim about when the probe ran.
+
+    KNOWN LIMIT: this proves the literals are PRESENT and the probe date is POSSIBLE, not that
+    either is earned. A block naming a version nobody ran passes, and so does a plausible date for a
+    probe that never happened; a code-heavy skill that adds the deferral phrase to dodge the second
     rule passes too. Those stay with the review — which is why the block has to say what was run,
     not only against what."""
     pinned = PIN.search(text)
@@ -294,6 +309,22 @@ def check_pin(skill: str, text: str) -> None:
             add(skill, "C5 no version pin",
                 "'Verified against' block names no `Probed on <date>` — a date of a commit or "
                 "release the block cites does not stand in for the date the probe ran")
+        else:
+            today = datetime.now(timezone.utc).date()
+            for raw in PROBE_DATE.findall(block):
+                try:
+                    probed = date.fromisoformat(raw)
+                except ValueError:
+                    add(skill, "C5 implausible probe date",
+                        f"Probed on {raw} is not a calendar date")
+                    continue
+                if probed > today:
+                    add(skill, "C5 implausible probe date",
+                        f"Probed on {raw} is in the future (checked {today} UTC)")
+                elif probed < REPO_INCEPTION:
+                    add(skill, "C5 implausible probe date",
+                        f"Probed on {raw} predates the repository (first commit "
+                        f"{REPO_INCEPTION.isoformat()})")
     if declared and not pinned:
         code_lines = sum(len(b.splitlines()) for _, b in FENCE.findall(text))
         if code_lines >= 40 and API_HINT.search(text) and not DEFERS.search(text):


### PR DESCRIPTION
Closes #165
Spec-rite: add-probe-date-plausibility

## O que muda

- **C5 valida o valor da data, não só a forma.** Cada data capturada por `[Pp]robed on (20\d\d-\d\d-\d\d)` no bloco normalizado passa por três regras, cada uma com seu finding:
  - `Probed on 2026-13-45 is not a calendar date` (`date.fromisoformat` levanta `ValueError`)
  - `Probed on 2099-01-01 is in the future (checked 2026-09-06 UTC)`
  - `Probed on 2020-01-01 predates the repository (first commit 2026-03-13)`
- **`REPO_INCEPTION = date(2026, 3, 13)`** é constante de propósito: o validador nunca chama git e um clone raso não teria histórico para derivar o piso, o que perderia a regra em silêncio. O comando que a mede (`git log --reverse --format='%cs %h' | head -1`) está no comentário ao lado.
- **UTC com `<=`**: o CI roda em UTC e o mantenedor em UTC-3, então um probe feito à noite já é "amanhã" em UTC. Uma data escrita para hoje nunca reprova — medido: `2026-09-06` fica em silêncio.
- **Datas que o bloco apenas cita ficam fora**: `fivem-lua` (commits do citizenfx) e `assettoserver-csp-lua` (`acc-lua-sdk`) seguem silenciosos; `svg-animation`, com duas datas após um literal, também.
- **Selftest**: três mutações novas em `observability`, uma por regra (24 → 27).
- **README**: a frase do C5 diz que a data "could actually be true"; contagem 27/27.
- **Nenhuma skill muda**: o dry-run das três regras sobre o catálogo, antes de qualquer edição, reportou zero datas implausíveis. `git diff --stat master -- skills` vazio.

## Uma escolha de desenho que vale nomear

Os três findings entram sob um rótulo novo, `C5 implausible probe date`, em vez do `C5 no version pin` existente. O sumário do validador agrupa por rótulo, então uma execução que diz `C5 implausible probe date 1` aponta direto para o defeito. Continua dentro da família C5 e a lista C1–C13 do README não muda.

## Critérios de aceitação

| # | Critério | Veredito | Evidência |
|---|---|---|---|
| 1 | três mutações disparam com o fragmento da regra; selftest 27/27 no CI | met | `CAUGHT` ×3; `26/27` local (MISSED só `C3 lua syntax`, sem luac) |
| 2 | `validate-skills.py` 0 findings sem editar skill | met | `skills checked: 35   findings: 0`; `git diff --stat master -- skills` vazio |
| 3 | docstring não declara mais a plausibilidade como não checada | met | KNOWN LIMIT agora diz "PRESENT and the probe date is POSSIBLE, not that either is earned… a plausible date for a probe that never happened" |
| 4 | strict verde; wrappers em sync | met | `Change 'add-probe-date-plausibility' is valid`; `generate.sh` → 0 untracked, nada gerado muda |

## Simulação (rito)

Quatro cópias temporárias pelo entry point real (`python3 scripts/validate-skills.py`):

| data em `observability` | observado |
|---|---|
| `2026-13-45` | `[C5 implausible probe date] Probed on 2026-13-45 is not a calendar date` |
| `2099-01-01` | `… is in the future (checked 2026-09-06 UTC)` |
| `2020-01-01` | `… predates the repository (first commit 2026-03-13)` |
| `2026-09-06` (hoje, borda do P2) | `<silent>` |

Contagens: 3/3 regras dispararam; 1/1 borda calada; 35/35 skills caladas sem edição; 32/32 datas de probe plausíveis no dry-run; 2/2 blocos com datas citadas calados; 1/1 bloco com duas datas após um literal calado; 0 arquivos em `skills/`; 1/1 miss local pré-existente. Nada escapou.

## Validações

| Comando | Resultado |
|---|---|
| `python3 scripts/validate-skills.py` | 35 skills, 0 findings |
| `python3 scripts/selftest-validate-skills.py` | 26/27 local (MISSED `C3 lua syntax`, luac ausente; CI instala lua5.4) |
| `bash scripts/validate-rite.sh` | `rite gate OK` (3 changes ativas: esta e duas de outra sessão, não tocadas) |
| `openspec validate add-probe-date-plausibility --strict` | valid |
| `validate-spec-rite.py` / `validate-skill-version.py` | 0 findings / 0 findings (0 skills changed) |
| `generate.sh` + `git status --untracked-files=all` | 0 untracked |
| `validate-repo-hygiene.py` / `scan-secrets.py` | 0 findings / no credentials |
| `agentskills validate` / `plugin validate --strict` / `npx skills add --list` | 35/35 / passed / 35 |

## Follow-ups (não feitos aqui)

1. Relatório de idade dos pins e política de expiração — fora do escopo por decisão do item.
2. Datas citadas fora do literal seguem sem validação, por desenho.
3. `REPO_INCEPTION` precisa ser re-medida se o histórico for reescrito; o comando está no comentário.

## Pendente do rito

- `openspec archive add-probe-date-plausibility --yes` após o merge, em PR própria (V.4 aberto de propósito).
