### PR TITLE
🐛 fix(agents): endurece o validador contra os oito achados do bug-hunter-analyst

### DIFF
--- a/openspec/changes/harden-agent-validator/.openspec.yaml
+++ b/openspec/changes/harden-agent-validator/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-07

--- a/openspec/changes/harden-agent-validator/design.md
+++ b/openspec/changes/harden-agent-validator/design.md
@@ -1,0 +1,89 @@
+# Design — endurecer o validador de agentes
+
+## Context
+
+`scripts/validate-agents.py` nasceu no PR #202 com A1–A7 e `selftest-validate-agents.py` com 22
+casos, que cobrem o caminho de conteúdo: campo ausente, YAML quebrado, nome fora do padrão, limites,
+`tools` mal declarado, corpo curto, seção ausente, subdiretório e órfão.
+
+O que ele não cobria é o caminho de **entrada malformada** e o de **valor nulo**, e foi isso que o
+`bug-hunter-analyst` atacou. Oito achados, dois deles falso verde.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Nenhum falso verde: um campo obrigatório sem valor reprova, e a checagem de órfão roda mesmo quando
+  o diretório canônico sumiu.
+- Nenhuma entrada de arquivo termina a execução por exceção; cada uma vira achado nomeado e os demais
+  agentes continuam sendo checados.
+- Uma decisão escrita para cada ponto onde hoje há comportamento não declarado.
+- Um caso de selftest por defeito, cada um declarando o check que deve provocar.
+
+**Non-Goals:**
+
+- Transformar erro de ambiente em achado silencioso. Cada tratamento nomeia o caminho e o exit
+  continua não-zero.
+- Cobrir as seis linhas de ataque que não produziram nada. Ficam registradas como já examinadas.
+- Mexer em agente, skill, `generate.sh`, H4 ou README.
+
+## Decisions
+
+**D1 — Presença é valor, não chave.** `field not in meta` vira um teste de valor nulo. É a correção
+mínima que fecha o achado 1 inteiro, incluindo `tools: ~`, sem tocar em nenhum dos checks seguintes:
+com o campo tratado como ausente, A2–A5 param de ter o que pular.
+
+**D2 — `check_layout()` sai do caminho condicional.** A ausência de `agents/` deixa de ser um
+`return` e passa a ser uma condição que a própria checagem de órfão avalia: sem fonte canônica,
+qualquer cópia gerada é órfã. O `return` antecipado existia para o caso legítimo "repositório sem
+agentes", que continua sendo zero achados — mas agora **porque a checagem rodou**, não porque foi
+pulada.
+
+**D3 — Recusar âncora e alias YAML, em vez de limitar a expansão.** Um teto de tamanho no bloco não
+para uma bomba pequena que expande muito, e um teto de tempo é frágil e dependente da máquina.
+Frontmatter de agente não tem uso legítimo para âncora: recusá-la remove a classe inteira, é
+determinístico, e a mensagem diz o que fazer. É o mesmo raciocínio de `lean-code` — a solução que
+não precisa de heurística ganha da que precisa.
+
+**D4 — A saída é sanitizada na fronteira de registro, não em cada interpolação.** Sanitizar em
+`add()` cobre todo achado presente e futuro; sanitizar em cada f-string cobre só os quatro sítios de
+hoje e é esquecido no quinto. O valor problemático continua visível, com o caractere não codificável
+substituído.
+
+**D5 — O A7 compara conteúdo.** `generate.sh` copia com `cp --no-preserve=mode`, então a cópia gerada
+é byte a byte igual à fonte; comparar é barato e fecha o buraco. A alternativa — declarar no cabeçalho
+que o A7 compara só o nome e que a divergência é problema do gate de sync — foi recusada: a lei que o
+requisito publica é "nada é publicado sem fonte canônica", e uma cópia divergente **é** conteúdo
+publicado sem fonte.
+
+**D6 — Qualquer espaço em branco depois dos `##` é aceito.** A regra atual exige espaço ASCII e
+reprova `##\tWhen to invoke`, que um renderizador de Markdown aceita. Reprovar um cabeçalho válido é
+um falso positivo do gate, e um gate que reprova o que a ferramenta aceita treina o autor a ignorá-lo.
+
+**D7 — Cada correção ganha um caso de selftest, e o formato dele não muda.** O arquivo já reprova
+quando o defeito é pego pelo check errado; os casos novos entram na mesma lista declarando o check
+que devem provocar. Nenhuma infraestrutura nova.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Composição e autoria da camada de agentes; a lei de órfão e o que ela compara | `agents-catalog` | already canonical — MODIFIED nos dois requisitos tocados |
+| Metodologia adversarial que produziu os oito achados | `bug-hunter` | link — os achados vieram de um agente que executa aquela metodologia; ela não é restatada aqui |
+| Menor privilégio em `tools` e contrato de saída | `agent-delegation` | already canonical — o achado do `tools: ~` é uma violação daquela regra passando pelo gate, não uma regra nova |
+| Não afirmar o que não foi probado | `verify-before-claiming` | link — o grupo Evidence cita, não restata |
+| Volume de código | `lean-code` | link — D3 e D4 são as duas aplicações da escada aqui: a solução sem heurística e a correção na fronteira em vez de em cada sítio |
+
+## Risks / Trade-offs
+
+- **Engolir exceção demais e transformar erro de ambiente em achado silencioso.** Mitigado por um
+  critério de aceite explícito: cada tratamento nomeia o caminho, e o exit continua não-zero.
+- **Recusar âncora YAML quebrar um agente legítimo.** Nenhum dos três publicados usa âncora, e o
+  formato do harness não a documenta. Se algum dia um caso legítimo aparecer, a mensagem do achado é
+  onde a exceção será discutida.
+- **O A7 comparando conteúdo duplicar o gate de sync do CI.** Aceito e escrito em D5: o gate de sync
+  compara a árvore inteira contra `generate.sh`; o A7 publica a lei de fonte canônica e agora a
+  cumpre. Dois gates que pegam o mesmo defeito por caminhos diferentes é redundância barata, não
+  duplicação de doutrina.
+- **Um nono ataque existir.** É o desenho: o selftest cresce por defeito encontrado, não por
+  antecipação. As seis linhas que não produziram nada estão registradas para não serem reexaminadas.

