### PR TITLE
🐛 fix(gates): -z no spec-rite, vendored no scan_diff, selftest com uma cópia, VERSION validado no ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,18 @@ jobs:
           exit $fail
 
       - name: Version coherence (VERSION == plugin.json == marketplace.json)
+        # The shape check comes BEFORE the manifest comparison: a malformed value the three files
+        # share (`2.15.1dirtychange`, measured on issue #172) is "coherent" by substring and passed.
+        # Same literal as SEMVER_RE in generate.sh and scripts/set-version.sh — the readers of a
+        # version must agree on what one is; copied, not sourced, because generate.sh has side
+        # effects at the top.
         run: |
           VERSION="$(tr -d '[:space:]' < VERSION)"
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+          if ! [[ "$VERSION" =~ $SEMVER_RE ]]; then
+            echo "::error::VERSION is '$VERSION' — expected MAJOR.MINOR.PATCH with an optional -prerelease suffix (the regex generate.sh and set-version.sh apply)."
+            exit 1
+          fi
           for f in .claude-plugin/plugin.json .claude-plugin/marketplace.json; do
             if ! grep -q "\"version\": \"$VERSION\"" "$f"; then
               echo "::error::$f version does not match VERSION ($VERSION)."

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ ai-skills/
 │   ├── bug-hunter/SKILL.md
 │   ├── fivem-lua/SKILL.md
 │   ├── fivem-fallback/SKILL.md
-│   └── r3f-*/SKILL.md                        # React Three Fiber skills (10 topics)
+│   └── r3f-*/SKILL.md                        # React Three Fiber skills, one per topic
 ├── .claude-plugin/
 │   ├── plugin.json                           # Claude Code plugin manifest (version-pinned)
 │   └── marketplace.json                      # Claude Code marketplace catalog

--- a/claude/skills/code-locale/SKILL.md
+++ b/claude/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.4.2
+  version: 1.4.3
   category: process
 license: MIT
 compatibility: >-

--- a/cursor/rules/code-locale.mdc
+++ b/cursor/rules/code-locale.mdc
@@ -9,9 +9,9 @@ Reference files (`references/…` below) live at https://github.com/solvelab/ai-
 
 # Code locale — prose follows the repo, the machine layer is English
 
-> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-05:
+> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-06:
 > `references/check-identifier-locale.py --selftest` (7 content tiers fire, 16 clean cases silent,
-> 6 path tiers fire, 9 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
+> 6 path tiers fire, 10 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
 > --selftest` (13 PostToolUse and 12 PreToolUse decisions) and `locale-stop-gate.py --selftest` (26
 > decisions in throwaway git repositories) all pass, and both hooks are the ones wired in
 > `~/.claude/settings.json` of the session that wrote this. The detector uses only the standard

--- a/openspec/changes/harden-gate-followups/.openspec.yaml
+++ b/openspec/changes/harden-gate-followups/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-06

--- a/openspec/changes/harden-gate-followups/design.md
+++ b/openspec/changes/harden-gate-followups/design.md
@@ -84,11 +84,17 @@ perfil de linguagem: reportado como pulado, nunca como aprovado.
 A exclusão é por **caminho** (`VENDOR_PARTS`, `.min.`); `is_minified()` lê o corpo do arquivo, que
 em modo diff não existe, e não entra — KNOWN LIMIT 12 diz isso.
 
-### D3 — Uma cópia por run; mutação aplicada e desfeita em `finally`
+### D3 — Uma cópia por run; mutação aplicada e desfeita em `finally`; premissa medida antes
 
-`shutil.copytree` do repositório (35 skills, cinco árvores geradas) é o custo dominante: 27 cópias
-em 49,1 s. A cópia passa a ser feita uma vez fora do laço; para cada mutação o laço guarda o
-estado original do alvo — `read_bytes()` se existe, `None` se não — aplica a mutação com o mesmo
+A issue assume que as 27 cópias são o custo. Medido antes de escrever (`measure-cost.py`, três
+repetições): uma `copytree` do catálogo (1 375 entradas sem `.git`) custa **0,07 s**; uma run de
+`validate-skills.py` custa **1,71 s**. As 27 cópias são 1,9 s dos 49,1 s; as 27 runs do validador
+são 46,2 s. A premissa está errada: o tempo é o validador, não a cópia. A cópia única fica mesmo
+assim — pelo que compra de verdade: 27 vezes menos churn de disco por PR e um lugar só para provar a
+isolação — e o ganho de tempo registrado é o que a medida permite, ~2 s por run.
+
+A cópia passa a ser feita uma vez fora do laço; para cada mutação o laço guarda o estado original do
+alvo — `read_bytes()` se existe, `None` se não — aplica a mutação com o mesmo
 `read_text()`/`write_text()` de antes, roda o validador, e em `finally` restaura os bytes ou remove
 o arquivo criado (C11) ou o diretório criado (C7, `shutil.rmtree`). Restaurar **bytes**, não texto:
 `read_text()` normaliza `\r\n` e uma restauração por texto deixaria a cópia diferente da origem
@@ -97,8 +103,14 @@ para a mutação seguinte.
 A ordem das mutações não muda e cada uma continua vendo a cópia limpa — a asserção `CAUGHT` de cada
 caso é a mesma de antes. O que muda é a garantia: antes a isolação vinha de uma cópia nova; agora
 vem da reversão, e um `finally` que não restaure deixaria a mutação anterior vazando para a
-seguinte. A prova é que os 27 casos continuam `CAUGHT` **e** que o validador na cópia depois do
-laço fica limpo (nenhuma mutação sobrou) — S.1.
+seguinte. Depois do laço a cópia é comparada byte a byte com a origem (`filecmp.cmp(shallow=False)`
+mais o conjunto de caminhos): uma restauração perdida vira `LEAKED` e reprova. Comparar, e não rodar
+o validador de novo, porque a run custa 1,7 s e "idêntica à origem" é a afirmação mais forte. A
+prova de que a checagem dispara — restauração neutralizada de propósito — está em S.1: `LEAKED` com
+três arquivos nomeados e cinco casos `MISSED` pelas mutações empilhadas.
+
+Paralelizar as runs do validador (o custo real) fica como follow-up em E.4: é uma otimização fora do
+escopo da issue, e agora tem a medida que a justifica.
 
 ### D4 — A regex do `generate.sh` no step, antes da comparação
 

--- a/openspec/changes/harden-gate-followups/design.md
+++ b/openspec/changes/harden-gate-followups/design.md
@@ -1,0 +1,156 @@
+## Context
+
+Os cinco pontos vêm de grupos E.4 já arquivados — cada um foi visto por quem fechava outra change,
+anotado como follow-up e deixado. Nenhum é um gate novo; todos são um gate existente medindo menos
+do que diz (1, 2, 4), pagando mais do que precisa (3) ou publicando um número que ninguém confere
+(5). Lido em `e7f5fe8` (2026-09-06):
+
+- `scripts/validate-spec-rite.py:167-170` — `changed_paths()` roda `git diff --name-only
+  base...HEAD` e faz `splitlines()`. `requires_registration()` (`:174`) e `touched_changes()`
+  (`:193`) comparam com `startswith("openspec/")` — um caminho quotado começa com `"`.
+- `scripts/validate-skill-version.py:162-173` — `split_nul_paths()` + `changed_paths()` com `-z`,
+  e `_probe_quoted_path()` (`:347-372`) commitando `skills/probe/references/café.md` num repositório
+  descartável com `core.quotePath=true`. O módulo importa `validate-spec-rite.py` em tempo de carga
+  (`_sibling_min_reason()`, `:84-101`) para `MIN_REASON`.
+- `skills/code-locale/references/check-identifier-locale.py:612-664` — `scan_diff()` lê `--- `,
+  `+++ `, `@@` e `+`; chama `scan_path()` só para arquivo adicionado; `lang` vem da extensão. `main()`
+  (`:878-880`) aplica `is_vendored()` e acumula em `vendored`, impresso em `:906`. O hook
+  `locale-stop-gate.py:294-296` chama `check.scan_diff(iter(...), allow, None)` e filtra
+  `is_vendored` por fora nos achados.
+- `scripts/selftest-validate-skills.py:117-134` — laço `for check, entry in MUTATIONS` com
+  `tempfile.TemporaryDirectory()` + `shutil.copytree(SRC, dst, ignore=(".git", "node_modules"))`
+  por iteração; 27 entradas em `MUTATIONS`; C7 cria um diretório, C11 cria um arquivo, os outros
+  reescrevem um arquivo existente com `read_text()`/`write_text()`.
+- `.github/workflows/ci.yml:70-79` — step *Version coherence*: `VERSION="$(tr -d '[:space:]' <
+  VERSION)"` e `grep -q "\"version\": \"$VERSION\""` nos dois manifests.
+- `generate.sh:27-36` e `scripts/set-version.sh:13-16` — `SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'`
+  com o comentário "the two readers must agree on what a version is".
+- `README.md:443` — `│   └── r3f-*/SKILL.md  # React Three Fiber skills (10 topics)` dentro do
+  bloco ```text da árvore; `scripts/validate-repo-hygiene.py:91-94` declara esse `(10 topics)`
+  como fora do alcance de H2 por estar em bloco de código.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Os dois leitores de diff do repositório (`validate-spec-rite.py`, `validate-skill-version.py`)
+  leem caminhos da mesma forma, e cada um prova isso no próprio selftest.
+- `scan_diff()` e `scan_path()` concordam sobre o que é vendored, e o pulo é contado, não silenciado.
+- O selftest do validador roda numa cópia só, com os 27 casos ainda detectados e o tempo medido.
+- O CI recusa um `VERSION` que `generate.sh` também recusaria, antes de comparar manifests.
+- Nenhum número solto na árvore do README.
+
+**Non-Goals**
+
+- Trocar a arquitetura dos gates ou adicionar checks novos (fora de escopo pela issue).
+- Extrair um módulo compartilhado `scripts/_git_paths.py` (ver D1).
+- Editar `validate-skill-version.py`, os hooks de locale ou `validate-repo-hygiene.py`: não estão
+  na lista de arquivos deste item. A docstring do hygiene que cita `README.md:345 (10 topics)` fica
+  um passo atrás — follow-up em `tasks.md` E.4.
+- Fazer o selftest do validador rodar em paralelo ou em `git worktree`: uma cópia com reversão já
+  remove o custo dominante (D3); paralelizar é otimização sem medida que a justifique.
+
+## Decisions
+
+### D1 — `split_nul_paths()` duplicado no spec-rite, não importado nem extraído
+
+`validate-skill-version.py` carrega `validate-spec-rite.py` em tempo de import para ler
+`MIN_REASON`. Importar na direção contrária fecharia um ciclo em tempo de carga (o spec-rite
+executaria o irmão, que executa o spec-rite). Um terceiro módulo `scripts/_git_paths.py` resolveria
+o ciclo, mas exigiria `sys.path` nos dois `--selftest` e criaria um arquivo para duas linhas de
+código. O helper é `out.split("\0")` com filtro de vazios; a duplicata carrega um comentário que
+nomeia o irmão e o motivo, e cada script prova a própria leitura com um probe em repositório
+descartável — é o probe, não a origem do código, que impede as duas cópias de divergirem.
+
+O probe do spec-rite difere do irmão no que prova: o caminho quotado fica **dentro de
+`openspec/changes/<id>/`** de uma change ativa, e a asserção é `evaluate()` mudo — o diff se
+registra pelo caminho que o git quotaria. O caso literal em `split_nul_paths()` (aspas, quebra de
+linha) fica ao lado, como no irmão.
+
+### D2 — `scan_diff()` pula o bloco vendored inteiro e devolve o caminho numa lista
+
+No `+++ `, depois de resolver `path`, `is_vendored(Path(path))` decide: se vendored, `lang = None`
+(nenhuma linha `+` entra em `run`), o path tier não roda, e o caminho vai para `vendored` — um
+parâmetro opcional `vendored: list | None = None` que `main()` passa e os hooks não precisam passar
+(`locale-stop-gate.py:294` chama com três posicionais e continua válido). `main()` imprime a lista
+na linha `skipped (vendored/generated/minified)` que já existe para o modo de arquivos, com o mesmo
+texto: "not this project's machine layer".
+
+Alternativa rejeitada: filtrar `is_vendored` nos achados depois de `scan_diff()` (o que o hook de
+Stop faz por fora). Filtrar depois ainda tokeniza o arquivo — um `dist/bundle.js` de 5 000 linhas é
+lido inteiro para jogar fora — e não conta o pulo, que é o que KNOWN LIMIT 10 exige para arquivo sem
+perfil de linguagem: reportado como pulado, nunca como aprovado.
+
+A exclusão é por **caminho** (`VENDOR_PARTS`, `.min.`); `is_minified()` lê o corpo do arquivo, que
+em modo diff não existe, e não entra — KNOWN LIMIT 12 diz isso.
+
+### D3 — Uma cópia por run; mutação aplicada e desfeita em `finally`
+
+`shutil.copytree` do repositório (35 skills, cinco árvores geradas) é o custo dominante: 27 cópias
+em 49,1 s. A cópia passa a ser feita uma vez fora do laço; para cada mutação o laço guarda o
+estado original do alvo — `read_bytes()` se existe, `None` se não — aplica a mutação com o mesmo
+`read_text()`/`write_text()` de antes, roda o validador, e em `finally` restaura os bytes ou remove
+o arquivo criado (C11) ou o diretório criado (C7, `shutil.rmtree`). Restaurar **bytes**, não texto:
+`read_text()` normaliza `\r\n` e uma restauração por texto deixaria a cópia diferente da origem
+para a mutação seguinte.
+
+A ordem das mutações não muda e cada uma continua vendo a cópia limpa — a asserção `CAUGHT` de cada
+caso é a mesma de antes. O que muda é a garantia: antes a isolação vinha de uma cópia nova; agora
+vem da reversão, e um `finally` que não restaure deixaria a mutação anterior vazando para a
+seguinte. A prova é que os 27 casos continuam `CAUGHT` **e** que o validador na cópia depois do
+laço fica limpo (nenhuma mutação sobrou) — S.1.
+
+### D4 — A regex do `generate.sh` no step, antes da comparação
+
+O step ganha `SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'` — o mesmo literal de
+`generate.sh:32` e `set-version.sh:15`, copiado e não importado, pelo mesmo motivo que os greps de
+frontmatter copiaram o `awk` (D4 de `close-ci-gate-holes`): `generate.sh` tem `set -euo pipefail`
+e efeitos colaterais no topo. `[[ "$VERSION" =~ $SEMVER_RE ]] || { echo "::error::VERSION is
+'$VERSION' — ..."; exit 1; }` vem **antes** do laço dos manifests: um valor malformado que os três
+arquivos compartilham (o caso medido, `2.15.1dirtychange`) passaria na comparação e tem de reprovar
+antes dela.
+
+### D5 — O comentário da árvore diz o que é, não quantos são
+
+`(10 topics)` vira `one skill per topic`. Um número no README fora de bloco de código é gatado por
+H2; dentro de bloco de código é revisão apenas, e a revisão o deixou errado por dois releases. A
+alternativa — mover a linha para fora do bloco para que H2 a leia — quebraria a árvore ilustrativa;
+tirar o número é a forma que não pode envelhecer.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Um gate lê o diff do jeito que o git escreve caminhos (`-z`, NUL) | `skills-catalog` (spec do repositório) | already canonical — o requisito ganha a frase; os dois scripts só a cumprem |
+| Um check declara dentro de si o que não cobre (KNOWN LIMIT) | `skills-catalog` + `verify-before-claiming` | already canonical — KNOWN LIMIT 12 do detector e a docstring do spec-rite só estendem o próprio texto |
+| Vendored/generated não é camada de máquina do projeto | `code-locale` | already canonical — `scan_diff()` passa a aplicar a exclusão que `scan_path()` e `main()` já aplicam; nenhum texto novo de doutrina |
+| Um gate carrega selftest com um defeito injetado por regra | `skills-authoring` (*Authoring rules are machine-enforced*) | already canonical — os dois selftests ganham um caso cada; nenhum texto copiado |
+| Prova observada, não esperada, antes de declarar entrega | `verify-before-claiming` | already canonical — citado no grupo de simulação de `tasks.md` |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — `split_nul_paths`, `vendored`, `original`, labels de selftest em inglês |
+
+Uma skill é editada (`code-locale`: versão e linha *Verified against*); nenhuma doutrina é
+restatada.
+
+## Risks / Trade-offs
+
+- **A duplicata de `split_nul_paths()` pode divergir do irmão.** → Cada script tem um probe em
+  repositório real com `core.quotePath=true`; uma divergência que importe (voltar a `splitlines()`)
+  reprova o selftest de quem a fizer.
+- **Pular vendored em `scan_diff()` pode esconder um achado legítimo em `build/` ou `dist/` de um
+  projeto que commita esses diretórios.** → É a mesma regra que o modo de arquivos já aplica a esses
+  caminhos há meses (`VENDOR_PARTS`), e o pulo é contado na saída; um projeto que quer medir `dist/`
+  já não conseguia pelo modo de arquivos.
+- **A reversão por bytes pode falhar no meio e contaminar o caso seguinte.** → `finally` restaura
+  mesmo quando `subprocess.run` levanta; e S.1 roda o validador na cópia depois do laço para provar
+  que ficou limpa.
+- **A regex pode recusar um `VERSION` que o semantic-release escreve.** → O semantic-release escreve
+  `X.Y.Z` puro (histórico: `2.30.0`, `2.15.1`); pré-release `-beta.1` passa pelo sufixo opcional. É
+  a regex que `generate.sh` já aplica no mesmo job, um step antes.
+- **Remover `(10 topics)` perde informação.** → O número estava errado; o que a linha tem de dizer é
+  que os `r3f-*` são um por tópico, e diz.
+
+## Open Questions
+
+Nenhuma. Os pontos que poderiam virar achismo — se o caminho quotado reprova mesmo, quanto custa a
+cópia, se o step aceita `2.15.1dirtychange`, se o hook de Stop ainda passa — foram medidos e estão em
+`tasks.md` com comando e saída.

--- a/openspec/changes/harden-gate-followups/proposal.md
+++ b/openspec/changes/harden-gate-followups/proposal.md
@@ -1,0 +1,84 @@
+# Change: Fechar os follow-ups dos gates — `-z` no spec-rite, vendored no `scan_diff`, selftest sem 27 cópias, `VERSION` no `ci.yml`
+
+## Why
+
+Cinco pontos anotados nos grupos E.4 das changes arquivadas em 2026-09-04/06 — todos sobre os
+gates e o que eles deixam passar — foram reproduzidos em `e7f5fe8` (2026-09-06) antes de escrever
+esta change:
+
+1. `scripts/validate-spec-rite.py:168` lê `git diff --name-only` **sem** `-z`. Um caminho com
+   caractere não-ASCII sai quotado (`"openspec/changes/probe-quoted/specs/caf\303\251.md"`), não
+   começa com `openspec/`, vira ofensor e não casa com `openspec/changes/<id>/`. Medido num clone
+   com uma change ativa e um arquivo `café.md` dentro dela: o gate emite `S3 unrelated change`
+   contra um PR que **toca** sua própria change. `validate-skill-version.py` já corrigiu o mesmo
+   ponto com `-z` + `split_nul_paths()` (#132); o irmão ficou para trás.
+2. `skills/code-locale/references/check-identifier-locale.py`: `is_vendored()` (`:393`) protege
+   `scan_path()` (`:525`) e o `main()` (`:878`), mas `scan_diff()` (`:612`) não a aplica. Um diff
+   que adiciona `node_modules/servicos_pedido/calculo.js` com `const usuario = 1` produz 2 achados
+   gatantes — o caminho fica mudo (o path tier herda a exclusão), o conteúdo não.
+3. `scripts/selftest-validate-skills.py:123` faz `shutil.copytree` do repositório inteiro **por
+   mutação**: 27 cópias por run, 49,1 s de parede em `e7f5fe8`; o step *Validator self-test* do CI
+   paga isso a cada PR.
+4. O step *Version coherence* do `ci.yml` lê `VERSION` com `tr -d '[:space:]'` e compara por
+   substring: `2.15.1dirtychange` nos três arquivos passa com `Version 2.15.1dirtychange coherent
+   across manifests.` — a regex ancorada que `generate.sh:32` e `set-version.sh:15` usam desde
+   #114 não chegou ao CI.
+5. `README.md:443` publica `r3f-*/SKILL.md # React Three Fiber skills (10 topics)` dentro de um
+   bloco de código; o gate H2/H3 ignora blocos de código por desenho e `game` tem 12 skills.
+
+## What Changes
+
+- `validate-spec-rite.py` lê o diff com `-z` e separa por NUL, com o helper `split_nul_paths()`
+  duplicado do irmão (comentário nomeia `validate-skill-version.py` e o motivo de não importar); o
+  selftest ganha um probe em repositório descartável com `core.quotePath=true` e um caminho não-ASCII
+  dentro de `openspec/changes/<id>/`, que tem de registrar o diff.
+- `check-identifier-locale.py`: `scan_diff()` aplica `is_vendored()` ao caminho do `+++`, pula o
+  bloco inteiro (caminho e linhas adicionadas) e devolve o caminho numa lista de pulados que o
+  `main()` imprime na linha `skipped (vendored/generated/minified)` que já existe; caso de selftest
+  com `node_modules/` no diff; KNOWN LIMIT 12 passa a dizer o que o modo `--diff` pula.
+  `code-locale` sobe para `1.4.3` e os wrappers são regenerados.
+- `selftest-validate-skills.py`: uma cópia por run; cada mutação é aplicada à cópia e desfeita
+  (bytes originais restaurados, arquivo criado removido, diretório criado removido) antes da
+  seguinte. Os 27 casos continuam todos `CAUGHT`; tempo antes/depois registrado em `tasks.md`.
+- `ci.yml`, step *Version coherence*: `VERSION` é validado contra
+  `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` **antes** da comparação com os manifests, e um
+  valor fora da forma reprova com `::error` nomeando o valor.
+- `README.md:443`: o comentário da árvore diz o que é (`one skill per topic`), sem contagem.
+
+Nenhuma dessas mudanças é **BREAKING** para consumidores do catálogo: nenhuma skill entra, sai ou
+muda de nome. O detector de locale fica **menos** ruidoso em `--diff` (um diff vendored deixa de
+reprovar); o spec-rite fica **mais** correto (um PR com caminho quotado dentro da própria change
+deixa de reprovar); o CI fica mais restritivo só para um `VERSION` malformado.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Nenhuma skill nova entra no catálogo.
+
+### Modified Capabilities
+
+- `skills-catalog`: *The repository itself is gated, not only its skills* — o gate que registra
+  um pull request lê os caminhos do diff separados por NUL, para que um caminho que o git quotaria
+  em modo de linha ainda ligue o diff à sua change (cenário *A quoted path still registers its
+  change*).
+- `skills-catalog`: *The identifier-locale check reads the path it is given* — em modo diff a
+  exclusão de árvores vendored cobre o arquivo inteiro que o cabeçalho `+++` nomeia, caminho e
+  linhas adicionadas, e o arquivo é contado como pulado, não como aprovado (cenário *A vendored
+  path in a diff is skipped, not measured*).
+
+## Impact
+
+- `scripts/validate-spec-rite.py` — `changed_paths()`, novo `split_nul_paths()`, docstring, dois
+  casos de selftest (helper literal + probe em repositório descartável).
+- `skills/code-locale/references/check-identifier-locale.py` — `scan_diff()`, `main()`, KNOWN LIMIT
+  12, um caso em `selftest_paths()` e a contagem impressa no `selftest OK`.
+- `skills/code-locale/SKILL.md` — `metadata.version` 1.4.2 → 1.4.3 e a linha *Verified against*
+  (contagem de casos mudos do path tier 9 → 10, data do probe); wrappers regenerados por
+  `./generate.sh` (`claude/skills/code-locale/`, `plugins/workflow/skills/code-locale/`).
+- `scripts/selftest-validate-skills.py` — laço de mutações; nenhuma mutação muda.
+- `.github/workflows/ci.yml` — só o step *Version coherence*.
+- `README.md:443` — um comentário numa árvore ilustrativa.
+- Os hooks `claude/global/hooks/locale-rite.py` e `locale-stop-gate.py` importam o detector e não
+  mudam; os selftests dos dois são rodados depois da edição (S.1).
+- Composição do catálogo (35 skills, descoberta via `npx`) fica idêntica.

--- a/openspec/changes/harden-gate-followups/proposal.md
+++ b/openspec/changes/harden-gate-followups/proposal.md
@@ -18,7 +18,9 @@ esta change:
    gatantes — o caminho fica mudo (o path tier herda a exclusão), o conteúdo não.
 3. `scripts/selftest-validate-skills.py:123` faz `shutil.copytree` do repositório inteiro **por
    mutação**: 27 cópias por run, 49,1 s de parede em `e7f5fe8`; o step *Validator self-test* do CI
-   paga isso a cada PR.
+   paga isso a cada PR. Medido antes de escrever: as cópias são 1,9 s desses 49,1 s — o resto são
+   as 27 runs do validador (1,7 s cada). A cópia única vale pelo churn e pela isolação provada, não
+   pelo relógio (`design.md` D3).
 4. O step *Version coherence* do `ci.yml` lê `VERSION` com `tr -d '[:space:]'` e compara por
    substring: `2.15.1dirtychange` nos três arquivos passa com `Version 2.15.1dirtychange coherent
    across manifests.` — a regex ancorada que `generate.sh:32` e `set-version.sh:15` usam desde
@@ -39,7 +41,9 @@ esta change:
   `code-locale` sobe para `1.4.3` e os wrappers são regenerados.
 - `selftest-validate-skills.py`: uma cópia por run; cada mutação é aplicada à cópia e desfeita
   (bytes originais restaurados, arquivo criado removido, diretório criado removido) antes da
-  seguinte. Os 27 casos continuam todos `CAUGHT`; tempo antes/depois registrado em `tasks.md`.
+  seguinte, e a cópia é comparada byte a byte com a origem depois do laço (`LEAKED` reprova). Os 27
+  casos continuam todos `CAUGHT`; tempo antes/depois registrado em `tasks.md` (49,7 s → 47,5 s,
+  média de três rounds alternados).
 - `ci.yml`, step *Version coherence*: `VERSION` é validado contra
   `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` **antes** da comparação com os manifests, e um
   valor fora da forma reprova com `::error` nomeando o valor.
@@ -81,4 +85,4 @@ _Nenhuma._ Nenhuma skill nova entra no catálogo.
 - `README.md:443` — um comentário numa árvore ilustrativa.
 - Os hooks `claude/global/hooks/locale-rite.py` e `locale-stop-gate.py` importam o detector e não
   mudam; os selftests dos dois são rodados depois da edição (S.1).
-- Composição do catálogo (35 skills, descoberta via `npx`) fica idêntica.
+- Composição do catálogo (36 skills, descoberta via `npx`) fica idêntica.

--- a/openspec/changes/harden-gate-followups/specs/skills-catalog/spec.md
+++ b/openspec/changes/harden-gate-followups/specs/skills-catalog/spec.md
@@ -1,0 +1,198 @@
+## MODIFIED Requirements
+
+### Requirement: The repository itself is gated, not only its skills
+
+The catalog SHALL carry a gate whose subject is the whole repository rather than a subtree, wired
+into CI, covering at minimum three classes that have escaped every other gate: a compiled artifact
+that is tracked, a published count of the catalog's contents that disagrees with the contents, and
+a published plugin description whose membership disagrees with the plugin's tree.
+Tracked-file discovery SHALL read the index rather than the filesystem, so that an ignored artifact
+present in a working directory is not a finding and one forced into the index is.
+
+The gate SHALL carry a self-test that injects one known defect per check and asserts detection, and
+each check SHALL state inside itself what it does not cover.
+
+The repository's other whole-repository checks SHALL measure what they claim to measure, and three
+classes that were measured escaping them SHALL be covered:
+
+- The check that keeps the generated wrapper trees in sync with `skills/` SHALL fail on a generated
+  file that is **untracked** after regeneration, naming the file, and not only on a tracked file
+  whose content changed — a diff against the index never sees an untracked file.
+- The check that a pull request registers its change SHALL require **relevance**, not existence: the
+  diff touches the directory of an active change, or the pull request body names an active change
+  on a `Spec-rite: <id>` line, or the diff archives a change, or the body carries the written
+  waiver. The mere presence of an unrelated active change SHALL NOT register a diff. The line
+  naming a change SHALL be matched as text, anchored to the start of a line, and never executed.
+- The frontmatter checks on `skills/*/SKILL.md` SHALL read only the frontmatter block — the text
+  between the two `---` delimiters, extracted the same way the wrapper generator extracts it — so a
+  field that appears only inside a code block in the body does not satisfy a check on the
+  frontmatter.
+- The checks that read a pull request's diff SHALL read its paths NUL-separated (`git diff
+  --name-only -z`) rather than line by line, so that a path git would quote and octal-escape in
+  line mode — one carrying a non-ASCII, control or quote character — is matched verbatim by the
+  workflow-directory exemption and by the change directory it belongs to. Every reader of the
+  diff in the repository SHALL read it the same way, and each SHALL prove it in its own self-test
+  against a repository that quotes paths.
+
+The job that runs these gates SHALL hold the least privilege the gates need: read-only repository
+contents, no credential persisted past the checkout, a declared timeout, and every third-party tool
+it runs pinned to a version that was probed, with the bump rule stated beside the pin. A job output
+that no consumer reads SHALL be removed or wired to one.
+
+#### Scenario: A compiled artifact forced into the index fails the build
+
+- **WHEN** a file matching the repository's bytecode ignore rules is nonetheless tracked
+- **THEN** the hygiene gate fails and names the file and the command that untracks it
+
+#### Scenario: An ignored artifact in the working directory is not a finding
+
+- **WHEN** a developer runs a Python file and leaves a `__pycache__` beside it
+- **THEN** the gate is silent, because the artifact is not in the index
+
+#### Scenario: A published count that disagrees with the tree fails the build
+
+- **WHEN** a document publishes a count of the catalog's skills that differs from the number of skill
+  directories
+- **THEN** the gate fails and names the file, the line, the claimed number and the real one
+
+#### Scenario: A published description that disagrees with the tree fails the build
+
+- **WHEN** a plugin manifest or its marketplace entry names a skill that is not under the plugin's
+  tree, omits one that is, or publishes a count that does not match the names it lists
+- **THEN** the gate fails and names the file, the group, the names in excess and the names missing
+
+#### Scenario: A bare count with no membership is refused
+
+- **WHEN** a published document carries a parenthetical count of topics or skills that names no
+  members, outside a code block
+- **THEN** the gate fails and names the file and the line, because a count that says which set it
+  counts is the only kind the tree can check
+
+#### Scenario: A check that cannot fire is caught
+
+- **WHEN** a change to the gate silently stops one of its checks from detecting its defect class
+- **THEN** the self-test fails, because a clean repository and a check that cannot fire are otherwise
+  indistinguishable
+
+#### Scenario: The uncovered part is declared, not implied
+
+- **WHEN** a check enforces its rule only over a named pattern or a named file list
+- **THEN** the pattern, the file list and what escapes them are stated in the check itself, so a
+  passing run is not read as full coverage
+
+#### Scenario: An untracked generated file fails the wrapper-sync check
+
+- **WHEN** a commit adds a file under `skills/<name>/` whose regenerated mirror under `plugins/` is
+  not tracked
+- **THEN** the wrapper-sync step fails and names the untracked file, instead of passing because the
+  diff against the index is empty
+
+#### Scenario: An unrelated active change does not register a diff
+
+- **WHEN** a pull request's diff touches a path outside the workflow's own directory, an active
+  change exists whose directory the diff does not touch, and the body names no active change and
+  carries no waiver
+- **THEN** the spec-rite gate fails, naming the active changes it found and the two ways of linking
+  the diff to one of them
+
+#### Scenario: A pull request that touches or names its change passes
+
+- **WHEN** the diff touches `openspec/changes/<id>/` of an active change, or the body carries
+  `Spec-rite: <id>` naming an active change
+- **THEN** the spec-rite gate passes, so a pull request that only ticks a task list, or a small fix
+  opened against a change in progress elsewhere, is not rejected
+
+#### Scenario: An archive-only pull request still passes
+
+- **WHEN** a pull request only moves a change into `openspec/changes/archive/` and syncs the specs
+- **THEN** the spec-rite gate passes, whether or not another change is active
+
+#### Scenario: A frontmatter field inside a code block does not count
+
+- **WHEN** a `SKILL.md` carries no `name:` in its frontmatter but a fenced `yaml` block in its body
+  contains `name: <dir>`
+- **THEN** the frontmatter check fails with `Missing name`, because only the block between the two
+  `---` delimiters is read
+
+#### Scenario: The validate job holds no writable token
+
+- **WHEN** the validate job runs on a pull request
+- **THEN** its permissions grant read-only repository contents, the checkout does not persist the
+  token, the job carries a timeout, and the spec-driven CLI it runs is pinned to a probed version
+
+#### Scenario: A quoted path still registers its change
+
+- **WHEN** a pull request's diff touches `openspec/changes/<id>/` of an active change only through
+  a path git would quote in line mode — a file named `café.md`, say — and the checkout quotes
+  paths
+- **THEN** the spec-rite gate reads the path verbatim, counts the diff as touching that change,
+  and passes, instead of reporting the quoted path as an unregistered file outside the workflow's
+  directory
+
+### Requirement: The identifier-locale check reads the path it is given
+
+The shipped identifier-locale check SHALL apply its tiers to the **path** of the artifact it scans —
+directory names and the file stem — and not only to the artifact's contents, because file, directory
+and module names are named by the doctrine as part of the machine layer. A check whose documented
+scope names an artifact class it never reads SHALL be treated as a defect in the check, not as a
+property of the artifact class.
+
+The path tier SHALL reuse the exclusions the check already applies to identifiers — vendored and
+generated trees, the minimum segment length, the kept domain terms and the allowlist file — so that
+one rule change cannot make the two halves disagree.
+
+The path measured SHALL be the part the scanned project owns: the path relative to the working
+directory when the artifact lies inside it, and the file's own name otherwise. Segments above the
+working directory SHALL NOT be scanned, because they name the machine, the user or the mount point
+rather than anything the project chose.
+
+In diff mode the path SHALL be checked only for files the diff **adds**. A file that already exists
+SHALL NOT be reported on every diff that touches it, because renaming it is the migration policy's
+decision and not this check's.
+
+In diff mode the vendored and generated exclusion SHALL apply to the whole file the `+++` header
+names — its path and its added lines alike — and that file SHALL be counted as skipped, never as
+passing, exactly as file mode counts it. The exclusion is decided on the path, because a diff
+carries no file body for the minified test to read.
+
+A path finding SHALL name the waiver that silences it. Since a file name carries no inline comment,
+that waiver SHALL be the allowlist file the check already reads.
+
+#### Scenario: A Portuguese file name with an English body is reported
+
+- **WHEN** the check scans a file whose body is English but whose path carries Portuguese segments
+- **THEN** it reports one finding per offending segment and exits non-zero
+- **AND** the finding names the path and the segment, in the same shape an identifier finding uses
+
+#### Scenario: An added path is measured and an existing one is not
+
+- **WHEN** a unified diff adds a file whose path carries a Portuguese segment
+- **THEN** the check reports it in diff mode
+- **AND** a diff that only modifies an already existing file with the same path reports nothing about
+  that path
+
+#### Scenario: The path above the working directory is out of scope
+
+- **WHEN** the artifact scanned lies inside the working directory
+- **THEN** only the segments relative to that directory are measured
+- **AND** an artifact outside the working directory has only its own file name measured
+
+#### Scenario: A path finding names its waiver
+
+- **WHEN** a path finding is printed
+- **THEN** it states the allowlist entry that silences it, because a file name cannot carry the
+  inline waiver an identifier uses
+
+#### Scenario: The path tier inherits the identifier exclusions
+
+- **WHEN** the scanned path lies in a vendored or generated tree, or its segments are shorter than
+  the minimum length, or they are kept domain terms, or they are listed in the allowlist
+- **THEN** the check reports nothing for that path, exactly as it already behaves for identifiers
+
+#### Scenario: A vendored path in a diff is skipped, not measured
+
+- **WHEN** a unified diff adds or modifies a file under a vendored or generated tree, such as
+  `node_modules/`, whose added lines carry Portuguese identifiers
+- **THEN** the check reports nothing for that file in diff mode, counts it in the skipped
+  vendored report, and exits zero, exactly as it already does when the same file is scanned by
+  path

--- a/openspec/changes/harden-gate-followups/tasks.md
+++ b/openspec/changes/harden-gate-followups/tasks.md
@@ -67,6 +67,11 @@
       bash timeit.sh "selftest-validate-skills BEFORE (e7f5fe8)" python3 scripts/selftest-validate-skills.py
       -> 27/27 defect classes detected
       -> selftest-validate-skills BEFORE (e7f5fe8) wall=49.1s rc=0
+      python3 measure-cost.py <worktree>        (3 repetições de cada, no mesmo tree)
+      -> files under source (incl. .git): 1375
+      -> copytree x3: ['0.08s', '0.06s', '0.08s']  -> mean 0.07s
+      -> validate-skills.py x3: ['1.71s', '1.74s', '1.69s']  -> mean 1.71s
+      -> 27 copies ~ 1.9s ; 27 validator runs ~ 46.2s          (a premissa da issue — "a cópia é o custo" — não se sustenta)
       ```
 
       ```
@@ -88,6 +93,7 @@
       git --version        -> git version 2.47.3
       python3 --version    -> Python 3.14.5
       openspec --version   -> 1.6.0
+      ls skills | wc -l    -> 36
       openspec new change harden-gate-followups --schema skills-rite
       -> Created change 'harden-gate-followups' at openspec/changes/harden-gate-followups/   (só .openspec.yaml; artefatos escritos a partir de openspec/schemas/skills-rite/templates/)
       ```
@@ -100,7 +106,7 @@
       - A issue #172 fala em "24 mutation classes"; o arquivo em `e7f5fe8` tem 27 (`MUTATIONS` cresceu
         em #131, #153, #157, #165). A contagem que vale é a medida: 27/27.
       - O tempo do selftest é medido nesta máquina (WSL2); o número no CI difere, e só a **razão**
-        antes/depois é transferível.
+        antes/depois (e a decomposição cópia/validador) é transferível.
 
 - [x] E.4 Checagem de escopo
 
@@ -110,6 +116,9 @@
       - `scripts/validate-repo-hygiene.py:91-94` cita `README.md:345 carries (10 topics)` como
         exemplo do que H2 não lê; depois desta change o exemplo não existe mais. O arquivo não está
         na lista deste item; atualizar a docstring é follow-up.
+      - O custo real do selftest do validador são as 27 runs de `validate-skills.py` (46 s de 49 s);
+        rodá-las em paralelo (`concurrent.futures`, uma cópia por worker) é a otimização que a
+        medida justifica e que a issue não pediu — follow-up.
       - `claude/global/hooks/locale-stop-gate.py:296` filtra `is_vendored` nos achados por fora;
         com D2 o filtro fica redundante (o detector já não produz esses achados). Remover é do dono
         do hook, não deste item.
@@ -120,60 +129,289 @@
 
 ## 2. Spec-rite lê o diff com `-z` (D1)
 
-- [ ] 2.1 `changed_paths()` roda `git diff --name-only -z` e separa por NUL com `split_nul_paths()`,
+- [x] 2.1 `changed_paths()` roda `git diff --name-only -z` e separa por NUL com `split_nul_paths()`,
       duplicado de `validate-skill-version.py` com comentário nomeando o irmão e o motivo
-- [ ] 2.2 Selftest: caso literal do helper (aspas, quebra de linha) e probe em repositório
+
+      ```
+      grep -n '"-z"\|def split_nul_paths\|Duplicated from validate-skill-version.py' scripts/validate-spec-rite.py
+      -> 176:def split_nul_paths(out: str) -> list[str]:
+      -> 180:    Duplicated from validate-skill-version.py rather than imported: that script loads THIS one at
+      -> 190:    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", "-z", f"{base}...{head}"],
+      ```
+
+- [x] 2.2 Selftest: caso literal do helper (aspas, quebra de linha) e probe em repositório
       descartável com `core.quotePath=true` — caminho não-ASCII dentro de `openspec/changes/<id>/`
       registra o diff (`evaluate()` mudo)
-- [ ] 2.3 Docstring: o parágrafo sobre `-z` e o que o modo de linha fazia com o caminho
+
+      ```
+      python3 scripts/validate-spec-rite.py --selftest
+      -> PATHS  NUL-separated names are read verbatim, quotes and newlines included
+      -> PATHS  a quoted path inside an active change registers the diff on a real repository
+      -> 6/6 defect classes detected, 10/10 false-positive cases stayed silent, 6/6 reader cases correct, 2/2 path-reader cases correct   exit=0
+      python3 probe-without-z.py <worktree>      (o mesmo probe com changed_paths() trocado pela versão de linha)
+      -> new reader : True
+      -> old reader : False | findings: ['S3 unrelated change: this diff touches 2']     (o probe reprova o leitor antigo)
+      python3 scripts/validate-skill-version.py --selftest   (importa este script em tempo de carga)
+      -> 7/7 defect classes detected, 11/11 false-positive cases stayed silent, 11/11 helper cases correct   exit=0
+      ```
+
+- [x] 2.3 Docstring: o parágrafo sobre `-z` e o que o modo de linha fazia com o caminho
+
+      ```
+      grep -n "Paths are read with\|The one plumbing probe" scripts/validate-spec-rite.py
+      -> 29:below, not by the selftest. The one plumbing probe it does run is the path reader, below.
+      -> 31:Paths are read with `git diff --name-only -z` and split on NUL, the way validate-skill-version.py
+      ```
 
 ## 3. `scan_diff()` aplica `is_vendored()` (D2)
 
-- [ ] 3.1 `scan_diff()` pula o bloco inteiro de um `+++` vendored e devolve o caminho na lista
+- [x] 3.1 `scan_diff()` pula o bloco inteiro de um `+++` vendored e devolve o caminho na lista
       `vendored` (parâmetro opcional); `main()` imprime na linha `skipped (vendored/...)` existente
-- [ ] 3.2 Selftest: diff que adiciona `node_modules/servicos_pedido/calculo.js` com `const usuario`
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py --diff vendored.diff   (o mesmo diff de E.2)
+      -> findings: 0
+      ->   skipped (vendored/generated/minified): 1 file(s) — not this project's machine layer
+      -> exit=0
+      grep -n "vendored=vendored\|if is_vendored(Path(path)):" skills/code-locale/references/check-identifier-locale.py
+      -> 654:            if is_vendored(Path(path)):
+      -> 886:        findings.extend(scan_diff(stream, allow, english, vendored=vendored))
+      ```
+
+- [x] 3.2 Selftest: diff que adiciona `node_modules/servicos_pedido/calculo.js` com `const usuario`
       fica mudo e conta um pulado; contagem do `selftest OK` atualizada
-- [ ] 3.3 KNOWN LIMIT 12 diz o que o modo `--diff` pula (por caminho; `is_minified` não roda)
-- [ ] 3.4 `code-locale` 1.4.2 → 1.4.3, linha *Verified against* re-probada; `./generate.sh` regenera
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py --selftest
+      -> CLEAN   path-clean/diff adds vendored file (skipped, counted)
+      -> selftest OK: 7 content tiers fire, 16 clean cases stay silent, 6 path tiers fire, 10 path cases stay silent, 2 en-unknown tiers fire, 5 en-unknown cases stay silent   exit=0
+      ```
+
+- [x] 3.3 KNOWN LIMIT 12 diz o que o modo `--diff` pula (por caminho; `is_minified` não roda)
+
+      ```
+      sed -n 61,64p skills/code-locale/references/check-identifier-locale.py
+      ->        A `+++` path in a vendored or generated tree (VENDOR_PARTS, `.min.`) is skipped whole in
+      ->        --diff mode — path and added lines — and reported as skipped, the same exclusion file mode
+      ->        applies. That decision is by PATH only: a diff carries no file body, so `is_minified` never
+      ->        runs in this mode, and a generated file outside those trees is measured as written code.
+      ```
+
+- [x] 3.4 `code-locale` 1.4.2 → 1.4.3, linha *Verified against* re-probada; `./generate.sh` regenera
       os wrappers; `locale-rite.py --selftest` e `locale-stop-gate.py --selftest` verdes depois da
       edição
 
+      ```
+      grep -n "^  version:" skills/code-locale/SKILL.md claude/skills/code-locale/SKILL.md plugins/workflow/skills/code-locale/SKILL.md
+      -> skills/code-locale/SKILL.md:17:  version: 1.4.3
+      -> claude/skills/code-locale/SKILL.md:17:  version: 1.4.3
+      -> plugins/workflow/skills/code-locale/SKILL.md:17:  version: 1.4.3
+      bash generate.sh   -> Generated 10 category plugins in plugins/ (descriptions derived from the tree)
+      diff -q skills/code-locale/references/check-identifier-locale.py plugins/workflow/skills/code-locale/references/check-identifier-locale.py   -> (idênticos)
+      python3 claude/global/hooks/locale-rite.py --selftest
+      -> selftest OK: 13 PostToolUse decisions, 12 PreToolUse decisions, inform mode, en-unknown, the allowlist, the legacy path, [...]   exit=0
+      python3 claude/global/hooks/locale-stop-gate.py --selftest
+      -> selftest OK: 26 decisions in temporary git repositories, 2 output shapes, 5 malformed payloads, plus the argv contract   exit=0
+      ```
+
 ## 4. Selftest do validador em uma cópia (D3)
 
-- [ ] 4.1 Uma `copytree` por run; cada mutação guarda bytes (ou ausência), aplica, roda, restaura em
-      `finally`; C7 remove o diretório, C11 remove o arquivo
-- [ ] 4.2 27/27 `CAUGHT`; validador limpo na cópia depois do laço; tempo antes/depois registrado
+- [x] 4.1 Uma `copytree` por run; cada mutação guarda bytes (ou ausência), aplica, roda, restaura em
+      `finally`; C7 remove o diretório, C11 remove o arquivo; cópia comparada byte a byte no fim
+
+      ```
+      grep -c "shutil.copytree(" scripts/selftest-validate-skills.py   -> 1
+      grep -n "read_bytes\|write_bytes\|rmtree\|unlink\|filecmp.cmp" scripts/selftest-validate-skills.py
+      -> 132:        original = target.read_bytes() if target is not None and target.exists() else None
+      -> 142:                shutil.rmtree(ghost, ignore_errors=True)
+      -> 144:                target.unlink(missing_ok=True)
+      -> 146:                target.write_bytes(original)
+      -> 158:        str(r) for r in src_files & dst_files if not filecmp.cmp(SRC / r, dst / r, shallow=False))
+      python3 probe-leak.py <worktree>      (o mesmo script com `target.write_bytes(original)` trocado por `pass`)
+      -> MISSED  C5 no version pin (date but no Probed on)          (+4 MISSED: as mutações de observability empilharam)
+      -> LEAKED  copy byte-identical to the source after all mutations reverted: skills/assettoserver-ops/SKILL.md, skills/claude-statusline/SKILL.md, skills/conventional-commit/SKILL.md
+      -> 22/27 defect classes detected                              (a checagem dispara; a reversão é o que isola)
+      ```
+
+- [x] 4.2 27/27 `CAUGHT`; cópia limpa depois do laço; tempo antes/depois registrado
+
+      ```
+      python3 scripts/selftest-validate-skills.py
+      -> CLEAN   copy byte-identical to the source after all mutations reverted
+      -> 27/27 defect classes detected   exit=0
+      bash bench.sh <worktree>      (velho = e7f5fe8 via `git show`, novo = worktree; alternados, 3 rounds, máquina ociosa)
+      -> round 1 OLD (e7f5fe8) wall=49.3s rc=0      round 1 NEW (worktree) wall=47.5s rc=0
+      -> round 2 OLD (e7f5fe8) wall=49.2s rc=0      round 2 NEW (worktree) wall=46.5s rc=0
+      -> round 3 OLD (e7f5fe8) wall=50.5s rc=0      round 3 NEW (worktree) wall=48.6s rc=0
+      -> média OLD 49,7 s ; média NEW 47,5 s ; ganho ~2,2 s (4 %) — o que a cópia custava (E.2: 1,9 s); o resto é o validador
+      ```
 
 ## 5. `VERSION` validado no step *Version coherence* (D4)
 
-- [ ] 5.1 `SEMVER_RE` (literal de `generate.sh:32`) aplicado a `VERSION` antes do laço dos
+- [x] 5.1 `SEMVER_RE` (literal de `generate.sh:32`) aplicado a `VERSION` antes do laço dos
       manifests, `::error` nomeando o valor
-- [ ] 5.2 Step extraído do YAML novo e rodado contra a fixture `2.15.1dirtychange` (reprova), contra
-      uma fixture `2.30.0` e `2.31.0-beta.1` (passam) e no worktree (passa)
+
+      ```
+      grep -n "SEMVER_RE" generate.sh scripts/set-version.sh .github/workflows/ci.yml
+      -> generate.sh:32:SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+      -> scripts/set-version.sh:15:SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+      -> .github/workflows/ci.yml:78:          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'
+      -> .github/workflows/ci.yml:79:          if ! [[ "$VERSION" =~ $SEMVER_RE ]]; then
+      ```
+
+- [x] 5.2 Step extraído do YAML novo e rodado contra a fixture `2.15.1dirtychange` (reprova), contra
+      `2.30.0` e `2.31.0-beta.1` (passam), contra vazio (reprova) e no worktree (passa)
+
+      ```
+      python3 extract-step.py .github/workflows/ci.yml "Version coherence" step-new-version-coherence.sh
+      bash run-step.sh vfix-bad step-new-version-coherence.sh
+      -> ::error::VERSION is '2.15.1dirtychange' — expected MAJOR.MINOR.PATCH with an optional -prerelease suffix (the regex generate.sh and set-version.sh apply).   exit=1
+      bash run-step.sh vfix-empty step-new-version-coherence.sh
+      -> ::error::VERSION is '' — expected MAJOR.MINOR.PATCH [...]   exit=1
+      bash run-step.sh vfix-good step-new-version-coherence.sh   -> Version 2.30.0 coherent across manifests.   exit=0
+      bash run-step.sh vfix-pre step-new-version-coherence.sh    -> Version 2.31.0-beta.1 coherent across manifests.   exit=0
+      bash run-step.sh <worktree> step-new-version-coherence.sh  -> Version 2.30.0 coherent across manifests.   exit=0
+      ```
 
 ## 6. README sem contagem na árvore (D5)
 
-- [ ] 6.1 `README.md:443` sem `(10 topics)`; `validate-repo-hygiene.py` verde
+- [x] 6.1 `README.md:443` sem `(10 topics)`; `validate-repo-hygiene.py` verde
+
+      ```
+      grep -n "r3f-\*/SKILL.md" README.md   -> 443:│   └── r3f-*/SKILL.md   # React Three Fiber skills, one per topic
+      grep -c "10 topics" README.md         -> 0
+      python3 scripts/validate-repo-hygiene.py   -> repo hygiene: 0 findings   exit=0
+      ```
 
 ## 7. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 Cada gate exercitado pelo caminho real (o script como o CI o invoca, o step literal do
+- [x] S.1 Cada gate exercitado pelo caminho real (o script como o CI o invoca, o step literal do
       `ci.yml`, o detector via `--diff`), antes e depois, com a saída observada registrada
-- [ ] S.2 Matriz de casos medida, em contagens
-- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+      Tudo em `3b0f0ca` (2026-09-06), worktree limpo antes e depois (`git status --porcelain | wc -l
+      -> 0` fora dos arquivos desta change). As reproduções que sujam árvore rodaram num **clone**
+      (`quoted-clone`) e em fixtures no scratchpad.
+
+      Buraco 1 — spec-rite pelo caminho do CI, no clone, antes e depois (o script copiado por cima):
+
+      ```
+      SPEC_RITE_BASE=base PR_BODY="" python3 scripts/validate-spec-rite.py   (e7f5fe8)
+      -> ::error::S3 unrelated change — [...] "openspec/changes/probe-quoted/specs/caf\303\251.md" [...]   exit=1
+      SPEC_RITE_BASE=base PR_BODY="" python3 scripts/validate-spec-rite.py   (95627a2)
+      -> spec-rite gate: 0 findings (base base, 2 changed path(s), 1 active change(s))   exit=0
+      ```
+
+      No worktree, com o payload que o runner escreve (`{"pull_request":{"body":"Closes #172\n\nSpec-rite: harden-gate-followups\n"}}`):
+
+      ```
+      GITHUB_EVENT_PATH=event.json bash scripts/validate-rite.sh
+      -> rite evidence gate: 0 findings
+      -> spec-rite gate: 0 findings (base origin/master, 15 changed path(s), 1 active change(s))
+      -> Totals: 3 passed, 0 failed (3 items)
+      -> rite gate OK
+      GITHUB_EVENT_PATH=event.json python3 scripts/validate-skill-version.py
+      -> skill-version gate: 0 findings (base origin/master, 1 skill(s) changed, 1 with content changes)
+      ```
+
+      Buraco 2 — detector via `--diff`, o mesmo arquivo `vendored.diff`, antes (`findings: 2`, E.2) e
+      depois (`findings: 0` + `skipped (vendored/generated/minified): 1 file(s)`, 3.1); os dois hooks
+      que importam o detector, pelo próprio `--selftest` (3.4).
+
+      Buraco 3 — selftest do validador pelo caminho do CI (`python3 scripts/selftest-validate-skills.py`):
+      27/27 + `CLEAN copy byte-identical` (4.2); com a restauração neutralizada: `LEAKED` + 22/27 (4.1);
+      bench alternado 3×3 (4.2).
+
+      Buraco 4 — step literal (`yaml.safe_load` → `jobs.validate.steps[2].run`, `bash -e`): antes
+      `exit=0` em `2.15.1dirtychange` (E.2); depois `exit=1` nomeando o valor, `exit=1` em vazio,
+      `exit=0` em `2.30.0`, `2.31.0-beta.1` e no worktree (5.2).
+
+      Buraco 5 — `grep -c "10 topics" README.md -> 0`; hygiene `0 findings` (6.1).
+
+      O gate runner inteiro (`gates.sh`, os mesmos comandos do `ci.yml`) no worktree:
+
+      ```
+      PASS generate :: Generated 10 category plugins in plugins/ (descriptions derived from the tree)
+      PASS version   PASS frontmatter
+      PASS validate-skills :: skills checked: 36   findings: 0
+      PASS selftest-validate-skills :: 27/27 defect classes detected
+      PASS locale-detector :: selftest OK: 7 content tiers fire, 16 clean cases stay silent, 6 path tiers fire, 10 path cases stay silent, [...]
+      PASS locale-rite   PASS backlog-rite-selftest   PASS verify-rite-selftest
+      PASS scan-secrets :: no credentials found
+      PASS scan-secrets-selftest :: 12/12 patterns fire on their sample, 3/3 context cases caught, 3/3 placeholder cases stayed silent
+      PASS hygiene :: repo hygiene: 0 findings      PASS hygiene-selftest :: 4/4 defect classes detected
+      PASS rite :: rite gate OK
+      PASS rite-evidence-selftest :: 7/7 defect classes detected, 1/1 known escapes stayed silent
+      PASS spec-rite-selftest :: 6/6 defect classes detected, 10/10 false-positive cases stayed silent, 6/6 reader cases correct, 2/2 path-reader cases correct
+      PASS smoke :: smoke: 17/17 cases passed
+      PASS plugin-validate :: ✔ Validation passed
+      PASS openspec-strict harden-gate-followups :: Change 'harden-gate-followups' is valid
+      ```
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | Tinha de disparar e disparou | 6/6 | spec-rite: probe com leitor antigo emite S3 (1); selftest do validador: restauração neutralizada → `LEAKED` (1); step: `2.15.1dirtychange` (1), vazio (1); detector antes do fix: 2 achados no hunk vendored contados como 1 (1); skill-version: 1.4.2→1.4.3 reconhecido como bump (1) |
+      | Tinha de ficar mudo e ficou | 9/9 | spec-rite: clone quotado depois do fix (1), worktree pelo `validate-rite.sh` (1), probe do selftest (1); detector: hunk vendored depois do fix (1), caso do selftest (1); step: `2.30.0` (1), `2.31.0-beta.1` (1), worktree (1); hygiene no README novo (1) |
+      | Versão antiga passou onde a nova falha / falhou onde a nova passa | 3/3 | step aceitou `2.15.1dirtychange`; detector mediu `node_modules/`; spec-rite reprovou o caminho quotado — cada um com a saída de `e7f5fe8` em E.2 |
+      | Selftests do CI | 5/5 | spec-rite 6/6+10/10+6/6+2/2; skill-version 7/7+11/11+11/11; detector 7+16+6+10+2+5; validador 27/27; hooks locale-rite 25 e stop-gate 26 decisões |
+      | Escape conhecido ficou mudo | 1/1 | `en-unknown` advisory em `filecmp`/`rmtree` (nomes da stdlib) no diff desta change: 3 avisos, `findings: 0`, exit 0 — comportamento declarado (KNOWN LIMIT 17) |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      - **A premissa do ponto 3 estava errada.** A issue diz que as 27 cópias são o custo; medido,
+        são 1,9 s de 49,1 s. O ganho de parede é ~2,2 s (4 %), não uma ordem de grandeza. A cópia
+        única fica pelo que compra de fato (churn, isolação provada por comparação byte a byte), e
+        o custo real — 27 runs do validador — está em E.4 como follow-up. A primeira versão desta
+        change rodava o validador uma 28ª vez como checagem de vazamento e ficou **mais lenta**
+        (50,6 s); trocado por `filecmp`, que é a afirmação mais forte e custa milissegundos.
+      - A restauração neutralizada não só disparou `LEAKED`: cinco casos C5 ficaram `MISSED`
+        porque as mutações de `observability` empilharam — prova de que a reversão é o que isola,
+        não só uma limpeza.
+      - O step *Version coherence* rodou aqui com o bash do WSL, não com o do `ubuntu-latest`
+        (E.3); `[[ =~ ]]` já roda em `generate.sh` no mesmo runner, um step antes.
+      - O detector emite 3 avisos `en-unknown` em `filecmp`/`rmtree` no diff desta change —
+        nomes da stdlib fora da lista de inglês; advisory por desenho, exit 0. Não adicionados a
+        `programming-words.txt` por não estarem no escopo.
+      - A issue cita "24 mutation classes"; são 27 em `e7f5fe8` (E.3).
 
 ## 8. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado (`code-locale`): name == directory,
-      description folded, author solvelab, semver, category no conjunto, license MIT, compatibility
-- [ ] Q.2 Conteúdo de skill tocado em inglês (catalog locale)
-- [ ] Q.3 Gatilhos de descrição testáveis — a descrição não muda
-- [ ] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md`
-- [ ] Q.5 Identificadores em inglês no que a change introduz (`code-locale`)
+- [x] Q.1 Frontmatter uniforme em `skills/code-locale/SKILL.md`: `PASS frontmatter` no gate runner
+      (name == directory, `description: >-`, `author: solvelab`, `version: 1.4.3`, `category:
+      process`, `license: MIT`, `compatibility` presente); wrappers regenerados idênticos (3.4)
+- [x] Q.2 Conteúdo de skill tocado em inglês — a única edição em `SKILL.md` é a linha *Verified
+      against* (data e contagem); docstring, comentários e KNOWN LIMIT do detector em inglês; os
+      deltas de spec em inglês
+- [x] Q.3 Gatilhos de descrição testáveis — a descrição não muda
+- [x] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md` (seis linhas, todas
+      *already canonical*; `split_nul_paths()` é duplicata de código com o motivo, não de doutrina)
+- [x] Q.5 Identificadores em inglês no que a change introduz (`split_nul_paths`, `vendored`,
+      `original`, `ghost`, `leaked`, `SEMVER_RE`, labels de selftest)
+
+      ```
+      git diff -- scripts .github skills/code-locale/references | python3 skills/code-locale/references/check-identifier-locale.py --diff -
+      -> findings: 0
+      ->   en-unknown: 3 segment(s) not in the English word list — advisory — they do not fail this run   (filecmp ×2, rmtree)
+      -> exit=0
+      ```
 
 ## 9. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate harden-gate-followups --strict` verde
-- [ ] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 35 skills
-- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+- [x] V.1 `openspec validate harden-gate-followups --strict` verde
+
+      ```
+      openspec validate harden-gate-followups --strict   -> Change 'harden-gate-followups' is valid   (openspec 1.6.0)
+      ```
+
+- [x] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 36 skills
+
+      ```
+      python3 scripts/validate-skills.py   -> skills checked: 36   findings: 0
+      ls skills | wc -l                    -> 36
+      ```
+
+- [x] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
+      não muda; `README.md:443` é a única linha de docs tocada (6.1); a linha *Verified against* de
+      `code-locale` reflete a contagem nova do selftest (3.4)
 - [ ] V.4 `openspec archive harden-gate-followups --yes` em PR separado, depois do merge

--- a/openspec/changes/harden-gate-followups/tasks.md
+++ b/openspec/changes/harden-gate-followups/tasks.md
@@ -1,0 +1,179 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `e7f5fe8` (topo de `master`, 2026-09-06):
+
+      - `scripts/validate-spec-rite.py` — 399 linhas; `changed_paths()` em 167-170 (`git diff
+        --name-only base...HEAD` + `splitlines()`); `requires_registration()` em 174-175 e
+        `touched_changes()` em 193-195 comparam com `startswith`; `DEFECTS`/`SILENT` em 246-275;
+        `selftest_reader()` em 297-332; KNOWN LIMIT em 23-29.
+      - `scripts/validate-skill-version.py` — 469 linhas; `split_nul_paths()` em 162-165,
+        `changed_paths()` com `-z` em 168-173, `_probe_quoted_path()` em 347-372,
+        `_sibling_min_reason()` em 84-101 importa o spec-rite em tempo de carga; docstring 38-43
+        explica `core.quotePath`.
+      - `skills/code-locale/references/check-identifier-locale.py` — 916 linhas; KNOWN LIMIT 1-17 em
+        26-76; `VENDOR_PARTS` em 386-389; `is_vendored()` em 393-394; `scan_path()` em 518-549
+        (aplica `is_vendored` em 525); `scan_diff()` em 612-664 (não aplica); `SELFTEST_PATH_CLEAN`
+        em 725-732; `selftest_paths()` em 760-794; `main()` em 828-910 (`is_vendored` em 878,
+        `vendored` impresso em 906).
+      - `skills/code-locale/SKILL.md` — `metadata.version: 1.4.2` (linha 17); linha *Verified
+        against* em 31-37 cita "9 path cases silent" e "Probed on 2026-09-05".
+      - `claude/global/hooks/locale-stop-gate.py:294-296` — `check.scan_diff(iter(...), allow,
+        None)` e filtro `is_vendored` nos achados; `claude/global/hooks/locale-rite.py:258` —
+        `check.is_vendored(path)`.
+      - `scripts/selftest-validate-skills.py` — 136 linhas; `MUTATIONS` em 12-115 (27 entradas);
+        laço em 117-134 com `copytree` em 123; C7 em 124-126 cria diretório; C11 em 129 cria
+        arquivo.
+      - `.github/workflows/ci.yml:70-79` — step *Version coherence*; `generate.sh:27-36` e
+        `scripts/set-version.sh:13-16` — `SEMVER_RE` idêntico nos dois.
+      - `README.md:443` — `r3f-*/SKILL.md  # React Three Fiber skills (10 topics)`;
+        `scripts/validate-repo-hygiene.py:91-94` — declara esse `(10 topics)` como revisão apenas.
+      - `openspec/specs/skills-catalog/spec.md` — *The repository itself is gated, not only its
+        skills* e *The identifier-locale check reads the path it is given*, texto integral copiado
+        para o delta.
+      - `openspec/changes/archive/2026-09-04-close-ci-gate-holes/{proposal,design,tasks}.md` e
+        `specs/skills-catalog/spec.md` — modelo de estilo; E.4 dele registra o follow-up do README.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      Cada buraco reproduzido antes de escrever, em `e7f5fe8` (2026-09-06):
+
+      ```
+      git ls-files | grep -cP '[^\x00-\x7F]'          -> 0   (o repo não tem caminho quotado hoje)
+      bash make-quoted-clone.sh <worktree> quoted-clone   (clone; branch base com openspec/changes/probe-quoted/tasks.md;
+                                                           branch work adiciona skills/x/references/café.md e
+                                                           openspec/changes/probe-quoted/specs/café.md; core.quotePath=true)
+      git diff --name-only base...HEAD
+      -> "openspec/changes/probe-quoted/specs/caf\303\251.md"
+      -> "skills/x/references/caf\303\251.md"
+      git diff --name-only -z base...HEAD | tr '\0' '\n'
+      -> openspec/changes/probe-quoted/specs/café.md
+      -> skills/x/references/café.md
+      SPEC_RITE_BASE=base PR_BODY="" python3 scripts/validate-spec-rite.py   (no clone, script de e7f5fe8)
+      -> ::error::S3 unrelated change — this diff touches 2 path(s) outside openspec/ — "openspec/changes/probe-quoted/specs/caf\303\251.md", "skills/x/references/caf\303\251.md" — and 1 active change(s) exist (probe-quoted), but the diff touches none of their directories [...]
+      -> spec-rite gate: 1 findings (base base, 2 changed path(s), 1 active change(s))   exit=1
+      ```
+
+      ```
+      python3 skills/code-locale/references/check-identifier-locale.py --diff vendored.diff
+          (--- /dev/null / +++ b/node_modules/servicos_pedido/calculo.js / +const usuario = 1; / +function calcularFrete() {})
+      -> node_modules/servicos_pedido/calculo.js:1: usuario  [pt-noun: 'usuario']
+      -> node_modules/servicos_pedido/calculo.js:2: calcularFrete  [pt-verb: 'calcular']
+      -> findings: 2   exit=1
+      ```
+
+      ```
+      bash timeit.sh "selftest-validate-skills BEFORE (e7f5fe8)" python3 scripts/selftest-validate-skills.py
+      -> 27/27 defect classes detected
+      -> selftest-validate-skills BEFORE (e7f5fe8) wall=49.1s rc=0
+      ```
+
+      ```
+      python3 extract-step.py .github/workflows/ci.yml "Version coherence" step-before-version-coherence.sh
+      -> extracted step 2 'Version coherence (VERSION == plugin.json == marketplace.json)'
+      bash make-version-fixture.sh vfix-bad 2.15.1dirtychange   (VERSION + plugin.json + marketplace.json iguais)
+      bash run-step.sh vfix-bad step-before-version-coherence.sh
+      -> Version 2.15.1dirtychange coherent across manifests.
+      -> exit=0                                                  (o buraco 4, reproduzido)
+      ```
+
+      ```
+      grep -n "10 topics" README.md      -> 443:│   └── r3f-*/SKILL.md   # React Three Fiber skills (10 topics)
+      ls plugins/game/skills | wc -l     -> 12
+      python3 scripts/validate-repo-hygiene.py   -> repo hygiene: 0 findings   (H2 não lê bloco de código, por desenho)
+      ```
+
+      ```
+      git --version        -> git version 2.47.3
+      python3 --version    -> Python 3.14.5
+      openspec --version   -> 1.6.0
+      openspec new change harden-gate-followups --schema skills-rite
+      -> Created change 'harden-gate-followups' at openspec/changes/harden-gate-followups/   (só .openspec.yaml; artefatos escritos a partir de openspec/schemas/skills-rite/templates/)
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      - O comportamento do step *Version coherence* **no runner do GitHub** não é medido aqui: o
+        shell do step é extraído literalmente do YAML e rodado com `bash -e` local; a run do PR desta
+        change é a prova no runner (S.3).
+      - A issue #172 fala em "24 mutation classes"; o arquivo em `e7f5fe8` tem 27 (`MUTATIONS` cresceu
+        em #131, #153, #157, #165). A contagem que vale é a medida: 27/27.
+      - O tempo do selftest é medido nesta máquina (WSL2); o número no CI difere, e só a **razão**
+        antes/depois é transferível.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz o que a issue #172 pediu e nada além. Notados pelo caminho e **não** feitos, como
+      follow-up:
+
+      - `scripts/validate-repo-hygiene.py:91-94` cita `README.md:345 carries (10 topics)` como
+        exemplo do que H2 não lê; depois desta change o exemplo não existe mais. O arquivo não está
+        na lista deste item; atualizar a docstring é follow-up.
+      - `claude/global/hooks/locale-stop-gate.py:296` filtra `is_vendored` nos achados por fora;
+        com D2 o filtro fica redundante (o detector já não produz esses achados). Remover é do dono
+        do hook, não deste item.
+      - `validate-skill-version.py` poderia importar `split_nul_paths()` do spec-rite em vez de
+        definir o seu (a direção de import que não fecha ciclo); não está na lista deste item.
+      - `scripts/validate-repo-hygiene.py:252` e `scripts/validate-rite-evidence.py:353` também
+        fazem `copytree` do repositório no selftest (uma vez cada, não por caso); fora de escopo.
+
+## 2. Spec-rite lê o diff com `-z` (D1)
+
+- [ ] 2.1 `changed_paths()` roda `git diff --name-only -z` e separa por NUL com `split_nul_paths()`,
+      duplicado de `validate-skill-version.py` com comentário nomeando o irmão e o motivo
+- [ ] 2.2 Selftest: caso literal do helper (aspas, quebra de linha) e probe em repositório
+      descartável com `core.quotePath=true` — caminho não-ASCII dentro de `openspec/changes/<id>/`
+      registra o diff (`evaluate()` mudo)
+- [ ] 2.3 Docstring: o parágrafo sobre `-z` e o que o modo de linha fazia com o caminho
+
+## 3. `scan_diff()` aplica `is_vendored()` (D2)
+
+- [ ] 3.1 `scan_diff()` pula o bloco inteiro de um `+++` vendored e devolve o caminho na lista
+      `vendored` (parâmetro opcional); `main()` imprime na linha `skipped (vendored/...)` existente
+- [ ] 3.2 Selftest: diff que adiciona `node_modules/servicos_pedido/calculo.js` com `const usuario`
+      fica mudo e conta um pulado; contagem do `selftest OK` atualizada
+- [ ] 3.3 KNOWN LIMIT 12 diz o que o modo `--diff` pula (por caminho; `is_minified` não roda)
+- [ ] 3.4 `code-locale` 1.4.2 → 1.4.3, linha *Verified against* re-probada; `./generate.sh` regenera
+      os wrappers; `locale-rite.py --selftest` e `locale-stop-gate.py --selftest` verdes depois da
+      edição
+
+## 4. Selftest do validador em uma cópia (D3)
+
+- [ ] 4.1 Uma `copytree` por run; cada mutação guarda bytes (ou ausência), aplica, roda, restaura em
+      `finally`; C7 remove o diretório, C11 remove o arquivo
+- [ ] 4.2 27/27 `CAUGHT`; validador limpo na cópia depois do laço; tempo antes/depois registrado
+
+## 5. `VERSION` validado no step *Version coherence* (D4)
+
+- [ ] 5.1 `SEMVER_RE` (literal de `generate.sh:32`) aplicado a `VERSION` antes do laço dos
+      manifests, `::error` nomeando o valor
+- [ ] 5.2 Step extraído do YAML novo e rodado contra a fixture `2.15.1dirtychange` (reprova), contra
+      uma fixture `2.30.0` e `2.31.0-beta.1` (passam) e no worktree (passa)
+
+## 6. README sem contagem na árvore (D5)
+
+- [ ] 6.1 `README.md:443` sem `(10 topics)`; `validate-repo-hygiene.py` verde
+
+## 7. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 Cada gate exercitado pelo caminho real (o script como o CI o invoca, o step literal do
+      `ci.yml`, o detector via `--diff`), antes e depois, com a saída observada registrada
+- [ ] S.2 Matriz de casos medida, em contagens
+- [ ] S.3 O que escapou ou se comportou diferente do esperado
+
+## 8. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado (`code-locale`): name == directory,
+      description folded, author solvelab, semver, category no conjunto, license MIT, compatibility
+- [ ] Q.2 Conteúdo de skill tocado em inglês (catalog locale)
+- [ ] Q.3 Gatilhos de descrição testáveis — a descrição não muda
+- [ ] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md`
+- [ ] Q.5 Identificadores em inglês no que a change introduz (`code-locale`)
+
+## 9. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate harden-gate-followups --strict` verde
+- [ ] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 35 skills
+- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo
+- [ ] V.4 `openspec archive harden-gate-followups --yes` em PR separado, depois do merge

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.4.2
+  version: 1.4.3
   category: process
 license: MIT
 compatibility: >-
@@ -28,9 +28,9 @@ compatibility: >-
 
 # Code locale — prose follows the repo, the machine layer is English
 
-> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-05:
+> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-06:
 > `references/check-identifier-locale.py --selftest` (7 content tiers fire, 16 clean cases silent,
-> 6 path tiers fire, 9 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
+> 6 path tiers fire, 10 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
 > --selftest` (13 PostToolUse and 12 PreToolUse decisions) and `locale-stop-gate.py --selftest` (26
 > decisions in throwaway git repositories) all pass, and both hooks are the ones wired in
 > `~/.claude/settings.json` of the session that wrote this. The detector uses only the standard

--- a/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
+++ b/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
@@ -58,6 +58,10 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        `--- /dev/null` header the diff itself writes. A file that already exists is never reported on
        its name: renaming it is the migration policy's decision (references/migration.md), not this
        check's. A rename appears as an add, so the new name is measured and the old one is not.
+       A `+++` path in a vendored or generated tree (VENDOR_PARTS, `.min.`) is skipped whole in
+       --diff mode — path and added lines — and reported as skipped, the same exclusion file mode
+       applies. That decision is by PATH only: a diff carries no file body, so `is_minified` never
+       runs in this mode, and a generated file outside those trees is measured as written code.
     13. A file name has nowhere to carry an inline `locale-ok:` comment, so ALLOWLIST_FILE is its only
        waiver — the path or one of its segments, one per line.
     14. An inline waiver covers ITS OWN line and the next one, nothing further. A waiver written at
@@ -609,8 +613,14 @@ def scan_markdown_fences(path: Path, allow: set, english: "set | None" = None) -
     return findings
 
 
-def scan_diff(stream, allow: set, english: "set | None" = None) -> list:
-    """Added lines only. This is what makes the rule adoptable in a legacy repository."""
+def scan_diff(stream, allow: set, english: "set | None" = None,
+              vendored: "list | None" = None) -> list:
+    """Added lines only. This is what makes the rule adoptable in a legacy repository.
+
+    A `+++` path in a vendored or generated tree is skipped whole — path tier and added lines — and
+    appended to `vendored` when the caller hands a list in, so the CLI can count it as skipped, not
+    passed, the same way file mode does (KNOWN LIMIT 12). The decision is `is_vendored()` on the path
+    alone: a diff carries no body for `is_minified()` to read."""
     findings, path, lineno, lang = [], "<diff>", 0, None
     run: list = []                                   # consecutive added lines, scanned together
     adds_file = False                                # the previous `--- ` header said /dev/null
@@ -641,6 +651,16 @@ def scan_diff(stream, allow: set, english: "set | None" = None) -> list:
             if candidate.startswith("b/"):
                 candidate = candidate[2:]
             path = candidate
+            if is_vendored(Path(path)):
+                # Same exclusion scan_path() and the file-mode CLI apply: not this project's machine
+                # layer. `lang = None` keeps every `+` line of this file out of `run`, and the path
+                # tier never runs — measured before this branch existed: a `node_modules/` hunk with
+                # `const usuario = 1` produced two gating findings in --diff mode and none by path.
+                lang = None
+                if vendored is not None:
+                    vendored.append(path)
+                adds_file = False
+                continue
             lang = EXT_LANG.get(Path(path).suffix.lower())
             if adds_file and path != "/dev/null":
                 findings.extend(scan_path(Path(path), allow, english=english))
@@ -791,6 +811,16 @@ def selftest_paths() -> list:
     print(f"  {'CLEAN  ' if not modified else 'FALSE+ '} path-clean/diff modifies existing file")
     if modified:
         failed.append("path-clean/diff modifies existing file")
+    # Diff mode applies the vendored exclusion to the whole file, not only to its path: the added
+    # lines below are Portuguese on purpose, and before issue #172 they were measured.
+    skipped: list = []
+    vendored = scan_diff(io.StringIO(
+        "--- /dev/null\n+++ b/node_modules/servicos_pedido/calculo.js\n"
+        "@@ -0,0 +1,2 @@\n+const usuario = 1;\n+function calcularFrete() {}\n"), set(), vendored=skipped)
+    ok = not vendored and skipped == ["node_modules/servicos_pedido/calculo.js"]
+    print(f"  {'CLEAN  ' if ok else 'FALSE+ '} path-clean/diff adds vendored file (skipped, counted)")
+    if not ok:
+        failed.append("path-clean/diff adds vendored file")
     return failed
 
 
@@ -817,7 +847,7 @@ def selftest() -> int:
     print(
         f"selftest OK: {len(SELFTEST_HITS)} content tiers fire, {len(SELFTEST_CLEAN)} clean cases "
         f"stay silent, {len(SELFTEST_PATH_HITS) + 1} path tiers fire, "
-        f"{len(SELFTEST_PATH_CLEAN) + 3} path cases stay silent, "
+        f"{len(SELFTEST_PATH_CLEAN) + 4} path cases stay silent, "
         f"{sum(1 for c in SELFTEST_EN_UNKNOWN if c[2])} en-unknown tiers fire, "
         f"{sum(1 for c in SELFTEST_EN_UNKNOWN if not c[2]) + 1} en-unknown cases stay silent"
     )
@@ -853,7 +883,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.diff:
         stream = sys.stdin if args.diff == "-" else open(args.diff, encoding="utf-8")
-        findings.extend(scan_diff(stream, allow, english))
+        findings.extend(scan_diff(stream, allow, english, vendored=vendored))
     elif args.stdin:
         lang = EXT_LANG.get("." + (args.lang or ""), args.lang)
         if lang not in COMMENT_SYNTAX:

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -4,7 +4,7 @@ and assert the validator fires. A checker that never fails is not a checker.
 Each entry is  label: (relpath, mutate, expect)  — `expect` is the check name the validator must
 print for that label, plus an optional fragment its finding must carry. It exists because one
 check can own more than one defect class (C8 has five headings) and a dict cannot repeat a key."""
-import shutil, subprocess, sys, tempfile, pathlib, re, os
+import filecmp, shutil, subprocess, sys, tempfile, pathlib, re, os
 
 SRC = pathlib.Path(__file__).resolve().parent.parent
 VAL = str(SRC / "scripts" / "validate-skills.py")
@@ -115,22 +115,50 @@ MUTATIONS = {
 }
 
 fails = []
-for check, entry in MUTATIONS.items():
-    relpath, mutate = entry[0], entry[1]
-    expect, fragment = (entry[2] if len(entry) > 2 else (check, ""))
-    with tempfile.TemporaryDirectory() as td:
-        dst = pathlib.Path(td) / "repo"
-        shutil.copytree(SRC, dst, ignore=shutil.ignore_patterns(".git", "node_modules"))
-        if relpath is None:                       # C7: a wrapper skill with no canonical source
-            (dst / "claude" / "skills" / "ghost-skill").mkdir(parents=True)
-            (dst / "claude" / "skills" / "ghost-skill" / "SKILL.md").write_text("---\nname: ghost-skill\n---\n")
-        else:
-            p = dst / relpath
-            p.write_text(mutate(p.read_text() if p.exists() else ""))   # C11 creates its file
-        out = subprocess.run([sys.executable, str(dst / "scripts" / "validate-skills.py")], cwd=dst, capture_output=True, text=True).stdout
+with tempfile.TemporaryDirectory() as td:
+    # One copy per run (issue #172). Measured on 2026-09-06 before assuming: a copytree of the catalog
+    # costs 0.07 s and a validator run 1.7 s, so the 27 copies were 1.9 s of a 49.1 s run — the wall
+    # time is the validator, not the copying. What the single copy buys is less disk churn per PR and
+    # one place to prove isolation: each mutation is reverted before the next, and the copy is compared
+    # to the source after the loop. Bytes, not text: read_text() normalises line endings, so a text
+    # restore would leave the copy different from the source for the case that follows.
+    dst = pathlib.Path(td) / "repo"
+    shutil.copytree(SRC, dst, ignore=shutil.ignore_patterns(".git", "node_modules"))
+    ghost = dst / "claude" / "skills" / "ghost-skill"
+    for check, entry in MUTATIONS.items():
+        relpath, mutate = entry[0], entry[1]
+        expect, fragment = (entry[2] if len(entry) > 2 else (check, ""))
+        target = None if relpath is None else dst / relpath
+        original = target.read_bytes() if target is not None and target.exists() else None
+        try:
+            if relpath is None:                       # C7: a wrapper skill with no canonical source
+                ghost.mkdir(parents=True)
+                (ghost / "SKILL.md").write_text("---\nname: ghost-skill\n---\n")
+            else:
+                target.write_text(mutate(target.read_text() if original is not None else ""))   # C11 creates its file
+            out = subprocess.run([sys.executable, str(dst / "scripts" / "validate-skills.py")], cwd=dst, capture_output=True, text=True).stdout
+        finally:                                      # the next case must see the copy clean
+            if relpath is None:
+                shutil.rmtree(ghost, ignore_errors=True)
+            elif original is None:
+                target.unlink(missing_ok=True)
+            else:
+                target.write_bytes(original)
         caught = expect.split()[0] in out and expect in out and fragment in out
         print(f"  {'CAUGHT ' if caught else 'MISSED '} {check}")
         if not caught:
             fails.append(check)
+    # The copy after the loop must be byte-identical to the source: a restore that missed a case would
+    # leak its defect into the next one. Compared file by file rather than by re-running the validator —
+    # a validator run costs 1.7 s, the comparison milliseconds, and "identical" is the stronger claim.
+    ignored = {".git", "node_modules"}
+    src_files = {p.relative_to(SRC) for p in SRC.rglob("*") if p.is_file() and not ignored & set(p.relative_to(SRC).parts)}
+    dst_files = {p.relative_to(dst) for p in dst.rglob("*") if p.is_file()}
+    leaked = sorted(str(r) for r in (src_files ^ dst_files)) + sorted(
+        str(r) for r in src_files & dst_files if not filecmp.cmp(SRC / r, dst / r, shallow=False))
+    print(f"  {'CLEAN  ' if not leaked else 'LEAKED '} copy byte-identical to the source after all mutations reverted"
+          + (f": {', '.join(leaked[:3])}" if leaked else ""))
+    if leaked:
+        fails.append("copy left dirty after the loop")
 print(f"\n{len(MUTATIONS)-len(fails)}/{len(MUTATIONS)} defect classes detected")
 sys.exit(1 if fails else 0)

--- a/scripts/validate-spec-rite.py
+++ b/scripts/validate-spec-rite.py
@@ -26,7 +26,16 @@ padded evidence box passes the shape gate, and a single tick in the tasks.md of 
 links any diff to it. Existence and relevance are required, reviewable artifacts; the review is what
 judges them. The selftest exercises the decision rules against synthetic inputs, not the git
 plumbing that feeds them: a misconfigured checkout is caught by the CI-only base-resolution failure
-below, not by the selftest.
+below, not by the selftest. The one plumbing probe it does run is the path reader, below.
+
+Paths are read with `git diff --name-only -z` and split on NUL, the way validate-skill-version.py
+reads them (issue #132). Without `-z`, git wraps any path that carries a non-ASCII, control or quote
+character in double quotes with octal escapes (core.quotePath, default true on a fresh checkout and
+on the ubuntu runners): `"openspec/changes/<id>/specs/caf\303\251.md"` starts with a quote, not with
+`openspec/`, so it stopped being exempt AND stopped touching its own change — the gate reported S3
+against a pull request that touched the change it belonged to (measured on issue #172, 2026-09-06).
+The selftest commits such a path inside an active change of a throwaway repository and asserts the
+diff registers, so the flag cannot be dropped silently.
 
 The waiver is read from the event payload the runner already writes (GITHUB_EVENT_PATH), not from
 an environment variable handed to the step: GitHub Actions prints a step's `env:` block into the
@@ -164,10 +173,23 @@ def read_pr_body() -> str:
     return body if isinstance(body, str) else ""
 
 
-def changed_paths(root: Path, base: str) -> list[str]:
-    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", f"{base}...HEAD"],
+def split_nul_paths(out: str) -> list[str]:
+    """`git diff --name-only -z` output -> paths, verbatim. NUL is the one byte a path cannot contain,
+    so nothing here is quoted, escaped or split on a newline inside a name.
+
+    Duplicated from validate-skill-version.py rather than imported: that script loads THIS one at
+    import time (for MIN_REASON), so importing back would close a cycle, and a third module for two
+    lines is more surface than the duplicate. Each script pins its own copy with a real-repository
+    probe in --selftest, which is what keeps the two from drifting apart."""
+    return [p for p in out.split("\0") if p]
+
+
+def changed_paths(root: Path, base: str, head: str = "HEAD") -> list[str]:
+    # -z: raw names separated by NUL. The default line mode quotes and octal-escapes any name with a
+    # non-ASCII, control or quote character, which the prefix rules below would then fail to match.
+    out = subprocess.run(["git", "-C", str(root), "diff", "--name-only", "-z", f"{base}...{head}"],
                          capture_output=True, text=True, check=True).stdout
-    return [line for line in out.splitlines() if line]
+    return split_nul_paths(out)
 
 
 # ── rules ─────────────────────────────────────────────────────────────────
@@ -332,6 +354,61 @@ def selftest_reader() -> int:
     return ok
 
 
+def _probe_quoted_path() -> bool:
+    """The one git-plumbing probe of the selftest: commit a path git would quote in line mode INSIDE
+    an active change and check that the diff registers. core.quotePath is forced on so the probe
+    measures the worst case whatever the box's config says. Same shape as the probe in
+    validate-skill-version.py; what it asserts differs — there the skill is recognised, here the
+    change is."""
+    global findings
+    change = "probe-quoted"
+    quoted = f"{CHANGES}/{change}/specs/café.md"
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        env = {**os.environ, "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_NOSYSTEM": "1",
+               "GIT_AUTHOR_NAME": "probe", "GIT_AUTHOR_EMAIL": "probe@localhost",
+               "GIT_COMMITTER_NAME": "probe", "GIT_COMMITTER_EMAIL": "probe@localhost"}
+
+        def git(*args: str) -> None:
+            subprocess.run(["git", "-C", tmp, "-c", "core.quotePath=true", *args],
+                           capture_output=True, text=True, check=True, env=env)
+
+        git("init", "-q", "-b", "main")
+        (root / CHANGES / change).mkdir(parents=True)
+        (root / CHANGES / change / "tasks.md").write_text("- [ ] E.1 x\n", encoding="utf-8")
+        (root / "skills/x").mkdir(parents=True)
+        (root / "skills/x/SKILL.md").write_text("---\n  version: 1.0.0\n---\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "base")
+        (root / CHANGES / change / "specs").mkdir()
+        (root / quoted).write_text("delta\n", encoding="utf-8")
+        (root / "skills/x/SKILL.md").write_text("---\n  version: 1.0.1\n---\nedit\n", encoding="utf-8")
+        git("add", "-A")
+        git("commit", "-q", "-m", "edit")
+
+        paths = changed_paths(root, "HEAD^")
+        findings = []
+        evaluate(paths, active_changes(root), "")
+        return paths == [quoted, "skills/x/SKILL.md"] and findings == []
+
+
+def selftest_paths() -> tuple[int, int]:
+    """The reader collect-side: what the rules never see. A `-z` dropped from changed_paths() makes
+    the quoted path an offender and the change untouched at once, and no synthetic case can show it."""
+    cases = [
+        ("NUL-separated names are read verbatim, quotes and newlines included",
+         split_nul_paths(f'{CHANGES}/x/tasks.md\0skills/y/references/café "x"\n.md\0')
+         == [f"{CHANGES}/x/tasks.md", 'skills/y/references/café "x"\n.md']),
+        ("a quoted path inside an active change registers the diff on a real repository",
+         _probe_quoted_path()),
+    ]
+    ok = 0
+    for label, passed in cases:
+        print(f"  {'PATHS' if passed else 'PATHS FAIL'}  {label}")
+        ok += bool(passed)
+    return ok, len(cases)
+
+
 def selftest() -> int:
     global findings, annotate
     annotate = False
@@ -357,12 +434,14 @@ def selftest() -> int:
 
     reader_ok = selftest_reader()
     reader_total = 6
+    paths_ok, paths_total = selftest_paths()
 
     print(f"\n{caught}/{len(DEFECTS)} defect classes detected, "
           f"{quiet}/{len(SILENT)} false-positive cases stayed silent, "
-          f"{reader_ok}/{reader_total} reader cases correct")
+          f"{reader_ok}/{reader_total} reader cases correct, "
+          f"{paths_ok}/{paths_total} path-reader cases correct")
     return 0 if (caught == len(DEFECTS) and quiet == len(SILENT)
-                 and reader_ok == reader_total) else 1
+                 and reader_ok == reader_total and paths_ok == paths_total) else 1
 
 
 # ── main ──────────────────────────────────────────────────────────────────

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.4.2
+  version: 1.4.3
   category: process
 license: MIT
 compatibility: >-
@@ -28,9 +28,9 @@ compatibility: >-
 
 # Code locale — prose follows the repo, the machine layer is English
 
-> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-05:
+> **Verified against**: `Python 3.11.2` · `Claude Code 2.1.261`. Probed on 2026-09-06:
 > `references/check-identifier-locale.py --selftest` (7 content tiers fire, 16 clean cases silent,
-> 6 path tiers fire, 9 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
+> 6 path tiers fire, 10 path cases silent, 2 en-unknown tiers fire, 5 silent), `locale-rite.py
 > --selftest` (13 PostToolUse and 12 PreToolUse decisions) and `locale-stop-gate.py --selftest` (26
 > decisions in throwaway git repositories) all pass, and both hooks are the ones wired in
 > `~/.claude/settings.json` of the session that wrote this. The detector uses only the standard

--- a/skills/code-locale/references/check-identifier-locale.py
+++ b/skills/code-locale/references/check-identifier-locale.py
@@ -58,6 +58,10 @@ KNOWN LIMIT — what this check does NOT catch. A passing run is not proof of fu
        `--- /dev/null` header the diff itself writes. A file that already exists is never reported on
        its name: renaming it is the migration policy's decision (references/migration.md), not this
        check's. A rename appears as an add, so the new name is measured and the old one is not.
+       A `+++` path in a vendored or generated tree (VENDOR_PARTS, `.min.`) is skipped whole in
+       --diff mode — path and added lines — and reported as skipped, the same exclusion file mode
+       applies. That decision is by PATH only: a diff carries no file body, so `is_minified` never
+       runs in this mode, and a generated file outside those trees is measured as written code.
     13. A file name has nowhere to carry an inline `locale-ok:` comment, so ALLOWLIST_FILE is its only
        waiver — the path or one of its segments, one per line.
     14. An inline waiver covers ITS OWN line and the next one, nothing further. A waiver written at
@@ -609,8 +613,14 @@ def scan_markdown_fences(path: Path, allow: set, english: "set | None" = None) -
     return findings
 
 
-def scan_diff(stream, allow: set, english: "set | None" = None) -> list:
-    """Added lines only. This is what makes the rule adoptable in a legacy repository."""
+def scan_diff(stream, allow: set, english: "set | None" = None,
+              vendored: "list | None" = None) -> list:
+    """Added lines only. This is what makes the rule adoptable in a legacy repository.
+
+    A `+++` path in a vendored or generated tree is skipped whole — path tier and added lines — and
+    appended to `vendored` when the caller hands a list in, so the CLI can count it as skipped, not
+    passed, the same way file mode does (KNOWN LIMIT 12). The decision is `is_vendored()` on the path
+    alone: a diff carries no body for `is_minified()` to read."""
     findings, path, lineno, lang = [], "<diff>", 0, None
     run: list = []                                   # consecutive added lines, scanned together
     adds_file = False                                # the previous `--- ` header said /dev/null
@@ -641,6 +651,16 @@ def scan_diff(stream, allow: set, english: "set | None" = None) -> list:
             if candidate.startswith("b/"):
                 candidate = candidate[2:]
             path = candidate
+            if is_vendored(Path(path)):
+                # Same exclusion scan_path() and the file-mode CLI apply: not this project's machine
+                # layer. `lang = None` keeps every `+` line of this file out of `run`, and the path
+                # tier never runs — measured before this branch existed: a `node_modules/` hunk with
+                # `const usuario = 1` produced two gating findings in --diff mode and none by path.
+                lang = None
+                if vendored is not None:
+                    vendored.append(path)
+                adds_file = False
+                continue
             lang = EXT_LANG.get(Path(path).suffix.lower())
             if adds_file and path != "/dev/null":
                 findings.extend(scan_path(Path(path), allow, english=english))
@@ -791,6 +811,16 @@ def selftest_paths() -> list:
     print(f"  {'CLEAN  ' if not modified else 'FALSE+ '} path-clean/diff modifies existing file")
     if modified:
         failed.append("path-clean/diff modifies existing file")
+    # Diff mode applies the vendored exclusion to the whole file, not only to its path: the added
+    # lines below are Portuguese on purpose, and before issue #172 they were measured.
+    skipped: list = []
+    vendored = scan_diff(io.StringIO(
+        "--- /dev/null\n+++ b/node_modules/servicos_pedido/calculo.js\n"
+        "@@ -0,0 +1,2 @@\n+const usuario = 1;\n+function calcularFrete() {}\n"), set(), vendored=skipped)
+    ok = not vendored and skipped == ["node_modules/servicos_pedido/calculo.js"]
+    print(f"  {'CLEAN  ' if ok else 'FALSE+ '} path-clean/diff adds vendored file (skipped, counted)")
+    if not ok:
+        failed.append("path-clean/diff adds vendored file")
     return failed
 
 
@@ -817,7 +847,7 @@ def selftest() -> int:
     print(
         f"selftest OK: {len(SELFTEST_HITS)} content tiers fire, {len(SELFTEST_CLEAN)} clean cases "
         f"stay silent, {len(SELFTEST_PATH_HITS) + 1} path tiers fire, "
-        f"{len(SELFTEST_PATH_CLEAN) + 3} path cases stay silent, "
+        f"{len(SELFTEST_PATH_CLEAN) + 4} path cases stay silent, "
         f"{sum(1 for c in SELFTEST_EN_UNKNOWN if c[2])} en-unknown tiers fire, "
         f"{sum(1 for c in SELFTEST_EN_UNKNOWN if not c[2]) + 1} en-unknown cases stay silent"
     )
@@ -853,7 +883,7 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.diff:
         stream = sys.stdin if args.diff == "-" else open(args.diff, encoding="utf-8")
-        findings.extend(scan_diff(stream, allow, english))
+        findings.extend(scan_diff(stream, allow, english, vendored=vendored))
     elif args.stdin:
         lang = EXT_LANG.get("." + (args.lang or ""), args.lang)
         if lang not in COMMENT_SYNTAX:


### PR DESCRIPTION
Closes #172

## Contexto

Cinco follow-ups anotados nos grupos E.4 de changes já arquivadas, todos sobre gates que mediam menos do que diziam ou pagavam mais do que precisavam. Cada um foi reproduzido em `e7f5fe8` antes de escrever (evidência em `openspec/changes/harden-gate-followups/tasks.md`, E.2).

## O que muda

- `scripts/validate-spec-rite.py` lê o diff com `git diff --name-only -z` e separa por NUL (`split_nul_paths()`, duplicado de `validate-skill-version.py` com o motivo: aquele importa este em tempo de carga, e importar de volta fecharia um ciclo). Um caminho quotado dentro de `openspec/changes/<id>/` deixava de tocar a própria change e o gate emitia `S3`. Selftest ganha o caso literal e um probe em repositório descartável com `core.quotePath=true`.
- `skills/code-locale/references/check-identifier-locale.py`: `scan_diff()` aplica `is_vendored()` ao caminho do `+++`, pula o bloco inteiro e conta o pulo na linha `skipped (vendored/generated/minified)` que já existia no modo de arquivos. KNOWN LIMIT 12 diz que a decisão é por caminho. Selftest com `node_modules/` em diff. `code-locale` 1.4.2 → 1.4.3; wrappers regenerados; hooks `locale-rite` e `locale-stop-gate` verdes.
- `scripts/selftest-validate-skills.py`: uma `copytree` por run; cada mutação guarda bytes, aplica, roda e restaura em `finally`; a cópia é comparada byte a byte com a origem no fim (`LEAKED` reprova). **Premissa medida antes de mudar**: as 27 cópias custavam 1,9 s dos 49,1 s; o custo real são as 27 runs do validador (1,7 s cada). O ganho de parede é o que a cópia custava.
- `.github/workflows/ci.yml`, step *Version coherence*: `VERSION` validado contra `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` (o literal de `generate.sh` e `set-version.sh`) antes da comparação com os manifests; `::error` nomeia o valor.
- `README.md:443`: `# React Three Fiber skills, one per topic`, sem contagem.

## Simulação

| Gate | Antes (`e7f5fe8`) | Depois |
|---|---|---|
| spec-rite, clone com `café.md` dentro da change ativa | `S3 unrelated change` exit=1 | `0 findings (2 changed path(s), 1 active change(s))` exit=0 |
| detector `--diff`, hunk em `node_modules/` com `const usuario` | `findings: 2` exit=1 | `findings: 0` + `skipped (vendored/...): 1 file(s)` exit=0 |
| selftest do validador (3 rounds alternados) | 49,3 / 49,2 / 50,5 s (média 49,7) | 47,5 / 46,5 / 48,6 s (média 47,5), 27/27 + `CLEAN copy byte-identical`; restauração neutralizada → `LEAKED` + 22/27 |
| step *Version coherence*, `VERSION=2.15.1dirtychange` | `coherent across manifests` exit=0 | `::error::VERSION is '2.15.1dirtychange' — ...` exit=1; vazio exit=1; `2.30.0`, `2.31.0-beta.1`, worktree exit=0 |
| README + hygiene | `(10 topics)` sobre 12 skills | `grep -c "10 topics"` → 0; hygiene 0 findings |

Contagens: 6/6 tinham de disparar e dispararam; 9/9 tinham de ficar mudos e ficaram; 1/1 escape conhecido mudo (`en-unknown` advisory em `filecmp`/`rmtree`).

## Evidência

| # | Critério | Verdict | Evidência |
|---|---|---|---|
| 1 | spec-rite selftest detecta caminho quotado; gate real verde | met | `2/2 path-reader cases correct`; probe reprova o leitor antigo; `spec-rite gate: 0 findings (base origin/master, 15 changed path(s))` |
| 2 | detector detecta vendored em `--diff`; hook de Stop verde | met | `CLEAN path-clean/diff adds vendored file (skipped, counted)`; `locale-stop-gate.py --selftest` 26 decisões OK |
| 3 | selftest do validador verde, tempo menor (os dois registrados) | met | 27/27; 49,7 s → 47,5 s; decomposição cópia/validador em tasks.md E.2 |
| 4 | `ci.yml` recusa `VERSION` inválido; run do PR verde | manual | step literal reprova a fixture (5.2); a run do PR é a prova no runner |
| 5 | `README.md:443` sem "(10 topics)"; hygiene verde | met | linha reescrita; `repo hygiene: 0 findings` |
| 6 | `openspec validate --strict` e `validate-rite.sh` verdes | met | `Change 'harden-gate-followups' is valid`; `rite gate OK` |

## Rito

Spec-rite: harden-gate-followups
Skill-version: code-locale 1.4.2 → 1.4.3 (`scan_diff` muda de comportamento em `--diff`)

## Known gaps

- Critério 4, metade "run do PR verde": só o runner do GitHub prova; aqui o step foi extraído do YAML e rodado com `bash -e`.
- O ganho de tempo do selftest é ~2 s (4 %), não uma ordem de grandeza: a premissa da issue (as cópias são o custo) estava errada — medido. Paralelizar as runs do validador é o follow-up que a medida justifica (E.4).
- `scripts/validate-repo-hygiene.py:91-94` ainda cita `README.md:345 (10 topics)` como exemplo; arquivo fora deste item (E.4).
- `locale-stop-gate.py:296` filtra `is_vendored` por fora, agora redundante; do dono do hook (E.4).
- V.4 (archive) em PR separado depois do merge.