### PR TITLE
📝 docs(catalog): as duas verificações que não sabiam reprovar

### DIFF
--- a/claude/skills/claude-statusline/SKILL.md
+++ b/claude/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.2.2
+  version: 1.3.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.

--- a/claude/skills/documentation/SKILL.md
+++ b/claude/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.1.0
+  version: 3.1.1
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/cursor/rules/claude-statusline.mdc
+++ b/cursor/rules/claude-statusline.mdc
@@ -133,9 +133,30 @@ echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp"},"c
   | ~/.claude/statusline.sh | sed 's/\x1b\[[0-9;]*m//g'
 ```
 
-Also test the empty case (`"current_usage": null`, no git repo) to confirm optional
-segments disappear cleanly. To exercise the git line, run it from inside a repo with
-staged and modified files.
+That input produces exactly three lines — measured against `references/statusline.sh`:
+
+```
+🤖 Opus 4.8 | ⚡ medium | 🧠 thinking enabled | ⏱️  1h 26m | 💰 $2.47
+📝 +1347 -156 | ↑ In 135k $0.10 · ♻️ 95% · ↓ Out 2k $0.05
+📊 ctx ▓▓▓▓▓░░░ 63% | 🚦 5h ▓▓▓▓░░░░ 57% | 7d ▓▓▓▓▓▓░░ 84%
+```
+
+Anything else is a defect: fewer lines means a segment silently returned empty, and a `jq` error on
+stderr means the input shape moved. Re-measure with the command above rather than trusting this
+block if you edited the script — the numbers here are what it printed, not what it ought to print.
+
+Also test the empty case (`"current_usage": null`, `"thinking": {"enabled": false}`, run outside a
+git repo). It must collapse to **two** lines, and the difference is what you check:
+
+```
+🤖 Opus 4.8 | ⚡ medium | 🧠 thinking disabled | 💰 $0.00
+📊 ctx ▓▓▓▓▓░░░ 63%
+```
+
+The `📝` token line is gone entirely, the `🚦` rate-limit segment has left the `📊` line, and the
+`⏱️` duration has left the header. A segment that renders as a bare separator (`|` with nothing
+after it) or as `$0.00` where it should be absent is the failure this case exists to catch. To
+exercise the git line, run it from inside a repo with staged and modified files.
 
 ---
 

--- a/openspec/changes/fix-verification-pass-values/.openspec.yaml
+++ b/openspec/changes/fix-verification-pass-values/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-06

--- a/openspec/changes/fix-verification-pass-values/design.md
+++ b/openspec/changes/fix-verification-pass-values/design.md
@@ -1,0 +1,65 @@
+## Context
+
+O requisito *A prescribed verification states what passes* entrou em `2026-09-06-update-documentation-prerequisites`
+pago por um defeito de campo. A change de origem declarou, na `D3`, que ele entra **sem validador**,
+porque separar critério de descrição de forma sobre prosa é julgamento que um detector erra nos dois
+sentidos — medido: 3 falsos positivos em 4 marcações.
+
+Este change é a primeira aplicação do requisito ao próprio catálogo, e a varredura que ele exigia.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Fechar as duas violações que a varredura confirmou.
+- Que a saída prometida pelo `claude-statusline` seja **medida**, não plausível.
+- Que o requisito aprenda o que a varredura ensinou: exemplo é prescrição.
+
+**Non-Goals**
+
+- Não reabrir a decisão do validador. A `D3` mediu e decidiu.
+- Não julgar as 67 linhas de prosa uma a uma — a amostra está declarada.
+- Não reescrever a seção `## Verify` além das duas frases.
+
+## Decisions
+
+**D1 — A saída entra medida, e a medição é registrada.** Escrever "a saída deve ser mais ou menos
+assim" repetiria o defeito num nível acima: uma promessa que o leitor também não consegue conferir. A
+saída vem de rodar `skills/claude-statusline/references/statusline.sh` com o JSON que o próprio
+documento já traz, e o comando fica no grupo de evidência.
+
+**D2 — "Cleanly" vira segmentos nomeados.** O caso vazio foi medido: a linha de tokens
+(`📝 … ↑ In … ♻️ … ↓ Out …`) desaparece inteira, o segmento de rate limit sai da linha do contexto, a
+duração some do cabeçalho, e `thinking` inverte. Isso se olha; "cleanly" não.
+
+**D3 — O delta é MODIFIED, não ADDED.** O requisito já existe e está certo; o que faltava era dizer
+que ele vale dentro de **exemplo**, e que ausência não é valor. Criar requisito novo para isso daria
+duas casas para uma regra só, contra *Single canonical home per rule*.
+
+**D4 — A cobertura parcial entra escrita, com os números.** Nove linhas de saída esperada julgadas
+uma a uma; 67 linhas de prosa em 17 skills, das quais 2 skills amostradas. O cenário *Partial coverage
+is declared, not implied* pede exatamente isso, e um número honesto de piso vale mais que um censo
+alegado.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Verificação prescrita diz o que aprova | `openspec/specs/skills-authoring` | already canonical — o requisito ganha um cenário, não muda de casa |
+| Como um guia de instalação escreve saída esperada | `documentation/references/templates.md` | already canonical — só o exemplo é corrigido, a regra fica |
+| O conteúdo da seção `## Verify` de uma status line | `claude-statusline` | already canonical |
+| Medir antes de afirmar, e relatar o que não deu para medir | `verify-before-claiming` | link (already canonical) — não repetir a escada aqui |
+
+## Risks / Trade-offs
+
+- [A saída medida envelhece quando o script mudar] → é o mesmo contrato de qualquer exemplo do
+  catálogo, e o requisito *Prescribed numbers carry the rule that produces them* já obriga a nomear o
+  comando que a produz — quem mexer no script tem como remedir em uma linha.
+- [A saída colada carregar dado da máquina] → o JSON de entrada é o do próprio documento, sem caminho
+  real além de `/tmp`; `scan-secrets.py` roda no CI como rede de baixo.
+- [A varredura amostrada esconder um terceiro caso] → aceito e declarado com número; o custo de
+  julgar 67 linhas de prosa agora é maior que o de abrir item quando um terceiro aparecer.
+
+## Open Questions
+
+- Nenhuma.