--- a/openspec/changes/harden-agent-validator/proposal.md
+++ b/openspec/changes/harden-agent-validator/proposal.md
@@ -1,0 +1,68 @@
+# Change: Endurecer o validador de agentes contra os oito achados
+
+## Why
+
+`scripts/validate-agents.py` foi entregue pelo PR #202 com A1–A7 e um selftest de 22 casos. Na prova
+de campo daquele mesmo PR, o agente `bug-hunter-analyst` — publicado por ele — foi apontado para o
+validador que o publicou e devolveu **oito** ataques, mais uma seção *TRIED AND FOUND NOTHING* com
+seis linhas que não produziram nada e a razão de cada uma.
+
+Dois deles são **falso verde**, não crash, e por isso são os graves:
+
+1. **Campo obrigatório com null explícito passa tudo.** `field not in meta` testa só a presença da
+   chave. `name:` sem valor satisfaz A1, e cada check seguinte é guardado por `if X is not None:` e
+   pula. Um agente com os cinco campos nulos sai `findings: 0`: bypass completo do núcleo do gate.
+   O subcaso `tools: ~` é o mais afiado — o comentário do próprio check diz que omitir `tools`
+   concede tudo, e um null explícito é equivalente a omitir em runtime.
+2. **`agents/` ausente faz o validador sair 0 sem checar órfão.** `main()` retorna antes de
+   `check_layout()`. Apagado ou renomeado o diretório canônico com cópias ainda em
+   `plugins/*/agents/`, a única checagem que pegaria isso é a que nunca roda.
+
+Os outros seis: três entradas de arquivo derrubam a execução por exceção não tratada (diretório com
+sufixo `.md`, bytes não-UTF-8 ou symlink pendurado, surrogate solto no `name` estourando no `print`),
+uma expansão de âncora YAML sem teto de recurso, o A7 comparando **stems** e não conteúdo (uma cópia
+gerada que divergiu passa), e uma decisão nunca escrita sobre `##\tWhen to invoke`.
+
+## What Changes
+
+- **Presença passa a ser valor presente, não chave presente.** Um campo obrigatório com valor nulo é
+  tratado como ausente, e os checks seguintes deixam de ser puláveis por null.
+- **`check_layout()` roda sempre**, mesmo sem `agents/`: é a checagem de órfão, e a ausência do
+  diretório canônico é justamente um dos estados que ela precisa reprovar.
+- **Nenhuma entrada de arquivo derruba a execução.** Diretório com sufixo `.md`, arquivo ilegível e
+  symlink pendurado viram achado nomeado, e os demais agentes continuam sendo checados.
+- **Âncoras e aliases YAML são recusados** no frontmatter de agente, o que remove a classe inteira da
+  bomba de expansão em vez de tentar limitá-la.
+- **A saída é à prova de caractere não codificável**, para que um surrogate solto vire achado legível
+  em vez de estourar no meio da listagem.
+- **A7 passa a comparar conteúdo**, não só nome: uma cópia gerada que divergiu da fonte canônica é
+  achado.
+- **A decisão sobre o espaço depois dos `##` é escrita e implementada**: qualquer espaço em branco é
+  aceito, porque é o que um renderizador de Markdown aceita.
+- O selftest cresce com um caso por defeito, cada um declarando o check que deve provocar — a lei que
+  aquele arquivo já aplica, e que reprova também quando o defeito é pego pelo check errado.
+
+**Não muda**: nenhum agente é criado, removido ou editado; nenhuma skill é tocada; `generate.sh`, o
+H4 e o `README` ficam como estão.
+
+## Capabilities
+
+### New Capabilities
+
+Nenhuma.
+
+### Modified Capabilities
+
+- `agents-catalog`: MODIFIED *A published agent declares its admission and its privilege* — o
+  requisito passa a dizer que um campo obrigatório declarado sem valor é ausente, e que o gate não
+  termina por exceção diante de entrada malformada. MODIFIED *Agents have a single canonical home and
+  no orphans* — a lei de órfão passa a dizer o que compara (nome **e** conteúdo) e que a ausência do
+  diretório canônico é ela própria um estado a reprovar.
+
+## Impact
+
+- `scripts/validate-agents.py` e `scripts/selftest-validate-agents.py`; nada mais em `scripts/`.
+- Nenhuma mudança em `.github/workflows/ci.yml`: os dois steps já existem e passam a exercitar as
+  regras novas.
+- Os três agentes publicados continuam aprovando sem edição — o gate fica mais estrito, e eles já o
+  cumpriam.

