### PR TITLE
🐛 fix(distribution): wrapper Copilot linka o SKILL.md por URL e install/update compartilham o bloco de pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Each skill has an AGENTS.md file with instructions for specific tasks.
 cp ~/ai-skills/cursor/rules/*.mdc /path/to/project/.cursor/rules/
 
 # GitHub Copilot — copy instruction files
-# (references/ resolve through the same repository URL; the SKILL.md link still expects the clone)
+# (the SKILL.md link and the references/ links both resolve through the repository URL)
 cp ~/ai-skills/copilot/instructions/*.instructions.md /path/to/project/.github/instructions/
 ```
 

--- a/copilot/instructions/api-resilience-testing.instructions.md
+++ b/copilot/instructions/api-resilience-testing.instructions.md
@@ -1,5 +1,5 @@
 # api-resilience-testing
 
-Follow the instructions in [SKILL.md](../../skills/api-resilience-testing/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/api-resilience-testing/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/api-resilience-testing/references/)

--- a/copilot/instructions/assettoserver-csp-lua.instructions.md
+++ b/copilot/instructions/assettoserver-csp-lua.instructions.md
@@ -1,5 +1,5 @@
 # assettoserver-csp-lua
 
-Follow the instructions in [SKILL.md](../../skills/assettoserver-csp-lua/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/assettoserver-csp-lua/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/assettoserver-csp-lua/references/)

--- a/copilot/instructions/assettoserver-ops.instructions.md
+++ b/copilot/instructions/assettoserver-ops.instructions.md
@@ -1,5 +1,5 @@
 # assettoserver-ops
 
-Follow the instructions in [SKILL.md](../../skills/assettoserver-ops/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/assettoserver-ops/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/assettoserver-ops/references/)

--- a/copilot/instructions/assettoserver-plugin.instructions.md
+++ b/copilot/instructions/assettoserver-plugin.instructions.md
@@ -1,5 +1,5 @@
 # assettoserver-plugin
 
-Follow the instructions in [SKILL.md](../../skills/assettoserver-plugin/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/assettoserver-plugin/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/assettoserver-plugin/references/)

--- a/copilot/instructions/backend-resilience.instructions.md
+++ b/copilot/instructions/backend-resilience.instructions.md
@@ -1,5 +1,5 @@
 # backend-resilience
 
-Follow the instructions in [SKILL.md](../../skills/backend-resilience/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/backend-resilience/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/backend-resilience/references/)

--- a/copilot/instructions/backlog.instructions.md
+++ b/copilot/instructions/backlog.instructions.md
@@ -1,5 +1,5 @@
 # backlog
 
-Follow the instructions in [SKILL.md](../../skills/backlog/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/backlog/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/backlog/references/)

--- a/copilot/instructions/bug-hunter.instructions.md
+++ b/copilot/instructions/bug-hunter.instructions.md
@@ -1,5 +1,5 @@
 # bug-hunter
 
-Follow the instructions in [SKILL.md](../../skills/bug-hunter/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/bug-hunter/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/bug-hunter/references/)

--- a/copilot/instructions/claude-statusline.instructions.md
+++ b/copilot/instructions/claude-statusline.instructions.md
@@ -1,5 +1,5 @@
 # claude-statusline
 
-Follow the instructions in [SKILL.md](../../skills/claude-statusline/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/claude-statusline/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/claude-statusline/references/)

--- a/copilot/instructions/code-locale.instructions.md
+++ b/copilot/instructions/code-locale.instructions.md
@@ -1,5 +1,5 @@
 # code-locale
 
-Follow the instructions in [SKILL.md](../../skills/code-locale/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/code-locale/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/code-locale/references/)

--- a/copilot/instructions/conventional-commit.instructions.md
+++ b/copilot/instructions/conventional-commit.instructions.md
@@ -1,3 +1,3 @@
 # conventional-commit
 
-Follow the instructions in [SKILL.md](../../skills/conventional-commit/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/conventional-commit/SKILL.md)

--- a/copilot/instructions/documentation.instructions.md
+++ b/copilot/instructions/documentation.instructions.md
@@ -1,5 +1,5 @@
 # documentation
 
-Follow the instructions in [SKILL.md](../../skills/documentation/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/documentation/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/documentation/references/)

--- a/copilot/instructions/execute-backlog.instructions.md
+++ b/copilot/instructions/execute-backlog.instructions.md
@@ -1,5 +1,5 @@
 # execute-backlog
 
-Follow the instructions in [SKILL.md](../../skills/execute-backlog/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/execute-backlog/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/execute-backlog/references/)

--- a/copilot/instructions/fivem-fallback.instructions.md
+++ b/copilot/instructions/fivem-fallback.instructions.md
@@ -1,5 +1,5 @@
 # fivem-fallback
 
-Follow the instructions in [SKILL.md](../../skills/fivem-fallback/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/fivem-fallback/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/fivem-fallback/references/)

--- a/copilot/instructions/fivem-lua.instructions.md
+++ b/copilot/instructions/fivem-lua.instructions.md
@@ -1,5 +1,5 @@
 # fivem-lua
 
-Follow the instructions in [SKILL.md](../../skills/fivem-lua/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/fivem-lua/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/fivem-lua/references/)

--- a/copilot/instructions/fivem-nui-react.instructions.md
+++ b/copilot/instructions/fivem-nui-react.instructions.md
@@ -1,5 +1,5 @@
 # fivem-nui-react
 
-Follow the instructions in [SKILL.md](../../skills/fivem-nui-react/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/fivem-nui-react/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/fivem-nui-react/references/)

--- a/copilot/instructions/helm-migration.instructions.md
+++ b/copilot/instructions/helm-migration.instructions.md
@@ -1,5 +1,5 @@
 # helm-migration
 
-Follow the instructions in [SKILL.md](../../skills/helm-migration/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/helm-migration/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/helm-migration/references/)

--- a/copilot/instructions/k8s-tune-resources.instructions.md
+++ b/copilot/instructions/k8s-tune-resources.instructions.md
@@ -1,3 +1,3 @@
 # k8s-tune-resources
 
-Follow the instructions in [SKILL.md](../../skills/k8s-tune-resources/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/k8s-tune-resources/SKILL.md)

--- a/copilot/instructions/lean-code.instructions.md
+++ b/copilot/instructions/lean-code.instructions.md
@@ -1,5 +1,5 @@
 # lean-code
 
-Follow the instructions in [SKILL.md](../../skills/lean-code/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/lean-code/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/lean-code/references/)

--- a/copilot/instructions/log-event-collector.instructions.md
+++ b/copilot/instructions/log-event-collector.instructions.md
@@ -1,3 +1,3 @@
 # log-event-collector
 
-Follow the instructions in [SKILL.md](../../skills/log-event-collector/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/log-event-collector/SKILL.md)

--- a/copilot/instructions/observability.instructions.md
+++ b/copilot/instructions/observability.instructions.md
@@ -1,3 +1,3 @@
 # observability
 
-Follow the instructions in [SKILL.md](../../skills/observability/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/observability/SKILL.md)

--- a/copilot/instructions/openspec-drivezone.instructions.md
+++ b/copilot/instructions/openspec-drivezone.instructions.md
@@ -1,3 +1,3 @@
 # openspec-drivezone
 
-Follow the instructions in [SKILL.md](../../skills/openspec-drivezone/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/openspec-drivezone/SKILL.md)

--- a/copilot/instructions/openspec.instructions.md
+++ b/copilot/instructions/openspec.instructions.md
@@ -1,3 +1,3 @@
 # openspec
 
-Follow the instructions in [SKILL.md](../../skills/openspec/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/openspec/SKILL.md)

--- a/copilot/instructions/python-rest-api.instructions.md
+++ b/copilot/instructions/python-rest-api.instructions.md
@@ -1,5 +1,5 @@
 # python-rest-api
 
-Follow the instructions in [SKILL.md](../../skills/python-rest-api/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/python-rest-api/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/python-rest-api/references/)

--- a/copilot/instructions/r3f-animation.instructions.md
+++ b/copilot/instructions/r3f-animation.instructions.md
@@ -1,5 +1,5 @@
 # r3f-animation
 
-Follow the instructions in [SKILL.md](../../skills/r3f-animation/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-animation/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-animation/references/)

--- a/copilot/instructions/r3f-assets.instructions.md
+++ b/copilot/instructions/r3f-assets.instructions.md
@@ -1,5 +1,5 @@
 # r3f-assets
 
-Follow the instructions in [SKILL.md](../../skills/r3f-assets/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-assets/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-assets/references/)

--- a/copilot/instructions/r3f-fundamentals.instructions.md
+++ b/copilot/instructions/r3f-fundamentals.instructions.md
@@ -1,5 +1,5 @@
 # r3f-fundamentals
 
-Follow the instructions in [SKILL.md](../../skills/r3f-fundamentals/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-fundamentals/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-fundamentals/references/)

--- a/copilot/instructions/r3f-geometry.instructions.md
+++ b/copilot/instructions/r3f-geometry.instructions.md
@@ -1,5 +1,5 @@
 # r3f-geometry
 
-Follow the instructions in [SKILL.md](../../skills/r3f-geometry/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-geometry/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-geometry/references/)

--- a/copilot/instructions/r3f-interaction.instructions.md
+++ b/copilot/instructions/r3f-interaction.instructions.md
@@ -1,5 +1,5 @@
 # r3f-interaction
 
-Follow the instructions in [SKILL.md](../../skills/r3f-interaction/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-interaction/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-interaction/references/)

--- a/copilot/instructions/r3f-lighting.instructions.md
+++ b/copilot/instructions/r3f-lighting.instructions.md
@@ -1,5 +1,5 @@
 # r3f-lighting
 
-Follow the instructions in [SKILL.md](../../skills/r3f-lighting/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-lighting/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-lighting/references/)

--- a/copilot/instructions/r3f-materials.instructions.md
+++ b/copilot/instructions/r3f-materials.instructions.md
@@ -1,5 +1,5 @@
 # r3f-materials
 
-Follow the instructions in [SKILL.md](../../skills/r3f-materials/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-materials/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-materials/references/)

--- a/copilot/instructions/r3f-physics.instructions.md
+++ b/copilot/instructions/r3f-physics.instructions.md
@@ -1,5 +1,5 @@
 # r3f-physics
 
-Follow the instructions in [SKILL.md](../../skills/r3f-physics/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-physics/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-physics/references/)

--- a/copilot/instructions/r3f-postprocessing.instructions.md
+++ b/copilot/instructions/r3f-postprocessing.instructions.md
@@ -1,5 +1,5 @@
 # r3f-postprocessing
 
-Follow the instructions in [SKILL.md](../../skills/r3f-postprocessing/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-postprocessing/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-postprocessing/references/)

--- a/copilot/instructions/r3f-shaders.instructions.md
+++ b/copilot/instructions/r3f-shaders.instructions.md
@@ -1,5 +1,5 @@
 # r3f-shaders
 
-Follow the instructions in [SKILL.md](../../skills/r3f-shaders/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/r3f-shaders/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/r3f-shaders/references/)

--- a/copilot/instructions/react-api-client.instructions.md
+++ b/copilot/instructions/react-api-client.instructions.md
@@ -1,5 +1,5 @@
 # react-api-client
 
-Follow the instructions in [SKILL.md](../../skills/react-api-client/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/react-api-client/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/react-api-client/references/)

--- a/copilot/instructions/svg-animation.instructions.md
+++ b/copilot/instructions/svg-animation.instructions.md
@@ -1,5 +1,5 @@
 # svg-animation
 
-Follow the instructions in [SKILL.md](../../skills/svg-animation/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/svg-animation/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/svg-animation/references/)

--- a/copilot/instructions/verify-before-claiming.instructions.md
+++ b/copilot/instructions/verify-before-claiming.instructions.md
@@ -1,5 +1,5 @@
 # verify-before-claiming
 
-Follow the instructions in [SKILL.md](../../skills/verify-before-claiming/SKILL.md)
+Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/verify-before-claiming/SKILL.md)
 
 Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/verify-before-claiming/references/)

--- a/generate.sh
+++ b/generate.sh
@@ -190,10 +190,13 @@ HEADER
     } > "$CURSOR_OUT/${name}.mdc"
 
     # --- GitHub Copilot ---
+    # The SKILL.md link is a repository URL for the same reason the references/ link below is: the
+    # file is copied alone into .github/instructions/, where `../../skills/<name>/` dangles (issue #173;
+    # rule R5 of #121 had converted only references/). blob/ for a file, tree/ for a directory.
     {
         echo "# ${name}"
         echo ""
-        echo "Follow the instructions in [SKILL.md](../../skills/${name}/SKILL.md)"
+        echo "Follow the instructions in [SKILL.md](${REPO_BLOB_URL}/skills/${name}/SKILL.md)"
         if [ "$has_refs" -eq 1 ]; then
             echo ""
             echo "Reference files: [references/](${REPO_TREE_URL}/skills/${name}/references/)"

--- a/generate.sh
+++ b/generate.sh
@@ -7,8 +7,8 @@
 #   codex/skills/<name>/AGENTS.md          @-include of the canonical SKILL.md
 #   cursor/rules/<name>.mdc                content inlined (Cursor has no file includes);
 #                                          references/ linked by repository URL
-#   copilot/instructions/<name>.instructions.md  markdown link to the canonical SKILL.md;
-#                                          references/ linked by repository URL
+#   copilot/instructions/<name>.instructions.md  SKILL.md and references/ linked by repository URL
+#                                          (the file is copied out of the clone alone)
 #   plugins/<group>/                       category-grouped Claude Code plugins (skills copied;
 #                                          group = metadata.category, git+process -> workflow)
 #

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,10 @@
 #
 # `--tool` is validated before anything is cloned or pulled, so a typo never leaves a clone
 # behind. On a re-run over an existing ~/ai-skills the pull is fast-forward only: a clone that
-# diverged from origin is refused with the same message and recovery hint update.sh gives.
+# diverged from origin is refused with the same message and recovery hint update.sh gives — the
+# same because it is the same code: scripts/lib/git-sync.sh, sourced from the clone itself (this
+# script runs via `curl | bash`, so the clone is the only place both scripts can read it from). A
+# clone that predates that file is refused with the hint to run the update.sh it carries, once.
 #
 # WHAT THE GUARD DOES NOT COVER: this script never inspects the working tree. Uncommitted edits in
 # ~/ai-skills are neither refused nor discarded here (a fast-forward pull that touches the same
@@ -173,14 +176,16 @@ fi
 # Clone or pull the repository
 if [ -d "$INSTALL_DIR" ]; then
     echo "📦 ~/ai-skills already exists. Pulling latest changes..."
-    # Same contract as update.sh: fast-forward only, own message first, git's `fatal:` line as an
-    # indented detail (advice.diverging=false drops the nine `hint:` lines that precede it).
-    if ! PULL_ERR="$(git -C "$INSTALL_DIR" -c advice.diverging=false pull --ff-only --quiet 2>&1)"; then
-        echo "  ❌ Fast-forward failed — local changes diverge from origin."
-        echo "     Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force"
-        [ -z "$PULL_ERR" ] || printf '     git: %s\n' "$PULL_ERR"
+    # The pull block is shared with update.sh and read from the clone it is about to sync (see the
+    # header). A clone older than that file has its own update.sh, which still carries the block.
+    SYNC_LIB="$INSTALL_DIR/scripts/lib/git-sync.sh"
+    if [ ! -f "$SYNC_LIB" ]; then
+        echo "  ❌ $SYNC_LIB not found — this clone predates it."
+        echo "     Bring it forward once with the updater it carries: cd ~/ai-skills && ./update.sh"
         exit 1
     fi
+    . "$SYNC_LIB"
+    pull_ff_only "$INSTALL_DIR" || exit 1
 else
     echo "📦 Cloning ai-skills into ~/ai-skills..."
     git clone "$REPO_URL" "$INSTALL_DIR"

--- a/openspec/changes/extend-install-form-links/.openspec.yaml
+++ b/openspec/changes/extend-install-form-links/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-06

--- a/openspec/changes/extend-install-form-links/design.md
+++ b/openspec/changes/extend-install-form-links/design.md
@@ -1,0 +1,135 @@
+## Context
+
+Lido em `e7f5fe8` (2026-09-06):
+
+- `generate.sh:84-90` — o comentário que justifica `REPO_BLOB_URL`/`REPO_TREE_URL`: os wrappers Cursor
+  e Copilot são os dois outputs que o README manda **copiar** para o projeto, então um caminho
+  relativo à árvore morre ao sair do checkout. `generate.sh:189` aplica isso ao Cursor via `sed` sobre
+  `](references/`; `generate.sh:199` aplica ao `references/` do Copilot; `generate.sh:196` escreve o
+  link do `SKILL.md` ainda relativo.
+- `install.sh:173-187` — `if [ -d "$INSTALL_DIR" ]` → bloco de pull (176-183); `else` → `git clone`.
+  O bloco de pull só roda quando o clone existe. `install.sh:23-24` e `update.sh:20-21`: os dois rodam
+  por `curl | bash` (README linhas 113-119 e 162), onde `${BASH_SOURCE[0]}` não aponta para nada útil.
+- `update.sh:46-49` — exige `$INSTALL_DIR/.git`; `56-69` — `--force` faz `reset --hard`, senão o bloco
+  de pull (61-68), idêntico ao de `install.sh` linha a linha.
+- `scripts/smoke-install-scripts.sh` — 17 casos; o caso 13 (`update.sh` divergido) e o 14
+  (`install.sh` divergido) afirmam cada um a **presença** das frases, nunca a igualdade entre os dois;
+  o fixture clona de um bare construído a partir do `HEAD` do checkout (linha 103), então o que o
+  clone carrega é o que está commitado.
+- `openspec/specs/skills-authoring/spec.md:639-698` — o requisito modificado; `:655-656` é a regra
+  que cobre só `references/`.
+- `openspec/specs/skills-catalog/spec.md:1266-1339` — *Distribution scripts refuse what they cannot
+  honor*; o cenário *A diverged clone is refused with the recovery hint, by both scripts* já pede a
+  mesma mensagem nos dois scripts.
+
+## Goals / Non-Goals
+
+**Goals**
+
+- Um `copilot/instructions/<name>.instructions.md` copiado sozinho resolve o link do `SKILL.md`.
+- O bloco de pull existe uma vez; a igualdade da mensagem é medida, não presumida.
+- Os 17 casos do smoke test continuam verdes sem alteração de expectativa.
+
+**Non-Goals**
+
+- Mudar o que o Copilot ou o Cursor carregam (fora de escopo pela issue): só o link.
+- Tocar `codex/skills/<name>/AGENTS.md` (`@../../skills/…` é um include lido no lugar, não copiado).
+- Tocar `README.md` (não está entre os arquivos do item; follow-up em `tasks.md` E.4).
+- Unificar o resto de `install.sh`/`update.sh` (checagem de `git`, cabeçalhos): a issue pede o bloco de
+  pull.
+
+## Decisions
+
+### D1 — O link do `SKILL.md` no Copilot usa `REPO_BLOB_URL`, a mesma variável do `references/`
+
+Uma linha: `[SKILL.md](${REPO_BLOB_URL}/skills/${name}/SKILL.md)`. A forma `blob/master` é a que
+`validate-skills.py` (`REPO_URL_PREFIX`, C12) já recomenda e a que o Cursor já usa para arquivos;
+`tree/master` fica para diretórios (`references/`). Probado: `curl -sI` da URL de `backlog` → `HTTP/2
+200` (E.2).
+
+Alternativa rejeitada: a URL da tag corrente (`blob/v2.30.0/…`), que a issue menciona ("na tag
+corrente"). `generate.sh` roda no release **antes** da tag existir (o `chore(release)` regenera os
+wrappers e só depois o semantic-release cria `vX.Y.Z`), então a URL apontaria para uma tag que ainda
+não existe no momento em que é escrita, e `references/` já é `master` — misturar as duas formas no
+mesmo arquivo seria pior que manter uma.
+
+### D2 — O arquivo compartilhado é lido do clone que vai ser sincronizado, não da pasta do script
+
+Os dois scripts rodam por `curl | bash`; nesse modo não há diretório do script. Mas o bloco de pull
+só executa sobre um clone existente em `$INSTALL_DIR` — `install.sh` entra nele por
+`[ -d "$INSTALL_DIR" ]`, `update.sh` exige `$INSTALL_DIR/.git` — e esse clone carrega `scripts/`.
+Logo `$INSTALL_DIR/scripts/lib/git-sync.sh` é o único caminho que os dois conhecem em todo modo de
+invocação, e é o mesmo arquivo nos dois. Na primeira instalação (sem clone) o bloco nem é necessário:
+o `git clone` não tem o que fazer fast-forward.
+
+Alternativas rejeitadas:
+
+- **Here-doc / função inline nos dois scripts** — é a duplicação de hoje com outro nome; uma correção
+  num não chega ao outro, exatamente o defeito medido em #113.
+- **Ler de `$(dirname "${BASH_SOURCE[0]}")` quando existe, senão do clone** — dois caminhos de carga,
+  duas versões possíveis do mesmo bloco numa só execução (o checkout de onde o script foi chamado
+  contra o clone em `~/ai-skills`); o smoke test passaria a exercitar um arquivo que o usuário por
+  `curl` nunca lê.
+- **Bootstrap por `git show origin/master:scripts/lib/git-sync.sh` quando o arquivo falta** — executa
+  conteúdo de `origin` **antes** de o guard de fast-forward decidir se o clone pode receber `origin`,
+  e a população que precisa disso é transitória (clones entre esta versão e o primeiro update).
+
+### D3 — Clone sem o arquivo: recusa com a dica de usar o updater que o clone carrega
+
+Um clone instalado antes desta versão não tem `scripts/lib/git-sync.sh`. Nos dois scripts, o caminho
+de pull checa `[ -f "$SYNC_LIB" ]` antes do `source` e, faltando, imprime a própria mensagem
+(nomeando o arquivo e o motivo) com a recuperação `cd ~/ai-skills && ./update.sh` — o `update.sh`
+antigo, presente nesse clone, ainda carrega o bloco inline, faz o fast-forward e traz o arquivo. Sem
+o guard, `source` de arquivo inexistente morre sob `set -e` com o `No such file or directory` do
+bash, sem dica — o caso "erro cru" que o requisito de `skills-catalog` proíbe.
+
+O guard é a única linha de comportamento que fica em dois lugares (uma checagem de arquivo e uma
+mensagem de duas linhas). O que a issue pede que exista uma vez — o pull, a mensagem de divergência,
+a dica de `--force`, o detalhe do git — está só em `pull_ff_only`.
+
+`update.sh --force` não carrega o arquivo: o `reset --hard` não passa pelo bloco de pull, e um clone
+antigo precisa continuar podendo ser resetado.
+
+### D4 — O smoke test mede a igualdade byte a byte, entre as saídas reais dos dois scripts
+
+Os casos 13 e 14 já produzem as duas saídas sobre o mesmo clone divergido. O caso novo recorta de
+cada uma o bloco de `Fast-forward failed` até a linha `git:` (três linhas) e afirma `test "$a" =
+"$b"` mais o tamanho do bloco (três linhas, para que dois recortes vazios não passem por iguais).
+Nenhum novo estado de fixture: reutiliza as saídas capturadas, e imprime os dois blocos quando
+diverge. Um segundo caso apaga `scripts/lib/git-sync.sh` do clone e afirma que `install.sh` e
+`update.sh` (sem `--force`) recusam com a dica de D3 e sem tocar o `HEAD`.
+
+O cabeçalho do smoke test passa a declarar que o arquivo compartilhado é lido do clone — isto é, do
+`HEAD` commitado, como já vale para `generate.sh` no caso 9 — e não da árvore de trabalho.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Um wrapper copiado sozinho referencia por URL do repositório | `skills-authoring` (spec, *Cross-skill references resolve in every install form*) | already canonical — o delta estende a regra ao link do `SKILL.md`; `generate.sh` só a implementa |
+| Os scripts de distribuição recusam com mensagem própria, e os dois dão a mesma dica | `skills-catalog` (spec, *Distribution scripts refuse what they cannot honor*) | already canonical — o arquivo compartilhado é implementação; o smoke test mede o cenário existente |
+| Um check declara o que não cobre | `skills-catalog` + `verify-before-claiming` | already canonical — cabeçalhos de `install.sh`, `update.sh`, `git-sync.sh` e do smoke test só estendem o próprio KNOWN LIMIT |
+| Reusar antes de escrever; sem abstração especulativa | `lean-code` | already canonical — uma função, um arquivo, sem camada de "lib" genérica além do que os dois scripts usam |
+| Identificadores em inglês no que a change introduz | `code-locale` | already canonical — `pull_ff_only`, `SYNC_LIB`, `git-sync.sh`, nomes dos casos |
+
+Nenhuma skill do catálogo é editada por esta change, então não há doutrina duplicada a mover.
+
+## Risks / Trade-offs
+
+- **Re-run de `install.sh` ou `update.sh` por `curl` sobre um clone anterior a esta versão passa a
+  recusar** (hoje faz o pull). → Mensagem própria com a recuperação de uma linha (D3); o `update.sh`
+  do próprio clone continua funcionando; população transitória. Medido no smoke test (caso 16).
+- **O smoke test exercita o `git-sync.sh` do `HEAD`, não o da árvore de trabalho.** → Já é assim
+  para `generate.sh` (caso 9, header do smoke); declarado no cabeçalho; uma edição não commitada no
+  arquivo é invisível ao smoke até o commit — o CI roda sobre commits, então o gate não perde nada.
+- **A URL `blob/master` aponta para o `SKILL.md` mais novo, não para a versão que gerou o wrapper.**
+  → Mesma escolha já feita para `references/` em #121; o wrapper Copilot é um ponteiro de uma linha,
+  não conteúdo inlined, e o README diz que `install.sh`/`update.sh` seguem `master` (linha 195).
+- **`source` de um arquivo do clone executa o que o clone carrega.** → É o mesmo nível de confiança
+  de `bash "$INSTALL_DIR/generate.sh"`, que `update.sh:85` já executa do mesmo clone.
+
+## Open Questions
+
+Nenhuma. O que poderia virar achismo — se o bloco de pull roda sem clone (não roda), se a URL
+responde (200), se os dois scripts rodam por `curl` (README 113-119 e 162) — foi lido ou probado e
+está em `tasks.md` com comando e saída.

--- a/openspec/changes/extend-install-form-links/proposal.md
+++ b/openspec/changes/extend-install-form-links/proposal.md
@@ -1,0 +1,68 @@
+# Change: Wrapper Copilot com link do SKILL.md por URL e bloco de pull compartilhado
+
+## Why
+
+Dois follow-ups de distribuição registrados em E.4 das changes `define-cross-skill-references`
+(#121) e `harden-distribution-scripts` (#113), lidos em `e7f5fe8` (topo de `master`, 2026-09-06):
+
+1. `generate.sh:196` escreve no wrapper Copilot `Follow the instructions in
+   [SKILL.md](../../skills/${name}/SKILL.md)`. O README (linha 151) manda copiar
+   `copilot/instructions/*.instructions.md` sozinho para `.github/instructions/` do projeto, e ali o
+   link relativo morre — o próprio README (linha 150) admite: *"the SKILL.md link still expects the
+   clone"*. A regra R5 de #121 converteu só os links de `references/` para URL do repositório; o link
+   do próprio `SKILL.md` ficou de fora. Medido: `grep -c '\.\./\.\./skills' copilot/instructions/*.md`
+   -> 36 arquivos, 36 links relativos.
+2. `install.sh:176-183` e `update.sh:61-68` carregam duas cópias do mesmo bloco — `pull --ff-only`
+   com `advice.diverging=false`, a mensagem *Fast-forward failed*, a dica `./update.sh --force`, o
+   `fatal:` do git indentado. Foi assim que #113 encontrou o `install.sh` cru enquanto o `update.sh`
+   já explicava. O E.4 de #113 desistiu de compartilhar porque "os dois rodam via `curl | bash` sem o
+   repositório presente" — mas o bloco de pull só roda **sobre um clone que já existe** em
+   `~/ai-skills`, e esse clone carrega `scripts/`.
+
+## What Changes
+
+- `generate.sh`, bloco do Copilot: o link do `SKILL.md` passa a ser
+  `https://github.com/solvelab/ai-skills/blob/master/skills/<name>/SKILL.md`, a mesma forma
+  (`REPO_BLOB_URL`) que o bloco já usa para `references/`. Os 36 `copilot/instructions/*.md` são
+  regenerados; nenhum outro wrapper muda (`claude/`, `codex/`, `cursor/`, `plugins/` sem diff).
+- `scripts/lib/git-sync.sh` (novo): a função `pull_ff_only <dir>` — o pull fast-forward, a mensagem
+  de divergência, a dica de `--force` e o detalhe do git — existe uma vez. `install.sh` (re-run sobre
+  um clone) e `update.sh` (caminho sem `--force`) carregam o arquivo **do clone que vão sincronizar**
+  (`$INSTALL_DIR/scripts/lib/git-sync.sh`), porque é o único lugar que os dois scripts conhecem quando
+  rodam por `curl | bash`. Um clone anterior a este arquivo é recusado com a dica de rodar o
+  `./update.sh` que ele mesmo carrega, uma vez.
+- `scripts/smoke-install-scripts.sh`: os 17 casos continuam; ganha o caso que compara byte a byte o
+  bloco de divergência impresso por `update.sh` e por `install.sh` sobre o mesmo clone divergido, e o
+  caso que prova a recusa sobre um clone sem o arquivo compartilhado.
+
+Nada aqui é **BREAKING** para consumidores do catálogo: nenhuma skill entra, sai ou muda de nome;
+`npx skills add` e os plugins não leem `copilot/`. Para quem instala pelo README, o wrapper Copilot
+copiado sozinho passa a resolver o link do `SKILL.md`; para quem re-roda o instalador por `curl` sobre
+um clone anterior a esta versão, o script pede uma passada pelo `update.sh` do próprio clone.
+
+## Capabilities
+
+### New Capabilities
+
+_Nenhuma._ Nenhum skill novo entra no catálogo.
+
+### Modified Capabilities
+
+- `skills-authoring`: *Cross-skill references resolve in every install form* — a regra dos wrappers
+  Cursor/Copilot passa a cobrir também o link do próprio `SKILL.md`, com o cenário em que um wrapper
+  copiado sozinho aponta o `SKILL.md` pela URL do repositório.
+
+## Impact
+
+- `generate.sh` (só o bloco `# --- GitHub Copilot ---`, ~:192-200) e, por regeneração, os 36
+  `copilot/instructions/<name>.instructions.md`.
+- `install.sh`, `update.sh` — o bloco de pull vira uma chamada a `pull_ff_only`; cabeçalhos dizem de
+  onde o arquivo compartilhado é lido e o que acontece quando não existe.
+- `scripts/lib/git-sync.sh` (novo), `scripts/smoke-install-scripts.sh` (dois casos novos; a matriz
+  passa de 17 para 19).
+- Nenhum `SKILL.md` é tocado; a composição do catálogo (36 skills) fica idêntica. `README.md` não
+  está entre os arquivos deste item: a nota da linha 150 (*"the SKILL.md link still expects the
+  clone"*) fica desatualizada e é registrada como follow-up em `tasks.md` E.4.
+- `skills-catalog` não muda: o cenário *A diverged clone is refused with the recovery hint, by both
+  scripts* já exige a mesma mensagem nos dois; o arquivo compartilhado é **como** ela passa a ser a
+  mesma, e o caso novo do smoke test é a medida desse cenário, não um requisito novo.

--- a/openspec/changes/extend-install-form-links/specs/skills-authoring/spec.md
+++ b/openspec/changes/extend-install-form-links/specs/skills-authoring/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-skill references resolve in every install form
+
+A skill SHALL be written so that every path it cites resolves, or is recognisable as belonging to
+another skill, in every form the catalog is installed in: a full clone with symlinks, `npx skills
+add` (which copies one `skills/<name>/` directory), a category plugin group (which copies the skills
+of one group), and the Cursor and Copilot wrappers the README instructs users to copy alone.
+
+- A reference to another skill SHALL name that skill in prose and, when it points at a file, SHALL
+  use the repository-root form `skills/<skill>/references/<file>` and say that the file lives in that
+  skill. The form `<skill>/references/<file>` with no `skills/` prefix SHALL NOT be used: it
+  resolves in no install form, the clone included.
+- A path outside `skills/` — `research/`, `claude/global/hooks/`, any entry only a clone carries —
+  SHALL be written as the repository URL.
+- Every `*.md` under a skill's `references/` directory, recursively, SHALL be reachable from that
+  skill's `SKILL.md`: linked directly, or linked from a reference file that is itself reachable. A
+  `README.md` inside a `references/` subdirectory counts as an index once it is linked.
+- The generated Cursor and Copilot wrappers SHALL point at `references/` through the repository URL,
+  never through a path relative to the catalog tree; a wrapper that links its own `SKILL.md`
+  instead of inlining it (the Copilot wrapper) SHALL point at that file through the repository
+  URL as well, for the same reason.
+
+#### Scenario: Clone or symlink install
+
+- **WHEN** a skill installed from a clone (directly or through `~/.claude/skills/<name>` symlinks)
+  cites `skills/<other>/references/<file>`
+- **THEN** the path resolves from the repository root, because the symlink target lives inside the
+  clone, and the validator's path check (C1) verifies the file exists
+
+#### Scenario: npx skills install
+
+- **WHEN** `npx skills add` has copied only `skills/<name>/` and the skill cites a file of another
+  skill
+- **THEN** every path under the skill's own directory resolves, and the cross-skill path is
+  recognisable by its `skills/<other>/` prefix and by the sentence naming `<other>`, so the reader
+  installs that skill instead of following a dead relative path
+
+#### Scenario: Plugin group install
+
+- **WHEN** a skill in one plugin group cites a reference file of a skill that lives in another group
+- **THEN** the sentence names the skill to install and the path is written in the canonical form;
+  the path is not read as a promise that the file is present in this group
+
+#### Scenario: Cursor or Copilot copy
+
+- **WHEN** a `cursor/rules/<name>.mdc` or `copilot/instructions/<name>.instructions.md` is copied
+  alone into a project, as the README instructs
+- **THEN** every `references/` link inside it is a repository URL that resolves without the catalog
+  tree, and `generate.sh` produces that URL from the canonical `references/` link
+
+#### Scenario: A wrapper copied alone links its own SKILL.md by repository URL
+
+- **WHEN** a `copilot/instructions/<name>.instructions.md` is copied alone into a project's
+  `.github/instructions/`, as the README instructs, and the assistant follows its link to the
+  canonical `SKILL.md`
+- **THEN** that link is `https://github.com/solvelab/ai-skills/blob/master/skills/<name>/SKILL.md`,
+  which resolves without the catalog tree, and no generated Copilot wrapper carries a
+  `../../skills/` path
+
+#### Scenario: A path only a clone carries is written as a URL
+
+- **WHEN** a skill needs to point at something outside `skills/` — a research directory, a hook
+  shipped under `claude/global/`
+- **THEN** it writes the repository URL, and the validator reports a bare `research/…` or
+  `claude/…` path as an out-of-skill path (C12)
+
+#### Scenario: A reference file nobody links is caught
+
+- **WHEN** a `*.md` is added under `references/` and neither `SKILL.md` nor any reachable reference
+  links it
+- **THEN** the validator reports it as an orphan reference (C11), because a file nobody points at is
+  a file nobody loads

--- a/openspec/changes/extend-install-form-links/tasks.md
+++ b/openspec/changes/extend-install-form-links/tasks.md
@@ -108,10 +108,27 @@
 
 ## 2. generate.sh — link do SKILL.md por URL no wrapper Copilot (D1)
 
-- [ ] 2.1 `generate.sh:196` escreve `[SKILL.md](${REPO_BLOB_URL}/skills/${name}/SKILL.md)`; os 36
+- [x] 2.1 `generate.sh:199` escreve `[SKILL.md](${REPO_BLOB_URL}/skills/${name}/SKILL.md)`; os 36
       wrappers regenerados; segundo `bash generate.sh` sem diff; nenhum outro wrapper muda
-- [ ] 2.2 `grep -c '\.\./\.\./skills' copilot/instructions/*.md` → 0 em todos; `curl -sI` de um link
+
+      ```
+      bash generate.sh   -> Generated wrappers for 36 skills: … Generated 10 category plugins in plugins/
+      git status --porcelain --untracked-files=all | <dir> | uniq -c   -> 36 copilot/instructions, 1 generate.sh
+      bash generate.sh (2ª vez); git status --porcelain --untracked-files=all | wc -l   -> 37   (mesmos 37; nada novo)
+      git diff --stat | tail -1   -> 37 files changed, 40 insertions(+), 37 deletions(-)
+      ```
+
+- [x] 2.2 `grep -c '\.\./\.\./skills' copilot/instructions/*.md` → 0 em todos; `curl -sI` de um link
       regenerado → 200
+
+      ```
+      grep -c '\.\./\.\./skills' copilot/instructions/*.md | grep -vc ':0$'   -> 0   (36 arquivos, todos :0)
+      cat copilot/instructions/backlog.instructions.md
+      -> # backlog
+      -> Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/backlog/SKILL.md)
+      -> Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/backlog/references/)
+      curl -sI https://github.com/solvelab/ai-skills/blob/master/skills/execute-backlog/SKILL.md | head -1   -> HTTP/2 200
+      ```
 
 ## 3. Bloco de pull compartilhado (D2, D3)
 

--- a/openspec/changes/extend-install-form-links/tasks.md
+++ b/openspec/changes/extend-install-form-links/tasks.md
@@ -1,0 +1,164 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Caminhos locais abertos e lidos, com o commit em que foram lidos
+
+      Lidos em `e7f5fe8` (topo de `master`, 2026-09-06):
+
+      - `generate.sh:84-90` — comentário e as duas variáveis `REPO_BLOB_URL`/`REPO_TREE_URL`;
+        `:142-206` — o laço por skill; `:189` — `sed` do Cursor sobre `](references/`; `:192-200` —
+        bloco `# --- GitHub Copilot ---`, com `:196` escrevendo
+        `[SKILL.md](../../skills/${name}/SKILL.md)` e `:199` já usando `${REPO_TREE_URL}` para
+        `references/`; `:168` — Codex `@../../skills/${name}/SKILL.md` (include lido no lugar, fora
+        deste item).
+      - `install.sh` — 216 linhas; `:23-24` "the README runs this script via `curl | bash`";
+        `:173-187` — `if [ -d "$INSTALL_DIR" ]` → pull (`:178-183`), `else` → `git clone`; o bloco de
+        pull só roda sobre clone existente.
+      - `update.sh` — 104 linhas; `:20-21` mesma nota de `curl | bash`; `:46-49` exige
+        `$INSTALL_DIR/.git`; `:56-69` — `--force` → `reset --hard`, senão o bloco de pull
+        (`:63-68`), idêntico ao de `install.sh:178-183` linha a linha.
+      - `scripts/smoke-install-scripts.sh` — 310 linhas, 17 casos; `:103` clona de um bare feito do
+        `HEAD`; `:265-291` — casos 13 (`update.sh` divergido) e 14 (`install.sh` divergido), cada um
+        com `want_out` das frases, nenhum comparando as duas saídas; `:302-310` matriz.
+      - `scripts/` — sem subdiretório `lib/` (`ls scripts/lib` → *No such file or directory*).
+      - `scripts/validate-skills.py:488-534` — `CATALOG_ONLY_ROOTS` inclui `copilot/`;
+        `REPO_URL_PREFIX = "https://github.com/solvelab/ai-skills/"` e a recomendação
+        `blob/master/<path>` (C12); nenhum check lê o conteúdo de `copilot/instructions/`.
+      - `.github/workflows/ci.yml:175-179` — step *Distribution scripts smoke test* roda
+        `bash scripts/smoke-install-scripts.sh`.
+      - `README.md:113-119` (`curl … install.sh | bash`, `bash -s -- --tool …`), `:150-151` (nota
+        *"the SKILL.md link still expects the clone"* + `cp … .github/instructions/`), `:162-171`
+        (`curl … update.sh | bash`, `cd ~/ai-skills && ./update.sh [--force]`), `:195` (`install.sh`
+        / `update.sh` seguem *Latest `master`*).
+      - `openspec/specs/skills-authoring/spec.md:639-698` — requisito modificado; `:655-656` a regra
+        só de `references/`; `:679-684` cenário *Cursor or Copilot copy*.
+      - `openspec/specs/skills-catalog/spec.md:1266-1339` — *Distribution scripts refuse what they
+        cannot honor*; cenário *A diverged clone is refused with the recovery hint, by both scripts*.
+      - `openspec/changes/archive/2026-09-05-define-cross-skill-references/proposal.md` (R5 só
+        converteu `references/`), `…/2026-09-04-harden-distribution-scripts/tasks.md:100-110` (E.4:
+        "não há de onde carregar um arquivo comum"), `…/2026-09-04-close-ci-gate-holes/*` (modelo).
+      - `openspec/schemas/skills-rite/{schema.yaml,templates/*.md}`, `openspec/config.yaml`.
+
+- [x] E.2 Ferramentas e comportamentos probados contra a versão instalada
+
+      ```
+      openspec --version   -> 1.6.0
+      gh --version         -> gh version 2.98.0 (2026-08-20)
+      git --version        -> git version 2.47.3
+      ls skills | wc -l    -> 36
+      ls copilot/instructions | wc -l -> 36
+      grep -c '\.\./\.\./skills' copilot/instructions/*.md | awk -F: '{s+=$2} END {print s}'   -> 36
+      cat copilot/instructions/backlog.instructions.md
+      -> Follow the instructions in [SKILL.md](../../skills/backlog/SKILL.md)
+      -> Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/backlog/references/)
+      ```
+
+      ```
+      curl -sI https://github.com/solvelab/ai-skills/blob/master/skills/backlog/SKILL.md | head -1
+      -> HTTP/2 200
+      -> date: Sun, 06 Sep 2026 05:41:59 GMT   x-github-request-id: A7DD:D301E:1863940:1D3030E:6A9CFD27
+      ```
+
+      ```
+      bash scripts/smoke-install-scripts.sh          (baseline, e7f5fe8, antes de qualquer edição)
+      -> smoke: origin=… head=e7f5fe8 skills=36
+      -> smoke: 17/17 cases passed — refusals that had to fire: 6/6, paths that had to succeed: 11/11
+      ```
+
+      ```
+      bash -c 'set -u; echo "BASH_SOURCE=[${BASH_SOURCE[0]:-}] dollar0=[$0]"'
+      -> BASH_SOURCE=[] dollar0=[bash]        (script que não vem de arquivo: sem diretório do script)
+      ```
+
+      ```
+      openspec new change extend-install-form-links --schema skills-rite
+      -> Created change 'extend-install-form-links' at openspec/changes/extend-install-form-links/
+      -> (só .openspec.yaml; artefatos escritos a partir de openspec/schemas/skills-rite/templates/)
+      openspec validate extend-install-form-links --strict
+      -> Change 'extend-install-form-links' is valid
+      ```
+
+- [x] E.3 O que não pôde ser probado
+
+      - `curl … | bash` de verdade (README 113-119, 162) não foi executado: o sandbox desta sessão
+        recusa `bash` lendo script de stdin. O análogo probado é `bash -c` (E.2): `BASH_SOURCE[0]`
+        vazio quando o script não vem de arquivo, que é o que sustenta D2 (ler o arquivo compartilhado
+        do clone, não da pasta do script). O smoke test roda `bash "$ROOT/install.sh"`, por arquivo.
+      - O comportamento sobre um clone **realmente** anterior a esta versão (instalado de uma release
+        publicada) não foi medido; o smoke test simula o estado apagando `scripts/lib/git-sync.sh` do
+        clone (caso 16), que é observacionalmente o mesmo para o guard de D3.
+      - O que o GitHub Copilot faz ao seguir uma URL num `.instructions.md` não foi observado; a
+        issue fixa o escopo em "só o link", e o cenário do spec afirma que a URL resolve (200), não o
+        que o assistente faz com ela.
+
+- [x] E.4 Checagem de escopo
+
+      A change faz o que a issue #173 pediu e nada além. Notados pelo caminho e **não** feitos, como
+      follow-up:
+
+      - `README.md:150` — a nota *"(references/ resolve through the same repository URL; the SKILL.md
+        link still expects the clone)"* fica desatualizada depois desta change; `README.md` não está
+        entre os arquivos do item. A árvore em `README.md:466-472` e a tabela de `scripts/` em `:490`
+        também não citam `scripts/lib/git-sync.sh`.
+      - `generate.sh:10-11` e `:84-88` (cabeçalho e comentário fora do bloco do Copilot) ainda dizem
+        que só `references/` aponta para o repositório; o item entrega só o bloco do Copilot.
+      - `codex/skills/<name>/AGENTS.md` usa `@../../skills/…` — include lido no lugar, não copiado; a
+        issue não o cita.
+      - `install.sh` e `update.sh` ainda duplicam a checagem de `git` instalado e o guard de D3
+        (quatro linhas); a issue pede o bloco de pull.
+
+## 2. generate.sh — link do SKILL.md por URL no wrapper Copilot (D1)
+
+- [ ] 2.1 `generate.sh:196` escreve `[SKILL.md](${REPO_BLOB_URL}/skills/${name}/SKILL.md)`; os 36
+      wrappers regenerados; segundo `bash generate.sh` sem diff; nenhum outro wrapper muda
+- [ ] 2.2 `grep -c '\.\./\.\./skills' copilot/instructions/*.md` → 0 em todos; `curl -sI` de um link
+      regenerado → 200
+
+## 3. Bloco de pull compartilhado (D2, D3)
+
+- [ ] 3.1 `scripts/lib/git-sync.sh` com `pull_ff_only <dir>`: o pull `--ff-only` com
+      `advice.diverging=false`, a mensagem de divergência, a dica de `--force` e o `git:` indentado —
+      texto byte a byte igual ao que os dois scripts imprimiam
+- [ ] 3.2 `install.sh` (re-run sobre clone) e `update.sh` (sem `--force`) carregam
+      `$INSTALL_DIR/scripts/lib/git-sync.sh` e chamam `pull_ff_only "$INSTALL_DIR" || exit 1`;
+      arquivo ausente → recusa própria com `cd ~/ai-skills && ./update.sh`; cabeçalhos atualizados
+- [ ] 3.3 `diff` das mensagens de divergência entre `install.sh` e `update.sh` vazio (o bloco literal
+      não existe mais em nenhum dos dois)
+
+## 4. Smoke test (D4)
+
+- [ ] 4.1 Caso novo: o bloco `Fast-forward failed … git:` recortado das saídas dos casos 13 e 14 é
+      byte a byte igual e tem três linhas
+- [ ] 4.2 Caso novo: clone sem `scripts/lib/git-sync.sh` → `install.sh` e `update.sh` recusam com a
+      dica, `HEAD` intocado; fixture restaurada
+- [ ] 4.3 Os 17 casos anteriores continuam verdes com as mesmas expectativas; cabeçalho declara que o
+      arquivo compartilhado é lido do clone (`HEAD`), não da árvore de trabalho
+
+## 5. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 O artefato foi exercitado pelo caminho real — `bash scripts/smoke-install-scripts.sh`, como
+      o CI o invoca — com a saída observada registrada; um wrapper Copilot regenerado citado; a linha
+      de status do `curl`
+- [ ] S.2 Matriz de casos medida, em contagens: o que tinha de disparar e disparou, o que tinha de
+      ficar mudo e ficou, escapes conhecidos que ficaram mudos
+- [ ] S.3 O que escapou ou se comportou diferente do esperado é nomeado aqui — ou fica dito que nada
+      escapou
+
+## 6. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica se nenhuma skill for tocada
+      (medir com `git diff --name-only master...HEAD | grep -c '^skills/'`)
+- [ ] Q.2 Conteúdo de skill tocado em inglês — não se aplica; o delta de spec e os cabeçalhos dos
+      scripts são em inglês
+- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição muda
+- [ ] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md`; nenhuma skill editada
+- [ ] Q.5 Identificadores em inglês no que a change introduz — `pull_ff_only`, `SYNC_LIB`,
+      `git-sync.sh`, nomes dos casos do smoke (`code-locale`), medido com o detector sobre o diff
+
+## 7. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate extend-install-form-links --strict` verde e `scripts/validate-rite.sh`
+      verde com `Spec-rite: extend-install-form-links`
+- [ ] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 36 skills
+- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
+      não muda; a nota do README (linha 150) é follow-up (E.4)
+- [ ] V.4 `openspec archive extend-install-form-links --yes` em PR separado, depois do merge

--- a/openspec/changes/extend-install-form-links/tasks.md
+++ b/openspec/changes/extend-install-form-links/tasks.md
@@ -132,50 +132,214 @@
 
 ## 3. Bloco de pull compartilhado (D2, D3)
 
-- [ ] 3.1 `scripts/lib/git-sync.sh` com `pull_ff_only <dir>`: o pull `--ff-only` com
+- [x] 3.1 `scripts/lib/git-sync.sh` com `pull_ff_only <dir>`: o pull `--ff-only` com
       `advice.diverging=false`, a mensagem de divergência, a dica de `--force` e o `git:` indentado —
       texto byte a byte igual ao que os dois scripts imprimiam
-- [ ] 3.2 `install.sh` (re-run sobre clone) e `update.sh` (sem `--force`) carregam
+
+      Em `fac8b54` (2026-09-06); os casos 13 e 14 do smoke continuam afirmando as mesmas frases
+      (`Fast-forward failed`, `./update.sh --force`, `git: fatal: Not possible to fast-forward`,
+      sem `hint:`, mensagem própria antes do `fatal:`) e passam sem alteração de expectativa:
+
+      ```
+      grep -n 'Fast-forward failed\|update.sh --force\|git: %s' install.sh update.sh scripts/lib/git-sync.sh
+      -> scripts/lib/git-sync.sh:27:        echo "  ❌ Fast-forward failed — local changes diverge from origin."
+      -> scripts/lib/git-sync.sh:28:        echo "     Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force"
+      -> scripts/lib/git-sync.sh:29:        [ -z "$pull_err" ] || printf '     git: %s\n' "$pull_err"
+      -> update.sh:7 e :87 — só o texto de uso e a dica da regeneração pulada, não o bloco de pull
+      bash -n install.sh && bash -n update.sh && bash -n scripts/lib/git-sync.sh   -> syntax ok
+      ```
+
+- [x] 3.2 `install.sh` (re-run sobre clone) e `update.sh` (sem `--force`) carregam
       `$INSTALL_DIR/scripts/lib/git-sync.sh` e chamam `pull_ff_only "$INSTALL_DIR" || exit 1`;
       arquivo ausente → recusa própria com `cd ~/ai-skills && ./update.sh`; cabeçalhos atualizados
-- [ ] 3.3 `diff` das mensagens de divergência entre `install.sh` e `update.sh` vazio (o bloco literal
+
+      ```
+      sed -n '/SYNC_LIB=/,/pull_ff_only/p' install.sh > a; … update.sh > b; diff a b
+      -> loader blocks identical (diff empty), 8 lines
+      bash scripts/smoke-install-scripts.sh   (fac8b54)
+      -> PASS  [refuse] install + update: clone without scripts/lib/git-sync.sh (exit 1 with hint)
+      ```
+
+- [x] 3.3 `diff` das mensagens de divergência entre `install.sh` e `update.sh` vazio (o bloco literal
       não existe mais em nenhum dos dois)
+
+      ```
+      grep -c 'Fast-forward failed' install.sh update.sh scripts/lib/git-sync.sh
+      -> install.sh:0   update.sh:0   scripts/lib/git-sync.sh:1
+      bash scripts/smoke-install-scripts.sh
+      -> PASS  [refuse] install + update: divergence message byte-identical from both scripts
+      ```
 
 ## 4. Smoke test (D4)
 
-- [ ] 4.1 Caso novo: o bloco `Fast-forward failed … git:` recortado das saídas dos casos 13 e 14 é
+- [x] 4.1 Caso novo: o bloco `Fast-forward failed … git:` recortado das saídas dos casos 13 e 14 é
       byte a byte igual e tem três linhas
-- [ ] 4.2 Caso novo: clone sem `scripts/lib/git-sync.sh` → `install.sh` e `update.sh` recusam com a
+
+      Caso 14b (`scripts/smoke-install-scripts.sh`, depois do caso 14): `divergence_block()` =
+      `sed -n '/Fast-forward failed/,/^     git: /p'` sobre `UPDATE_DIVERGED_OUT` e
+      `INSTALL_DIVERGED_OUT`; três `want`: 3 linhas em cada, `test "$a" = "$b"`. Provado que reprova:
+      `install.sh` mutado na árvore de trabalho (sem o guard do arquivo e com um bloco próprio de
+      divergência com outra dica) e o smoke rodado de novo:
+
+      ```
+      bash scripts/smoke-install-scripts.sh   (install.sh mutado, não commitado)
+      -> FAIL  [refuse] install + update: divergence message byte-identical from both scripts
+      ->         - install.sh block is three lines (message, hint, git detail)
+      ->         - the two blocks are byte-identical
+      -> smoke: 17/19 cases passed — refusals that had to fire: 6/8, paths that had to succeed: 11/11
+      cp install.sh.bak install.sh; git status --porcelain | wc -l   -> 0
+      ```
+
+- [x] 4.2 Caso novo: clone sem `scripts/lib/git-sync.sh` → `install.sh` e `update.sh` recusam com a
       dica, `HEAD` intocado; fixture restaurada
-- [ ] 4.3 Os 17 casos anteriores continuam verdes com as mesmas expectativas; cabeçalho declara que o
+
+      Caso 16 (depois do caso 15): `rm "$INSTALL/scripts/lib/git-sync.sh"`, os dois scripts com
+      `want_rc 1`, `want_out "scripts/lib/git-sync.sh not found"`, `want_out "cd ~/ai-skills &&
+      ./update.sh"`, `want_no_out "No such file or directory"`, `HEAD` igual antes/depois; restaurado
+      com `git checkout -- scripts/lib/git-sync.sh`. Na mesma rodada mutada de 4.1 (guard removido):
+
+      ```
+      -> FAIL  [refuse] install + update: clone without scripts/lib/git-sync.sh (exit 1 with hint)
+      ->         - output lacks: scripts/lib/git-sync.sh not found
+      ->         - output lacks: cd ~/ai-skills && ./update.sh
+      ->         - output must not contain: No such file or directory
+      ```
+
+- [x] 4.3 Os 17 casos anteriores continuam verdes com as mesmas expectativas; cabeçalho declara que o
       arquivo compartilhado é lido do clone (`HEAD`), não da árvore de trabalho
+
+      Nenhum `want*` dos casos 1-15 foi editado (diff do arquivo: cabeçalho, duas capturas de `$OUT`,
+      os casos 14b e 16). Baseline em `e7f5fe8`: 17/17 (E.2); em `fac8b54`:
+
+      ```
+      bash scripts/smoke-install-scripts.sh
+      -> smoke: origin=… head=fac8b54 skills=36
+      -> PASS ×19
+      -> smoke: 19/19 cases passed — refusals that had to fire: 8/8, paths that had to succeed: 11/11
+      sed -n 27,31p scripts/smoke-install-scripts.sh
+      -> # output, which the "Wrappers in sync" CI step guarantees for the same HEAD. The shared pull block
+      -> # (scripts/lib/git-sync.sh) is read by both scripts from the CLONE, i.e. from this checkout's HEAD:
+      ```
 
 ## 5. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 O artefato foi exercitado pelo caminho real — `bash scripts/smoke-install-scripts.sh`, como
+- [x] S.1 O artefato foi exercitado pelo caminho real — `bash scripts/smoke-install-scripts.sh`, como
       o CI o invoca — com a saída observada registrada; um wrapper Copilot regenerado citado; a linha
       de status do `curl`
-- [ ] S.2 Matriz de casos medida, em contagens: o que tinha de disparar e disparou, o que tinha de
-      ficar mudo e ficou, escapes conhecidos que ficaram mudos
-- [ ] S.3 O que escapou ou se comportou diferente do esperado é nomeado aqui — ou fica dito que nada
-      escapou
+
+      Tudo em `fac8b54` (2026-09-06), no worktree, tree limpo antes e depois (`git status --porcelain
+      | wc -l -> 0`). O smoke test é o ponto de entrada que `.github/workflows/ci.yml:179` invoca:
+
+      ```
+      bash scripts/smoke-install-scripts.sh
+      -> smoke: origin=/tmp/ai-skills-smoke.hRHQ1t/origin.git head=fac8b54 skills=36
+      -> PASS  [accept] install: default (claude symlinks)
+      -> PASS  [accept] install: idempotent re-run (0 linked / 36 up to date)
+      -> … (casos 3-13 PASS, texto idêntico ao baseline de e7f5fe8)
+      -> PASS  [refuse] update: diverged, no --force (exit 1 with hint)
+      -> PASS  [refuse] install: re-run over a diverged clone (exit 1 with hint)
+      -> PASS  [refuse] install + update: divergence message byte-identical from both scripts
+      -> PASS  [accept] update: diverged, --force (reset to origin)
+      -> PASS  [refuse] install + update: clone without scripts/lib/git-sync.sh (exit 1 with hint)
+      -> smoke: 19/19 cases passed — refusals that had to fire: 8/8, paths that had to succeed: 11/11
+      ```
+
+      O caso 2 (re-run idempotente) e o 14 (re-run divergido) são `install.sh` carregando
+      `pull_ff_only` do clone; o 9-11 e o 13 são `update.sh` fazendo o mesmo — nenhum deles mudou de
+      expectativa.
+
+      Wrapper regenerado, pelo caminho do usuário (`cat` do arquivo que o README manda copiar):
+
+      ```
+      cat copilot/instructions/backlog.instructions.md
+      -> # backlog
+      ->
+      -> Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/backlog/SKILL.md)
+      ->
+      -> Reference files: [references/](https://github.com/solvelab/ai-skills/tree/master/skills/backlog/references/)
+      curl -sI https://github.com/solvelab/ai-skills/blob/master/skills/execute-backlog/SKILL.md | head -1
+      -> HTTP/2 200
+      ```
+
+      O runner completo (`generate.sh` + tree limpo, versão, frontmatter, validate-skills e selftest,
+      detectores de locale e hooks, scan-secrets e selftest, higiene e selftest, rite com
+      `Spec-rite: extend-install-form-links`, evidence/spec-rite selftests, smoke, plugin validate,
+      `openspec validate --strict`): 20 linhas `PASS`, `dirty-after: 0`.
+
+- [x] S.2 Matriz de casos medida, em contagens
+
+      | Expectativa | Casos | Resultado |
+      |---|---|---|
+      | Tinha de disparar e disparou | 8/8 | recusas do smoke em `fac8b54`: `--tool bogus` (1), `--tool` sem valor (1), bogus sobre clone (1), generate.sh falhando (1), update divergido (1), install divergido (1), mensagem byte-idêntica (1), clone sem `git-sync.sh` (1) |
+      | Tinha de ficar mudo e ficou | 11/11 | caminhos de sucesso do smoke (install ×5, update ×6), idênticos ao baseline 11/11 de `e7f5fe8` |
+      | Versão antiga passou onde a nova falha | 2/2 | `install.sh` mutado (bloco próprio de divergência, sem guard do arquivo): 17/19, os dois casos novos `FAIL` e só eles |
+      | Link relativo restante | 0/36 | `grep -c '\.\./\.\./skills' copilot/instructions/*.md` → todos `:0` |
+      | URL responde | 2/2 | `backlog` (E.2) e `execute-backlog` (2.2): `HTTP/2 200` |
+      | Escape conhecido ficou mudo | 1/1 | o guard de D3 existe em dois lugares (loader de 8 linhas idêntico nos dois scripts, medido em 3.2); nenhum caso do smoke compara os dois loaders — o caso 16 prova cada um separadamente |
+
+- [x] S.3 O que escapou ou se comportou diferente do esperado
+
+      - Na rodada mutada (4.1), o caso 14b reprovou com **duas** asserções, não uma: o `install.sh`
+        mutado imprimiu o bloco do `pull_ff_only` (stdout) **e** o bloco próprio, então o recorte do
+        `sed` devolveu seis linhas e "three lines" caiu junto com "byte-identical". Esperado era só a
+        segunda; a primeira é redundante mas correta, e fica — é o guard contra dois recortes vazios.
+      - `curl … | bash` real não foi executado (E.3); o análogo `bash -c` mostra `BASH_SOURCE`
+        vazio, que é o fato que D2 usa. O CI roda o smoke por arquivo, como aqui.
+      - Um clone anterior a esta versão re-executando `install.sh`/`update.sh` por `curl` passa a
+        ser recusado com a dica (caso 16), onde antes fazia o pull — mudança de comportamento fora
+        dos 17 casos medidos, declarada em `design.md` D3 e Risks, transitória por construção.
+      - O loader de D3 (checagem `[ -f ]` + duas linhas de mensagem) fica duplicado nos dois
+        scripts, por necessidade: não há de onde carregar o guard que verifica se há de onde carregar.
+        É a única duplicação que a change deixa; registrada em E.4.
 
 ## 6. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — não se aplica se nenhuma skill for tocada
-      (medir com `git diff --name-only master...HEAD | grep -c '^skills/'`)
-- [ ] Q.2 Conteúdo de skill tocado em inglês — não se aplica; o delta de spec e os cabeçalhos dos
-      scripts são em inglês
-- [ ] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição muda
-- [ ] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md`; nenhuma skill editada
-- [ ] Q.5 Identificadores em inglês no que a change introduz — `pull_ff_only`, `SYNC_LIB`,
-      `git-sync.sh`, nomes dos casos do smoke (`code-locale`), medido com o detector sobre o diff
+- [x] Q.1 Frontmatter uniforme em todo `SKILL.md` tocado — **não se aplica**: nenhuma skill é tocada
+      (`git diff --name-only master...HEAD` → 36 `copilot/instructions/*`, `generate.sh`,
+      `install.sh`, `update.sh`, `scripts/lib/git-sync.sh`, `scripts/smoke-install-scripts.sh` e os
+      cinco arquivos da change; nenhum caminho sob `skills/`); o gate de versão confirma:
+      `validate-skill-version.py` → `0 findings (base origin/master, 0 skill(s) changed, 0 with
+      content changes)`
+- [x] Q.2 Conteúdo de skill tocado em inglês — não se aplica; o delta de spec, `git-sync.sh` e os
+      cabeçalhos dos scripts estão em inglês, como o catálogo exige
+- [x] Q.3 Gatilhos de descrição testáveis — não se aplica: nenhuma descrição de skill muda
+- [x] Q.4 Sem doutrina duplicada: ver a tabela de Canonical Home em `design.md` (cinco linhas, todas
+      *already canonical*); nenhuma skill editada; o texto da mensagem de divergência existe uma vez
+      (3.3)
+- [x] Q.5 Identificadores em inglês no que a change introduz — `pull_ff_only`, `pull_err`, `SYNC_LIB`,
+      `git-sync.sh`, `divergence_block`, `UPDATE_DIVERGED_OUT`/`INSTALL_DIVERGED_OUT`,
+      `UPDATE_MSG`/`INSTALL_MSG`, nomes dos casos (`code-locale`)
+
+      ```
+      git diff master...HEAD -- install.sh update.sh scripts generate.sh > diff173.patch   (215 linhas)
+      python3 skills/code-locale/references/check-identifier-locale.py --diff - < diff173.patch
+      -> findings: 0
+      ```
 
 ## 7. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate extend-install-form-links --strict` verde e `scripts/validate-rite.sh`
+- [x] V.1 `openspec validate extend-install-form-links --strict` verde e `scripts/validate-rite.sh`
       verde com `Spec-rite: extend-install-form-links`
-- [ ] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 36 skills
-- [ ] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
-      não muda; a nota do README (linha 150) é follow-up (E.4)
+
+      ```
+      openspec validate extend-install-form-links --strict   -> Change 'extend-install-form-links' is valid   (openspec 1.6.0)
+      printf '{"pull_request":{"body":"Closes #173\n\nSpec-rite: extend-install-form-links\n"}}' > event173.json
+      GITHUB_EVENT_PATH=event173.json bash scripts/validate-rite.sh
+      -> Totals: 3 passed, 0 failed (3 items)
+      -> rite gate OK
+      ```
+
+- [x] V.2 Descoberta do catálogo intacta: `python3 scripts/validate-skills.py` verde, 36 skills
+
+      ```
+      python3 scripts/validate-skills.py   -> skills checked: 36   findings: 0
+      ls skills | wc -l                    -> 36
+      python3 scripts/validate-repo-hygiene.py   -> repo hygiene: 0 findings
+      claude plugin validate . --strict          -> ✔ Validation passed
+      ```
+
+- [x] V.3 README / docs atualizados onde a change altera composição ou uso do catálogo — a composição
+      não muda; `README.md` não está entre os arquivos do item, e a nota da linha 150 (*"the SKILL.md
+      link still expects the clone"*) fica desatualizada: follow-up registrado em E.4 e como *Known
+      gap* no PR
 - [ ] V.4 `openspec archive extend-install-form-links --yes` em PR separado, depois do merge

--- a/scripts/lib/git-sync.sh
+++ b/scripts/lib/git-sync.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# git-sync.sh — the fast-forward pull install.sh and update.sh share. Sourced, never executed.
+#
+# Both scripts used to carry this block verbatim, and a fix in one did not reach the other: issue
+# #113 found install.sh dying on git's raw `fatal: Need to specify how to reconcile divergent
+# branches` while update.sh already explained the divergence and how to recover. One function, one
+# message (issue #173). scripts/smoke-install-scripts.sh asserts the two scripts print it
+# byte-identically.
+#
+# WHERE IT IS READ FROM: both scripts are documented as `curl … | bash`, where there is no script
+# directory to source a sibling from — but the pull only ever runs over an existing clone in
+# ~/ai-skills, and that clone carries this file. So each script sources
+# `$INSTALL_DIR/scripts/lib/git-sync.sh`, the clone it is about to sync. A clone that predates this
+# file is refused by the caller with the hint to run the update.sh that clone carries, once.
+#
+# WHAT IT DOES NOT COVER: the working tree. A fast-forward that touches a locally modified file fails
+# on git's side, and that failure is reported under the divergence message like any other pull
+# failure — including a network failure, whose `fatal:` line is the only useful detail and is why
+# git's output is kept.
+
+# pull_ff_only <dir>: fast-forward <dir> to its upstream. Returns 1 after printing the divergence
+# message when git refuses. advice.diverging=false drops git's nine `hint:` lines; the `fatal:` line
+# is kept as an indented detail.
+pull_ff_only() {
+    local dir="$1" pull_err
+    if ! pull_err="$(git -C "$dir" -c advice.diverging=false pull --ff-only --quiet 2>&1)"; then
+        echo "  ❌ Fast-forward failed — local changes diverge from origin."
+        echo "     Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force"
+        [ -z "$pull_err" ] || printf '     git: %s\n' "$pull_err"
+        return 1
+    fi
+}

--- a/scripts/smoke-install-scripts.sh
+++ b/scripts/smoke-install-scripts.sh
@@ -25,7 +25,10 @@
 # the guard's own declared blind spots — untracked files under skills/ and edits outside
 # VERSION/skills/ — are exercised only in the direction the scripts promise (regeneration runs),
 # not judged. The "update clean" case also requires the committed wrappers to match generate.sh's
-# output, which the "Wrappers in sync" CI step guarantees for the same HEAD.
+# output, which the "Wrappers in sync" CI step guarantees for the same HEAD. The shared pull block
+# (scripts/lib/git-sync.sh) is read by both scripts from the CLONE, i.e. from this checkout's HEAD:
+# an uncommitted edit to that file is not what the cases exercise, the same way case 9 runs the
+# clone's generate.sh.
 #
 # Usage: bash scripts/smoke-install-scripts.sh   (from anywhere; CI runs it on every PR)
 set -euo pipefail
@@ -278,6 +281,7 @@ want "own message precedes git's fatal line" \
     test "$(grep -nF 'Fast-forward failed' <<<"$OUT" | head -1 | cut -d: -f1)" -lt "$(grep -nF 'fatal:' <<<"$OUT" | head -1 | cut -d: -f1)"
 want "HEAD unchanged" test "$(head_of "$INSTALL")" = "$LOCAL"
 finish refuse "update: diverged, no --force (exit 1 with hint)"
+UPDATE_DIVERGED_OUT="$OUT"
 
 # ── 14. divergence: install.sh re-run gives the same refusal ──────────────
 run "$H1" bash "$ROOT/install.sh"
@@ -289,6 +293,23 @@ want_no_out "hint:"
 want_no_out "Configuring for"
 want "HEAD unchanged" test "$(head_of "$INSTALL")" = "$LOCAL"
 finish refuse "install: re-run over a diverged clone (exit 1 with hint)"
+INSTALL_DIVERGED_OUT="$OUT"
+
+# ── 14b. one divergence message, not two copies ──────────────────────────
+# Cases 13 and 14 assert that each script prints the phrases; neither compares the two outputs. The
+# block used to be duplicated in both scripts, and a fix in one did not reach the other (issue #113
+# found install.sh raw while update.sh explained). Since issue #173 it is one function in
+# scripts/lib/git-sync.sh; this case measures the equality instead of assuming it. The block is cut
+# from "Fast-forward failed" through the indented `git:` line, and its size is asserted so that two
+# empty cuts cannot pass as equal.
+divergence_block() { sed -n '/Fast-forward failed/,/^     git: /p' <<<"$1"; }
+UPDATE_MSG="$(divergence_block "$UPDATE_DIVERGED_OUT")"
+INSTALL_MSG="$(divergence_block "$INSTALL_DIVERGED_OUT")"
+OUT="$(printf 'update.sh:\n%s\ninstall.sh:\n%s\n' "$UPDATE_MSG" "$INSTALL_MSG")"
+want "update.sh block is three lines (message, hint, git detail)" test "$(wc -l <<<"$UPDATE_MSG" | tr -d ' ')" = 3
+want "install.sh block is three lines (message, hint, git detail)" test "$(wc -l <<<"$INSTALL_MSG" | tr -d ' ')" = 3
+want "the two blocks are byte-identical" test "$UPDATE_MSG" = "$INSTALL_MSG"
+finish refuse "install + update: divergence message byte-identical from both scripts"
 
 # ── 15. divergence: update --force resets to origin ───────────────────────
 run "$H1" bash "$ROOT/update.sh" --force
@@ -298,6 +319,31 @@ want_out "Wrappers regenerated"
 want "HEAD is origin/master" test "$(head_of "$INSTALL")" = "$(head_of "$AUTHOR")"
 want "local commit's file is gone" test ! -e "$INSTALL/smoke-local-note.txt"
 finish accept "update: diverged, --force (reset to origin)"
+
+# ── 16. a clone without the shared pull block: refused with the hint, by both ─
+# A clone installed before scripts/lib/git-sync.sh existed has no file to source. Both scripts
+# must say so in their own words and point at the update.sh that clone carries, instead of dying
+# on bash's `No such file or directory` under set -e. --force is not exercised here on purpose: it
+# does not read the file, so an old clone stays resettable. HEAD must not move.
+rm "$INSTALL/scripts/lib/git-sync.sh"
+BEFORE="$(head_of "$INSTALL")"
+run "$H1" bash "$ROOT/install.sh"
+want_rc 1
+want_out "scripts/lib/git-sync.sh not found"
+want_out "cd ~/ai-skills && ./update.sh"
+want_no_out "No such file or directory"
+want_no_out "Configuring for"
+INSTALL_OUT="$OUT"
+run "$H1" bash "$ROOT/update.sh"
+want_rc 1
+want_out "scripts/lib/git-sync.sh not found"
+want_out "cd ~/ai-skills && ./update.sh"
+want_no_out "No such file or directory"
+want_no_out "Wrappers regenerated"
+want "HEAD unchanged (no pull ran)" test "$(head_of "$INSTALL")" = "$BEFORE"
+OUT="$(printf 'install.sh:\n%s\nupdate.sh:\n%s\n' "$INSTALL_OUT" "$OUT")"
+finish refuse "install + update: clone without scripts/lib/git-sync.sh (exit 1 with hint)"
+git -C "$INSTALL" checkout -q -- scripts/lib/git-sync.sh
 
 # ── matrix ────────────────────────────────────────────────────────────────
 total=$((refused_total + accepted_total))

--- a/update.sh
+++ b/update.sh
@@ -19,6 +19,11 @@
 # that ran is proof that those two paths were clean in the index, nothing more.
 # There is no interactive prompt on purpose: the README runs this script via `curl | bash`, where
 # stdin is the script itself.
+#
+# The fast-forward pull and its divergence message are shared with install.sh: scripts/lib/git-sync.sh,
+# sourced from the clone itself, because under `curl | bash` the clone is the only place both scripts
+# can read it from. A clone that predates that file is refused with the hint to run the update.sh it
+# carries, once; `--force` never needs the file.
 set -euo pipefail
 
 INSTALL_DIR="$HOME/ai-skills"
@@ -58,14 +63,16 @@ if [ "$FORCE" -eq 1 ]; then
     echo "  ⚠️  --force: discarding local changes, resetting to $UPSTREAM"
     git -C "$INSTALL_DIR" reset --hard "$UPSTREAM" --quiet
 else
-    # advice.diverging=false drops git's nine `hint:` lines; the `fatal:` line is kept as an
-    # indented detail because on a network failure it is the only useful information.
-    if ! PULL_ERR="$(git -C "$INSTALL_DIR" -c advice.diverging=false pull --ff-only --quiet 2>&1)"; then
-        echo "  ❌ Fast-forward failed — local changes diverge from origin."
-        echo "     Re-run with --force to discard them: cd ~/ai-skills && ./update.sh --force"
-        [ -z "$PULL_ERR" ] || printf '     git: %s\n' "$PULL_ERR"
+    # The pull block is shared with install.sh and read from the clone it is about to sync (see the
+    # header). --force does not need it: a clone older than that file must still be resettable.
+    SYNC_LIB="$INSTALL_DIR/scripts/lib/git-sync.sh"
+    if [ ! -f "$SYNC_LIB" ]; then
+        echo "  ❌ $SYNC_LIB not found — this clone predates it."
+        echo "     Bring it forward once with the updater it carries: cd ~/ai-skills && ./update.sh"
         exit 1
     fi
+    . "$SYNC_LIB"
+    pull_ff_only "$INSTALL_DIR" || exit 1
 fi
 
 AFTER=$(git -C "$INSTALL_DIR" rev-parse HEAD)


### PR DESCRIPTION
Closes #173

## Contexto

Dois follow-ups de distribuição anotados em E.4 de #121 e #113, lidos em `e7f5fe8`: (1) `generate.sh:196` escrevia no wrapper Copilot `[SKILL.md](../../skills/<name>/SKILL.md)`, e o README manda copiar `copilot/instructions/*.instructions.md` sozinho para `.github/instructions/`, onde o link relativo morre — R5 de #121 converteu só `references/`; medido: 36 wrappers, 36 links relativos. (2) `install.sh:176-183` e `update.sh:61-68` carregavam duas cópias do bloco de `pull --ff-only` + mensagem de divergência + dica de `--force`; foi assim que #113 achou o `install.sh` cru enquanto o `update.sh` já explicava. O E.4 de #113 desistiu de compartilhar porque "os dois rodam via `curl | bash`" — mas o bloco de pull só roda **sobre um clone que já existe** em `~/ai-skills`, e esse clone carrega `scripts/`.

## O que muda

- `generate.sh` (só o bloco `# --- GitHub Copilot ---`): o link do `SKILL.md` usa `${REPO_BLOB_URL}` — `https://github.com/solvelab/ai-skills/blob/master/skills/<name>/SKILL.md`, a mesma forma já usada para `references/`. Os 36 `copilot/instructions/*.md` regenerados; segundo `bash generate.sh` sem diff; `claude/`, `codex/`, `cursor/`, `plugins/` intocados. Escolhido `blob/master` e não a tag corrente: `generate.sh` roda no commit de release **antes** de a tag existir (design.md D1).
- `scripts/lib/git-sync.sh` (novo): `pull_ff_only <dir>` — o pull `--ff-only` com `advice.diverging=false`, a mensagem *Fast-forward failed*, a dica `./update.sh --force` e o `fatal:` do git indentado, uma vez. `install.sh` (re-run sobre clone) e `update.sh` (sem `--force`) carregam `$INSTALL_DIR/scripts/lib/git-sync.sh` — o clone que vão sincronizar, o único caminho que os dois conhecem sob `curl | bash` (`BASH_SOURCE[0]` vazio, probado). Clone anterior ao arquivo: recusa própria com `cd ~/ai-skills && ./update.sh` (o updater que esse clone carrega ainda tem o bloco inline); `--force` não lê o arquivo.
- `scripts/smoke-install-scripts.sh`: 17 casos intactos + caso 14b (o bloco `Fast-forward failed … git:` recortado das saídas reais dos casos 13 e 14 é byte a byte igual e tem três linhas) + caso 16 (clone sem o arquivo → os dois scripts recusam com a dica, `HEAD` intocado). Cabeçalho declara que o arquivo compartilhado é lido do `HEAD` commitado, como já vale para `generate.sh` no caso 9.
- Spec: `skills-authoring` MODIFIED *Cross-skill references resolve in every install form* — a regra dos wrappers cobre o link do próprio `SKILL.md`; cenário novo *A wrapper copied alone links its own SKILL.md by repository URL*.

## Simulação (caminho real)

| ponto de entrada | evidência | resultado |
|---|---|---|
| `bash scripts/smoke-install-scripts.sh` (o que `ci.yml:179` roda), `fac8b54` | `smoke: 19/19 cases passed — refusals that had to fire: 8/8, paths that had to succeed: 11/11` | 17 casos antigos sem mudança de expectativa (baseline `e7f5fe8`: 17/17, 6/6 + 11/11) |
| rodada mutada (`install.sh` com bloco próprio de divergência e sem o guard, não commitado) | `17/19` — `FAIL` só em 14b (`install.sh block is three lines`, `the two blocks are byte-identical`) e 16 (`output lacks: scripts/lib/git-sync.sh not found`, `output must not contain: No such file or directory`) | os dois casos novos sabem reprovar; árvore restaurada (dirty 0) |
| `cat copilot/instructions/backlog.instructions.md` | `Follow the instructions in [SKILL.md](https://github.com/solvelab/ai-skills/blob/master/skills/backlog/SKILL.md)` | `grep -c '\.\./\.\./skills' copilot/instructions/*.md` → 0 em 36/36 |
| `curl -sI https://github.com/solvelab/ai-skills/blob/master/skills/execute-backlog/SKILL.md \| head -1` | `HTTP/2 200` | `backlog` idem (x-github-request-id `A7DD:D301E:1863940:1D3030E:6A9CFD27`) |
| escape conhecido | loader de 8 linhas (`[ -f $SYNC_LIB ]` + mensagem) duplicado nos dois scripts, `diff` vazio | inevitável: não há de onde carregar o guard que verifica se há de onde carregar |

## Evidência

| gate | comando | resultado |
|---|---|---|
| runner completo | `bash gates.sh <worktree> "Spec-rite: extend-install-form-links"` | 20 PASS, 0 FAIL, dirty-after 0 |
| smoke | `bash scripts/smoke-install-scripts.sh` | 19/19 (8/8 recusas, 11/11 caminhos) |
| mensagem única | `grep -c 'Fast-forward failed' install.sh update.sh scripts/lib/git-sync.sh` | 0 / 0 / 1 |
| generate | `bash generate.sh` ×2 + `git status --porcelain --untracked-files=all` | 36 wrappers + generate.sh na 1ª; nada novo na 2ª |
| spec | `openspec validate extend-install-form-links --strict` | válido (openspec 1.6.0) |
| rito | `GITHUB_EVENT_PATH=event173.json bash scripts/validate-rite.sh` | evidence 0 findings, spec-rite 0 findings, rite gate OK |
| skill-version | `GITHUB_EVENT_PATH=event173.json python3 scripts/validate-skill-version.py` | 0 findings (0 skills changed) |
| locale | `check-identifier-locale.py --diff - < diff173.patch` (215 linhas) | findings: 0 |
| segredos | `python3 scripts/scan-secrets.py` | no credentials found |
| catálogo | `python3 scripts/validate-skills.py`; `claude plugin validate . --strict` | 36 skills, 0 findings; Validation passed |

## Rito

Spec-rite: extend-install-form-links

Skill-version: nenhuma skill editada (`0 skill(s) changed` no gate); nenhum bump.

## Known gaps

- `README.md:150` ainda diz *"the SKILL.md link still expects the clone"* — desatualizado; README fora dos arquivos do item (follow-up, tasks.md E.4). A árvore (`:466-472`) e a tabela de `scripts/` (`:490`) não citam `scripts/lib/git-sync.sh`.
- `generate.sh:10-11` e `:84-88` (fora do bloco do Copilot) ainda falam só de `references/`.
- Clone anterior a `scripts/lib/git-sync.sh` re-executando `install.sh`/`update.sh` por `curl` é recusado com a dica em vez de fazer o pull (caso 16) — deliberado, transitório; `--force` continua funcionando.
- `curl | bash` real não exercitado (sandbox recusa bash lendo stdin); análogo `bash -c` mostra `BASH_SOURCE` vazio; o CI roda o smoke por arquivo.
- V.4 (archive da change) fica para PR separado depois do merge.