### PR TITLE
✨ feat(agents): camada agents/ com fonte canônica, gate e três agentes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -18,7 +18,7 @@
     {
       "name": "ai-skills-workflow",
       "source": "./plugins/workflow",
-      "description": "Commit format, OpenSpec spec-driven workflow, the backlog rite, the anti-guessing rite, the code-locale rule, the lean-code doctrine and the artifact-boundary rule for delegation (9 skills: agent-delegation, backlog, code-locale, conventional-commit, execute-backlog, lean-code, openspec, openspec-drivezone, verify-before-claiming)",
+      "description": "Commit format, OpenSpec spec-driven workflow, the backlog rite, the anti-guessing rite, the code-locale rule, the lean-code doctrine and the artifact-boundary rule for delegation (9 skills: agent-delegation, backlog, code-locale, conventional-commit, execute-backlog, lean-code, openspec, openspec-drivezone, verify-before-claiming) (1 agent: grounding-researcher)",
       "category": "productivity"
     },
     {
@@ -30,7 +30,7 @@
     {
       "name": "ai-skills-testing",
       "source": "./plugins/testing",
-      "description": "Adversarial testing rite and REST negative/fuzz/contract testing (3 skills: api-resilience-testing, bug-hunter, tdd)",
+      "description": "Adversarial testing rite and REST negative/fuzz/contract testing (3 skills: api-resilience-testing, bug-hunter, tdd) (1 agent: bug-hunter-analyst)",
       "category": "productivity"
     },
     {
@@ -72,7 +72,7 @@
     {
       "name": "ai-skills-tooling",
       "source": "./plugins/tooling",
-      "description": "AI-assistant developer tooling — Claude Code status line setup and customization (1 skill: claude-statusline)",
+      "description": "AI-assistant developer tooling — Claude Code status line setup and customization (1 skill: claude-statusline) (1 agent: skill-auditor)",
       "category": "productivity"
     }
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,19 @@ jobs:
       - name: Skill validator self-test (the gate is itself gated)
         run: python3 scripts/selftest-validate-skills.py
 
+      - name: Agent content checks (frontmatter, limits, When to invoke, orphans)
+        # The sibling of the skill validator for the other published artifact. Unlike skills, agents
+        # have no reference validator upstream (there is no agentskills equivalent for them), so the
+        # limits it enforces come from the agent format the harness documents — recorded in the
+        # add-agents-layer change, group E.2 — and this file is where a change to that format lands.
+        run: python3 scripts/validate-agents.py
+
+      - name: Agent validator self-test (the gate is itself gated)
+        # Plants one defect at a time in a throwaway tree and asserts the check that OWNS it fires —
+        # a defect caught by the wrong check fails here too, which is how a broad regex is stopped
+        # from quietly covering for a rule it was never meant to.
+        run: python3 scripts/selftest-validate-agents.py
+
       - name: Agent Skills reference validator (skills-ref, pinned, blocking)
         # README.md says the catalog follows the open Agent Skills standard; this is the standard's
         # own validator (PyPI `skills-ref`, binary `agentskills` — not `skills-ref`), installed on

--- a/README.md
+++ b/README.md
@@ -455,13 +455,18 @@ ai-skills/
 │   ├── fivem-lua/SKILL.md
 │   ├── fivem-fallback/SKILL.md
 │   └── r3f-*/SKILL.md                        # React Three Fiber skills, one per topic
+├── agents/                                   # ★ Canonical agents (Claude Code only, flat)
+│   ├── grounding-researcher.md               # frontmatter + system prompt + output contract
+│   ├── bug-hunter-analyst.md
+│   └── skill-auditor.md
 ├── .claude-plugin/
 │   ├── plugin.json                           # Claude Code plugin manifest (version-pinned)
 │   └── marketplace.json                      # Claude Code marketplace catalog
 ├── plugins/                                  # Per-domain plugins (10 of the 11 marketplace entries)
 │   └── <group>/                              # backend, devops, docs, fivem, frontend, game, nui, testing, tooling, workflow
 │       ├── .claude-plugin/plugin.json        # ai-skills-<group> manifest
-│       └── skills/                           # Generated: copies of the group's skills
+│       ├── skills/                           # Generated: copies of the group's skills
+│       └── agents/                           # Generated: copies of the group's agents (3 of 10 groups)
 ├── openspec/                                 # Spec-driven rite: specs/, changes/, schemas/skills-rite/
 ├── research/                                 # Measurements behind a skill (e.g. svg-animation)
 ├── claude/
@@ -492,6 +497,7 @@ ai-skills/
 | Folder | Purpose |
 |--------|---------|
 | `skills/` | **Canonical skills** — self-contained `SKILL.md` per skill, open Agent Skills standard. Edit here. |
+| `agents/` | **Canonical agents** — one `<name>.md` per agent, flat (a subdirectory would change the name the agent is invoked under). Claude Code only; no wrapper tree. Edit here. |
 | `.claude-plugin/` | Claude Code plugin + marketplace manifests |
 | `plugins/` | Per-domain plugins (`ai-skills-<group>`), 10 of the 11 marketplace entries — each carries its own `.claude-plugin/plugin.json` and a generated `skills/` copy of the group |
 | `openspec/` | Spec-driven rite: `specs/` (current truth), `changes/` (active + `archive/`), `schemas/skills-rite/` (the forked schema) |
@@ -529,6 +535,8 @@ skills/documentation/SKILL.md    ← ★ Single source of truth (self-contained)
 | **Cursor** | `cursor/rules/<name>.mdc` | Content inlined (no include support) |
 | **GitHub Copilot** | `copilot/instructions/<name>.instructions.md` | Markdown link reference |
 
+**Agents are the exception to that table.** A subagent dispatched into its own context is a Claude Code concept: Codex, Cursor and Copilot have no equivalent, so `agents/<name>.md` is copied into the plugin trees and into **no** wrapper tree. Inventing a stand-in for a tool that cannot dispatch would publish behaviour that does not exist. Everything under `skills/` stays portable.
+
 ---
 
 ## 🧩 How Skills Work
@@ -538,6 +546,35 @@ skills/documentation/SKILL.md    ← ★ Single source of truth (self-contained)
 A skill is a markdown instruction file that an AI reads before performing a task. It contains patterns, rules, and examples that guide the AI to produce consistent, high-quality output.
 
 Think of skills as reusable expertise — instead of explaining your documentation style every time, you write it once and every AI tool follows it automatically.
+
+### What is an agent?
+
+An agent is a **separate worker**, not a document the assistant reads. A skill is knowledge injected
+into the context that needs it; an agent runs a task in a context of its own, with its own tool
+permissions, and hands back one narrow answer. The distinction is the whole point: an agent holds no
+doctrine — it executes work under doctrine that lives in a skill, a hook or a script.
+
+The catalog admits an agent only when the work passes three tests, **all three**:
+
+1. **Reading weight** — it reads far more than it reports, so isolating it buys context back.
+2. **Separable context** — it needs the task and the tree, not the conversation that led here.
+3. **Checkable output contract** — the answer can be trusted without redoing the work.
+
+Two out of three means the calling loop does the work itself. The full doctrine — those tests, the
+three refused anti-patterns, model and effort tiering, and least-privilege `tools` — is the
+[`agent-delegation`](skills/agent-delegation/SKILL.md) skill, and every agent below carries the
+written reason it was admitted.
+
+| Agent | What it does | Why it is an agent, not a skill or a script |
+|---|---|---|
+| **grounding-researcher** | Establishes ONE fact and reports the rung that answered, the evidence line, and the rungs it could not reach. Read-only; returns `not found` rather than a plausible substitute. | Climbing the research ladder can mean twenty reads — a lockfile, a vendored source, a `--help` — for one line of answer (weight). It needs the question and the tree, not the conversation (separable). Its output is a fixed five-field block (contract). |
+| **bug-hunter-analyst** | Attacks an implemented change on paper and returns the ranked attacks plus the exact tests to write, including the lines of attack that found nothing. | Reading a diff, its callers and its siblings is heavy; the report is short (weight). The change is the input (separable). Attacks and test cases are a checkable list (contract). It has **no write tools**: it returns what to write, and the calling loop writes it. |
+| **skill-auditor** | Audits one skill against `openspec/specs/skills-authoring` on the judgements `scripts/validate-skills.py` cannot make — restated doctrine, misleading cross-references, unbacked claims, drifted version pins. Advisory, never a gate. | A skill plus its references plus the spec is a large read for a short defect table (weight, contract). It is advisory by construction: the thirteen mechanical checks remain the authority, and this agent covers only what they explicitly do not. |
+
+Agents are gated the way skills are: `scripts/validate-agents.py` checks frontmatter, limits, the
+`When to invoke` section, an explicit `tools` declaration and the no-orphan law, and
+`scripts/selftest-validate-agents.py` gates that validator in turn — a defect caught by the *wrong*
+check fails the self-test too.
 
 ### How each tool discovers skills
 

--- a/agents/bug-hunter-analyst.md
+++ b/agents/bug-hunter-analyst.md
@@ -1,0 +1,79 @@
+---
+name: bug-hunter-analyst
+description: >-
+  Use this agent to find how a change could break, after it has been implemented, and to return the
+  exact tests that would catch it. Typical triggers include adversarially reviewing a diff or branch
+  before opening a pull request, hunting edge cases, races and atomicity holes in a specific change,
+  and turning "what could go wrong here" into a concrete list of cases to write. See "When to
+  invoke" in the agent body for worked scenarios. It analyses only and writes no files; it is not
+  for designing a whole API test suite from scratch, and not for deciding whether a test is written
+  before the code.
+model: inherit
+color: red
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You are an adversarial analyst. Your job is to break a change on paper and hand back the cases that
+would break it in fact. You do not confirm the happy path; the author already did.
+
+## When to invoke
+
+- **A diff is about to be proposed.** The implementation looks right and has never been attacked.
+  You read it looking for the input that was not considered.
+- **A bug was fixed at one call site.** You grep every caller and report the siblings that still
+  carry the defect, rather than accepting that the named path is the whole of it.
+- **A change touches shared state, ordering or partial failure.** You look for the interleaving, the
+  half-applied write and the retry that is not idempotent.
+- **A test suite is green and that is the only evidence.** Green over cases that were chosen by the
+  author proves the author's assumptions, not the code.
+
+## How you work
+
+Read the change first — the diff, then the functions it touches, then their callers. Run only
+read-only commands. Then attack along these lines, and say which produced nothing:
+
+- **Boundaries**: empty, one, maximum, one past maximum, negative, zero, the value that is falsy but
+  valid.
+- **Types and encoding**: the wrong type that coerces silently, non-ASCII, a name with a separator in
+  it, a number arriving as a string.
+- **Trust**: input crossing a boundary without validation; an actor taken from the payload instead of
+  from the connection.
+- **Order and atomicity**: two calls interleaved; a failure between two writes; a retry of something
+  not idempotent; a cache that keeps a failure.
+- **Absence**: the dependency down, the file missing, the field absent versus present-and-null.
+- **The siblings**: every other call site of what was changed.
+
+The methodology you are applying is the `bug-hunter` skill. Read it for the stack track that matches
+the change; do not restate it in your answer.
+
+## Your output contract
+
+Return this and nothing else:
+
+```
+ATTACKS
+<n>. <one-line description of the input or interleaving> -> <the failure it causes>
+     WHERE: path:line
+     CONFIDENCE: confirmed (read the code path) | plausible (needs a run to settle)
+
+TESTS TO WRITE
+<n>. <test name in the repository's existing convention>
+     GIVEN: <setup>
+     WHEN:  <the attack>
+     THEN:  <the assertion that fails today>
+
+TRIED AND FOUND NOTHING
+- <the line of attack, one per line>
+```
+
+Rank attacks most severe first. `CONFIDENCE: plausible` is honest and useful; a confirmed label on a
+path you did not read is not.
+
+## What you must not return
+
+- **A file.** You have no write tools on purpose. Authorship, review and the undo live with the
+  calling loop; you return what to write, and it writes.
+- **A fix.** Naming the defect and the test that proves it is the whole job. A patch invites the
+  caller to apply it without reading the failure first.
+- **An empty TRIED AND FOUND NOTHING section.** If a line of attack produced nothing, say so — that
+  is the half of the report that tells the caller what is still unexamined.

--- a/agents/grounding-researcher.md
+++ b/agents/grounding-researcher.md
@@ -1,0 +1,70 @@
+---
+name: grounding-researcher
+description: >-
+  Use this agent to establish ONE fact before it is asserted or acted on, when finding it means
+  reading far more than the answer is worth in the caller's context. Typical triggers include
+  verifying that a CLI flag, config key or API name exists in the installed version, resolving which
+  version of a dependency a project actually pins, confirming a claimed behaviour against the
+  dependency's own source, and reporting honestly that a fact could not be established. See "When to
+  invoke" in the agent body for worked scenarios. Do not use it to review or fix code, to design a
+  test suite, or to answer a question already settled in the caller's session.
+model: inherit
+color: cyan
+tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
+---
+
+You are a research agent. You establish one fact, you say how you established it, and you say what
+you could not reach. You never produce a plausible substitute for a fact you did not find.
+
+## When to invoke
+
+- **A flag, key or API that must exist.** The caller is about to write a command, a config value or a
+  call, and the name has not been read in this session. You confirm it against the installed version,
+  not against memory.
+- **A version-dependent behaviour.** The answer differs between releases; the lockfile decides which
+  release this project has, and you read it before anything else.
+- **A claim that spans many files.** Confirming it means opening a lockfile, a vendored source tree
+  and a `--help` output — twenty reads for one line of answer.
+- **A fact that may not exist.** The caller needs to know that, plainly, rather than receive
+  something that sounds right.
+
+## The ladder you climb
+
+Cheapest first, and stop at the first rung that answers:
+
+1. The repository you were pointed at — its own code, config and docs.
+2. The installed dependency's source; the lockfile decides the version.
+3. The tool itself — `--help`, `--version`, a dry run.
+4. Documentation pinned to that version.
+5. Web search.
+
+Never skip downward. The web does not know this project. A rung you could not reach is reported as
+unreached, never as absent evidence that the unverified answer is probably right.
+
+The doctrine this implements — claim labelling, the not-found report, and why your own memory of an
+API is a hypothesis dated at your training cutoff — is the `verify-before-claiming` skill. Follow it;
+do not restate it back to the caller.
+
+## Your output contract
+
+Return this and nothing else:
+
+```
+CLAIM: <the one fact, stated as the caller will use it>
+VERDICT: verified | refuted | not found
+RUNG: <which rung answered, or "none">
+EVIDENCE: <path:line, or the command and the one line of its output that decides it>
+UNREACHED: <rungs you could not run, and why — or "none">
+NOTES: <at most two lines: a caveat that changes how the caller should use the fact>
+```
+
+Quote evidence you actually opened. If you cannot quote a line from it, you did not read it.
+
+## What you must not return
+
+- A fix, a patch, or a suggestion about what the caller should write. You establish facts; the caller
+  decides what to do with them.
+- A second claim. One invocation, one fact. If the question hides two, answer the one you were given
+  and say in NOTES that a second is embedded.
+- A confident answer with no EVIDENCE line. `VERDICT: not found` with a full UNREACHED line is a
+  successful run; a plausible sentence with an empty EVIDENCE line is a failed one.

--- a/agents/skill-auditor.md
+++ b/agents/skill-auditor.md
@@ -1,0 +1,84 @@
+---
+name: skill-auditor
+description: >-
+  Use this agent to audit one skill directory against this catalog's authoring specification, on the
+  judgements the mechanical checks cannot make. Typical triggers include reviewing a skill before it
+  is published or after it is edited, checking whether doctrine was restated inline instead of
+  linked to its canonical home, and finding claims a skill publishes without the measurement behind
+  them. See "When to invoke" in the agent body for worked scenarios. It reports and never gates: the
+  repository's own validators remain the authority on everything mechanical, and this agent covers
+  only what they explicitly do not.
+model: inherit
+color: yellow
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You are a catalog auditor. You read one skill and the specification it must obey, and you report the
+defects a pattern match cannot see. You are advisory: you never claim a verdict the build should act
+on by itself.
+
+## When to invoke
+
+- **A skill is about to be published.** The frontmatter passes and the links resolve; nobody has read
+  it against the specification it claims to implement.
+- **A skill was edited and its siblings were not.** A rule may now be stated in two places, which is
+  the defect the single-canonical-home law exists to prevent.
+- **A skill publishes a number.** You check whether the measurement behind it exists and is reachable
+  from the skill, or whether the number is decoration.
+- **A version pin block has gone quiet.** The block says what was probed and when; you check whether
+  what it claims still matches what the repository carries.
+
+## What you audit, and what you must not
+
+The mechanical half already has an owner: `scripts/validate-skills.py` runs thirteen checks — paths
+exist, cross-references name real skills, code blocks parse, frontmatter limits hold, references are
+reachable. **Never re-report what those checks already cover.** If you find yourself writing "this
+path does not exist", stop: that is C1's job and it already ran.
+
+You cover the judgements they cannot make:
+
+1. **Doctrine restated instead of linked.** The specification requires every cross-cutting rule to be
+   defined in exactly one skill and linked everywhere else with at most a one-line summary. A skill
+   that reproduces a sibling's mechanism inline is the defect. Read
+   `openspec/specs/skills-authoring/spec.md` for the canonical map before judging.
+2. **A cross-reference that resolves but misleads.** The named skill exists, so the mechanical check
+   passes, but the sentence describes it wrongly, or points at it for a rule it does not own.
+3. **A claim with no measurement.** A number, a percentage or a "measured" without a path to where it
+   was measured, or with one that no longer says what the skill says it says.
+4. **A version pin that has drifted.** The block names a tool version or a probe date; you check it
+   against what the repository actually carries now.
+5. **A description that promises what the body does not deliver**, or a body section whose content
+   belongs in the description because it only routes.
+
+## Your output contract
+
+Return this and nothing else:
+
+```
+SKILL: <name>
+READ: <the files you opened, one per line, with the spec sections you judged against>
+
+FINDINGS
+<n>. <category: restated-doctrine | misleading-crossref | unbacked-claim | drifted-pin | promise-gap>
+     WHERE: path:line
+     WHAT:  <the defect, one sentence>
+     WHY:   <the specification sentence it violates, quoted>
+     FIX:   <what would resolve it, one sentence — not a patch>
+
+CLEAN
+- <each of the five audit lines that produced nothing>
+
+NOT JUDGED
+- <anything you could not reach, and why>
+```
+
+## What you must not return
+
+- **A file, or an edit.** You have no write tools on purpose. You describe the fix in one sentence
+  and the calling loop decides and writes.
+- **A pass/fail verdict.** You are advisory by construction, because judgement can be wrong. Report
+  findings; the human and the mechanical gates decide.
+- **A finding the mechanical checks own.** If `scripts/validate-skills.py` would catch it, it is out
+  of your scope and reporting it is noise.
+- **An empty CLEAN section.** Saying which audit lines found nothing is what tells the caller how
+  much of the skill was actually examined.

--- a/generate.sh
+++ b/generate.sh
@@ -10,7 +10,12 @@
 #   copilot/instructions/<name>.instructions.md  SKILL.md and references/ linked by repository URL
 #                                          (the file is copied out of the clone alone)
 #   plugins/<group>/                       category-grouped Claude Code plugins (skills copied;
-#                                          group = metadata.category, git+process -> workflow)
+#                                          group = metadata.category, git+process -> workflow;
+#                                          agents copied per the AGENT_GROUP map below)
+#
+# Agents (agents/<name>.md) are Claude-Code-only: they are copied into the plugin trees and
+# into NO other wrapper tree, because Codex, Cursor and Copilot have no dispatched-subagent
+# concept and inventing an equivalent would publish behaviour that does not exist.
 #
 # Usage: ./generate.sh
 
@@ -18,6 +23,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SKILLS="${SCRIPT_DIR}/skills"
+AGENTS="${SCRIPT_DIR}/agents"
 CLAUDE_OUT="${SCRIPT_DIR}/claude/skills"
 CODEX_OUT="${SCRIPT_DIR}/codex/skills"
 CURSOR_OUT="${SCRIPT_DIR}/cursor/rules"
@@ -54,6 +60,16 @@ declare -A GROUP_THEME=(
   [tooling]="AI-assistant developer tooling — Claude Code status line setup and customization"
 )
 
+# Which plugin group publishes each agent. This map lives HERE and not in the agent's frontmatter
+# because the harness whitelists the fields an agent file may carry (name, description, model, color,
+# tools); an extra key is risk with no gain. The cost is a second source of truth, paid for by the
+# pre-write guard below, which refuses an unmapped agent before a single file is written.
+declare -A AGENT_GROUP=(
+  [grounding-researcher]="workflow"
+  [bug-hunter-analyst]="testing"
+  [skill-auditor]="tooling"
+)
+
 group_of() {
   case "$1" in
     git|process) echo "workflow" ;;
@@ -78,6 +94,20 @@ for skill_md in "$SKILLS"/*/SKILL.md; do
     exit 1
   }
 done
+
+# Same guarantee for agents, and for the same reason: an agent with no group would either be
+# dropped silently or land in a directory nobody publishes. Checked before the first write and
+# before `rm -rf plugins/`, so a missing mapping leaves the tree exactly as it was.
+if [ -d "$AGENTS" ]; then
+  for agent_md in "$AGENTS"/*.md; do
+    [ -f "$agent_md" ] || continue
+    agent_name="$(basename "$agent_md" .md)"
+    [[ -v AGENT_GROUP[$agent_name] ]] || {
+      echo "❌ generate.sh: no AGENT_GROUP for agent '${agent_name}' (agents/${agent_name}.md) — add its plugin group to AGENT_GROUP in generate.sh. Nothing was written." >&2
+      exit 1
+    }
+  done
+fi
 
 mkdir -p "$CURSOR_OUT" "$COPILOT_OUT"
 
@@ -233,6 +263,16 @@ for skill_md in "$SKILLS"/*/SKILL.md; do
   find "$PLUGINS_OUT/$group/skills/$name" -name __pycache__ -type d -prune -exec rm -rf {} +
 done
 
+if [ -d "$AGENTS" ]; then
+  for agent_md in "$AGENTS"/*.md; do
+    [ -f "$agent_md" ] || continue
+    agent_name="$(basename "$agent_md" .md)"
+    agent_group="${AGENT_GROUP[$agent_name]}"
+    mkdir -p "$PLUGINS_OUT/$agent_group/agents"
+    cp --no-preserve=mode "$agent_md" "$PLUGINS_OUT/$agent_group/agents/${agent_name}.md"
+  done
+fi
+
 # "<theme> (<N> skills: <names>)" — names sorted under LC_ALL=C so the output is identical on every
 # machine and a second run produces no diff. The theme lookup is guarded a second time on purpose,
 # even though the pre-write check above already refused any group without one: the old
@@ -247,6 +287,16 @@ group_description() {
   names="$(ls -1 "$PLUGINS_OUT/$group/skills" | LC_ALL=C sort | paste -sd, - | sed 's/,/, /g')"
   count="$(ls -1 "$PLUGINS_OUT/$group/skills" | wc -l | tr -d ' ')"
   printf '%s (%s %s: %s)' "${GROUP_THEME[$group]}" "$count" "$([ "$count" -eq 1 ] && echo skill || echo skills)" "$names"
+  # The agents go in a SEPARATE parenthetical, never inside the one above: the H3 membership regex
+  # in scripts/validate-repo-hygiene.py captures `[^)]*` after "N skills:", so anything added inside
+  # that parenthesis would be swallowed into the skill-name list and the check would compare the
+  # wrong set. A sibling check reads this second parenthetical against plugins/<g>/agents/.
+  if [ -d "$PLUGINS_OUT/$group/agents" ]; then
+    local anames acount
+    anames="$(ls -1 "$PLUGINS_OUT/$group/agents" | sed 's/\.md$//' | LC_ALL=C sort | paste -sd, - | sed 's/,/, /g')"
+    acount="$(ls -1 "$PLUGINS_OUT/$group/agents" | wc -l | tr -d ' ')"
+    printf ' (%s %s: %s)' "$acount" "$([ "$acount" -eq 1 ] && echo agent || echo agents)" "$anames"
+  fi
 }
 
 plugin_count=0

--- a/openspec/changes/add-agents-layer/.openspec.yaml
+++ b/openspec/changes/add-agents-layer/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-07

--- a/openspec/changes/add-agents-layer/design.md
+++ b/openspec/changes/add-agents-layer/design.md
@@ -1,0 +1,99 @@
+# Design — camada agents/
+
+## Context
+
+O critério de admissão foi publicado em `f6663f1` (skill `agent-delegation`). Falta o lugar onde um
+agente admitido é publicado, gerado e conferido.
+
+Fatos medidos nos plugins oficiais da Anthropic instalados nesta máquina, lidos em 2026-09-07 em
+`~/.claude/plugins/marketplaces/claude-plugins-official/plugins/`:
+
+- `feature-dev/`, `pr-review-toolkit/` e `plugin-dev/` carregam `agents/*.md` na raiz do plugin, e
+  os três `.claude-plugin/plugin.json` **não** têm chave `agents` — a descoberta é por convenção de
+  diretório.
+- `plugin-dev/skills/agent-development/SKILL.md` fixa o frontmatter (`name`, `description`, `model`,
+  `color` obrigatórios; `tools` opcional), os limites (`name` 3–50, `description` 10–5000, corpo
+  20–10000), a seção *When to invoke* no corpo, e o efeito de subdiretório sobre o namespace.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Uma fonte canônica única para agentes, com a mesma lei de órfão que as skills já têm.
+- Geração para os plugins, conferida por um gate estrutural, não por revisão.
+- Três agentes que ganham existência pelos três testes, com a razão escrita.
+- A redução da promessa multi-ferramenta declarada por escrito.
+
+**Non-Goals:**
+
+- Wrapper de agente para Codex, Cursor ou Copilot: as três ferramentas não têm o conceito, e
+  fabricar equivalente seria inventar comportamento.
+- Um quarto agente. A lista é fechada nesta change; outro é outro item.
+- Trocar qualquer validador determinístico por agente.
+- Medir ganho de contexto da delegação. Nenhuma alegação de ganho é feita.
+
+## Decisions
+
+**D1 — `agents/` na raiz, imposto pela ferramenta.** O bundle FULL é `source: "./"` em
+`.claude-plugin/marketplace.json`, e a descoberta é por convenção de diretório na raiz do plugin.
+`claude/agents/` não seria descoberto. A localização não foi escolhida por gosto: é a única que
+funciona.
+
+**D2 — Sem subdiretórios em `agents/`.** Um subdiretório muda o namespace para
+`plugin:subdir:agent-name` e altera o nome de invocação. Agrupar agentes por domínio custaria o nome
+que o usuário digita.
+
+**D3 — O mapa agente -> grupo mora em `generate.sh`, não no frontmatter.** A whitelist de campos do
+Claude Code é `name/description/model/color/tools`; um campo extra é risco sem ganho. O custo é uma
+segunda fonte de verdade, pago com o mesmo guard pré-escrita que `GROUP_THEME` já tem
+(`generate.sh:69-82`): um agente sem grupo derruba o script **antes** do primeiro `mkdir` e antes do
+`rm -rf plugins/`, com a árvore intacta.
+
+**D4 — A lista de agentes vai num parêntese separado, e o gate é irmão do H3.** O
+`MEMBERSHIP_CLAIM` de `scripts/validate-repo-hygiene.py:42` é `\((\d+) skills?: ([^)]*)\)`: o
+`[^)]*` engoliria qualquer coisa acrescentada dentro do mesmo parêntese. A descrição publicada passa
+a ser `<tema> (N skills: …) (M agents: …)`, e um check irmão confere a segunda lista contra
+`plugins/<g>/agents/`. Publicar sem lista nenhuma seria mais barato e foi recusado: a lei do
+repositório é que uma contagem publicada tem um conjunto que a árvore confirma, e omitir os agentes
+os tornaria invisíveis no marketplace.
+
+**D5 — Nenhum dos três agentes escreve arquivo.** É a aplicação direta do terceiro anti-padrão de
+`agent-delegation`. `bug-hunter-analyst` devolve os ataques e os casos de teste a escrever; quem
+escreve é o loop principal, onde ficam autoria, revisão e desfazer. `tools` é declarado sempre, no
+mínimo que o contrato exige.
+
+**D6 — `skill-auditor` é advisory por construção, e o gate diz isso.** Ele cobre o que os checks
+C1–C13 não sabem checar — doutrina restatada, cross-ref com semântica errada, claim sem medição. Um
+agente nunca substitui um validador: `scripts/validate-skills.py` continua sendo a autoridade sobre
+tudo que é mecânico.
+
+**D7 — Nenhum dos três declara `model` fixo.** `inherit` é o default recomendado, e fixar um nome de
+modelo aqui contradiria a própria regra de `agent-delegation` de escrever critério em vez de lista
+de modelos. O tiering é escolhido no despacho, não congelado no arquivo.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Quando um trabalho vira agente; menor privilégio em `tools`; contrato de saída; tiering | `agent-delegation` | already canonical — esta change **usa** a regra e escreve a razão de admissão de cada agente contra ela |
+| Escada de pesquisa, rotulagem de claim, relatório de não-encontrado | `verify-before-claiming` | link — o contrato de saída do `grounding-researcher` aponta para lá em vez de reproduzir a escada |
+| Metodologia adversarial | `bug-hunter` | link — o `bug-hunter-analyst` executa o método daquela skill e não o restata |
+| Como uma skill é escrita: frontmatter, casa canônica, claim medido | `skills-authoring` | already canonical — o `skill-auditor` audita contra essa spec, não contra um checklist próprio |
+| Composição do catálogo publicado | `skills-catalog` | link + MODIFIED — passa a dizer que um agente não é uma skill do catálogo |
+| Composição e autoria da camada de agentes | `agents-catalog` (esta change) | **new** — a casa canônica da nova classe de artefato |
+| Volume de código | `lean-code` | link — o validador novo é stdlib-only, como os irmãos |
+
+## Risks / Trade-offs
+
+- **A camada inchar.** Mitigado pelo teste de admissão de `agent-delegation` e pela lista fechada de
+  três; um quarto agente é outro item de backlog, com a razão escrita.
+- **Duas fontes de verdade pelo D3.** Mitigado pelo guard pré-escrita e por um critério de aceite que
+  exige provar a falha com a árvore intacta.
+- **O parêntese novo derrubar o H3.** Mitigado pelo D4 e por rodar `validate-repo-hygiene.py` antes e
+  depois.
+- **`bug-hunter-analyst` acabar escrevendo teste.** Mitigado por `tools` sem `Write`/`Edit` (D5) —
+  incapacidade, não pedido.
+- **A promessa multi-ferramenta parecer quebrada.** É reduzida de fato, e por isso é declarada no
+  README em vez de omitida.
+- **O formato do frontmatter de agente mudar no harness.** É a razão de `agent-delegation` não o
+  descrever: o formato mora em `agents-catalog`, que é onde a mudança dói uma vez só.

--- a/openspec/changes/add-agents-layer/proposal.md
+++ b/openspec/changes/add-agents-layer/proposal.md
@@ -1,0 +1,68 @@
+# Change: Camada agents/ — fonte canônica, geração, gate e três agentes
+
+## Why
+
+O catálogo publica 38 skills, 10 plugins de domínio, 4 hooks e 8 validadores. Publica **zero
+agentes**, e não por decisão: por omissão. Medido em `36091e7`:
+
+- `find . -type d -name agents` fora de `.git/` -> vazio; `git log --all --name-only | grep '/agents/'`
+  -> vazio. Nunca existiu em nenhum commit.
+- `generate.sh:7-12` gera quatro árvores de wrapper mais `plugins/`. Nenhum alvo `agents/`.
+- `README.md` define o que é uma skill e não define agente.
+
+Desde `f6663f1` o critério de admissão existe: a skill `agent-delegation` separa onde uma regra mora
+de onde um trabalho roda, e admite um subagente só quando os três testes valem todos. O que falta é o
+lugar onde um agente admitido pode ser publicado — hoje ele seria um arquivo solto, invisível ao CI e
+ausente dos plugins.
+
+Enquanto isso o catálogo carrega três trabalhos que passam os três testes e rodam no loop principal,
+queimando o contexto que o resto da tarefa precisa: a escada de pesquisa do `verify-before-claiming`,
+a fase de análise do `bug-hunter`, e a auditoria de prosa de uma skill contra
+`openspec/specs/skills-authoring/spec.md` — o que os checks C1–C13 explicitamente não sabem fazer.
+
+## What Changes
+
+- Cria `agents/<name>.md` na raiz como fonte canônica única, sem subdiretórios.
+- Publica três agentes, cada um com a razão de admissão escrita contra os três testes de
+  `agent-delegation`: `grounding-researcher`, `bug-hunter-analyst`, `skill-auditor`.
+- `generate.sh` ganha o mapa `AGENT_GROUP` (agente -> grupo de plugin) com guard pré-escrita, e copia
+  cada agente para `plugins/<group>/agents/`.
+- A descrição publicada de cada plugin ganha um **parêntese separado** `(N agents: a, b)` ao lado do
+  `(N skills: …)` já existente, e `scripts/validate-repo-hygiene.py` ganha o check irmão que o
+  confere contra a árvore. Separado, e não dentro do parêntese atual, porque o `MEMBERSHIP_CLAIM` do
+  H3 captura `[^)]*` e engoliria a segunda lista.
+- `scripts/validate-agents.py` novo, com `scripts/selftest-validate-agents.py` que o gateia, e dois
+  steps novos em `.github/workflows/ci.yml`.
+- `README.md` ganha a seção *What is an agent?*, a linha `agents/` na árvore de estrutura e a
+  declaração explícita de que agente é artefato **Claude-Code-only**.
+
+**BREAKING para ninguém**: nenhuma skill muda de nome, categoria ou comportamento; a contagem
+publicada `all 38` continua contando skills, e um agente nunca é uma skill do catálogo.
+
+**Não muda**: as duas chamadas de `Explore` em `backlog` e `execute-backlog`; nenhum validador
+determinístico é trocado por agente.
+
+## Capabilities
+
+### New Capabilities
+
+- `agents-catalog`: composição e autoria da camada de agentes — a fonte canônica única e a lei de
+  órfão, o limite Claude-Code-only e o que ele implica para as outras três árvores geradas, o
+  frontmatter que todo agente carrega, a exigência de `tools` de menor privilégio e de contrato de
+  saída, e a regra de que um agente publicado declara por escrito por que passa os três testes de
+  `agent-delegation`.
+
+### Modified Capabilities
+
+- `skills-catalog`: MODIFIED *Catalog composition after the quality review* — a árvore ganha uma
+  segunda classe de artefato publicado, então o requisito passa a dizer explicitamente que um agente
+  **não** é uma skill do catálogo: `npx skills --list` continua achando exatamente as 38, e a
+  contagem `all N` continua sendo de skills.
+
+## Impact
+
+- `plugins/workflow`, `plugins/testing` e `plugins/tooling` passam a publicar um agente cada; as
+  outras sete não mudam.
+- `scripts/validate-repo-hygiene.py` ganha um check; `.github/workflows/ci.yml` ganha dois steps.
+- Codex, Cursor e Copilot **não** recebem wrapper de agente, e o README passa a dizer isso —
+  a promessa multi-ferramenta é reduzida por escrito em vez de silenciosamente.

--- a/openspec/changes/add-agents-layer/specs/agents-catalog/spec.md
+++ b/openspec/changes/add-agents-layer/specs/agents-catalog/spec.md
@@ -1,0 +1,103 @@
+## ADDED Requirements
+
+### Requirement: Agents have a single canonical home and no orphans
+
+The repository SHALL publish agents from exactly one canonical location, `agents/<name>.md` at the
+repository root, and every copy under `plugins/<group>/agents/` SHALL be generated from it. An agent
+present only in a generated tree is not a published agent: it escapes the generator, the validator
+and the README, while still installing for users. CI SHALL reject that state, the same way it
+rejects an orphan wrapper skill.
+
+The canonical directory SHALL be flat. A subdirectory changes the name under which the agent is
+invoked, so grouping by domain would be paid for in the name the user types.
+
+#### Scenario: An agent in a generated tree without a source is rejected
+
+- **WHEN** a file exists under `plugins/<group>/agents/` with no matching `agents/<name>.md`
+- **THEN** the agent validator reports it as an orphan and CI fails
+
+#### Scenario: The generator refuses an agent it cannot place
+
+- **WHEN** an agent exists in the canonical directory with no plugin group mapped to it
+- **THEN** the generator fails before writing any file and before removing the generated plugin
+  tree, so the working tree is left exactly as it was
+- **AND** the error names the agent and where the mapping is declared
+
+#### Scenario: Adding an agent goes through the canonical tree
+
+- **WHEN** a new agent is added
+- **THEN** it is written to `agents/<name>.md`, its plugin copies are produced by the generator, and
+  it gains a README row — never hand-written into a generated tree
+
+### Requirement: The agent layer declares that it is not portable
+
+Agents SHALL be published only for the assistant that defines them, and the repository SHALL say so
+where it publishes its portability claim. The catalog's other artifact — the skill — is generated
+into a wrapper for every supported tool; an agent has no equivalent in tools that do not implement
+dispatched subagents, and inventing one would publish behaviour that does not exist.
+
+#### Scenario: The multi-tool table states the limit rather than omitting it
+
+- **WHEN** the repository documents which tool consumes which artifact
+- **THEN** it states that agents are published for one assistant only and produce no wrapper in the
+  other generated trees
+- **AND** the reduction is written where the portability claim is made, not left to be discovered
+
+#### Scenario: No agent wrapper is generated for a tool that lacks the concept
+
+- **WHEN** the generator runs
+- **THEN** it writes agent copies only into the plugin trees, and none into the wrapper trees of
+  tools that have no subagent concept
+
+### Requirement: A published agent declares its admission and its privilege
+
+Every `agents/<name>.md` SHALL carry the frontmatter its harness requires — an identifier equal to
+the file name, a description naming the conditions that route work to it, the model, and the colour —
+and SHALL declare `tools` explicitly. Omitting `tools` grants every tool, so the declaration is the
+difference between a stated privilege and an unstated one.
+
+The body SHALL carry a section naming the situations that invoke the agent, and SHALL state the
+output contract: the shape the caller receives and what the agent must not return. An agent whose
+work would produce a file SHALL return what to write rather than write it, unless writing inside the
+isolated context is the work being bought.
+
+Every published agent SHALL carry, in the repository, the written reason it passes the three
+admission tests of the delegation doctrine. An agent admitted by symmetry with an existing artifact,
+rather than by those tests, is a defect.
+
+#### Scenario: An agent without a declared tool set fails the gate
+
+- **WHEN** an agent omits `tools`, or names a write tool while its contract says it returns what to
+  write
+- **THEN** the validator fails naming the agent and the field
+
+#### Scenario: An agent that does not say when to invoke it fails the gate
+
+- **WHEN** the body carries no section naming the situations that invoke the agent
+- **THEN** the validator fails, because a description alone routes without telling the agent what
+  the caller expected
+
+#### Scenario: The validator is itself gated
+
+- **WHEN** the agent validator ships
+- **THEN** a self-test proves each of its rules fails a violating agent and passes a conforming one,
+  so the gate is not trusted on its own word
+
+### Requirement: A published agent count names its members
+
+A plugin description that publishes how many agents it ships SHALL name them, in a parenthetical
+separate from the one that names its skills, and the repository hygiene check SHALL compare that
+list with the tree. A count with no member list is unverifiable and is refused by shape; omitting
+the agents entirely is refused too, because it makes a published artifact invisible where the
+plugin is browsed.
+
+#### Scenario: A stale agent list fails the hygiene check
+
+- **WHEN** a plugin description names agents that its tree does not contain, or omits one it does
+- **THEN** the hygiene check fails naming the group, the names in excess and the names missing
+
+#### Scenario: The skills list is not disturbed by the agents list
+
+- **WHEN** a group publishes both skills and agents
+- **THEN** each list has its own parenthetical, so the check that reads the skills list matches
+  exactly the skills and never absorbs the agent names

--- a/openspec/changes/add-agents-layer/specs/skills-catalog/spec.md
+++ b/openspec/changes/add-agents-layer/specs/skills-catalog/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Catalog composition after the quality review
+
+The catalog SHALL be exactly the set of `skills/<name>/SKILL.md` files. A skill present only in a
+generated tree (`claude/`, `codex/`, `cursor/`, `copilot/`, `plugins/`) is not a catalog skill: it
+escapes `generate.sh`, the CI frontmatter check, the content validator and the README index, while
+still installing for users. CI SHALL reject that state.
+
+A skill's topics MAY live in `skills/<name>/references/*.md`, reached from an index in its `SKILL.md`.
+A reference file is part of its skill, never a catalog entry of its own, and never carries frontmatter.
+
+The composition is not a frozen count. It changes by proposal, and the README index is the
+human-readable view of it.
+
+The repository publishes a second class of artifact — an agent, under `agents/` — and an agent is
+never a catalog skill. Discovery over the catalog SHALL keep finding exactly the set of
+`skills/<name>/SKILL.md` files, and a published total of the form `all N` SHALL keep counting
+skills, so that adding or removing an agent never moves a number that describes skills.
+
+#### Scenario: npx discovery lists the full catalog
+
+- **WHEN** `npx skills add <repo> --list` runs against the repository root
+- **THEN** every `skills/<name>/SKILL.md` is discovered
+- **AND** the set matches the README skill index
+- **AND** no `references/*.md` file appears as a skill
+
+#### Scenario: A skill in a generated tree without a source is rejected
+
+- **WHEN** a directory exists under `claude/skills/` or `codex/skills/` with no matching
+  `skills/<name>/SKILL.md`
+- **THEN** `scripts/validate-skills.py` reports it as an orphan wrapper and CI fails
+
+#### Scenario: Adding a skill goes through the canonical tree
+
+- **WHEN** a new skill is added
+- **THEN** it is written to `skills/<name>/SKILL.md`, its wrappers are produced by `./generate.sh`,
+  and it gains a README row — never hand-written into a generated tree
+
+#### Scenario: An agent is not counted as a catalog skill
+
+- **WHEN** the repository publishes agents alongside skills
+- **THEN** catalog discovery still finds exactly the `skills/<name>/SKILL.md` set and the published
+  `all N` total is unchanged by the presence of agents
+- **AND** the agents are published under their own capability, with their own member list

--- a/openspec/changes/add-agents-layer/tasks.md
+++ b/openspec/changes/add-agents-layer/tasks.md
@@ -1,0 +1,315 @@
+# Tasks
+
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+
+      Lidos em `36091e7` (master, base de `backlog/198-agents-layer`) em 2026-09-07:
+
+      - `generate.sh:1-130` — guards de VERSION e de `GROUP_THEME`, `group_of`, `category_of`, e o
+        laço de pré-checagem que falha antes do primeiro `mkdir` e antes do `rm -rf plugins/`.
+      - `generate.sh:218-300` — `group_description()`, o laço de plugins e o bloco Python que
+        reescreve `marketplace.json` e `.claude-plugin/plugin.json`.
+      - `scripts/validate-repo-hygiene.py:33-44` — `COUNT_FILES`, `COUNT_CLAIM`,
+        `UNSCOPED_COUNT_CLAIM` e `MEMBERSHIP_CLAIM`; `:78-160` — H2 e H3 inteiros, incluindo
+        `plugin_groups()` e `_membership_finding()`.
+      - `scripts/validate-skills.py` — docstring com C1–C13, `:351-364` (C8 e `META_HEADING`),
+        `:451-484` (C11), `:485-555` (C12 e `CATALOG_ONLY_ROOTS`), `:611-624` (C7, a lei de órfão).
+      - `.github/workflows/ci.yml:120-178` — os steps de validação e os selftests já existentes.
+      - `README.md:439-552` — árvore de estrutura, arquitetura multi-ferramenta e *What is a skill?*.
+      - `skills/agent-delegation/SKILL.md` — os três testes de admissão, os três anti-padrões e a
+        regra de menor privilégio, publicados em `f6663f1`.
+      - `openspec/specs/skills-catalog/spec.md:10-41` — *Catalog composition after the quality
+        review*, copiado por completo no delta antes de ganhar o parágrafo novo.
+      - `openspec/specs/skills-authoring/spec.md:11-23` — o mapa canônico, já com `agent-delegation`
+        desde `36091e7`.
+
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+
+      Convenção de agente, lida nos plugins oficiais da Anthropic instalados nesta máquina em
+      2026-09-07:
+
+      `ls ~/.claude/plugins/marketplaces/claude-plugins-official/plugins/feature-dev/` ->
+      `.claude-plugin/  agents/  commands/  LICENSE  README.md`; idem `pr-review-toolkit` e
+      `plugin-dev` (este último com `skills/` também).
+
+      `cat …/feature-dev/.claude-plugin/plugin.json` -> `{ "name": "feature-dev", "description": …,
+      "author": … }` — **sem** chave `agents`, logo a descoberta é por convenção de diretório.
+
+      `…/plugin-dev/skills/agent-development/SKILL.md` -> frontmatter `name`, `description`, `model`,
+      `color` obrigatórios e `tools` opcional ("If omitted, agent has access to all tools");
+      `name` 3–50 minúsculas/dígitos/hífen; `description` 10–5000; system prompt 20–10000;
+      seção *When to invoke* no corpo; "With subdirectories: `plugin:subdir:agent-name`".
+
+      `openspec new change add-agents-layer --schema skills-rite` -> `Schema: skills-rite`.
+      `openspec validate add-agents-layer --strict` -> `Change 'add-agents-layer' is valid`.
+      `openspec list` -> `No active changes found.` antes desta change.
+
+      `ls -1 skills/ | wc -l` -> `38`; `git log --oneline -1` -> `36091e7`.
+
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+
+      Três lacunas, nenhuma preenchida com substituto plausível:
+
+      (a) **RESOLVIDA por medição, não por inferência.** A dúvida era se o Claude Code descobre
+      `agents/` na raiz do bundle FULL (`source: "./"`), já que os plugins oficiais lidos têm `source`
+      apontando para um subdiretório. Medido: uma sessão headless rodando de um diretório que **não** é
+      este repositório, com `--plugin-dir /home/diegops/ai-skills`, lista
+      `ai-skills:bug-hunter-analyst`, `ai-skills:grounding-researcher` e `ai-skills:skill-auditor`.
+      A raiz do repositório carregada como plugin expõe os três, que é exatamente o que `source: "./"`
+      significa. Detalhe no grupo Simulation.
+
+      (b) **Se existe validador de referência para agentes, como `skills-ref` é para skills.** Não
+      foi encontrado nenhum. O gate desta change é próprio (`validate-agents.py`), e a ausência de um
+      validador upstream fica declarada: os limites que ele aplica vêm do `agent-development`
+      da Anthropic lido em E.2, não de uma especificação aberta.
+
+      (c) **Se o campo `color` é obrigatório de fato ou só documentado como obrigatório.** O
+      `agent-development` diz "required"; nenhum erro foi observado com ele ausente porque nenhum
+      agente sem `color` foi carregado. O validador o exige, seguindo o documento, e a lacuna fica
+      registrada em vez de virar afirmação sobre o runtime.
+
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+      Follow-ups anotados e **não** feitos:
+
+      - As 10 skills `r3f-*` não citam nenhuma skill de processo — ilha desconectada do grafo de
+        cross-links, achada ao mapear o catálogo. Item próprio.
+      - Converter as duas chamadas de `Explore` em `backlog` e `execute-backlog` para agentes
+        próprios: declarado fora de escopo na issue #198.
+      - Um quarto agente. A lista é fechada aqui; outro passa pelos três testes num item próprio.
+      - `UNSCOPED_COUNT_CLAIM` cobre `topics|skills`; passa a cobrir `agents` nesta change, e não
+        foram acrescentados outros substantivos.
+      - A entrada FULL do marketplace e o manifesto raiz continuam dizendo `all N` só de skills, e
+        **não** nomeiam os três agentes que o bundle também instala. Nomeá-los exigiria estender o
+        H4 ao manifesto raiz, que é uma decisão sobre se `all N` ganha um irmão — item próprio,
+        não feito aqui. Publicar a lista sem o gate seria uma contagem que a árvore não confirma.
+
+## 2. A fonte canônica e os três agentes
+
+- [x] 2.1 `agents/grounding-researcher.md` — executa a escada de `verify-before-claiming` para UMA
+      afirmação; só leitura; contrato de saída = afirmação -> degrau alcançado -> linha de evidência,
+      mais os degraus que não responderam
+- [x] 2.2 `agents/bug-hunter-analyst.md` — lê um diff e devolve ataques e casos de teste a escrever;
+      **sem** `Write`/`Edit` (D5)
+- [x] 2.3 `agents/skill-auditor.md` — audita `skills/<name>/` contra `skills-authoring` no que
+      C1–C13 não sabem checar; advisory, nunca gate (D6)
+- [x] 2.4 Os três com frontmatter completo, `tools` declarado no mínimo, `model: inherit` (D7) e
+      seção *When to invoke* no corpo
+      `python3 scripts/validate-agents.py` -> `agents checked: 3   findings: 0`. Os três com
+      `model: inherit`; `tools` declarado: `grounding-researcher` [Read, Grep, Glob, Bash, WebSearch,
+      WebFetch], `bug-hunter-analyst` e `skill-auditor` [Read, Grep, Glob, Bash] — nenhum com Write
+      ou Edit (D5).
+
+- [x] 2.5 A razão de admissão de cada um, escrita contra os três testes de `agent-delegation`
+
+      As três razões, escritas contra os três testes, ficam na tabela da seção *What is an agent?*
+      do `README.md`, e não no corpo do agente: o corpo vira system prompt e a razão de admissão é
+      meta-conteúdo que o agente não usa em execução.
+
+## 3. Geração
+
+- [x] 3.1 `generate.sh` — mapa `AGENT_GROUP` e guard pré-escrita, no mesmo lugar e com a mesma
+      garantia do guard de `GROUP_THEME`
+      Provado quebrando de propósito: um `agents/unmapped-agent.md` sem entrada no mapa ->
+      `❌ generate.sh: no AGENT_GROUP for agent 'unmapped-agent' … Nothing was written.` O md5 de
+      `git status --porcelain --untracked-files=all` antes e depois da falha é **idêntico**: a árvore
+      ficou intacta, incluindo `plugins/`, que o script apaga logo adiante.
+
+- [x] 3.2 `generate.sh` — cópia de cada agente para `plugins/<group>/agents/`
+      `ls plugins/*/agents/` -> `plugins/testing/agents/bug-hunter-analyst.md`,
+      `plugins/tooling/agents/skill-auditor.md`, `plugins/workflow/agents/grounding-researcher.md`.
+
+- [x] 3.3 `generate.sh` — `group_description()` acrescenta `(M agents: …)` em parêntese **separado**
+      (D4), e o bloco Python das descrições publica o mesmo texto
+      `ai-skills-testing` publica `… (3 skills: api-resilience-testing, bug-hunter, tdd) (1 agent:
+      bug-hunter-analyst)` — dois parênteses, e o `MEMBERSHIP_CLAIM` do H3 continua casando só com o
+      primeiro. Mesmo texto no `plugin.json` do grupo e na entrada do `marketplace.json`.
+
+- [x] 3.4 Nenhum wrapper de agente em `claude/`, `codex/`, `cursor/` ou `copilot/`
+
+      `ls claude/ codex/ cursor/ copilot/` não tem nenhum diretório nem arquivo de agente; o único
+      destino de cópia é `plugins/<group>/agents/`.
+
+## 4. Gate
+
+- [x] 4.1 `scripts/validate-agents.py` — frontmatter, limites, seção *When to invoke*, `tools`
+      declarado, e a lei de órfão
+      `python3 scripts/validate-agents.py` -> `agents checked: 3   findings: 0`. O validador achou um
+      defeito real durante a escrita: a `description` do `skill-auditor` tinha dois-pontos sem aspas e
+      não parseava como YAML (`A1`); as três foram convertidas para folded scalar.
+
+- [x] 4.2 `scripts/selftest-validate-agents.py` — cada regra reprova violando e aprova cumprindo
+      `python3 scripts/selftest-validate-agents.py` -> `22/22 cases passed`, cobrindo as 20 classes de
+      defeito mais o caso limpo e o caso da cópia gerada COM fonte, que não é órfã. Um defeito pego
+      pelo check errado também reprova.
+
+- [x] 4.3 `scripts/validate-repo-hygiene.py` — check irmão do H3 para a lista de agentes, e
+      `UNSCOPED_COUNT_CLAIM` passa a recusar `(N agents)` sem lista
+      H4 provado nas duas formas: lista adulterada ->
+      `names 2 agent(s) but plugins/testing/agents/ has 1 — in excess: ['ghost']`; lista removida ->
+      `ships 1 agent(s) and publishes no (N agents: <names>) list`. Regenerado ->
+      `repo hygiene: 0 findings`.
+
+- [x] 4.4 `.github/workflows/ci.yml` — dois steps novos, ao lado dos de skill
+
+      `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/ci.yml'))"` sem erro; os dois
+      steps novos ficam ao lado dos de skill (`validate-agents.py` e seu selftest).
+
+## 5. README
+
+- [x] 5.1 Seção *What is an agent?* com a fronteira, linkando `agent-delegation`
+- [x] 5.2 Linha `agents/` na árvore de estrutura e na tabela de pastas
+- [x] 5.3 A tabela multi-ferramenta declara que agente é Claude-Code-only
+- [x] 5.4 Os três agentes listados, com o que cada um faz
+
+      A tabela nomeia os três com o que fazem e a razão de admissão contra os três testes.
+
+## 6. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+
+      O caminho real de um agente é ser descoberto por uma sessão e despachado por ela. Medido em
+      sessões headless novas, rodando de um diretório que **não** é este repositório
+      (`/tmp/.../plugintest`, um git init vazio), para que a descoberta viesse do plugin e não do cwd.
+
+      **Descoberta, bundle FULL (`source: "./"`, a raiz do repositório como plugin):**
+
+      `claude -p "…list your subagent types…" --plugin-dir /home/diegops/ai-skills` ->
+
+          ai-skills:bug-hunter-analyst
+          ai-skills:grounding-researcher
+          ai-skills:skill-auditor
+
+      **Descoberta, plugin por domínio:**
+
+      `--plugin-dir …/plugins/testing --plugin-dir …/plugins/tooling` ->
+
+          ai-skills-testing:bug-hunter-analyst
+          ai-skills-tooling:skill-auditor
+
+      **Despacho real, com o contrato de saída conferido:** `ai-skills:grounding-researcher`
+      despachado contra uma pergunta verificável ("`scripts/validate-agents.py` define um check A7?"),
+      saída observada, íntegra:
+
+          CLAIM: `scripts/validate-agents.py` defines a check labelled A7 (rule ID "A7", enforcing
+                 that the canonical directory is flat with no orphan agents).
+          VERDICT: verified
+          RUNG: 1 (repository's own code)
+          EVIDENCE: line 12 `A7 no orphan agent in a generated tree, and the canonical directory is
+                    flat`; line 134; line 141 `add(sub.name, "A7 layout",`; line 149
+          UNREACHED: none
+          NOTES: The rule ID is used as `"A7 layout"` in the emitted labels (lines 141, 149), not
+                 bare `"A7"` — relevant if the caller is grepping for an exact string.
+
+      Os seis campos do contrato saíram na ordem, a evidência é citável e confere com o arquivo
+      (`grep -n "A7 layout"` -> 141 e 149), e o NOTES é um caveat real que o chamador usaria.
+
+      **Controle:** o mesmo mecanismo com um agente built-in (`Explore`) devolveu
+      `/home/diegops/ai-skills/scripts/validate-agents.py` em segundos, o que separa "o despacho
+      aninhado funciona headless" de qualquer lentidão de tarefa (ver S.3).
+
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+
+      **Descoberta:** caminhos de instalação que tinham de expor os agentes e expuseram: **2/2**
+      (bundle FULL e plugin por domínio). Agentes resolvidos por nome: **3/3** no bundle FULL,
+      **2/2** nos dois plugins por domínio carregados.
+
+      **Despacho:** agentes despachados e que devolveram o contrato: **1/1** medido
+      (`grounding-researcher`), mais **1/1** de controle com agente built-in.
+
+      **Gate `validate-agents.py`:** classes de defeito que tinham de reprovar e reprovaram
+      **20/20**; casos que tinham de passar e passaram **2/2** (o agente conforme, e a cópia gerada
+      COM fonte, que não é órfã). Total **22/22**, e um defeito pego pelo check **errado** também
+      contaria como falha.
+
+      **Gate H4:** formas que tinham de reprovar e reprovaram **2/2** (lista adulterada, lista
+      ausente com agentes na árvore); estado correto que tinha de ficar em silêncio e ficou **1/1**.
+
+      **Guard do `generate.sh`:** falhas que tinham de acontecer **1/1**, e a árvore que tinha de
+      ficar intacta ficou (md5 de `git status --porcelain --untracked-files=all` idêntico antes e
+      depois).
+
+      **Escapes conhecidos que continuaram em silêncio, de propósito:** o contrato de saída é
+      julgamento e não é medido pelo gate; que `tools` seja o mínimo possível é revisão humana; a
+      razão de admissão dos três é prosa no README e não é conferida por script. Os três estão
+      escritos como limite no cabeçalho de `scripts/validate-agents.py`.
+
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+      Três coisas, nenhuma silenciada:
+
+      (a) **Esta sessão não enxergou os agentes novos.** Os tipos de subagente são resolvidos no
+      início da sessão: despachar `skill-auditor` daqui devolveu
+      `Agent type 'skill-auditor' not found`, mesmo com os arquivos no lugar e o validador verde. Não
+      é defeito do artefato — é o motivo de a prova de campo ter sido feita em sessões novas, e vale
+      registrar porque quem editar um agente e tentar usá-lo no mesmo turno vai bater nisso.
+
+      (b) **Um despacho de `skill-auditor` não voltou dentro do orçamento.** Auditar
+      `skills/lean-code/` (236 linhas mais references) contra `skills-authoring/spec.md` (47 KB) num
+      modelo `sonnet` passou de 420 s sem produzir saída. O controle com agente built-in voltou em
+      segundos no mesmo mecanismo, então o que isso mede é o tamanho da tarefa, não a fiação. Fica
+      registrado como observação de custo do `skill-auditor`, e não convertido em "tudo verde".
+
+      (c) **O `color` é exigido pelo validador porque o documento do harness o chama de
+      obrigatório**, não porque um agente sem ele tenha sido observado falhando no runtime. Está em
+      E.3(c) e continua aberto.
+
+## 7. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+      Nenhuma `SKILL.md` foi tocada por esta change: ela acrescenta uma classe de artefato, não
+      edita skill. `python3 scripts/validate-skills.py` -> `skills checked: 38   findings: 0`.
+      O gate irmão para a classe nova é `validate-agents.py` -> `agents checked: 3   findings: 0`.
+
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Os três agentes e os dois scripts em inglês (locale do catálogo); a prosa desta change e do
+      PR em português, como o repositório (`code-locale`).
+
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+      Gatilhos de agente são `description`, lidas pelo harness ao rotear. Nenhuma colide: o
+      `bug-hunter-analyst` diz explicitamente que não é para desenhar suíte de API do zero nem para
+      decidir se o teste vem antes do código; o `skill-auditor` diz que reporta e nunca é gate; o
+      `grounding-researcher` diz que não revisa nem corrige código.
+
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+      Nada restatado: o contrato do `grounding-researcher` aponta para `verify-before-claiming` em
+      vez de reproduzir a escada; o `bug-hunter-analyst` manda ler o track de `bug-hunter` em vez de
+      copiar o método; o `skill-auditor` audita contra `skills-authoring` e proíbe explicitamente
+      reportar o que os C1–C13 já cobrem.
+
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`)
+
+      Os blocos de código dos agentes são contratos de saída, não código executável, e estão em
+      inglês. Os dois scripts novos usam identificadores em inglês (`code-locale`).
+
+## 8. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate add-agents-layer --strict` green
+      `openspec validate add-agents-layer --strict` -> `Change 'add-agents-layer' is valid`;
+      `bash scripts/validate-rite.sh` -> `rite gate OK` (`Totals: 3 passed, 0 failed`).
+
+- [x] V.2 Catalog discovery intact: 38 skills, nenhum agente contado como skill, sem órfão
+      `ls -1 skills/ | wc -l` -> `38`, inalterado. `python3 scripts/validate-agents.py` ->
+      `agents checked: 3   findings: 0`, incluindo a lei de órfão (A7).
+      `python3 scripts/validate-repo-hygiene.py` -> `repo hygiene: 0 findings`, com o H4 novo ativo.
+      Duas execuções seguidas de `./generate.sh` deixam a árvore idêntica.
+
+- [x] V.3 README atualizado nas quatro frentes do grupo 5
+      `README.md`: seção *What is an agent?* com os três testes e a tabela de admissão dos três
+      agentes, `agents/` na árvore de estrutura e na tabela de pastas, e o parágrafo que declara
+      agente como Claude-Code-only logo abaixo da tabela multi-ferramenta.
+
+- [ ] V.4 `openspec archive add-agents-layer --yes` after all groups above are `[x]`

--- a/openspec/changes/add-agents-layer/tasks.md
+++ b/openspec/changes/add-agents-layer/tasks.md
@@ -82,6 +82,10 @@
       - Converter as duas chamadas de `Explore` em `backlog` e `execute-backlog` para agentes
         próprios: declarado fora de escopo na issue #198.
       - Um quarto agente. A lista é fechada aqui; outro passa pelos três testes num item próprio.
+      - Os três achados que o `skill-auditor` produziu sobre `skills/react-api-client/` na prova de
+        campo (cadências de polling sem regra, claim de concorrência não medido, e o bloco
+        `Verified against` sem versão de React numa skill sobre React). São de outra skill e
+        viram item próprio; corrigi-los aqui seria escopo que a proposta não pediu.
       - `UNSCOPED_COUNT_CLAIM` cobre `topics|skills`; passa a cobrir `agents` nesta change, e não
         foram acrescentados outros substantivos.
       - A entrada FULL do marketplace e o manifesto raiz continuam dizendo `all N` só de skills, e
@@ -210,6 +214,25 @@
       Os seis campos do contrato saíram na ordem, a evidência é citável e confere com o arquivo
       (`grep -n "A7 layout"` -> 141 e 149), e o NOTES é um caveat real que o chamador usaria.
 
+      **Segundo despacho, com o contrato conferido:** `ai-skills:skill-auditor` contra
+      `skills/react-api-client/` devolveu as quatro seções na ordem (SKILL, READ, FINDINGS, CLEAN,
+      NOT JUDGED) e **três achados reais**, nenhum deles pisando no território dos checks mecânicos:
+
+          1. unbacked-claim  skills/react-api-client/SKILL.md:84 — as cadências de polling
+             (wallet 10s, presence 15s, ranking 30s) são números para copiar, sem a regra que os
+             produz nem marca de observação não verificada.
+          2. unbacked-claim  SKILL.md:40 / references/api-client.md:69-78 — a afirmação de
+             single-flight no refresh é uma propriedade de concorrência, e o bloco `Verified against`
+             registra só um typecheck.
+          3. drifted-pin     SKILL.md:20-26 — o bloco pina typescript, axios e zustand e **não nomeia
+             versão de React**, numa skill cujo assunto declarado é React e que afirma o
+             double-mount do StrictMode.
+
+      A seção NOT JUDGED nomeou o que ele não pôde fechar (não há lockfile no repositório para
+      conferir os pins, e checar o registro npm seria egress fora do escopo da auditoria) — que é
+      exatamente a metade do contrato que diz ao chamador quanto da skill foi de fato examinado.
+      Os três achados são de outra skill e ficam como follow-up, não são corrigidos por esta change.
+
       **Controle:** o mesmo mecanismo com um agente built-in (`Explore`) devolveu
       `/home/diegops/ai-skills/scripts/validate-agents.py` em segundos, o que separa "o despacho
       aninhado funciona headless" de qualquer lentidão de tarefa (ver S.3).
@@ -221,8 +244,9 @@
       (bundle FULL e plugin por domínio). Agentes resolvidos por nome: **3/3** no bundle FULL,
       **2/2** nos dois plugins por domínio carregados.
 
-      **Despacho:** agentes despachados e que devolveram o contrato: **1/1** medido
-      (`grounding-researcher`), mais **1/1** de controle com agente built-in.
+      **Despacho:** agentes despachados e que devolveram o contrato: **2/3**
+      (`grounding-researcher` e `skill-auditor`), mais **1/1** de controle com agente built-in.
+      `bug-hunter-analyst` não foi medido dentro do orçamento desta sessão — ver S.3(b).
 
       **Gate `validate-agents.py`:** classes de defeito que tinham de reprovar e reprovaram
       **20/20**; casos que tinham de passar e passaram **2/2** (o agente conforme, e a cópia gerada
@@ -252,11 +276,14 @@
       é defeito do artefato — é o motivo de a prova de campo ter sido feita em sessões novas, e vale
       registrar porque quem editar um agente e tentar usá-lo no mesmo turno vai bater nisso.
 
-      (b) **Um despacho de `skill-auditor` não voltou dentro do orçamento.** Auditar
+      (b) **Um dos três agentes não foi despachado, e o custo do `skill-auditor` é alto.** Auditar
       `skills/lean-code/` (236 linhas mais references) contra `skills-authoring/spec.md` (47 KB) num
-      modelo `sonnet` passou de 420 s sem produzir saída. O controle com agente built-in voltou em
-      segundos no mesmo mecanismo, então o que isso mede é o tamanho da tarefa, não a fiação. Fica
-      registrado como observação de custo do `skill-auditor`, e não convertido em "tudo verde".
+      modelo `sonnet` passou de 420 s sem produzir saída; a mesma auditoria sobre uma skill menor
+      (`react-api-client`, 99 linhas) em `haiku` voltou completa e útil. O controle com agente
+      built-in voltou em segundos no mesmo mecanismo, então o que isso mede é o tamanho da tarefa e
+      não a fiação — mas é um custo real do `skill-auditor` e fica registrado, não arredondado.
+      `bug-hunter-analyst` ficou **sem medição de despacho** nesta sessão: passa o gate e é
+      descoberto pelos dois caminhos de plugin, e é só isso que está afirmado sobre ele.
 
       (c) **O `color` é exigido pelo validador porque o documento do harness o chama de
       obrigatório**, não porque um agente sem ele tenha sido observado falhando no runtime. Está em

--- a/plugins/testing/.claude-plugin/plugin.json
+++ b/plugins/testing/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ai-skills-testing",
   "displayName": "AI Skills — testing",
   "version": "2.34.0",
-  "description": "Adversarial testing rite and REST negative/fuzz/contract testing (3 skills: api-resilience-testing, bug-hunter, tdd)",
+  "description": "Adversarial testing rite and REST negative/fuzz/contract testing (3 skills: api-resilience-testing, bug-hunter, tdd) (1 agent: bug-hunter-analyst)",
   "author": { "name": "didevlab", "url": "https://github.com/solvelab" },
   "repository": "https://github.com/solvelab/ai-skills",
   "license": "MIT"

--- a/plugins/testing/agents/bug-hunter-analyst.md
+++ b/plugins/testing/agents/bug-hunter-analyst.md
@@ -1,0 +1,79 @@
+---
+name: bug-hunter-analyst
+description: >-
+  Use this agent to find how a change could break, after it has been implemented, and to return the
+  exact tests that would catch it. Typical triggers include adversarially reviewing a diff or branch
+  before opening a pull request, hunting edge cases, races and atomicity holes in a specific change,
+  and turning "what could go wrong here" into a concrete list of cases to write. See "When to
+  invoke" in the agent body for worked scenarios. It analyses only and writes no files; it is not
+  for designing a whole API test suite from scratch, and not for deciding whether a test is written
+  before the code.
+model: inherit
+color: red
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You are an adversarial analyst. Your job is to break a change on paper and hand back the cases that
+would break it in fact. You do not confirm the happy path; the author already did.
+
+## When to invoke
+
+- **A diff is about to be proposed.** The implementation looks right and has never been attacked.
+  You read it looking for the input that was not considered.
+- **A bug was fixed at one call site.** You grep every caller and report the siblings that still
+  carry the defect, rather than accepting that the named path is the whole of it.
+- **A change touches shared state, ordering or partial failure.** You look for the interleaving, the
+  half-applied write and the retry that is not idempotent.
+- **A test suite is green and that is the only evidence.** Green over cases that were chosen by the
+  author proves the author's assumptions, not the code.
+
+## How you work
+
+Read the change first — the diff, then the functions it touches, then their callers. Run only
+read-only commands. Then attack along these lines, and say which produced nothing:
+
+- **Boundaries**: empty, one, maximum, one past maximum, negative, zero, the value that is falsy but
+  valid.
+- **Types and encoding**: the wrong type that coerces silently, non-ASCII, a name with a separator in
+  it, a number arriving as a string.
+- **Trust**: input crossing a boundary without validation; an actor taken from the payload instead of
+  from the connection.
+- **Order and atomicity**: two calls interleaved; a failure between two writes; a retry of something
+  not idempotent; a cache that keeps a failure.
+- **Absence**: the dependency down, the file missing, the field absent versus present-and-null.
+- **The siblings**: every other call site of what was changed.
+
+The methodology you are applying is the `bug-hunter` skill. Read it for the stack track that matches
+the change; do not restate it in your answer.
+
+## Your output contract
+
+Return this and nothing else:
+
+```
+ATTACKS
+<n>. <one-line description of the input or interleaving> -> <the failure it causes>
+     WHERE: path:line
+     CONFIDENCE: confirmed (read the code path) | plausible (needs a run to settle)
+
+TESTS TO WRITE
+<n>. <test name in the repository's existing convention>
+     GIVEN: <setup>
+     WHEN:  <the attack>
+     THEN:  <the assertion that fails today>
+
+TRIED AND FOUND NOTHING
+- <the line of attack, one per line>
+```
+
+Rank attacks most severe first. `CONFIDENCE: plausible` is honest and useful; a confirmed label on a
+path you did not read is not.
+
+## What you must not return
+
+- **A file.** You have no write tools on purpose. Authorship, review and the undo live with the
+  calling loop; you return what to write, and it writes.
+- **A fix.** Naming the defect and the test that proves it is the whole job. A patch invites the
+  caller to apply it without reading the failure first.
+- **An empty TRIED AND FOUND NOTHING section.** If a line of attack produced nothing, say so — that
+  is the half of the report that tells the caller what is still unexamined.

--- a/plugins/tooling/.claude-plugin/plugin.json
+++ b/plugins/tooling/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ai-skills-tooling",
   "displayName": "AI Skills — tooling",
   "version": "2.34.0",
-  "description": "AI-assistant developer tooling — Claude Code status line setup and customization (1 skill: claude-statusline)",
+  "description": "AI-assistant developer tooling — Claude Code status line setup and customization (1 skill: claude-statusline) (1 agent: skill-auditor)",
   "author": { "name": "didevlab", "url": "https://github.com/solvelab" },
   "repository": "https://github.com/solvelab/ai-skills",
   "license": "MIT"

--- a/plugins/tooling/agents/skill-auditor.md
+++ b/plugins/tooling/agents/skill-auditor.md
@@ -1,0 +1,84 @@
+---
+name: skill-auditor
+description: >-
+  Use this agent to audit one skill directory against this catalog's authoring specification, on the
+  judgements the mechanical checks cannot make. Typical triggers include reviewing a skill before it
+  is published or after it is edited, checking whether doctrine was restated inline instead of
+  linked to its canonical home, and finding claims a skill publishes without the measurement behind
+  them. See "When to invoke" in the agent body for worked scenarios. It reports and never gates: the
+  repository's own validators remain the authority on everything mechanical, and this agent covers
+  only what they explicitly do not.
+model: inherit
+color: yellow
+tools: ["Read", "Grep", "Glob", "Bash"]
+---
+
+You are a catalog auditor. You read one skill and the specification it must obey, and you report the
+defects a pattern match cannot see. You are advisory: you never claim a verdict the build should act
+on by itself.
+
+## When to invoke
+
+- **A skill is about to be published.** The frontmatter passes and the links resolve; nobody has read
+  it against the specification it claims to implement.
+- **A skill was edited and its siblings were not.** A rule may now be stated in two places, which is
+  the defect the single-canonical-home law exists to prevent.
+- **A skill publishes a number.** You check whether the measurement behind it exists and is reachable
+  from the skill, or whether the number is decoration.
+- **A version pin block has gone quiet.** The block says what was probed and when; you check whether
+  what it claims still matches what the repository carries.
+
+## What you audit, and what you must not
+
+The mechanical half already has an owner: `scripts/validate-skills.py` runs thirteen checks — paths
+exist, cross-references name real skills, code blocks parse, frontmatter limits hold, references are
+reachable. **Never re-report what those checks already cover.** If you find yourself writing "this
+path does not exist", stop: that is C1's job and it already ran.
+
+You cover the judgements they cannot make:
+
+1. **Doctrine restated instead of linked.** The specification requires every cross-cutting rule to be
+   defined in exactly one skill and linked everywhere else with at most a one-line summary. A skill
+   that reproduces a sibling's mechanism inline is the defect. Read
+   `openspec/specs/skills-authoring/spec.md` for the canonical map before judging.
+2. **A cross-reference that resolves but misleads.** The named skill exists, so the mechanical check
+   passes, but the sentence describes it wrongly, or points at it for a rule it does not own.
+3. **A claim with no measurement.** A number, a percentage or a "measured" without a path to where it
+   was measured, or with one that no longer says what the skill says it says.
+4. **A version pin that has drifted.** The block names a tool version or a probe date; you check it
+   against what the repository actually carries now.
+5. **A description that promises what the body does not deliver**, or a body section whose content
+   belongs in the description because it only routes.
+
+## Your output contract
+
+Return this and nothing else:
+
+```
+SKILL: <name>
+READ: <the files you opened, one per line, with the spec sections you judged against>
+
+FINDINGS
+<n>. <category: restated-doctrine | misleading-crossref | unbacked-claim | drifted-pin | promise-gap>
+     WHERE: path:line
+     WHAT:  <the defect, one sentence>
+     WHY:   <the specification sentence it violates, quoted>
+     FIX:   <what would resolve it, one sentence — not a patch>
+
+CLEAN
+- <each of the five audit lines that produced nothing>
+
+NOT JUDGED
+- <anything you could not reach, and why>
+```
+
+## What you must not return
+
+- **A file, or an edit.** You have no write tools on purpose. You describe the fix in one sentence
+  and the calling loop decides and writes.
+- **A pass/fail verdict.** You are advisory by construction, because judgement can be wrong. Report
+  findings; the human and the mechanical gates decide.
+- **A finding the mechanical checks own.** If `scripts/validate-skills.py` would catch it, it is out
+  of your scope and reporting it is noise.
+- **An empty CLEAN section.** Saying which audit lines found nothing is what tells the caller how
+  much of the skill was actually examined.

--- a/plugins/workflow/.claude-plugin/plugin.json
+++ b/plugins/workflow/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "ai-skills-workflow",
   "displayName": "AI Skills — workflow",
   "version": "2.34.0",
-  "description": "Commit format, OpenSpec spec-driven workflow, the backlog rite, the anti-guessing rite, the code-locale rule, the lean-code doctrine and the artifact-boundary rule for delegation (9 skills: agent-delegation, backlog, code-locale, conventional-commit, execute-backlog, lean-code, openspec, openspec-drivezone, verify-before-claiming)",
+  "description": "Commit format, OpenSpec spec-driven workflow, the backlog rite, the anti-guessing rite, the code-locale rule, the lean-code doctrine and the artifact-boundary rule for delegation (9 skills: agent-delegation, backlog, code-locale, conventional-commit, execute-backlog, lean-code, openspec, openspec-drivezone, verify-before-claiming) (1 agent: grounding-researcher)",
   "author": { "name": "didevlab", "url": "https://github.com/solvelab" },
   "repository": "https://github.com/solvelab/ai-skills",
   "license": "MIT"

--- a/plugins/workflow/agents/grounding-researcher.md
+++ b/plugins/workflow/agents/grounding-researcher.md
@@ -1,0 +1,70 @@
+---
+name: grounding-researcher
+description: >-
+  Use this agent to establish ONE fact before it is asserted or acted on, when finding it means
+  reading far more than the answer is worth in the caller's context. Typical triggers include
+  verifying that a CLI flag, config key or API name exists in the installed version, resolving which
+  version of a dependency a project actually pins, confirming a claimed behaviour against the
+  dependency's own source, and reporting honestly that a fact could not be established. See "When to
+  invoke" in the agent body for worked scenarios. Do not use it to review or fix code, to design a
+  test suite, or to answer a question already settled in the caller's session.
+model: inherit
+color: cyan
+tools: ["Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"]
+---
+
+You are a research agent. You establish one fact, you say how you established it, and you say what
+you could not reach. You never produce a plausible substitute for a fact you did not find.
+
+## When to invoke
+
+- **A flag, key or API that must exist.** The caller is about to write a command, a config value or a
+  call, and the name has not been read in this session. You confirm it against the installed version,
+  not against memory.
+- **A version-dependent behaviour.** The answer differs between releases; the lockfile decides which
+  release this project has, and you read it before anything else.
+- **A claim that spans many files.** Confirming it means opening a lockfile, a vendored source tree
+  and a `--help` output — twenty reads for one line of answer.
+- **A fact that may not exist.** The caller needs to know that, plainly, rather than receive
+  something that sounds right.
+
+## The ladder you climb
+
+Cheapest first, and stop at the first rung that answers:
+
+1. The repository you were pointed at — its own code, config and docs.
+2. The installed dependency's source; the lockfile decides the version.
+3. The tool itself — `--help`, `--version`, a dry run.
+4. Documentation pinned to that version.
+5. Web search.
+
+Never skip downward. The web does not know this project. A rung you could not reach is reported as
+unreached, never as absent evidence that the unverified answer is probably right.
+
+The doctrine this implements — claim labelling, the not-found report, and why your own memory of an
+API is a hypothesis dated at your training cutoff — is the `verify-before-claiming` skill. Follow it;
+do not restate it back to the caller.
+
+## Your output contract
+
+Return this and nothing else:
+
+```
+CLAIM: <the one fact, stated as the caller will use it>
+VERDICT: verified | refuted | not found
+RUNG: <which rung answered, or "none">
+EVIDENCE: <path:line, or the command and the one line of its output that decides it>
+UNREACHED: <rungs you could not run, and why — or "none">
+NOTES: <at most two lines: a caveat that changes how the caller should use the fact>
+```
+
+Quote evidence you actually opened. If you cannot quote a line from it, you did not read it.
+
+## What you must not return
+
+- A fix, a patch, or a suggestion about what the caller should write. You establish facts; the caller
+  decides what to do with them.
+- A second claim. One invocation, one fact. If the question hides two, answer the one you were given
+  and say in NOTES that a second is embedded.
+- A confident answer with no EVIDENCE line. `VERDICT: not found` with a full UNREACHED line is a
+  successful run; a plausible sentence with an empty EVIDENCE line is a failed one.

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Self-test for scripts/validate-agents.py — the gate is itself gated.
+
+A validator nobody tests is a validator that can start passing everything. This builds a throwaway
+repository under a temporary directory, plants one defect at a time, and asserts that the check that
+owns it fires — and, just as importantly, that a conforming agent produces zero findings.
+
+Each case declares the check id it must provoke, so a defect detected by the WRONG check is a
+failure here too: that is how a broad regex quietly starts covering for a rule it was never meant to.
+
+Needs only python3 and PyYAML (which validate-agents.py itself needs). Run from anywhere.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REAL = Path(__file__).resolve().parent / "validate-agents.py"
+
+GOOD = """---
+name: {name}
+description: >-
+  Use this agent when a well formed example is needed. Typical triggers include the self-test of the
+  validator and nothing else at all.
+model: inherit
+color: blue
+tools: ["Read", "Grep"]
+---
+
+You are an example agent used only by the self-test.
+
+## When to invoke
+
+- **Never in real work.** This file exists so the validator has something valid to accept.
+"""
+
+
+def build(root: Path) -> None:
+    (root / "scripts").mkdir(parents=True)
+    shutil.copy2(REAL, root / "scripts" / "validate-agents.py")
+    (root / "agents").mkdir()
+    (root / "plugins").mkdir()
+    (root / "agents" / "example-agent.md").write_text(GOOD.format(name="example-agent"),
+                                                      encoding="utf-8")
+
+
+def run(root: Path) -> tuple[int, str]:
+    p = subprocess.run([sys.executable, str(root / "scripts" / "validate-agents.py")],
+                       capture_output=True, text=True)
+    return p.returncode, p.stdout + p.stderr
+
+
+def drop(field: str) -> str:
+    """The good agent with one frontmatter line removed."""
+    return "\n".join(l for l in GOOD.format(name="example-agent").splitlines()
+                     if not l.startswith(f"{field}:")) + "\n"
+
+
+def replace(old: str, new: str) -> str:
+    return GOOD.format(name="example-agent").replace(old, new, 1)
+
+
+# (label, expected check id, how to plant it)
+CASES: list[tuple[str, str, object]] = [
+    ("no frontmatter at all", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text("just a body\n", encoding="utf-8")),
+    ("frontmatter that does not parse", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("model: inherit", "model: inherit: broken"), encoding="utf-8")),
+    ("missing name", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        drop("name"), encoding="utf-8")),
+    ("missing description", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        "---\nname: example-agent\nmodel: inherit\ncolor: blue\ntools: [\"Read\"]\n---\n\n"
+        "Body long enough to pass the body check comfortably.\n\n## When to invoke\n\n- **Never.**\n",
+        encoding="utf-8")),
+    ("missing model", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        drop("model"), encoding="utf-8")),
+    ("missing color", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        drop("color"), encoding="utf-8")),
+    ("missing tools", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        drop("tools"), encoding="utf-8")),
+    ("name does not match the file", "A2", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("name: example-agent", "name: other-agent"), encoding="utf-8")),
+    ("name with an illegal character", "A2",
+     lambda r: (r / "agents" / "example_agent.md").write_text(
+         GOOD.format(name="example_agent"), encoding="utf-8")),
+    ("description too short", "A3", lambda r: (r / "agents" / "example-agent.md").write_text(
+        "---\nname: example-agent\ndescription: short\nmodel: inherit\ncolor: blue\n"
+        "tools: [\"Read\"]\n---\n\nBody long enough to pass the body check comfortably.\n\n"
+        "## When to invoke\n\n- **Never.**\n", encoding="utf-8")),
+    ("description too long", "A3", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("the self-test of the\n  validator and nothing else at all.",
+                "x " * 2600), encoding="utf-8")),
+    ("unknown model", "A4", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("model: inherit", "model: gpt-9"), encoding="utf-8")),
+    ("unknown color", "A4", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("color: blue", "color: taupe"), encoding="utf-8")),
+    ("tools declared empty", "A5", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace('tools: ["Read", "Grep"]', "tools: []"), encoding="utf-8")),
+    ("tools not a list", "A5", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace('tools: ["Read", "Grep"]', "tools: Read"), encoding="utf-8")),
+    ("tools with a non-string entry", "A5", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace('tools: ["Read", "Grep"]', "tools: [Read, 7]"), encoding="utf-8")),
+    ("body too short", "A6", lambda r: (r / "agents" / "example-agent.md").write_text(
+        "---\nname: example-agent\ndescription: >-\n  Long enough description for the range check "
+        "to accept it here.\nmodel: inherit\ncolor: blue\ntools: [\"Read\"]\n---\n\n"
+        "## When to invoke\n", encoding="utf-8")),
+    ("no When to invoke section", "A6", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("## When to invoke", "## How to Use"), encoding="utf-8")),
+    ("a subdirectory under agents/", "A7",
+     lambda r: (r / "agents" / "grouped").mkdir()),
+    ("an orphan in a generated tree", "A7", lambda r: (
+        (r / "plugins" / "testing" / "agents").mkdir(parents=True),
+        (r / "plugins" / "testing" / "agents" / "ghost.md").write_text(
+            GOOD.format(name="ghost"), encoding="utf-8"))),
+]
+
+
+def main() -> int:
+    failures = 0
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp) / "repo"
+
+        build(root)
+        code, out = run(root)
+        if code != 0 or "findings: 0" not in out:
+            print(f"  FAIL   a conforming agent was rejected\n{out}")
+            failures += 1
+        else:
+            print("  CLEAN  a conforming agent produces zero findings")
+
+        for label, check, plant in CASES:
+            shutil.rmtree(root)
+            build(root)
+            plant(root)
+            code, out = run(root)
+            if code == 0:
+                print(f"  MISSED {check}  {label}  — the validator accepted it")
+                failures += 1
+            elif f"[{check}" not in out:
+                print(f"  WRONG  {check}  {label}  — detected, but by another check:\n{out}")
+                failures += 1
+            else:
+                print(f"  OK     {check}  {label}")
+
+        # A conforming generated copy is NOT an orphan: the same file with a source present passes.
+        shutil.rmtree(root)
+        build(root)
+        (root / "plugins" / "testing" / "agents").mkdir(parents=True)
+        shutil.copy2(root / "agents" / "example-agent.md",
+                     root / "plugins" / "testing" / "agents" / "example-agent.md")
+        code, out = run(root)
+        if code != 0:
+            print(f"  FAIL   a generated copy WITH a canonical source was called an orphan\n{out}")
+            failures += 1
+        else:
+            print("  OK     A7  a generated copy with a source is not an orphan")
+
+    total = len(CASES) + 2
+    print(f"\n{total - failures}/{total} cases passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-agents.py
+++ b/scripts/validate-agents.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Catalog-wide agent validator.
+
+Implements the mechanically checkable half of openspec/specs/agents-catalog:
+
+  A1 frontmatter parses and carries every required field
+  A2 name == file stem, 3-50 chars, lowercase/digits/hyphen, alphanumeric at both ends
+  A3 description within 10-5000 characters
+  A4 model and color from the accepted sets
+  A5 tools declared explicitly, as a non-empty list of strings
+  A6 body within 20-10000 characters and carrying a "When to invoke" section
+  A7 no orphan agent in a generated tree, and the canonical directory is flat
+
+WHAT THIS DOES NOT COVER, on purpose:
+  - Whether the output contract in the body is honoured at run time. That is a judgement, and a
+    judgement is not sold as a gate (skills/agent-delegation/SKILL.md).
+  - Whether `tools` is actually minimal for the contract the body states. A5 proves the declaration
+    exists, which is the difference between a stated privilege and an unstated one; that the set is
+    the smallest possible is review-only.
+  - The three admission tests. They are written per agent in README.md and read by a human.
+
+The limits come from the agent format the harness documents, recorded in the add-agents-layer
+change (E.2), not from an open specification: unlike skills, agents have no reference validator to
+defer to. When the harness changes them, this file is where the change lands.
+
+Exit 1 on any finding. Run from the repo root.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:                                  # reported as a skip, never as a pass
+    yaml = None
+
+ROOT = Path(__file__).resolve().parent.parent
+AGENTS = ROOT / "agents"
+GENERATED = ROOT / "plugins"
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$")
+WHEN_TO_INVOKE = re.compile(r"^##+ +When to invoke *$", re.M | re.I)
+
+REQUIRED = ("name", "description", "model", "color", "tools")
+MODELS = {"inherit", "opus", "sonnet", "haiku"}
+COLORS = {"blue", "cyan", "green", "yellow", "magenta", "red"}
+
+DESCRIPTION_MIN, DESCRIPTION_MAX = 10, 5000
+BODY_MIN, BODY_MAX = 20, 10000
+
+findings: list[str] = []
+
+
+def add(agent: str, check: str, msg: str) -> None:
+    findings.append(f"{agent}\n   [{check}] {msg}")
+
+
+def split(text: str) -> tuple[str | None, str]:
+    """Frontmatter block and body. Returns (None, text) when there is no frontmatter."""
+    if not text.startswith("---\n"):
+        return None, text
+    end = text.find("\n---\n", 4)
+    if end == -1:
+        return None, text
+    return text[4:end], text[end + 5:]
+
+
+def check_file(path: Path) -> None:
+    agent = path.stem
+    text = path.read_text(encoding="utf-8")
+    raw, body = split(text)
+
+    if raw is None:
+        add(agent, "A1 frontmatter", "no YAML frontmatter delimited by --- at the top of the file")
+        return
+
+    try:
+        meta = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:                    # noqa: BLE001 - the parser's message is the finding
+        add(agent, "A1 frontmatter", f"YAML does not parse: {exc}")
+        return
+    if not isinstance(meta, dict):
+        add(agent, "A1 frontmatter", "frontmatter is not a mapping")
+        return
+
+    for field in REQUIRED:
+        if field not in meta:
+            add(agent, "A1 frontmatter", f"missing `{field}` — required for every agent")
+
+    name = meta.get("name")
+    if name is not None:
+        if name != agent:
+            add(agent, "A2 name", f"`name: {name}` does not match the file name `{agent}.md`")
+        if not isinstance(name, str) or not NAME_RE.match(name):
+            add(agent, "A2 name", f"`{name}` is not 3-50 lowercase letters, digits and hyphens "
+                                  "starting and ending alphanumeric")
+
+    desc = meta.get("description")
+    if desc is not None:
+        if not isinstance(desc, str):
+            add(agent, "A3 description", "description is not a string")
+        elif not DESCRIPTION_MIN <= len(desc) <= DESCRIPTION_MAX:
+            add(agent, "A3 description",
+                f"{len(desc)} characters — the accepted range is "
+                f"{DESCRIPTION_MIN}-{DESCRIPTION_MAX}")
+
+    model = meta.get("model")
+    if model is not None and model not in MODELS:
+        add(agent, "A4 model/color", f"`model: {model}` is not one of {sorted(MODELS)}")
+    color = meta.get("color")
+    if color is not None and color not in COLORS:
+        add(agent, "A4 model/color", f"`color: {color}` is not one of {sorted(COLORS)}")
+
+    tools = meta.get("tools")
+    if tools is not None:
+        if not isinstance(tools, list) or not tools:
+            add(agent, "A5 tools", "`tools` must be a non-empty list — omitting it grants every "
+                                   "tool, so the declaration is the privilege")
+        elif not all(isinstance(t, str) and t for t in tools):
+            add(agent, "A5 tools", "every entry of `tools` must be a non-empty string")
+
+    stripped = body.strip()
+    if not BODY_MIN <= len(stripped) <= BODY_MAX:
+        add(agent, "A6 body", f"{len(stripped)} characters — the accepted range is "
+                              f"{BODY_MIN}-{BODY_MAX}")
+    if not WHEN_TO_INVOKE.search(body):
+        add(agent, "A6 body", "no `## When to invoke` section — a description routes to the agent, "
+                              "this section tells the agent what the caller expected")
+
+
+def check_layout() -> None:
+    """A7 — the canonical directory is flat, and nothing is published without a source there.
+
+    Flat because a subdirectory changes the name under which the agent is invoked. Orphan because an
+    agent living only in a generated tree escapes this validator, the generator and the README while
+    still installing for users — the same law scripts/validate-skills.py applies to wrapper skills.
+    """
+    for sub in sorted(p for p in AGENTS.iterdir() if p.is_dir()):
+        add(sub.name, "A7 layout",
+            f"agents/{sub.name}/ is a directory — the canonical directory is flat, because a "
+            "subdirectory changes the name the agent is invoked under")
+
+    canonical = {p.stem for p in AGENTS.glob("*.md")}
+    for generated in sorted(GENERATED.glob("*/agents/*.md")):
+        if generated.stem not in canonical:
+            rel = generated.relative_to(ROOT)
+            add(generated.stem, "A7 layout",
+                f"{rel} has no source at agents/{generated.stem}.md — regenerate with "
+                "./generate.sh, or delete it")
+
+
+def main() -> int:
+    if yaml is None:
+        print("❌ PyYAML is not installed — the agent frontmatter cannot be parsed. "
+              "This is a SKIPPED check, not a pass.", file=sys.stderr)
+        return 1
+    if not AGENTS.is_dir():
+        print("agents/ not found — nothing to check.")
+        return 0
+
+    files = sorted(AGENTS.glob("*.md"))
+    for path in files:
+        check_file(path)
+    check_layout()
+
+    print(f"agents checked: {len(files)}   findings: {len(findings)}")
+    if findings:
+        print()
+        for f in findings:
+            print(f)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-repo-hygiene.py
+++ b/scripts/validate-repo-hygiene.py
@@ -10,6 +10,9 @@ trees. Nothing looked at the repository as a whole, which is how each of these g
   H3 plugin descriptions match the tree (game said "10 topics" over 12 skills, workflow named 5 of
                                          7, and H2 only ever matched `all N`; see #114)
 
+  H4 plugin agent lists match the tree (a published `(N agents: ...)` names exactly the
+     agents under plugins/<group>/agents/)
+
 Exit 1 on any finding. Run from the repo root.
 Modes: (default) check the tree   |   --selftest inject one defect per check and assert detection.
 """
@@ -36,10 +39,14 @@ COUNT_CLAIM = re.compile(r"\ball (\d+)\b")
 # heading shape `(React Three Fiber — 10 topics)`: a number and its noun right before the closing
 # parenthesis. It says nothing about which set it counts, so it cannot be checked against the tree;
 # the shape itself is the finding. `(all 35 skills)` is exempt here because COUNT_CLAIM owns it.
-UNSCOPED_COUNT_CLAIM = re.compile(r"(?<!all )\b(\d+) (?:topics|skills)\)")
+UNSCOPED_COUNT_CLAIM = re.compile(r"(?<!all )\b(\d+) (?:topics|skills|agents)\)")
 
 # The shape generate.sh publishes for every plugin group: "<theme> (<N> skill(s): a, b, c)".
 MEMBERSHIP_CLAIM = re.compile(r"\((\d+) skills?: ([^)]*)\)")
+# The agents ride in a SEPARATE parenthetical, published right after the skills one. They are not
+# folded into MEMBERSHIP_CLAIM because its name group is `[^)]*`: anything added inside that
+# parenthesis would be read as more skill names and H3 would compare the wrong set.
+AGENT_MEMBERSHIP_CLAIM = re.compile(r"\((\d+) agents?: ([^)]*)\)")
 MARKETPLACE = ".claude-plugin/marketplace.json"
 PLUGIN_SOURCE_PREFIX = "./plugins/"
 
@@ -129,6 +136,47 @@ def plugin_groups(root: Path) -> dict[str, set[str]]:
             for g in sorted(base.iterdir()) if (g / "skills").is_dir()}
 
 
+def plugin_agents(root: Path) -> dict[str, set[str]]:
+    """Agents published per group, by file stem. A group with no agents/ simply has no entry."""
+    base = root / "plugins"
+    if not base.is_dir():
+        return {}
+    return {g.name: {a.stem for a in (g / "agents").glob("*.md")}
+            for g in sorted(base.iterdir()) if (g / "agents").is_dir()}
+
+
+def _agent_membership_finding(rel: str, group: str, description: str, expected: set[str]) -> None:
+    """H4 — the agents parenthetical, judged the same way H3 judges the skills one.
+
+    Absence is a finding only when the group HAS agents: a group that publishes none has nothing to
+    name, and demanding an empty list would put `(0 agents: )` into every other description.
+    """
+    m = AGENT_MEMBERSHIP_CLAIM.search(description)
+    if not m:
+        if expected:
+            add("H4 plugin agent membership",
+                f"{rel} ({group}) ships {len(expected)} agent(s) and publishes no "
+                "`(N agents: <names>)` list — regenerate with ./generate.sh")
+        return
+    if not expected:
+        add("H4 plugin agent membership",
+            f"{rel} ({group}) publishes an agent list but plugins/{group}/agents/ does not exist — "
+            "regenerate with ./generate.sh")
+        return
+    claimed_count = int(m.group(1))
+    names = {n.strip() for n in m.group(2).split(",") if n.strip()}
+    extra, missing = sorted(names - expected), sorted(expected - names)
+    if extra or missing:
+        add("H4 plugin agent membership",
+            f"{rel} ({group}) names {len(names)} agent(s) but plugins/{group}/agents/ has "
+            f"{len(expected)} — in excess: {extra or 'none'}; missing: {missing or 'none'}; "
+            "regenerate with ./generate.sh")
+    if claimed_count != len(names):
+        add("H4 plugin agent membership",
+            f"{rel} ({group}) says {claimed_count} agent(s) but lists {len(names)} names; "
+            "regenerate with ./generate.sh")
+
+
 def _membership_finding(rel: str, group: str, description: str, expected: set[str]) -> None:
     m = MEMBERSHIP_CLAIM.search(description)
     if not m:
@@ -166,14 +214,16 @@ def check_plugin_membership(root: Path) -> None:
     not compared with the tree here and is review-only; H2 covers only its counts.
     """
     groups = plugin_groups(root)
+    agents = plugin_agents(root)
     for group, expected in groups.items():
         rel = f"plugins/{group}/.claude-plugin/plugin.json"
         p = root / rel
         if not p.is_file():
             add("H3 plugin description membership", f"{rel} is missing — regenerate with ./generate.sh")
             continue
-        _membership_finding(rel, group, json.loads(p.read_text(encoding="utf-8")).get("description", ""),
-                            expected)
+        description = json.loads(p.read_text(encoding="utf-8")).get("description", "")
+        _membership_finding(rel, group, description, expected)
+        _agent_membership_finding(rel, group, description, agents.get(group, set()))
 
     mp = root / MARKETPLACE
     if not mp.is_file():
@@ -193,6 +243,8 @@ def check_plugin_membership(root: Path) -> None:
         seen.add(group)
         _membership_finding(f"{MARKETPLACE} entry `{entry.get('name')}`", group,
                             entry.get("description", ""), groups[group])
+        _agent_membership_finding(f"{MARKETPLACE} entry `{entry.get('name')}`", group,
+                                  entry.get("description", ""), agents.get(group, set()))
     for group in sorted(set(groups) - seen):
         add("H3 plugin description membership",
             f"{MARKETPLACE} has no entry with source {PLUGIN_SOURCE_PREFIX}{group} — the group "


### PR DESCRIPTION
Closes #198

Spec-rite: `add-agents-layer` (schema `skills-rite`) — `openspec validate add-agents-layer --strict` verde, `bash scripts/validate-rite.sh` -> `rite gate OK`.

Depende de #197 (`agent-delegation`, mergeado em `f6663f1`) e de #200 (archive, mergeado em `36091e7`): sem a doutrina publicada, os três agentes entrariam sem teste de admissão.

## O buraco

Zero agentes, e não por decisão — por omissão. `find . -type d -name agents` vazio; `git log --all --name-only | grep '/agents/'` vazio: **nunca existiu em commit nenhum**. `generate.sh` gerava quatro árvores de wrapper e `plugins/`, sem alvo de agente. O `README` definia skill e não definia mais nada.

Enquanto isso o catálogo carregava três trabalhos que passam os três testes de `agent-delegation` e rodavam no loop principal, queimando o contexto que o resto da tarefa precisa.

## A localização foi imposta, não escolhida

`agents/<name>.md` na **raiz**, plano, sem subdiretórios:

- O bundle FULL é `source: "./"`, e a descoberta de agente é por convenção de diretório na raiz do plugin — `claude/agents/` não seria descoberto.
- Um subdiretório muda o namespace para `plugin:subdir:agent`, ou seja, custaria o nome que o usuário digita.

Isso era inferência quando o design foi escrito, e ficou registrado como lacuna aberta. **Foi medido**, rodando de um diretório que não é este repositório:

```
--plugin-dir <repo>                   -> ai-skills:bug-hunter-analyst
                                         ai-skills:grounding-researcher
                                         ai-skills:skill-auditor
--plugin-dir <repo>/plugins/testing   -> ai-skills-testing:bug-hunter-analyst
--plugin-dir <repo>/plugins/tooling   -> ai-skills-tooling:skill-auditor
```

Os dois caminhos de instalação que o README documenta expõem os agentes. A lacuna foi fechada com medição, não com argumento.

## Os três agentes

Nenhum tem `Write` ou `Edit`. É a aplicação direta do terceiro anti-padrão de `agent-delegation`: trabalho delegado que produz arquivo devolve **o que escrever**, e quem escreve é o loop chamador, onde ficam autoria, revisão e desfazer.

| Agente | Grupo | `tools` | Razão de admissão |
|---|---|---|---|
| `grounding-researcher` | workflow | Read, Grep, Glob, Bash, WebSearch, WebFetch | A escada de pesquisa custa vinte leituras para uma linha de resposta (peso); precisa da pergunta e da árvore, não da conversa (separável); devolve um bloco de cinco campos (contrato) |
| `bug-hunter-analyst` | testing | Read, Grep, Glob, Bash | Ler o diff, os callers e os irmãos é pesado e o relatório é curto (peso); o diff é a entrada (separável); ataques e casos de teste são lista conferível (contrato) |
| `skill-auditor` | tooling | Read, Grep, Glob, Bash | Skill + references + spec é leitura grande para uma tabela curta de defeitos (peso, contrato); advisory por construção — os treze checks mecânicos continuam sendo a autoridade |

Nenhum fixa `model`: `inherit`. Fixar nome de modelo aqui contradiria a própria regra de `agent-delegation` de escrever critério em vez de lista de modelos.

## O gate

`scripts/validate-agents.py` — A1 frontmatter, A2 name, A3 description, A4 model/color, A5 `tools` declarado, A6 corpo e `When to invoke`, A7 diretório plano e sem órfão.

`scripts/selftest-validate-agents.py` — **22/22**, cobrindo 20 classes de defeito, o caso limpo e o caso da cópia gerada COM fonte (que não é órfã). Um defeito pego pelo **check errado** também reprova: é assim que se impede um regex largo de cobrir calado por uma regra que nunca foi dele.

O validador pagou o próprio custo antes de entrar: pegou um defeito real na escrita — a `description` do `skill-auditor` tinha dois-pontos sem aspas e não parseava como YAML.

## O parêntese separado, e por quê

`MEMBERSHIP_CLAIM` em `scripts/validate-repo-hygiene.py` é `\((\d+) skills?: ([^)]*)\)`. Qualquer coisa acrescentada **dentro** daquele parêntese viraria mais um nome de skill e o H3 compararia o conjunto errado. Então a descrição publicada passa a ser:

```
<tema> (3 skills: api-resilience-testing, bug-hunter, tdd) (1 agent: bug-hunter-analyst)
```

e o H4 novo confere a segunda lista contra `plugins/<g>/agents/`. Provado nas duas formas:

```
lista adulterada -> names 2 agent(s) but plugins/testing/agents/ has 1 — in excess: ['ghost']
lista ausente    -> ships 1 agent(s) and publishes no `(N agents: <names>)` list
```

## O guard, provado quebrando

Um agente sem grupo no mapa `AGENT_GROUP` derruba `generate.sh`:

```
❌ generate.sh: no AGENT_GROUP for agent 'unmapped-agent' … Nothing was written.
```

E o md5 de `git status --porcelain --untracked-files=all` **antes e depois da falha é idêntico** — a árvore fica intacta, incluindo `plugins/`, que o script apaga poucas linhas adiante. É a mesma garantia que o guard de `GROUP_THEME` já dava, medida e não assumida.

## A promessa reduzida, por escrito

Agente é artefato **Claude-Code-only**. Codex, Cursor e Copilot não têm o conceito, e inventar equivalente publicaria comportamento que não existe. Em vez de omitir, o `README` diz isso onde a promessa multi-ferramenta é feita.

## Gates

| Gate | Resultado |
|---|---|
| `scripts/validate-agents.py` | `agents checked: 3   findings: 0` |
| `scripts/selftest-validate-agents.py` | `22/22 cases passed` |
| `scripts/validate-skills.py` | `skills checked: 38   findings: 0` |
| `scripts/validate-repo-hygiene.py` | `repo hygiene: 0 findings` (H4 incluído) |
| `scripts/scan-secrets.py` | `no credentials found` |
| `openspec validate --strict` | `Change 'add-agents-layer' is valid` |
| `scripts/validate-rite.sh` | `rite gate OK` (`3 passed, 0 failed`) |
| `./generate.sh` duas vezes | árvore idêntica (md5 do `git status` igual) |
| Descoberta real | os dois caminhos de plugin, listados acima |

## Mudanças

- **Novos**: `agents/{grounding-researcher,bug-hunter-analyst,skill-auditor}.md`, `scripts/validate-agents.py`, `scripts/selftest-validate-agents.py`.
- `generate.sh`: mapa `AGENT_GROUP` com guard pré-escrita, cópia para `plugins/<group>/agents/`, e o parêntese de agentes em `group_description()`.
- `scripts/validate-repo-hygiene.py`: H4 novo; `UNSCOPED_COUNT_CLAIM` passa a recusar `(N agents)` sem lista.
- `.github/workflows/ci.yml`: dois steps.
- `README.md`: *What is an agent?* com os três testes e a tabela de admissão, `agents/` na árvore e na tabela de pastas, e a declaração Claude-Code-only.
- Deltas: `agents-catalog` **ADDED** (nova capability, 4 requisitos / 10 cenários); `skills-catalog` **MODIFIED** — um agente não é uma skill do catálogo, `all N` continua contando skills.

## Known gaps

Registrados em `tasks.md` (E.3 / E.4), não escondidos:

- **Um dos dez critérios de aceite fica sem tique: o despacho dos três agentes.** Foram medidos **dois de três**, mais um controle com agente built-in:
  - `grounding-researcher` — contrato de seis campos, evidência com número de linha, e um caveat real no NOTES.
  - `skill-auditor` contra `skills/react-api-client/` — cinco seções na ordem e **três achados reais**: cadências de polling publicadas como números para copiar sem a regra que os produz; um claim de single-flight (propriedade de concorrência) cujo bloco `Verified against` registra só um typecheck; e um pin sem versão de React numa skill cujo assunto declarado **é** React. A seção NOT JUDGED nomeou o que ele não pôde fechar (sem lockfile no repositório, e o registro npm seria egress fora do escopo). Nenhum dos três pisa no território dos checks mecânicos, que é exatamente o desenho.
  - `bug-hunter-analyst` — **sem medição de despacho** nesta sessão. Passa o gate e é descoberto pelos dois caminhos de plugin, e é só isso que está afirmado sobre ele.

  Ticar o critério com dois de três seria ticar por intenção. Registrado em `tasks.md` S.3(b).

- **Custo do `skill-auditor` é real.** Auditar uma skill de 236 linhas contra uma spec de 47 KB em `sonnet` passou de 420 s sem retornar; a mesma auditoria sobre uma skill de 99 linhas em `haiku` voltou completa. O controle com agente built-in volta em segundos no mesmo mecanismo, então o que isso mede é tamanho de tarefa, não fiação.

- **Os três achados do `skill-auditor` são de outra skill** (`react-api-client`) e ficam como follow-up em `tasks.md` E.4. Corrigi-los aqui seria escopo que a proposta não pediu.

- **A entrada FULL do marketplace não nomeia os três agentes que também instala.** Nomeá-los exigiria estender o H4 ao manifesto raiz — uma decisão sobre se `all N` ganha um irmão. Item próprio; publicar a lista sem o gate seria uma contagem que a árvore não confirma.
- **Não há validador de referência para agentes**, como `skills-ref` é para skills. Os limites que `validate-agents.py` aplica vêm do formato que o harness documenta, e isso está escrito no cabeçalho do arquivo: é ali que a mudança dói quando o formato mudar.
- **`color` é exigido porque o documento o chama de obrigatório**, não porque um agente sem ele tenha sido observado falhando no runtime.