--- a/openspec/changes/harden-agent-validator/specs/agents-catalog/spec.md
+++ b/openspec/changes/harden-agent-validator/specs/agents-catalog/spec.md
@@ -1,0 +1,107 @@
+## MODIFIED Requirements
+
+### Requirement: Agents have a single canonical home and no orphans
+
+The repository SHALL publish agents from exactly one canonical location, `agents/<name>.md` at the
+repository root, and every copy under `plugins/<group>/agents/` SHALL be generated from it. An agent
+present only in a generated tree is not a published agent: it escapes the generator, the validator
+and the README, while still installing for users. CI SHALL reject that state, the same way it
+rejects an orphan wrapper skill.
+
+The canonical directory SHALL be flat. A subdirectory changes the name under which the agent is
+invoked, so grouping by domain would be paid for in the name the user types.
+
+The check SHALL compare the generated copy with its canonical source by **content**, not by name
+alone: a copy that has drifted from the source — hand-edited, or left behind by a stale generator run
+— is published content with no canonical source, which is the state this requirement exists to
+refuse. The check SHALL also run when the canonical directory is absent, because a missing
+`agents/` with generated copies still present is itself that state, and a validator that returns
+early there cannot see the very regression it owns.
+
+#### Scenario: An agent in a generated tree without a source is rejected
+
+- **WHEN** a file exists under `plugins/<group>/agents/` with no matching `agents/<name>.md`
+- **THEN** the agent validator reports it as an orphan and CI fails
+
+#### Scenario: The generator refuses an agent it cannot place
+
+- **WHEN** an agent exists in the canonical directory with no plugin group mapped to it
+- **THEN** the generator fails before writing any file and before removing the generated plugin
+  tree, so the working tree is left exactly as it was
+- **AND** the error names the agent and where the mapping is declared
+
+#### Scenario: Adding an agent goes through the canonical tree
+
+- **WHEN** a new agent is added
+- **THEN** it is written to `agents/<name>.md`, its plugin copies are produced by the generator, and
+  it gains a README row — never hand-written into a generated tree
+
+#### Scenario: A generated copy that drifted from its source is reported
+
+- **WHEN** a file under `plugins/<group>/agents/` differs in content from `agents/<name>.md`
+- **THEN** the validator reports it, naming both paths
+
+#### Scenario: A missing canonical directory does not silence the orphan check
+
+- **WHEN** the canonical directory does not exist and generated copies do
+- **THEN** the orphan check still runs and reports every copy as having no source
+- **AND** a repository that legitimately publishes no agents still reports zero findings, because the
+  check ran and found nothing — not because it was skipped
+
+
+### Requirement: A published agent declares its admission and its privilege
+
+Every `agents/<name>.md` SHALL carry the frontmatter its harness requires — an identifier equal to
+the file name, a description naming the conditions that route work to it, the model, and the colour —
+and SHALL declare `tools` explicitly. Omitting `tools` grants every tool, so the declaration is the
+difference between a stated privilege and an unstated one.
+
+A required field declared with no value SHALL be treated as absent. A key present and null satisfies
+a membership test while stating nothing, and `tools` declared null is equivalent at run time to
+omitting it — the case the privilege rule above exists to refuse.
+
+The gate SHALL NOT end by unhandled exception on malformed input. A directory carrying the file
+suffix, a file that cannot be decoded, a dangling symlink, an unencodable character in a field, and
+an anchor or alias in the frontmatter SHALL each become a reported finding that names the path, and
+the remaining agents SHALL still be checked. A gate that crashes on the first bad input reports
+nothing about the inputs after it.
+
+The body SHALL carry a section naming the situations that invoke the agent, and SHALL state the
+output contract: the shape the caller receives and what the agent must not return. An agent whose
+work would produce a file SHALL return what to write rather than write it, unless writing inside the
+isolated context is the work being bought.
+
+Every published agent SHALL carry, in the repository, the written reason it passes the three
+admission tests of the delegation doctrine. An agent admitted by symmetry with an existing artifact,
+rather than by those tests, is a defect.
+
+#### Scenario: An agent without a declared tool set fails the gate
+
+- **WHEN** an agent omits `tools`, or names a write tool while its contract says it returns what to
+  write
+- **THEN** the validator fails naming the agent and the field
+
+#### Scenario: An agent that does not say when to invoke it fails the gate
+
+- **WHEN** the body carries no section naming the situations that invoke the agent
+- **THEN** the validator fails, because a description alone routes without telling the agent what
+  the caller expected
+
+#### Scenario: The validator is itself gated
+
+- **WHEN** the agent validator ships
+- **THEN** a self-test proves each of its rules fails a violating agent and passes a conforming one,
+  so the gate is not trusted on its own word
+
+#### Scenario: A required field present but null fails the gate
+
+- **WHEN** an agent declares a required field with no value, or an explicit null
+- **THEN** the validator reports it as missing, and every check that field feeds still runs
+
+#### Scenario: Malformed input is reported, not fatal
+
+- **WHEN** the canonical directory contains a directory named like an agent file, a file that cannot
+  be decoded, or a dangling symlink
+- **THEN** each is reported as a finding naming the path, the remaining agents are still checked, and
+  the run still exits non-zero
+