--- a/openspec/changes/fix-verification-pass-values/proposal.md
+++ b/openspec/changes/fix-verification-pass-values/proposal.md
@@ -1,0 +1,59 @@
+# Change: As duas verificações do catálogo que não sabem reprovar
+
+## Why
+
+A change `update-documentation-prerequisites` (#154) acrescentou ao `skills-authoring` o requisito
+*A prescribed verification states what passes*, e o `E.4` dela registrou que a varredura por
+violações ainda não tinha sido feita.
+
+Feita, sobre as 35 skills e 133 arquivos, em duas passadas: comentário de saída esperada (9 linhas,
+todas na `documentation`) e prosa com verbo de verificação (67 linhas em 17 skills, das quais foram
+julgadas as 2 skills com passo executável). Dois achados.
+
+**`skills/claude-statusline/SKILL.md:130-142`** manda rodar o script contra um JSON de mentira e
+**não diz o que a saída deve ser** — nem uma linha, nem um campo obrigatório, nem um formato. O
+leitor executa, vê alguma coisa, e não tem contra o que comparar. O segundo teste da mesma seção pede
+confirmar que os segmentos opcionais somem *"cleanly"*, e "cleanly" não se observa.
+
+**`skills/documentation/references/examples.md:158`** traz `# Expected: All containers start without
+errors`, que descreve uma **ausência** em vez de um valor. As outras oito linhas de saída esperada do
+mesmo arquivo estão certas — `Docker version 24.x.x or higher`, `All services show "Up" status`,
+`{"status": "healthy", …}` — e é o contraste que expõe esta. Exemplo é o que se imita, e este é o
+exemplo da skill que escreveu a regra.
+
+## What Changes
+
+- `skills/claude-statusline/SKILL.md`, seção `## Verify`: a saída que o comando produz passa a estar
+  escrita, **medida** rodando `references/statusline.sh` com o JSON do próprio documento; e o teste
+  do caso vazio nomeia quais segmentos somem, no lugar de "cleanly".
+- `skills/documentation/references/examples.md`: a linha de ausência vira um valor observável.
+- `metadata.version` das duas skills sobe; árvores geradas regeneradas.
+- Delta em `skills-authoring`: o requisito existente ganha o cenário que a varredura ensinou — linha
+  fraca num **exemplo** de skill é defeito de primeira classe, porque exemplo é imitado.
+
+## Deliberately not done
+
+- **Julgar as 67 linhas de prosa uma a uma.** Foram amostradas as 2 skills com passo executável. A
+  cobertura parcial é declarada aqui e no PR, conforme o cenário *Partial coverage is declared, not
+  implied*; vira item próprio se esta entrega mostrar que vale.
+- **Validador para o requisito.** A `D3` da change de origem mediu que um detector sobre prosa dá
+  falso positivo nos dois sentidos (3 em 4 marcações), e a decisão continua valendo.
+- **Reescrever a seção `## Verify` além das duas frases apontadas.** O resto dela está correto.
+
+## Capabilities
+
+### New Capabilities
+
+_None._
+
+### Modified Capabilities
+
+- `skills-authoring`: MODIFIED requirement *A prescribed verification states what passes* — ganha o
+  cenário do exemplo. Uma saída esperada escrita num **exemplo** da skill vale como prescrição, porque
+  é o que o leitor copia; e uma que descreve ausência ("without errors", "no failures") não é valor.
+
+## Impact
+
+- `skills/claude-statusline/SKILL.md` e `skills/documentation/references/examples.md`.
+- `claude/`, `cursor/`, `plugins/` regenerados por `generate.sh`.
+- Nenhuma skill entra, sai ou muda de nome: composição do catálogo e descoberta por `npx` intactas.

--- a/openspec/changes/fix-verification-pass-values/specs/skills-authoring/spec.md
+++ b/openspec/changes/fix-verification-pass-values/specs/skills-authoring/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: A prescribed verification states what passes
+
+A skill that tells the reader to verify a step SHALL state the value that passes, not only the
+command and the output it prints. A verification whose expected result is satisfied by any run of the
+command does not verify; it reassures, which is worse than no verification because it consumes the
+reader's attention and returns nothing.
+
+Where one command's output distinguishes failures that need opposite remedies, the skill SHALL
+prescribe a table mapping each observable result to its meaning, rather than a single "expected"
+line that can only describe the success case.
+
+This applies to a skill's **examples** as much as to its instructions: an example is what a reader
+copies, so an expected-output line written there is a prescription. A stated result that describes an
+**absence** — "without errors", "no failures", "cleanly" — is not a passing value, because nothing
+observable distinguishes it from a run that failed in a way the reader did not think to look for.
+
+#### Scenario: A version probe names the version that passes
+
+- **WHEN** a skill prescribes a command whose purpose is to establish that a dependency is present at
+  a supported version
+- **THEN** the prescribed step states the minimum or the range that passes, so that a reader running
+  it against an unsupported version fails the step instead of continuing
+
+#### Scenario: An expected output that any run satisfies is a defect
+
+- **WHEN** the expected result of a prescribed verification is a shape the command prints regardless
+  of whether the underlying condition holds
+- **THEN** it is treated as a missing criterion and rewritten to name the passing value, because the
+  step as written cannot fail
+
+#### Scenario: Opposite remedies get a table, not a line
+
+- **WHEN** one prescribed command has results that mean different failures and call for different
+  fixes
+- **THEN** the skill maps each result to its meaning and its remedy in a table, instead of naming
+  only the success case and leaving the reader to guess which failure they hit
+
+#### Scenario: The criterion is reviewed by hand, and that is declared
+
+- **WHEN** a skill adds or edits a prescribed verification
+- **THEN** the criterion is reviewed by a human, and the skill's change records that no validator
+  covers this rule, because distinguishing a criterion from a shape description in prose is a
+  judgement a checker would get wrong in both directions
+
+#### Scenario: An example carries the same obligation as an instruction
+
+- **WHEN** a skill's reference examples show a command followed by an expected-output line
+- **THEN** that line names an observable value, because a reader imitates the example rather than
+  re-deriving the rule from the skill body
+
+#### Scenario: An absence is not a passing value
+
+- **WHEN** a prescribed result is stated as the absence of a problem — "without errors", "no
+  failures", "disappears cleanly"
+- **THEN** it is rewritten to name what the reader sees when the step succeeded: the lines that
+  appear, the segments that are gone, the exact string printed

--- a/openspec/changes/fix-verification-pass-values/tasks.md
+++ b/openspec/changes/fix-verification-pass-values/tasks.md
@@ -1,0 +1,134 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `1b7b592` (topo de `master`, 2026-09-06):
+
+      - `skills/claude-statusline/SKILL.md` — 9,9K; a seção `## Verify` em `:130-142`, com o bloco
+        `bash` que canaliza um JSON de exemplo para `~/.claude/statusline.sh` e passa por
+        `sed 's/\x1b\[[0-9;]*m//g'`; a frase "to confirm optional segments disappear cleanly" logo
+        abaixo.
+      - `skills/claude-statusline/references/statusline.sh` — 12,2K, o script que a skill entrega.
+      - `skills/documentation/references/examples.md` — as nove linhas de saída esperada; a de `:158`
+        é `# Expected: All containers start without errors`, e as outras oito nomeiam valor.
+      - `openspec/specs/skills-authoring/spec.md:703` — o requisito *A prescribed verification states
+        what passes*, com quatro cenários, entrado por `2026-09-06-update-documentation-prerequisites`.
+      - `openspec/changes/archive/2026-09-06-update-documentation-prerequisites/design.md` — a `D3`,
+        que decide o requisito sem validador e registra a medição que sustenta a decisão.
+
+- [x] E.2 Ferramentas e fontes sondadas: comando -> fragmento da saída
+
+      - Varredura por comentário de saída esperada em `skills/*/**/*.md` (regex
+        `# (Expected|Esperado|Should print|Output)`) -> `linhas de saída esperada no catálogo: 9`,
+        todas em `skills/documentation/references/examples.md` e `references/templates.md`.
+      - Varredura por prosa com verbo de verificação (`verify|confirm|check that|conferir que`) ->
+        `linhas em prosa que prescrevem verificação: 67, em 17 skills`, com
+        `documentation 16`, `verify-before-claiming 6`, `claude-statusline 5`, `k8s-tune-resources 5`.
+      - `echo '<json do documento>' | bash skills/claude-statusline/references/statusline.sh | sed …`
+        -> três linhas: `🤖 Opus 4.8 | ⚡ medium | 🧠 thinking enabled | ⏱️  1h 26m | 💰 $2.47`,
+        `📝 +1347 -156 | ↑ In 135k $0.10 · ♻️ 95% · ↓ Out 2k $0.05`,
+        `📊 ctx ▓▓▓▓▓░░░ 63% | 🚦 5h ▓▓▓▓░░░░ 57% | 7d ▓▓▓▓▓▓░░ 84%`; `exit=0`.
+      - O mesmo script com `current_usage: null`, fora de repositório git -> duas linhas:
+        `🤖 Opus 4.8 | ⚡ medium | 🧠 thinking disabled | 💰 $0.00` e `📊 ctx ▓▓▓▓▓░░░ 63%`.
+      - `openspec validate fix-verification-pass-values --strict` ->
+        `Change 'fix-verification-pass-values' is valid`.
+
+- [x] E.3 O que não deu para sondar
+
+      As 67 linhas de prosa não foram julgadas uma a uma: foram amostradas as duas skills com passo
+      executável (`claude-statusline` e `k8s-tune-resources`), e só a primeira tinha violação. As
+      outras 15 skills ficaram sem julgamento individual, então o número deste change é **piso, não
+      censo** — e é assim que ele é reportado. Também não foi sondado o comportamento do
+      `statusline.sh` em terminal sem suporte a emoji ou a barra de blocos: a saída medida é a de um
+      terminal UTF-8, e o documento não afirma nada sobre os outros.
+
+- [x] E.4 Escopo e desdobramentos
+
+      Um desdobramento fica registrado: julgar as 15 skills restantes das 17 que a segunda varredura
+      marcou. Não entra aqui porque o custo de ler 67 linhas de prosa agora é maior que o de abrir um
+      item quando um terceiro caso aparecer — e o critério que abriu **este** item era justamente
+      "mais de um caso", que já foi satisfeito com dois.
+
+## 2. As duas correções
+
+- [x] 2.1 `claude-statusline`: a seção `## Verify` passa a trazer a saída medida
+- [x] 2.2 `claude-statusline`: "disappear cleanly" vira os segmentos nomeados
+- [x] 2.3 `documentation/references/examples.md:158`: a ausência vira valor observável
+- [x] 2.4 `metadata.version` das duas skills sobe
+
+## 3. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 O artefato foi exercitado pelo seu ponto de entrada real
+
+      A seção `## Verify` é uma instrução executável, e o ponto de entrada dela é o próprio comando
+      que ela manda rodar — com o script que a skill entrega, não com o instalado na máquina.
+
+      - entry point: `echo '<o JSON do documento>' | bash skills/claude-statusline/references/statusline.sh | sed 's/\x1b\[[0-9;]*m//g'`
+        -> `🤖 Opus 4.8 | ⚡ medium | 🧠 thinking enabled | ⏱️  1h 26m | 💰 $2.47`, mais duas linhas,
+        `exit=0`
+      - entry point: o mesmo com `current_usage: null` e fora de repositório git ->
+        `🤖 Opus 4.8 | ⚡ medium | 🧠 thinking disabled | 💰 $0.00` e `📊 ctx ▓▓▓▓▓░░░ 63%`
+      - entry point: `bash generate.sh` -> `Generated wrappers for 35 skills`
+      - entry point: `python3 scripts/validate-skills.py` -> `skills checked: 35   findings: 0`
+
+- [x] S.2 Matriz de casos medida, como contagens
+
+      Varredura: 133 arquivos de skill lidos; 9/9 linhas de saída esperada julgadas uma a uma, com
+      8/9 corretas e 1/9 fraca; 67 linhas de prosa marcadas em 17 skills, das quais 2/17 skills
+      amostradas por terem passo executável, com 1/2 em violação. Confirmados: 2 casos — o gatilho do
+      `E.4` da change de origem era "mais de um".
+
+      Correção: 2/2 casos fechados. Saída do `## Verify` medida em 2/2 cenários (cheio e vazio),
+      com 3 linhas e 2 linhas respectivamente. Versões: 2/2 skills tocadas com bump.
+
+      Portões: 35/35 skills sem achado; 22/22 classes de defeito no selftest; 4/4 na higiene;
+      12/12 padrões de segredo; 6/6 items do rito validados.
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      Uma coisa. A **primeira varredura devolveu zero achados**, o que contradizia o que já se sabia —
+      o `templates.md` tem três `# Expected` visíveis a olho nu. A causa era o filtro que eu tinha
+      posto para olhar só dentro de cerca de código: o `templates.md` traz cercas **escapadas** dentro
+      de blocos markdown, e o pareamento não-guloso da regex casava o abre-cerca externo com o
+      escape interno, cortando 8.364 dos 13.042 caracteres do arquivo. Sem o filtro, os 9 achados
+      aparecem. É a mesma classe do defeito que o requisito cobre: um instrumento cujo resultado
+      esperado — zero — é satisfeito por um erro de leitura, e não distingue "não há violação" de
+      "não olhei".
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado
+      Evidência: o loop do `ci.yml` replicado -> `frontmatter fail=0 sobre 35 skills`;
+      `claude-statusline` em `1.3.0` e `documentation` em `3.1.1`, ambos semver,
+      `author: solvelab`, `license: MIT`, `compatibility` presente, `name` == diretório.
+- [x] Q.2 Todo conteúdo de skill tocado em inglês (locale do catálogo)
+      Evidência: as duas seções reescritas são inglês; `check-identifier-locale.py --selftest` ->
+      `selftest OK`; `validate-skills.py` -> `skills checked: 35   findings: 0`.
+- [x] Q.3 Gatilhos da description testáveis e sem colisão
+      Evidência: `git diff master -- skills/ | grep -cE '^[-+] *description'` -> `0`; nenhuma
+      description foi tocada, e nenhum gatilho se moveu.
+- [x] Q.4 Sem doutrina duplicada
+      Evidência: a regra do valor que aprova continua só no `skills-authoring`; o `claude-statusline`
+      **aplica** a regra sem reafirmá-la, e o `examples.md` corrige um exemplo sem reescrever a regra
+      do `templates.md`. Tabela Canonical Home do `design.md`: quatro linhas, três `already canonical`
+      e uma `link`.
+- [x] Q.5 Todo exemplo de código em skill tocada usa identificador em inglês
+      Evidência: os blocos novos são saída de terminal, sem identificador; o `# Expected` reescrito do
+      `examples.md` cita `Started`, `Error` e `Exited`, que são strings do próprio `docker compose`;
+      detector de locale -> `findings: 0`.
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate --strict` verde e `validate-rite.sh` verde
+      Evidência: `openspec validate fix-verification-pass-values --strict` ->
+      `Change 'fix-verification-pass-values' is valid`; `bash scripts/validate-rite.sh` ->
+      `rite gate OK`, `Totals: 6 passed, 0 failed`.
+- [x] V.2 Descoberta do catálogo intacta
+      Evidência: `ls -d skills/*/ | wc -l` -> `35`, inalterado; nenhuma skill criada, removida ou
+      renomeada; `bash generate.sh` -> `Generated wrappers for 35 skills`;
+      `validate-repo-hygiene.py` -> `repo hygiene: 0 findings`, que cobre as contagens publicadas.
+- [x] V.3 README e docs atualizados onde o change altera composição ou uso
+      Evidência: nenhuma mudança de composição ou de uso — duas seções de conteúdo e dois bumps.
+      `README.md` intocado de propósito; o check H2 da higiene é o que acusaria contagem defasada, e
+      está verde.
+- [ ] V.4 `openspec archive fix-verification-pass-values --yes` depois do merge do PR

--- a/plugins/docs/skills/documentation/SKILL.md
+++ b/plugins/docs/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.1.0
+  version: 3.1.1
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/plugins/docs/skills/documentation/references/examples.md
+++ b/plugins/docs/skills/documentation/references/examples.md
@@ -155,7 +155,8 @@ docker compose build
 # Expected: Successfully built all images
 
 docker compose up -d
-# Expected: All containers start without errors
+# Expected: every service line ends in "Started" — a line ending in "Error" or
+#           "Exited" names the container that failed
 
 docker compose ps
 # Expected: All services show "Up" status

--- a/plugins/tooling/skills/claude-statusline/SKILL.md
+++ b/plugins/tooling/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.2.2
+  version: 1.3.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
@@ -136,9 +136,30 @@ echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp"},"c
   | ~/.claude/statusline.sh | sed 's/\x1b\[[0-9;]*m//g'
 ```
 
-Also test the empty case (`"current_usage": null`, no git repo) to confirm optional
-segments disappear cleanly. To exercise the git line, run it from inside a repo with
-staged and modified files.
+That input produces exactly three lines — measured against `references/statusline.sh`:
+
+```
+🤖 Opus 4.8 | ⚡ medium | 🧠 thinking enabled | ⏱️  1h 26m | 💰 $2.47
+📝 +1347 -156 | ↑ In 135k $0.10 · ♻️ 95% · ↓ Out 2k $0.05
+📊 ctx ▓▓▓▓▓░░░ 63% | 🚦 5h ▓▓▓▓░░░░ 57% | 7d ▓▓▓▓▓▓░░ 84%
+```
+
+Anything else is a defect: fewer lines means a segment silently returned empty, and a `jq` error on
+stderr means the input shape moved. Re-measure with the command above rather than trusting this
+block if you edited the script — the numbers here are what it printed, not what it ought to print.
+
+Also test the empty case (`"current_usage": null`, `"thinking": {"enabled": false}`, run outside a
+git repo). It must collapse to **two** lines, and the difference is what you check:
+
+```
+🤖 Opus 4.8 | ⚡ medium | 🧠 thinking disabled | 💰 $0.00
+📊 ctx ▓▓▓▓▓░░░ 63%
+```
+
+The `📝` token line is gone entirely, the `🚦` rate-limit segment has left the `📊` line, and the
+`⏱️` duration has left the header. A segment that renders as a bare separator (`|` with nothing
+after it) or as `$0.00` where it should be absent is the failure this case exists to catch. To
+exercise the git line, run it from inside a repo with staged and modified files.
 
 ---
 

--- a/skills/claude-statusline/SKILL.md
+++ b/skills/claude-statusline/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Configure or customize the Claude Code status line — the shell-script status bar at the bottom of the CLI that shows model, effort tier, context usage, git state, cost (cumulative session + per-turn token cost), rate limits and prompt-cache health. Use when the user wants to set up, change, share, or debug their Claude Code status line / status bar, mentions statusLine in settings.json or a statusline.sh script, wants a context/token/cost/git/effort indicator in the CLI, or shares a status-line gist to install. Ships a ready-made 3-line script (references/statusline.sh) and the full list of available JSON fields (references/fields.md). Do NOT use for shell prompt themes (PS1, starship, powerlevel10k) or non-Claude-Code status bars.
 metadata:
   author: solvelab
-  version: 1.2.2
+  version: 1.3.0
   category: tooling
 license: MIT
 compatibility: Works in Claude Code (CLI, desktop, IDE). Requires `jq` on PATH. Bash script targets macOS/Linux (incl. WSL); Git Bash on Windows.
@@ -136,9 +136,30 @@ echo '{"model":{"display_name":"Opus 4.8"},"workspace":{"current_dir":"/tmp"},"c
   | ~/.claude/statusline.sh | sed 's/\x1b\[[0-9;]*m//g'
 ```
 
-Also test the empty case (`"current_usage": null`, no git repo) to confirm optional
-segments disappear cleanly. To exercise the git line, run it from inside a repo with
-staged and modified files.
+That input produces exactly three lines — measured against `references/statusline.sh`:
+
+```
+🤖 Opus 4.8 | ⚡ medium | 🧠 thinking enabled | ⏱️  1h 26m | 💰 $2.47
+📝 +1347 -156 | ↑ In 135k $0.10 · ♻️ 95% · ↓ Out 2k $0.05
+📊 ctx ▓▓▓▓▓░░░ 63% | 🚦 5h ▓▓▓▓░░░░ 57% | 7d ▓▓▓▓▓▓░░ 84%
+```
+
+Anything else is a defect: fewer lines means a segment silently returned empty, and a `jq` error on
+stderr means the input shape moved. Re-measure with the command above rather than trusting this
+block if you edited the script — the numbers here are what it printed, not what it ought to print.
+
+Also test the empty case (`"current_usage": null`, `"thinking": {"enabled": false}`, run outside a
+git repo). It must collapse to **two** lines, and the difference is what you check:
+
+```
+🤖 Opus 4.8 | ⚡ medium | 🧠 thinking disabled | 💰 $0.00
+📊 ctx ▓▓▓▓▓░░░ 63%
+```
+
+The `📝` token line is gone entirely, the `🚦` rate-limit segment has left the `📊` line, and the
+`⏱️` duration has left the header. A segment that renders as a bare separator (`|` with nothing
+after it) or as `$0.00` where it should be absent is the failure this case exists to catch. To
+exercise the git line, run it from inside a repo with staged and modified files.
 
 ---
 

--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   same commit as the code. Do NOT use for non-software documentation tasks.
 metadata:
   author: solvelab
-  version: 3.1.0
+  version: 3.1.1
   category: docs
 license: MIT
 compatibility: Works in Claude Code, Claude.ai, and any environment with filesystem access.

--- a/skills/documentation/references/examples.md
+++ b/skills/documentation/references/examples.md
@@ -155,7 +155,8 @@ docker compose build
 # Expected: Successfully built all images
 
 docker compose up -d
-# Expected: All containers start without errors
+# Expected: every service line ends in "Started" — a line ending in "Error" or
+#           "Exited" names the container that failed
 
 docker compose ps
 # Expected: All services show "Up" status


### PR DESCRIPTION
Closes #164

O `E.4` da change #154 registrou que a varredura por violações do requisito **A prescribed
verification states what passes** ainda não tinha sido feita, e que o critério para abrir item era
"mais de um caso". Feita. Dois.

## A varredura

133 arquivos, 35 skills, duas passadas:

| Passada | O que casa | Achados |
|---|---|---|
| comentário de saída esperada (`# Expected`, `# Esperado`, `Should print`, `Output`) | 9 linhas, todas na `documentation` | 8 corretas, **1 fraca** |
| prosa com verbo de verificação (`verify`, `confirm`, `check that`, `conferir que`) | 67 linhas em 17 skills | 2 skills amostradas por terem passo executável, **1 violação** |

**A cobertura é parcial e está declarada**, conforme *Partial coverage is declared, not implied*: as
heurísticas não veem verificação em tabela nem passo que implique conferência sem esses verbos, e as
67 linhas de prosa foram **amostradas**, não julgadas uma a uma. O número é piso, não censo. O
julgamento é humano por desenho — a `D3` de #154 mediu que detector sobre prosa erra nos dois
sentidos.

## Caso 1 — `claude-statusline`, seção `## Verify`

Mandava rodar o script contra um JSON de mentira e **não dizia o que a saída deve ser**. Nem uma
linha, nem um campo obrigatório, nem um formato.

Agora traz as três linhas que ele imprime, **medidas** rodando `references/statusline.sh` com o JSON
do próprio documento:

```
🤖 Opus 4.8 | ⚡ medium | 🧠 thinking enabled | ⏱️  1h 26m | 💰 $2.47
📝 +1347 -156 | ↑ In 135k $0.10 · ♻️ 95% · ↓ Out 2k $0.05
📊 ctx ▓▓▓▓▓░░░ 63% | 🚦 5h ▓▓▓▓░░░░ 57% | 7d ▓▓▓▓▓▓░░ 84%
```

E `"to confirm optional segments disappear cleanly"` — que não se observa — virou as **duas** linhas
do caso vazio, com a diferença nomeada: a linha `📝` some inteira, o `🚦` sai da linha `📊`, o `⏱️` sai
do cabeçalho.

Conferido depois de escrito: `diff` entre o que o script imprime e o que o documento passou a
prometer → **idêntico**.

## Caso 2 — `documentation/references/examples.md:158`

`# Expected: All containers start without errors` descreve uma **ausência**. As outras oito linhas
de saída esperada do mesmo arquivo nomeiam valor, e era o contraste que a expunha. Virou:

```
# Expected: every service line ends in "Started" — a line ending in "Error" or
#           "Exited" names the container that failed
```

Exemplo é o que se imita, e este é o exemplo da skill que escreveu a regra. Daí o delta.

## Delta: `MODIFIED`, não `ADDED`

O requisito existe e está certo. Faltava dizer que ele vale dentro de **exemplo**, e que ausência não
é valor. Dois cenários novos — *An example carries the same obligation as an instruction* e *An
absence is not a passing value*. Criar requisito novo daria duas casas para uma regra só, contra
*Single canonical home per rule*.

## O que escapou

**A primeira varredura devolveu zero achados**, contradizendo o que se vê a olho nu — o
`templates.md` tem três `# Expected`. A culpa era do filtro que olhava só dentro de cerca de código:
esse arquivo traz cercas **escapadas** dentro de blocos markdown, e o pareamento não-guloso casava o
abre-cerca externo com o escape interno, cortando **8.364 dos 13.042** caracteres.

Zero satisfeito por erro de leitura, indistinguível de "não há violação". É a mesma classe do defeito
que este requisito cobre — desta vez no instrumento que o fiscaliza.

## Portões

| Portão | Resultado |
|---|---|
| `openspec validate --strict` | `Change 'fix-verification-pass-values' is valid` |
| `validate-rite.sh` | `rite gate OK` · `6 passed, 0 failed` |
| `validate-skill-version.py` | `0 findings (2 skills changed, 2 with content changes)` |
| `validate-spec-rite.py` | `0 findings (14 changed paths)` |
| `validate-skills.py` | `skills checked: 35   findings: 0` |
| `selftest-validate-skills.py` | `27/27 defect classes detected` |
| `check-identifier-locale.py --selftest` | `selftest OK` |
| `scan-secrets.py` | `no credentials found` |
| `validate-repo-hygiene.py` (+selftest) | `0 findings` · `4/4` |
| `generate.sh` + `git diff` sobre árvore commitada | wrappers em dia, nenhum untracked |
| frontmatter (loop do `ci.yml`) | `fail=0` sobre 35 skills |
| saída prometida vs. saída real | `diff` vazio |

Versões: `claude-statusline` `1.2.2` → `1.3.0`, `documentation` `3.1.0` → `3.1.1`.

Os 10 critérios do item estão marcados.

## Deliberadamente fora

- **Julgar as 67 linhas de prosa uma a uma** — 15 das 17 skills ficaram sem julgamento individual, e
  está escrito no `E.3`. Abre item quando um terceiro caso aparecer.
- **Validador para o requisito** — a `D3` de #154 mediu e decidiu.
- Reescrever o `## Verify` além das duas frases apontadas.

Spec-rite: fix-verification-pass-values