--- a/openspec/changes/harden-agent-validator/tasks.md
+++ b/openspec/changes/harden-agent-validator/tasks.md
@@ -1,0 +1,254 @@
+# Tasks
+
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at
+
+      Lidos em `d10969c` (master, base de `backlog/205-harden-agent-validator`) em 2026-09-07:
+
+      - `scripts/validate-agents.py` inteiro — `add()`, `split()`, `check_file()`, `check_layout()` e
+        `main()`, incluindo o `return` antecipado quando `agents/` não existe e os cinco blocos
+        `if X is not None:`.
+      - `scripts/selftest-validate-agents.py` inteiro — `GOOD`, `build()`, `run()`, `drop()`,
+        `replace()`, a lista `CASES` e as duas asserções positivas do final.
+      - `openspec/specs/agents-catalog/spec.md` — os dois requisitos tocados, copiados por completo no
+        delta antes de serem modificados.
+      - `.github/workflows/ci.yml` — os dois steps de agente, para confirmar que nenhum precisa mudar.
+      - `agents/*.md` (os três) e `plugins/*/agents/*.md` (as três cópias geradas).
+      - `generate.sh` — a linha que copia o agente, `cp --no-preserve=mode`, que é o que torna a
+        comparação de conteúdo do A7 válida byte a byte.
+
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded
+
+      O relatório que originou o item é a saída do agente `ai-skills:bug-hunter-analyst` despachado
+      contra `scripts/validate-agents.py` numa sessão headless em 2026-09-07. Oito ataques, cada um
+      com `WHERE:` em `path:line` e `CONFIDENCE:`; seis linhas em *TRIED AND FOUND NOTHING* com a
+      razão de cada uma não ter produzido nada.
+
+      Estado antes da correção: `python3 scripts/selftest-validate-agents.py` -> `22/22 cases passed`
+      — ou seja, o selftest existente aprovava um validador com dois falsos verdes.
+
+      Depois: `python3 scripts/selftest-validate-agents.py` -> `33/33 cases passed`;
+      `python3 scripts/validate-agents.py` -> `agents checked: 3   findings: 0`.
+
+      `openspec new change harden-agent-validator --schema skills-rite` -> `Schema: skills-rite`;
+      `openspec validate harden-agent-validator --strict` -> `Change 'harden-agent-validator' is valid`.
+
+      `cmp -s agents/<n>.md plugins/<g>/agents/<n>.md` para os três -> idênticos, o que confirma a
+      premissa do D5.
+
+- [x] E.3 Anything that could NOT be probed is written down as an open question (design.md, or here
+      when there is no design.md) — never stated as fact, never filled with a plausible substitute
+
+      Duas lacunas, nenhuma preenchida com substituto plausível:
+
+      (a) **O ataque 4 (bomba de expansão YAML) nunca foi executado.** O próprio relatório o marcou
+      `CONFIDENCE: plausible` e disse que não executou payload. Esta change **também não** executa: ela
+      remove a classe recusando âncora e alias, e o caso de selftest prova que um alias é recusado —
+      não que uma bomba teria estourado a máquina. A afirmação que fica é "âncora é recusada", não
+      "a bomba era explorável".
+
+      (b) **Se algum consumidor usa âncora YAML legitimamente no frontmatter de um agente.** Os três
+      publicados não usam, e o formato documentado pelo harness não a menciona. Não há como saber de
+      agentes fora deste repositório; a mensagem do achado é onde essa exceção seria discutida.
+
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed
+
+      **Escopo levantado, e registrado:** a issue #205 foi escrita descrevendo **seis** achados,
+      porque eu tinha lido só a cauda do relatório ao abri-la. São **oito**, e os dois que faltavam
+      são os graves (falso verde por null explícito; `agents/` ausente pulando a checagem de órfão).
+      O levantamento está comentado na issue e os critérios de aceite passaram a cobrir os oito.
+      Levantar veredito não pede permissão; baixar pediria.
+
+      Follow-ups anotados e **não** feitos:
+
+      - As seis linhas de *TRIED AND FOUND NOTHING* (CRLF, alias recursivo em `tools`, normalização
+        Unicode no stem, frontmatter vazio degenerado, dois órfãos do mesmo stem, corrida de
+        filesystem) ficam registradas como já examinadas e **não** viram teste.
+      - O relatório observou que o frontmatter vazio degenerado (`---\n---\n`) é rotulado pelo check
+        errado — reprova, mas como "sem frontmatter" em vez de "frontmatter vazio". Não é falso verde
+        e não foi tocado.
+      - Nada em `agents/`, `skills/`, `generate.sh`, `.github/workflows/` ou `README.md` foi alterado.
+
+## 2. Os dois falsos verdes
+
+- [x] 2.1 Presença passa a ser valor: campo obrigatório com null explícito reprova, e A2–A5 deixam de
+      ser puláveis (ataque 1)
+      `meta.get(field) is None` no lugar de `field not in meta`, e a mensagem distingue ausente de
+      declarado-sem-valor. Selftest: `name declared with no value`, `tools declared as an explicit
+      null` e `description declared as null`, os três reprovando em A1.
+
+- [x] 2.2 `check_layout()` roda mesmo sem `agents/`, e o `return` antecipado sai de `main()` (ataque 2)
+
+      `main()` deixa de retornar quando `agents/` não existe; `check_layout()` roda sempre e trata a
+      ausência como o estado que ela própria reprova. Asserção positiva no selftest: com o diretório
+      canônico apagado e uma cópia gerada presente, o A7 dispara.
+
+## 3. As entradas que derrubavam a execução
+
+- [x] 3.1 Diretório com sufixo `.md` é do A7, e `check_file` não reporta o mesmo defeito duas vezes (ataque 3)
+      `check_file` retorna cedo em diretório, com o comentário dizendo que o A7 é o dono — antes o
+      mesmo defeito produzia dois achados. Selftest: `a directory named like an agent file` -> A7.
+
+- [x] 3.2 Arquivo ilegível e symlink pendurado viram achado nomeado; os demais agentes continuam sendo checados (ataque 6)
+      `except (UnicodeDecodeError, FileNotFoundError, PermissionError, OSError)` vira achado que
+      nomeia o caminho. O guard de diretório é `is_dir()` e **não** `is_file()` de propósito:
+      `is_file()` também recusa symlink pendurado, que precisa virar achado. Selftest:
+      `bytes that are not UTF-8` e `a dangling symlink`, os dois em A1.
+
+- [x] 3.3 A saída é sanitizada em `add()`, para que um surrogate solto vire achado legível (ataque 5)
+      `_printable()` na fronteira de `add()`. Selftest: `a lone surrogate in name` -> A2, e a regra
+      anti-traceback prova que a execução completa.
+
+- [x] 3.4 Âncora e alias YAML recusados por loader próprio, removendo a classe (ataque 4)
+
+      `_NoAliasLoader(yaml.SafeLoader)` recusa `AliasEvent` com mensagem própria. Selftest:
+      `a YAML anchor and alias in the frontmatter` -> A1.
+
+## 4. As duas regras que faltavam
+
+- [x] 4.1 A7 compara conteúdo além do nome: cópia gerada divergente é achado (ataque 7)
+      A7 compara `read_bytes()` da fonte com o da cópia. Premissa conferida: `cmp -s` entre os três
+      agentes e suas cópias em `plugins/*/agents/` -> idênticos. Selftest:
+      `a generated copy that drifted from its source` -> A7.
+
+- [x] 4.2 Qualquer espaço em branco depois dos `##` é aceito, e a decisão está escrita (ataque 8)
+
+      `^#{2,}\s+When to invoke\s*$`. Decisão escrita no D6 e no comentário do próprio regex.
+      Asserção positiva no selftest: cabeçalho com tabulação é **aceito**.
+
+## 5. Selftest
+
+- [x] 5.1 Um caso por defeito corrigido, cada um declarando o check que deve provocar
+      Nove casos novos na lista `CASES`, cada um declarando o check que deve provocar — e um defeito
+      pego pelo check errado continua reprovando, que é a lei que o arquivo já aplicava.
+
+- [x] 5.2 Traceback passa a reprovar em **todos** os casos, não só nos que se esperava que quebrassem
+      `Traceback (most recent call last)` na saída reprova em qualquer caso, com rótulo `CRASH`. É a
+      generalização do que os ataques 3, 5 e 6 tinham em comum.
+
+- [x] 5.3 Duas asserções positivas: o cabeçalho com tabulação é aceito; o diretório canônico ausente
+      **não** silencia a checagem de órfão
+
+      Cabeçalho com tabulação aceito, e diretório canônico ausente não silenciando o A7.
+
+## 6. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+
+      O caminho real destes dois scripts é serem rodados — pelo autor e pelos dois steps do CI. Os
+      dois falsos verdes foram exercitados numa árvore descartável, para medir o **antes documentado**
+      contra o depois observado.
+
+      **Ataque 1, campo obrigatório com null explícito.** Um agente com os cinco campos declarados sem
+      valor. Antes, pelo caminho de código lido: `findings: 0`, aprovação limpa. Observado agora:
+
+          agents checked: 1   findings: 5
+          nulls
+             [A1 frontmatter] missing `name` — required for every agent (declared with no value, which states nothing)
+             … idem description, model, color, tools
+          exit=1
+
+      **Ataque 2, diretório canônico ausente com cópia publicada.** Antes:
+      `agents/ not found — nothing to check.` e exit 0. Observado agora:
+
+          agents checked: 0   findings: 1
+          ghost
+             [A7 layout] plugins/testing/agents/ghost.md has no source at agents/ghost.md — regenerate with ./generate.sh, or delete it
+          exit=1
+
+      **Contra a árvore real**: `python3 scripts/validate-agents.py` ->
+      `agents checked: 3   findings: 0` — o gate ficou mais estrito e os três agentes publicados já o
+      cumpriam, sem edição.
+
+      **Selftest**: `python3 scripts/selftest-validate-agents.py` -> `33/33 cases passed`, contra
+      `22/22` antes desta change. Os 22 antigos continuam passando.
+
+- [x] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+
+      - Ataques que tinham de deixar de passar e deixaram: **8/8** — os dois falsos verdes medidos
+        ponta a ponta acima, e os outros seis cobertos por caso de selftest que declara o check dono.
+      - Casos de selftest que tinham de reprovar e reprovaram: **20/20** antigos + **9/9** novos.
+      - Casos que tinham de **passar** e passaram: **4/4** — o agente conforme, a cópia gerada com
+        fonte, o cabeçalho com tabulação, e o repositório sem agentes (zero achados porque a checagem
+        rodou, não porque foi pulada).
+      - Defeito pego pelo check errado: **0** — continua sendo reprovação, e nenhum caso caiu nela.
+      - Traceback em qualquer caso: **0/33**, agora medido em todos e não só onde se esperava.
+      - Cópias geradas conferidas byte a byte contra a fonte: **3/3** idênticas, que é a premissa do
+        A7 novo.
+
+      Escapes conhecidos que continuaram em silêncio, de propósito: as seis linhas de *TRIED AND FOUND
+      NOTHING* do relatório não viraram teste e estão nomeadas em E.4; e o frontmatter vazio
+      degenerado continua rotulado pelo check errado — reprova, mas como "sem frontmatter". Não é
+      falso verde, e não foi tocado.
+
+- [x] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+      Três coisas, nenhuma silenciada:
+
+      (a) **O escopo do item estava errado quando eu o abri: seis achados, e são oito.** Eu tinha lido
+      só a cauda da saída do agente. Os dois que faltavam eram os graves — os únicos dois falsos
+      verdes do conjunto. Levantado, comentado na issue e coberto pelos critérios. Está aqui e em E.4
+      porque é a segunda vez nesta sequência que um número meu não bateu com a fonte.
+
+      (b) **A primeira correção do ataque 3 produzia dois achados para um defeito.** Guardar
+      `check_file` e deixar o A7 também reportar fazia um diretório `ghost.md/` aparecer duas vezes.
+      Corrigido antes do commit: `check_file` retorna cedo em diretório e o A7 é o dono. E o guard é
+      `is_dir()` e não `is_file()` de propósito — `is_file()` recusa symlink pendurado, que precisa
+      virar achado.
+
+      (c) **A bomba de expansão YAML nunca foi executada, nem antes nem agora.** O relatório a marcou
+      `plausible` e disse que não executou payload; esta change remove a classe recusando âncora, e o
+      caso de selftest prova que um alias é recusado — **não** que a bomba era explorável. A afirmação
+      que fica é essa, e está em E.3(a).
+
+## 7. Quality Gates (MANDATORY)
+
+- [x] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+      Nenhuma `SKILL.md` foi tocada: esta change mexe em dois scripts. `validate-skills.py` ->
+      `skills checked: 38   findings: 0`.
+
+- [x] Q.2 All touched skill content in English (catalog locale)
+      Os dois scripts em inglês, comentários incluídos; a prosa desta change e do PR em português.
+
+- [x] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+      Nenhuma `description` foi tocada — nem de skill nem de agente. `validate-agents.py` ->
+      `agents checked: 3   findings: 0`, com o gate mais estrito.
+
+- [x] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+      Nada restatado: a metodologia adversarial que produziu os achados é linkada a `bug-hunter`, e a
+      regra de menor privilégio é de `agent-delegation` — o achado do `tools: ~` é uma violação dela
+      passando pelo gate, não uma regra nova escrita aqui.
+
+- [x] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`)
+
+      Identificadores em inglês nos dois scripts (`code-locale`). C9 rodou sobre as 38 skills sem
+      achados.
+
+## 8. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate harden-agent-validator --strict` green
+      `openspec validate harden-agent-validator --strict` -> `Change 'harden-agent-validator' is
+      valid`; `bash scripts/validate-rite.sh` -> `rite gate OK`.
+
+- [x] V.2 Catalog discovery intact: 38 skills, 3 agentes, sem órfão e sem cópia divergente
+      38 skills, 3 agentes. `validate-agents.py` 0 achados com o gate endurecido;
+      `validate-repo-hygiene.py` -> `repo hygiene: 0 findings`; `./generate.sh` não move nenhuma cópia
+      de agente.
+
+- [x] V.3 README / docs updated where the change alters catalog composition or usage
+      Nada a atualizar: a composição do catálogo não muda e o `README` já descreve o gate sem
+      enumerar os checks. O que mudou é o rigor do validador, documentado no cabeçalho dele.
+
+- [ ] V.4 `openspec archive harden-agent-validator --yes` after all groups above are `[x]`

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -116,6 +116,34 @@ CASES: list[tuple[str, str, object]] = [
         (r / "plugins" / "testing" / "agents").mkdir(parents=True),
         (r / "plugins" / "testing" / "agents" / "ghost.md").write_text(
             GOOD.format(name="ghost"), encoding="utf-8"))),
+
+    # ── The eight attacks the bug-hunter-analyst agent found against the first version (issue #205).
+    # Two of them were false GREEN, and those two are the reason this block exists: a gate that
+    # crashes is loud, a gate that passes a bad agent is not.
+    ("name declared with no value", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("name: example-agent", "name:"), encoding="utf-8")),
+    ("tools declared as an explicit null", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace('tools: ["Read", "Grep"]', "tools: ~"), encoding="utf-8")),
+    ("description declared as null", "A1", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("description: >-\n  Use this agent when a well formed example is needed. Typical "
+                "triggers include the self-test of the\n  validator and nothing else at all.",
+                "description: null"), encoding="utf-8")),
+    ("a directory named like an agent file", "A7",
+     lambda r: (r / "agents" / "ghost.md").mkdir()),
+    ("bytes that are not UTF-8", "A1",
+     lambda r: (r / "agents" / "broken.md").write_bytes(b"---\nname: broken\n\xff\xfe---\n")),
+    ("a dangling symlink", "A1",
+     lambda r: (r / "agents" / "dangling.md").symlink_to(r / "nowhere" / "missing.md")),
+    ("a lone surrogate in name", "A2", lambda r: (r / "agents" / "example-agent.md").write_text(
+        replace("name: example-agent", 'name: "\\uD800"'), encoding="utf-8")),
+    ("a YAML anchor and alias in the frontmatter", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace('tools: ["Read", "Grep"]', "tools: &t [\"Read\"]\nextra: *t"), encoding="utf-8")),
+    ("a generated copy that drifted from its source", "A7", lambda r: (
+        (r / "plugins" / "testing" / "agents").mkdir(parents=True),
+        (r / "plugins" / "testing" / "agents" / "example-agent.md").write_text(
+            replace("color: blue", "color: red"), encoding="utf-8"))),
 ]
 
 
@@ -137,7 +165,12 @@ def main() -> int:
             build(root)
             plant(root)
             code, out = run(root)
-            if code == 0:
+            if "Traceback (most recent call last)" in out:
+                # A gate that ends by exception reports nothing about the inputs after the bad one.
+                # Checked for every case, not only the ones we thought could crash (issue #205).
+                print(f"  CRASH  {check}  {label}  — the validator raised instead of reporting:\n{out}")
+                failures += 1
+            elif code == 0:
                 print(f"  MISSED {check}  {label}  — the validator accepted it")
                 failures += 1
             elif f"[{check}" not in out:
@@ -145,6 +178,35 @@ def main() -> int:
                 failures += 1
             else:
                 print(f"  OK     {check}  {label}")
+
+        # A tab after the hashes is a heading every Markdown renderer accepts, so the gate accepts it
+        # too (issue #205, attack 8). A gate that rejects what the tool accepts teaches the author to
+        # ignore the gate.
+        shutil.rmtree(root)
+        build(root)
+        (root / "agents" / "example-agent.md").write_text(
+            replace("## When to invoke", "##\tWhen to invoke"), encoding="utf-8")
+        code, out = run(root)
+        if code != 0:
+            print(f"  FAIL   A6  a tab after the heading hashes was rejected\n{out}")
+            failures += 1
+        else:
+            print("  OK     A6  a tab after the heading hashes is accepted")
+
+        # The canonical directory is gone and a generated copy is still published: the state A7 owns,
+        # and the one the early return used to hide by never running the check (issue #205, attack 2).
+        shutil.rmtree(root)
+        build(root)
+        (root / "plugins" / "testing" / "agents").mkdir(parents=True)
+        shutil.copy2(root / "agents" / "example-agent.md",
+                     root / "plugins" / "testing" / "agents" / "example-agent.md")
+        shutil.rmtree(root / "agents")
+        code, out = run(root)
+        if code == 0 or "[A7" not in out:
+            print(f"  MISSED A7  a missing canonical directory silenced the orphan check\n{out}")
+            failures += 1
+        else:
+            print("  OK     A7  a missing canonical directory does not silence the orphan check")
 
         # A conforming generated copy is NOT an orphan: the same file with a source present passes.
         shutil.rmtree(root)
@@ -159,7 +221,7 @@ def main() -> int:
         else:
             print("  OK     A7  a generated copy with a source is not an orphan")
 
-    total = len(CASES) + 2
+    total = len(CASES) + 4
     print(f"\n{total - failures}/{total} cases passed")
     return 1 if failures else 0
 

--- a/scripts/validate-agents.py
+++ b/scripts/validate-agents.py
@@ -11,6 +11,12 @@ Implements the mechanically checkable half of openspec/specs/agents-catalog:
   A6 body within 20-10000 characters and carrying a "When to invoke" section
   A7 no orphan agent in a generated tree, and the canonical directory is flat
 
+HARDENED against the eight attacks the bug-hunter-analyst agent found against the first version
+(issue #205). Two of them were false GREEN, not crashes: a required field declared null passed every
+check, and a missing canonical directory returned before the orphan check ever ran. The rest were
+unhandled exceptions on malformed input, an unbounded YAML alias expansion, an A7 that compared names
+and not content, and a heading rule that rejected a tab a Markdown renderer accepts.
+
 WHAT THIS DOES NOT COVER, on purpose:
   - Whether the output contract in the body is honoured at run time. That is a judgement, and a
     judgement is not sold as a gate (skills/agent-delegation/SKILL.md).
@@ -41,7 +47,30 @@ AGENTS = ROOT / "agents"
 GENERATED = ROOT / "plugins"
 
 NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$")
-WHEN_TO_INVOKE = re.compile(r"^##+ +When to invoke *$", re.M | re.I)
+# Any whitespace after the hashes, not only an ASCII space: `##\tWhen to invoke` is a heading every
+# Markdown renderer accepts, and a gate that rejects what the tool accepts teaches the author to
+# ignore the gate (issue #205, attack 8).
+WHEN_TO_INVOKE = re.compile(r"^#{2,}\s+When to invoke\s*$", re.M | re.I)
+
+if yaml is not None:
+    class _NoAliasLoader(yaml.SafeLoader):
+        """SafeLoader that refuses YAML anchors and aliases.
+
+        `safe_load` blocks unsafe tag construction, not alias amplification: nested anchors doubling a
+        list at each level expand exponentially and exhaust the runner (issue #205, attack 4). A size
+        or time ceiling does not stop a small payload that expands hugely, and is machine-dependent.
+        Agent frontmatter has no legitimate use for an anchor, so the class is removed instead of
+        bounded.
+        """
+
+        def compose_node(self, parent, index):                 # noqa: D102 - PyYAML hook
+            if self.check_event(yaml.events.AliasEvent):
+                event = self.peek_event()
+                raise yaml.YAMLError(
+                    f"YAML alias `*{event.anchor}` is not accepted in agent frontmatter "
+                    "(anchors and aliases are refused; write the value out)")
+            return super().compose_node(parent, index)
+
 
 REQUIRED = ("name", "description", "model", "color", "tools")
 MODELS = {"inherit", "opus", "sonnet", "haiku"}
@@ -53,8 +82,16 @@ BODY_MIN, BODY_MAX = 20, 10000
 findings: list[str] = []
 
 
+def _printable(s: str) -> str:
+    """Replace characters stdout cannot encode — a lone surrogate from a `\\uD800` escape in the
+    frontmatter reaches here as a valid Python str and only fails at `print`, after the summary line
+    is already out (issue #205, attack 5). Sanitising at the recording boundary covers every finding,
+    present and future; sanitising at each interpolation covers only the sites that exist today."""
+    return s.encode("utf-8", "replace").decode("utf-8", "replace")
+
+
 def add(agent: str, check: str, msg: str) -> None:
-    findings.append(f"{agent}\n   [{check}] {msg}")
+    findings.append(_printable(f"{agent}\n   [{check}] {msg}"))
 
 
 def split(text: str) -> tuple[str | None, str]:
@@ -69,7 +106,21 @@ def split(text: str) -> tuple[str | None, str]:
 
 def check_file(path: Path) -> None:
     agent = path.stem
-    text = path.read_text(encoding="utf-8")
+    if path.is_dir():
+        # A directory carrying the .md suffix is a LAYOUT defect and A7 owns it; reporting it here
+        # too would print two findings for one problem. Not silently skipped: A7's own scan sees
+        # every directory under agents/ (issue #205, attack 3).
+        return
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, FileNotFoundError, PermissionError, OSError) as exc:
+        # Bytes that are not UTF-8, a dangling symlink (which `is_file()` also rejects, so the guard
+        # above must not be widened to it), an unreadable file: each was an unhandled exception that
+        # ended the run and left every alphabetically later agent unchecked (issue #205, attack 6).
+        add(agent, "A1 frontmatter",
+            f"{path.relative_to(ROOT)} could not be read as UTF-8 text: "
+            f"{type(exc).__name__}: {exc}")
+        return
     raw, body = split(text)
 
     if raw is None:
@@ -77,7 +128,7 @@ def check_file(path: Path) -> None:
         return
 
     try:
-        meta = yaml.safe_load(raw)
+        meta = yaml.load(raw, Loader=_NoAliasLoader)
     except yaml.YAMLError as exc:                    # noqa: BLE001 - the parser's message is the finding
         add(agent, "A1 frontmatter", f"YAML does not parse: {exc}")
         return
@@ -86,8 +137,15 @@ def check_file(path: Path) -> None:
         return
 
     for field in REQUIRED:
-        if field not in meta:
-            add(agent, "A1 frontmatter", f"missing `{field}` — required for every agent")
+        # Presence is a VALUE, not a key. `name:` with nothing after it, `~` and `null` all satisfy a
+        # membership test while stating nothing, and every check below is guarded by `is not None` —
+        # so an agent with all five fields null used to pass the whole gate clean. `tools: ~` was the
+        # sharpest case: null is equivalent at run time to omitting it, which grants every tool
+        # (issue #205, attack 1).
+        if meta.get(field) is None:
+            add(agent, "A1 frontmatter",
+                f"missing `{field}` — required for every agent"
+                f"{' (declared with no value, which states nothing)' if field in meta else ''}")
 
     name = meta.get("name")
     if name is not None:
@@ -131,24 +189,46 @@ def check_file(path: Path) -> None:
 
 
 def check_layout() -> None:
-    """A7 — the canonical directory is flat, and nothing is published without a source there.
+    """A7 — the canonical directory is flat, nothing is published without a source there, and no
+    generated copy has drifted from the source it claims.
 
     Flat because a subdirectory changes the name under which the agent is invoked. Orphan because an
     agent living only in a generated tree escapes this validator, the generator and the README while
     still installing for users — the same law scripts/validate-skills.py applies to wrapper skills.
-    """
-    for sub in sorted(p for p in AGENTS.iterdir() if p.is_dir()):
-        add(sub.name, "A7 layout",
-            f"agents/{sub.name}/ is a directory — the canonical directory is flat, because a "
-            "subdirectory changes the name the agent is invoked under")
 
-    canonical = {p.stem for p in AGENTS.glob("*.md")}
+    Runs even when `agents/` is absent: a missing canonical directory with generated copies still
+    present is exactly the state this check owns, and the early return that used to skip it here made
+    the one check that would catch that regression the one that never ran (issue #205, attack 2).
+
+    Content, not just the name: `generate.sh` copies with `cp --no-preserve=mode`, so a published copy
+    is byte-identical to its source. A copy that differs was hand-edited or left by a stale generator
+    run, and is published content whose canonical source says something else (issue #205, attack 7).
+    """
+    if AGENTS.is_dir():
+        for sub in sorted(p for p in AGENTS.iterdir() if p.is_dir()):
+            add(sub.name, "A7 layout",
+                f"agents/{sub.name}/ is a directory — the canonical directory is flat, because a "
+                "subdirectory changes the name the agent is invoked under")
+
+    canonical = {p.stem: p for p in AGENTS.glob("*.md") if p.is_file()} if AGENTS.is_dir() else {}
     for generated in sorted(GENERATED.glob("*/agents/*.md")):
-        if generated.stem not in canonical:
-            rel = generated.relative_to(ROOT)
+        rel = generated.relative_to(ROOT)
+        source = canonical.get(generated.stem)
+        if source is None:
             add(generated.stem, "A7 layout",
                 f"{rel} has no source at agents/{generated.stem}.md — regenerate with "
                 "./generate.sh, or delete it")
+            continue
+        try:
+            drifted = source.read_bytes() != generated.read_bytes()
+        except OSError as exc:
+            add(generated.stem, "A7 layout",
+                f"{rel} could not be compared with its source: {type(exc).__name__}: {exc}")
+            continue
+        if drifted:
+            add(generated.stem, "A7 layout",
+                f"{rel} differs from its canonical source agents/{generated.stem}.md — the published "
+                "copy has drifted; regenerate with ./generate.sh")
 
 
 def main() -> int:
@@ -156,11 +236,10 @@ def main() -> int:
         print("❌ PyYAML is not installed — the agent frontmatter cannot be parsed. "
               "This is a SKIPPED check, not a pass.", file=sys.stderr)
         return 1
-    if not AGENTS.is_dir():
-        print("agents/ not found — nothing to check.")
-        return 0
-
-    files = sorted(AGENTS.glob("*.md"))
+    # No early return when agents/ is missing: check_layout() owns exactly that state (issue #205,
+    # attack 2). A repository that legitimately publishes no agents still reports zero findings —
+    # because the check ran, not because it was skipped.
+    files = sorted(AGENTS.glob("*.md")) if AGENTS.is_dir() else []
     for path in files:
         check_file(path)
     check_layout()


### PR DESCRIPTION
Closes #205

Spec-rite: `harden-agent-validator` (schema `skills-rite`) — `openspec validate harden-agent-validator --strict` verde, `bash scripts/validate-rite.sh` -> `rite gate OK`.

## De onde vieram os achados

O `validate-agents.py` foi entregue no PR #202 com A1–A7 e um selftest de 22 casos. Na prova de campo **daquele mesmo PR**, o `bug-hunter-analyst` publicado por ele foi apontado para o validador que o publicou. Voltou com oito ataques e uma seção `TRIED AND FOUND NOTHING` com seis linhas que não produziram nada.

O selftest de 22 casos aprovava um validador com **dois falsos verdes**. É o argumento inteiro para o rito de campo existir.

## Os dois graves, medidos antes e depois

**Ataque 1 — campo obrigatório com null explícito passava tudo.** `field not in meta` testa só a presença da chave; cada check seguinte era guardado por `if X is not None:` e pulava. Um agente com os cinco campos declarados sem valor saía limpo. O subcaso `tools: ~` era o mais afiado: o comentário do próprio check diz que omitir `tools` concede tudo, e null é equivalente a omitir em runtime.

```
antes (pelo caminho de código):  agents checked: 1   findings: 0   exit=0
depois (medido):                 agents checked: 1   findings: 5   exit=1
  [A1] missing `name` — required for every agent (declared with no value, which states nothing)
  … idem description, model, color, tools
```

**Ataque 2 — `agents/` ausente saía 0 sem checar órfão.** `main()` retornava antes de `check_layout()`. Apagado o diretório canônico com cópias ainda em `plugins/*/agents/`, a única checagem que pegaria isso era a que nunca rodava.

```
antes:   agents/ not found — nothing to check.                    exit=0
depois:  agents checked: 0   findings: 1                          exit=1
  [A7 layout] plugins/testing/agents/ghost.md has no source at agents/ghost.md
```

## Os outros seis

| # | Defeito | Correção |
|---|---|---|
| 3 | diretório `agents/<n>.md/` -> `IsADirectoryError` | `check_file` retorna cedo em diretório; o A7 é o dono, e não há dois achados para um defeito |
| 4 | expansão de âncora YAML sem teto | loader que **recusa** âncora e alias — remove a classe, em vez de tentar limitá-la |
| 5 | surrogate solto estourando no `print` | sanitização em `add()`, na fronteira de registro |
| 6 | bytes não-UTF-8 / symlink pendurado | vira achado que nomeia o caminho; os demais agentes seguem checados |
| 7 | A7 comparava **stems**, não conteúdo | compara bytes: cópia gerada divergente é achado |
| 8 | `##\tWhen to invoke` recusado | qualquer espaço em branco é aceito, como o Markdown aceita |

Duas decisões que vale ler no `design.md`:

- **D3, recusar âncora em vez de limitar expansão.** Teto de tamanho não para bomba pequena que expande muito, e teto de tempo é frágil e dependente da máquina. Frontmatter de agente não tem uso legítimo para âncora.
- **D5, o A7 passa a comparar conteúdo.** A alternativa era declarar no cabeçalho que ele compara só o nome e que divergência é problema do gate de sync. Recusada: a lei que o requisito publica é *"nada é publicado sem fonte canônica"*, e uma cópia divergente **é** conteúdo publicado sem fonte.

E um guard sutil: o retorno antecipado usa `is_dir()` e **não** `is_file()` de propósito — `is_file()` também recusa symlink pendurado, que precisa virar achado.

## Selftest: 22 -> 33, e uma regra nova

Nove casos novos, um por defeito, cada um declarando o check que deve provocar — a lei que o arquivo já aplicava, e que reprova também quando o defeito é pego pelo check errado.

Mais duas asserções positivas (cabeçalho com tabulação é aceito; diretório canônico ausente **não** silencia o A7) e uma regra geral: **`Traceback` na saída reprova em qualquer caso**, não só nos que se esperava que quebrassem. É a generalização do que os ataques 3, 5 e 6 tinham em comum.

## Matriz medida

Ataques que tinham de deixar de passar **8/8** · casos de selftest reprovando **20/20** antigos + **9/9** novos · casos que tinham de passar **4/4** · defeito pego pelo check errado **0** · traceback **0/33** · cópias geradas idênticas à fonte **3/3**.

Contra a árvore real: `agents checked: 3   findings: 0` — o gate ficou mais estrito e os três agentes publicados já o cumpriam, sem edição.

## Gates

| Gate | Resultado |
|---|---|
| `scripts/validate-agents.py` | `agents checked: 3   findings: 0` |
| `scripts/selftest-validate-agents.py` | `33/33 cases passed` |
| `scripts/validate-skills.py` | `skills checked: 38   findings: 0` |
| `scripts/validate-repo-hygiene.py` | `repo hygiene: 0 findings` |
| `openspec validate --strict` | válido |
| `scripts/validate-rite.sh` | `rite gate OK` (`4 passed, 0 failed`) |
| `./generate.sh` pós-commit | limpo, sem diff e sem untracked |

## Escopo levantado, e por quê

**O item foi aberto dizendo seis achados. São oito.** Ao abri-lo eu tinha lido só a cauda da saída do agente, e os dois que faltavam eram justamente os dois falsos verdes. Levantei o escopo, comentei na issue e os critérios passaram a cobrir os oito. Levantar veredito não pede permissão; baixar pediria. Está registrado em `tasks.md` E.4 e S.3(a).

## Known gaps

- **A bomba de expansão YAML nunca foi executada**, nem antes nem agora. O relatório a marcou `CONFIDENCE: plausible` e disse que não executou payload. Esta change remove a classe, e o caso de selftest prova que **um alias é recusado** — não que a bomba era explorável. A afirmação que fica é essa.
- **Se algum consumidor usa âncora YAML legitimamente** no frontmatter de um agente é desconhecido: os três publicados não usam e o formato documentado não a menciona. A mensagem do achado é onde essa exceção seria discutida.
- **As seis linhas de `TRIED AND FOUND NOTHING`** ficam registradas como já examinadas e **não** viraram teste — para não serem reexaminadas nem testadas por antecipação.
- **O frontmatter vazio degenerado (`---\n---\n`) continua rotulado pelo check errado**: reprova, mas como "sem frontmatter". Não é falso verde, e não foi tocado.
