### PR TITLE
🐛 fix(scripts): fecha os doze buracos do validador de agentes

### DIFF
--- a/openspec/changes/harden-agent-validator-against-twelve/.openspec.yaml
+++ b/openspec/changes/harden-agent-validator-against-twelve/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-07

--- a/openspec/changes/harden-agent-validator-against-twelve/design.md
+++ b/openspec/changes/harden-agent-validator-against-twelve/design.md
@@ -1,0 +1,91 @@
+# Design — hardening the agent validator against twelve findings
+
+## Context
+
+`scripts/validate-agents.py` and its 33-case self-test were hardened once already, under issue #205,
+against six findings from the same analyst. The twelve findings here came from a second pass run
+during the field proof of issue #222, and from a mutation measurement that used the self-test itself
+as the runner: 205 mutants, 151 killed, 54 survived, with 20 survivors sitting on the limit constants
+and the boundary comparisons.
+
+The two crashes are the important ones. They are not new requirements — the published requirement
+already forbids them, in the sentence *"A gate that crashes on the first bad input reports nothing
+about the inputs after it."* What this change adds to the spec is the two input classes that reach
+that state, so the next reader does not have to rediscover them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- No frontmatter value ends the process by traceback; every one becomes a finding carrying the id of
+  the check that owns it.
+- A6 accepts only a heading a Markdown renderer would render as one, and only outside fenced blocks.
+- Every limit the gate enforces has a witness on each side and one at the value, so moving the
+  constant kills a test.
+- The mutation number is re-measured under the conditions of the first measurement, so the two are
+  comparable, and published as measured.
+
+**Non-Goals:**
+
+- Making mutation testing a CI gate of this repository. The doctrine shipped by #222 is scoped to a
+  change; turning it into a pipeline is a decision of its own.
+- Touching any published skill or agent, or the generated trees.
+- Rewriting A7's drift check, which is correct and tested.
+
+## Decisions
+
+**D1 — The type guard goes before the membership test, not around it.** `model not in MODELS` raises
+only because an unhashable value reaches it. Wrapping the expression in `try` would convert the crash
+into a silent pass for the very field the check owns. The value is checked for being a string first,
+and a non-string is the finding.
+
+**D2 — `RecursionError` is caught beside `yaml.YAMLError`, in both gates.** It is raised by the parser
+on input the parser cannot handle, which is exactly what the existing handler is for; it is simply not
+a subclass of `YAMLError`. `scripts/validate-skills.py:408` and `:592` carry the same bare
+`except _yaml.YAMLError` over the same `safe_load`, so they are fixed in this change. Fixing only
+`validate-agents.py` would leave the sibling gate crashing on the same 1 KB payload.
+
+**D3 — A6 stops using `\s+`.** The intent was "the heading text follows the hashes on the same line";
+`\s` includes `\n`, so an empty heading followed by a paragraph satisfies it. The fix is `[ \t]+`.
+Separately, fenced blocks are removed before the search, the way the sibling validator already does
+for its own citation check — the same construct, so the same treatment.
+
+**D4 — Finding 10 is researched before it is coded.** A duplicate frontmatter key (`tools: ~` then
+`tools: ["Read"]`) currently yields no finding: PyYAML keeps the last value silently, so the gate
+judges a value the harness's own reader may not pick. Which key the harness takes is a fact about the
+harness, not a guess to encode — it is probed by planting an agent with duplicate keys in a scratch
+project and asking a fresh session what privilege it holds. If the probe cannot settle it, the finding
+is recorded as a written gap in the Evidence group and no code is written for it, because a test built
+on the wrong assumption locks the wrong behaviour in.
+
+**D5 — Boundary witnesses live in the self-test, not in the gate.** Findings 5, 6, 7 and 12 name no
+defect in the validator's behaviour; they name the absence of evidence that the behaviour is what the
+gate claims. The fix is cases, on both sides and at the value, plus the two-agent case whose absence
+is what let the crash stay invisible.
+
+**D6 — The re-measurement is reported as it comes out.** If survivors on the limit constants do not
+fall to zero, the number is published with the condition rather than adjusted. A measurement that
+disagrees with the change is information about the change.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Fix the root cause, grep every caller, never patch only the named path | `lean-code` | link — D2 applies it and points there |
+| Adversarial defect classes and the enumerate/generate/score layers | `bug-hunter` | already canonical — this change is an application of it, not an edit to it |
+| Measure a claim before publishing it; report what could not be probed | `verify-before-claiming` | link — D4 and D6 apply it |
+| What a published agent must declare and what its gate must survive | `agents-catalog` (spec) | already canonical — this change modifies it |
+
+## Risks / Trade-offs
+
+- **A stricter A6 and A5 could reject a published agent.** Checked before writing the change: the
+  three published agents pass today and must still pass; the self-test carries the accepting cases.
+- **Removing fenced blocks before the A6 search could hide a legitimate heading** that a reader
+  intended inside a fence. That is the correct outcome: a heading inside a fence is not rendered as a
+  heading, so it does not satisfy the requirement either.
+- **The `RecursionError` guard could mask a real stack overflow in our own code.** It is caught only
+  around the parse call, never around the checks.
+
+## Open questions
+
+- Finding 10, until D4's probe settles it.

--- a/openspec/changes/harden-agent-validator-against-twelve/proposal.md
+++ b/openspec/changes/harden-agent-validator-against-twelve/proposal.md
@@ -1,0 +1,60 @@
+# Change: Harden the agent validator against the twelve field-proof findings
+
+## Why
+
+`openspec/specs/agents-catalog/spec.md:74` already requires it: *"The gate SHALL NOT end by unhandled
+exception on malformed input ... and the remaining agents SHALL still be checked. A gate that crashes
+on the first bad input reports nothing about the inputs after it."* Two inputs break that today, and
+were reproduced first-hand on `e56579a`: a `model` declared as a list raises `TypeError: cannot use
+'list' as a set element`, and a `tools` value of 500 nested flow sequences raises `RecursionError`,
+which is not a `yaml.YAMLError` and so escapes the handler. With the first planted, a second broken
+agent placed after it alphabetically is never reported.
+
+Two more inputs produce a false GREEN on A6: a body whose `##` sits alone on its line with
+`When to invoke` on the next passes, because the check's `\s+` matches a newline; and a body whose
+only `## When to invoke` lives inside a fenced code block passes, because the search runs over the
+raw body. Both were planted and both returned `agents checked: 1   findings: 0`.
+
+The remaining findings come from the same field proof (PR #223, issue #222), where a mutation run
+left 54 of 205 mutants alive with the suite green — 20 of them on the limit constants and the
+boundary comparisons, which have no witness in the 33 cases.
+
+## What Changes
+
+- `scripts/validate-agents.py`: malformed values become findings instead of tracebacks; A6 recognises
+  a heading a Markdown renderer would render, and only outside fenced blocks; canonical and generated
+  files are discovered regardless of the case of their suffix and of their depth; a whitespace-only
+  entry in `tools` stops counting as a declared privilege; `NAME_RE` stops accepting a trailing
+  newline.
+- `scripts/validate-skills.py`: the same `RecursionError` escape at `:408` and `:592`. It is the same
+  defect in a sibling that parses the same input with the same construct; fixing only the caller the
+  report named is the symptom patch `lean-code` exists to refuse.
+- `scripts/selftest-validate-agents.py` and `scripts/selftest-validate-skills.py`: a case per finding,
+  both sides of every limit constant and the value itself, and a case with two agents where the first
+  is defective.
+- The mutation measurement is re-run under the same conditions and the new number is published beside
+  today's 54, whatever it turns out to be.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `agents-catalog`: MODIFIED *Agents have a single canonical home and no orphans* — discovery of
+  canonical files and of orphans is agnostic to the case of the suffix and to depth, because a file
+  that escapes discovery escapes every check that follows.
+- `agents-catalog`: MODIFIED *A published agent declares its admission and its privilege* — the
+  malformed-input classes the gate must survive are named to include a value of the wrong shape and a
+  payload whose nesting exhausts the parser; a declared privilege must be a non-blank name; the
+  self-test must carry a witness on each side of every limit the gate enforces and one at the value;
+  and a defect fixed in one gate must be fixed in every sibling gate that carries the same construct.
+
+## Impact
+
+- `scripts/validate-agents.py`, `scripts/validate-skills.py` and both self-tests. No skill, no agent
+  and no generated tree changes, so `generate.sh` does not run and the skill-version gate reports no
+  skill touched.
+- Every pull request inherits a stricter A6 and a stricter A5: a body that passed by accident will
+  now be reported. No published agent in the repository relies on either escape — verified before
+  the change and re-verified after.

--- a/openspec/changes/harden-agent-validator-against-twelve/specs/agents-catalog/spec.md
+++ b/openspec/changes/harden-agent-validator-against-twelve/specs/agents-catalog/spec.md
@@ -1,0 +1,152 @@
+## MODIFIED Requirements
+
+### Requirement: Agents have a single canonical home and no orphans
+
+The repository SHALL publish agents from exactly one canonical location, `agents/<name>.md` at the
+repository root, and every copy under `plugins/<group>/agents/` SHALL be generated from it. An agent
+present only in a generated tree is not a published agent: it escapes the generator, the validator
+and the README, while still installing for users. CI SHALL reject that state, the same way it
+rejects an orphan wrapper skill.
+
+The canonical directory SHALL be flat. A subdirectory changes the name under which the agent is
+invoked, so grouping by domain would be paid for in the name the user types.
+
+Discovery of both trees SHALL be agnostic to the case of the file suffix and to depth. A file whose
+suffix differs only in case escapes every check that follows it, and a generated copy nested below
+`plugins/<group>/agents/` escapes the orphan check while still shipping. Discovery is the first gate;
+anything it misses is unchecked rather than approved, so its patterns SHALL NOT encode an assumption
+that a filesystem is case-sensitive or that a generated tree is flat.
+
+The check SHALL compare the generated copy with its canonical source by **content**, not by name
+alone: a copy that has drifted from the source — hand-edited, or left behind by a stale generator run
+— is published content with no canonical source, which is the state this requirement exists to
+refuse. The check SHALL also run when the canonical directory is absent, because a missing
+`agents/` with generated copies still present is itself that state, and a validator that returns
+early there cannot see the very regression it owns.
+
+#### Scenario: An agent in a generated tree without a source is rejected
+
+- **WHEN** a file exists under `plugins/<group>/agents/` with no matching `agents/<name>.md`
+- **THEN** the agent validator reports it as an orphan and CI fails
+
+#### Scenario: The generator refuses an agent it cannot place
+
+- **WHEN** an agent exists in the canonical directory with no plugin group mapped to it
+- **THEN** the generator fails before writing any file and before removing the generated plugin
+  tree, so the working tree is left exactly as it was
+- **AND** the error names the agent and where the mapping is declared
+
+#### Scenario: Adding an agent goes through the canonical tree
+
+- **WHEN** a new agent is added
+- **THEN** it is written to `agents/<name>.md`, its plugin copies are produced by the generator, and
+  it gains a README row — never hand-written into a generated tree
+
+#### Scenario: A generated copy that drifted from its source is reported
+
+- **WHEN** a file under `plugins/<group>/agents/` differs in content from `agents/<name>.md`
+- **THEN** the validator reports it, naming both paths
+
+#### Scenario: A missing canonical directory does not silence the orphan check
+
+- **WHEN** the canonical directory does not exist and generated copies do
+- **THEN** the orphan check still runs and reports every copy as having no source
+- **AND** a repository that legitimately publishes no agents still reports zero findings, because the
+  check ran and found nothing — not because it was skipped
+
+#### Scenario: A file the discovery pattern would miss is still judged
+
+- **WHEN** a canonical file carries an uppercase suffix, or a generated copy sits in a subdirectory
+  below `plugins/<group>/agents/`
+- **THEN** it is discovered and judged like any other, rather than passing because nothing looked at it
+
+### Requirement: A published agent declares its admission and its privilege
+
+Every `agents/<name>.md` SHALL carry the frontmatter its harness requires — an identifier equal to
+the file name, a description naming the conditions that route work to it, the model, and the colour —
+and SHALL declare `tools` explicitly. Omitting `tools` grants every tool, so the declaration is the
+difference between a stated privilege and an unstated one.
+
+A required field declared with no value SHALL be treated as absent. A key present and null satisfies
+a membership test while stating nothing, and `tools` declared null is equivalent at run time to
+omitting it — the case the privilege rule above exists to refuse. A declared tool name SHALL carry a
+non-blank value for the same reason: a name made only of spaces is a privilege stated in form and
+absent in substance.
+
+The gate SHALL NOT end by unhandled exception on malformed input. A directory carrying the file
+suffix, a file that cannot be decoded, a dangling symlink, an unencodable character in a field, an
+anchor or alias in the frontmatter, **a field whose value is a collection where a scalar is
+required, and a payload whose nesting exhausts the parser** SHALL each become a reported finding that
+names the path, and the remaining agents SHALL still be checked. A gate that crashes on the first bad
+input reports nothing about the inputs after it. Guarding a value SHALL be done by checking its shape
+before the test that cannot survive it, never by wrapping that test in a handler that would turn the
+crash into a silent pass for the field the check owns.
+
+Where a defect of this kind is fixed in one gate, every sibling gate in the repository that parses
+the same input with the same construct SHALL be fixed in the same change. A gate hardened alone
+leaves the identical input fatal one file over.
+
+The body SHALL carry a section naming the situations that invoke the agent, and SHALL state the
+output contract: the shape the caller receives and what the agent must not return. That section
+SHALL be recognised only where a Markdown renderer would render it as a heading: hashes followed on
+the same line by the heading text, outside any fenced code block. An agent whose work would produce a
+file SHALL return what to write rather than write it, unless writing inside the isolated context is
+the work being bought.
+
+Every published agent SHALL carry, in the repository, the written reason it passes the three
+admission tests of the delegation doctrine. An agent admitted by symmetry with an existing artifact,
+rather than by those tests, is a defect.
+
+The self-test that gates this validator SHALL carry, for every limit the gate enforces, a case on
+each side of the limit and one at the value itself. A suite that proves only that a limit fires
+leaves the limit's position unmeasured, so moving the constant breaks nothing and the check is
+covered on paper and untested in fact.
+
+#### Scenario: An agent without a declared tool set fails the gate
+
+- **WHEN** an agent omits `tools`, or names a write tool while its contract says it returns what to
+  write
+- **THEN** the validator fails naming the agent and the field
+
+#### Scenario: An agent that does not say when to invoke it fails the gate
+
+- **WHEN** the body carries no section naming the situations that invoke the agent
+- **THEN** the validator fails, because a description alone routes without telling the agent what
+  the caller expected
+
+#### Scenario: The validator is itself gated
+
+- **WHEN** the agent validator ships
+- **THEN** a self-test proves each of its rules fails a violating agent and passes a conforming one,
+  so the gate is not trusted on its own word
+
+#### Scenario: A required field present but null fails the gate
+
+- **WHEN** an agent declares a required field with no value, or an explicit null
+- **THEN** the validator reports it as missing, and every check that field feeds still runs
+
+#### Scenario: Malformed input is reported, not fatal
+
+- **WHEN** the canonical directory contains a directory named like an agent file, a file that cannot
+  be decoded, or a dangling symlink
+- **THEN** each is reported as a finding naming the path, the remaining agents are still checked, and
+  the run still exits non-zero
+
+#### Scenario: A value of the wrong shape does not end the run
+
+- **WHEN** a scalar field is declared as a sequence or a mapping, or a value nests deeply enough to
+  exhaust the parser
+- **THEN** it is reported as a finding naming the path and the field, and an agent placed after it is
+  still checked
+
+#### Scenario: A heading that is not rendered as one does not satisfy the body rule
+
+- **WHEN** the invocation section's hashes stand alone on their line, or the only such heading lies
+  inside a fenced code block
+- **THEN** the validator reports the section as missing
+
+#### Scenario: A limit is proved at its own value
+
+- **WHEN** the gate enforces a minimum or a maximum
+- **THEN** the self-test carries an accepted case at the limit, a rejected case one past it, and an
+  accepted case one inside it, so a changed constant fails a test

--- a/openspec/changes/harden-agent-validator-against-twelve/tasks.md
+++ b/openspec/changes/harden-agent-validator-against-twelve/tasks.md
@@ -87,12 +87,13 @@
       `selftest-validate-skills` 27 -> **28/28**; findings reproduced before the fix and re-run
       after it, **9/9** now reported; the pre-fix regression proof, **1/1**; mutation over
       `scripts/validate-agents.py` under the conditions of the first measurement (`cosmic-ray
-      8.7.0`, the self-test as runner, default operators): **205 mutants / 54 survivors** before,
-      **229 / 46** after — survivors on the limit constants and on the boundary comparisons
-      **20 -> 0**, with 4 survivors remaining on the frontmatter split offsets and 16 on `|` in type
-      annotations, which have no runtime effect.
-- [x] S.3 What escaped or behaved differently than expected is named here. **Two escapes, both mine,
-      both caught by the layers this catalog just published.** (1) The discovery helper
+      8.7.0`, the self-test as runner, default operators): **205 mutants / 54 survivors / 73.7%**
+      before, **229 / 45 / 80.3%** after. Survivors on the limit constants and on the `<=` boundary
+      chains: **20 -> 0**. Of the 45 that remain, 16 are `|` in type annotations and have no runtime
+      effect, 4 are the frontmatter split offsets, and 25 are elsewhere — 8 of them on
+      `if end == -1` and 3 on `if __name__ == "__main__"`.
+- [x] S.3 What escaped or behaved differently than expected is named here. **Three escapes, all mine,
+      all caught by a layer rather than by review.** (1) The discovery helper
       `agent_files()` filtered on `is_file()`, which is False for a dangling symlink, so it silently
       stopped judging the very input A1 owns; the existing self-test caught it immediately
       (`51/52`, `MISSED A1 a dangling symlink`) and the helper now documents why the filter is not
@@ -101,7 +102,11 @@
       the mutant `BODY_MIN = 20 -> 19` survived the second measurement. **The suite did not catch
       that; the mutation score did**, which is the exact claim the `bug-hunter` scoring layer makes,
       landing on the change written immediately after it. Fixed, asserted on the stripped form, and
-      the mutant is dead in the third run.
+      the mutant is dead from the third run on. (3) `name != agent` survived mutation to
+      `name > agent`, because every mismatch case in the suite happened to carry a name that sorts
+      AFTER the file stem, so the two operators answered identically; a case whose name sorts before
+      it was added and the mutant died. All three were found by a layer, not by reading the diff, and
+      all three are recorded here rather than quietly repaired.
 
 ## 7. Quality Gates (MANDATORY)
 

--- a/openspec/changes/harden-agent-validator-against-twelve/tasks.md
+++ b/openspec/changes/harden-agent-validator-against-twelve/tasks.md
@@ -41,57 +41,90 @@
 
 ## 2. The two crashes
 
-- [ ] 2.1 A scalar field declared as a collection becomes a finding naming the field, checked by
+- [x] 2.1 A scalar field declared as a collection becomes a finding naming the field, checked by
       shape before the membership test, never by wrapping the test in a handler
-- [ ] 2.2 `RecursionError` is caught beside `yaml.YAMLError` around the parse call in
+- [x] 2.2 `RecursionError` is caught beside `yaml.YAMLError` around the parse call in
       `scripts/validate-agents.py`, and in `scripts/validate-skills.py` at `:408` and `:592`
-- [ ] 2.3 A case with two agents, the first defective, proves the run reaches the second
+- [x] 2.3 A case with two agents, the first defective, proves the run reaches the second
 
 ## 3. The two false GREENs
 
-- [ ] 3.1 `WHEN_TO_INVOKE` stops matching a newline between the hashes and the text
-- [ ] 3.2 Fenced blocks are removed before the A6 search, the way the sibling validator already does
+- [x] 3.1 `WHEN_TO_INVOKE` stops matching a newline between the hashes and the text
+- [x] 3.2 Fenced blocks are removed before the A6 search, the way the sibling validator already does
 
 ## 4. Discovery and privilege
 
-- [ ] 4.1 Canonical and generated files are discovered regardless of the case of their suffix
-- [ ] 4.2 An orphan is found at any depth below `plugins/<group>/agents/`
-- [ ] 4.3 A whitespace-only entry in `tools` is reported
-- [ ] 4.4 `NAME_RE` stops accepting a trailing newline
+- [x] 4.1 Canonical and generated files are discovered regardless of the case of their suffix
+- [x] 4.2 An orphan is found at any depth below `plugins/<group>/agents/`
+- [x] 4.3 A whitespace-only entry in `tools` is reported
+- [x] 4.4 `NAME_RE` stops accepting a trailing newline
 
 ## 5. Boundary witnesses
 
-- [ ] 5.1 `DESCRIPTION_MIN`, `DESCRIPTION_MAX`, `BODY_MIN` and `BODY_MAX` each gain an accepted case
+- [x] 5.1 `DESCRIPTION_MIN`, `DESCRIPTION_MAX`, `BODY_MIN` and `BODY_MAX` each gain an accepted case
       at the value, a rejected case one past it and an accepted case one inside it
-- [ ] 5.2 The mutation measurement is re-run under the conditions of the first one and the number is
+- [x] 5.2 The mutation measurement is re-run under the conditions of the first one and the number is
       recorded beside today's 54, whatever it is
 
 ## 6. Simulation & Field Proof (MANDATORY)
 
-- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
-      observed output are recorded (or: this change touches no runtime artifact)
-- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
-      silent and did, known escapes that stayed silent
-- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
-      explicitly that nothing did
+- [x] S.1 The artifact was exercised through its real entry point — both artifacts are gates, and
+      their entry point is being run. `python3 scripts/validate-agents.py` on the real tree ->
+      `agents checked: 3   findings: 0`; `python3 scripts/selftest-validate-agents.py` ->
+      `53/53 cases passed`; `python3 scripts/selftest-validate-skills.py` ->
+      `28/28 defect classes detected`. Each finding was also planted one at a time in a throwaway
+      tree and the fixed gate answered, e.g. `##` alone -> `[A6 body] no ## When to invoke section`,
+      `model: [inherit]` -> `[A4 model/color] model is a list, not one of ['haiku', 'inherit',
+      'opus', 'sonnet']`, nested YAML -> `[A1 frontmatter] YAML nesting exhausts the parser`,
+      `agents/rogue.MD` -> `[A1 frontmatter] no YAML frontmatter delimited by ---`, nested orphan ->
+      `[A7 layout] plugins/testing/agents/sub/ghost.md has no source`. The `RecursionError` case was
+      run against the PRE-fix validator taken from `origin/master`, which answered
+      `rc=1 traceback=True`, and against the fixed one, which answered
+      `rc=1 traceback=False finding_novo=True` — the case is a real regression gate, not a
+      restatement of current behaviour.
+- [x] S.2 Case matrix measured, as counts: `selftest-validate-agents` 33 -> **53/53**, of which 14
+      new cases had to fire and did and 5 new accepting blocks had to stay silent and did;
+      `selftest-validate-skills` 27 -> **28/28**; findings reproduced before the fix and re-run
+      after it, **9/9** now reported; the pre-fix regression proof, **1/1**; mutation over
+      `scripts/validate-agents.py` under the conditions of the first measurement (`cosmic-ray
+      8.7.0`, the self-test as runner, default operators): **205 mutants / 54 survivors** before,
+      **229 / 46** after — survivors on the limit constants and on the boundary comparisons
+      **20 -> 0**, with 4 survivors remaining on the frontmatter split offsets and 16 on `|` in type
+      annotations, which have no runtime effect.
+- [x] S.3 What escaped or behaved differently than expected is named here. **Two escapes, both mine,
+      both caught by the layers this catalog just published.** (1) The discovery helper
+      `agent_files()` filtered on `is_file()`, which is False for a dangling symlink, so it silently
+      stopped judging the very input A1 owns; the existing self-test caught it immediately
+      (`51/52`, `MISSED A1 a dangling symlink`) and the helper now documents why the filter is not
+      there. (2) The self-test helper `sized()` built the body BEFORE `.strip()`, so asking for 19
+      characters produced 17 — the suite looked like it had a witness at `BODY_MIN` and did not, and
+      the mutant `BODY_MIN = 20 -> 19` survived the second measurement. **The suite did not catch
+      that; the mutation score did**, which is the exact claim the `bug-hunter` scoring layer makes,
+      landing on the change written immediately after it. Fixed, asserted on the stripped form, and
+      the mutant is dead in the third run.
 
 ## 7. Quality Gates (MANDATORY)
 
-- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
-      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
-      compatibility present
-- [ ] Q.2 All touched skill content in English (catalog locale)
-- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
-      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
-- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
-      its canonical skill (see design.md Canonical Home table)
-- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
-      names; a term kept in another language carries its reason inline (`code-locale`)
+- [x] Q.1 No SKILL.md is touched by this change — `python3 scripts/validate-skill-version.py` ->
+      `0 skill(s) changed, 0 with content changes`, and `python3 scripts/validate-skills.py` ->
+      `skills checked: 38   findings: 0` confirms none drifted
+- [x] Q.2 Everything this change writes is English: the two gates, both self-tests and the change
+      itself. `check-identifier-locale.py --diff -` over the staged diff -> `findings: 0`
+- [x] Q.3 No `description` and no trigger surface is touched, so routing is unchanged
+- [x] Q.4 No doctrine restated: D2 applies `lean-code`'s root-cause rule by linking it, and the
+      adversarial method stays in `bug-hunter`; the table is in design.md
+- [x] Q.5 The code this change writes is Python in `scripts/`, not a skill example; identifiers,
+      helper names and comments are English
 
 ## 8. Validation & Closure (MANDATORY)
 
-- [ ] V.1 `openspec validate <id> --strict` green
-- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
-      no orphan/renamed leftovers
-- [ ] V.3 README / docs updated where the change alters catalog composition or usage
-- [ ] V.4 `openspec archive <id> --yes` after all groups above are `[x]`
+- [x] V.1 `openspec validate harden-agent-validator-against-twelve --strict` ->
+      `Change 'harden-agent-validator-against-twelve' is valid`; `bash scripts/validate-rite.sh` ->
+      `rite gate OK`
+- [x] V.2 `npx -y skills add . --list` -> 44 skills, the 38 under `skills/` plus the 6 under
+      `.claude/skills/`; this change adds, removes and renames none
+- [x] V.3 No composition or usage change. `README.md:592` describes what the agent gate checks and
+      names no count, so it stays accurate as written
+- [ ] V.4 `openspec archive harden-agent-validator-against-twelve --yes` — left for after the merge,
+      the way #224, #208, #203, #195 and the rest of this repository's rites have closed; the pull
+      request reports the change as active and names this as what closes it

--- a/openspec/changes/harden-agent-validator-against-twelve/tasks.md
+++ b/openspec/changes/harden-agent-validator-against-twelve/tasks.md
@@ -1,0 +1,97 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at. Read at `501b3cf` on 2026-09-07:
+      `scripts/validate-agents.py` (checks A1-A7; `NAME_RE` at :49, `WHEN_TO_INVOKE` at :53, the
+      limit constants at :79-80, the parse handler at :130-134, the membership tests at :168 and
+      :171, the blank-tool test at :179, the A6 search at :186, the globs at :213, :214 and :242),
+      `scripts/selftest-validate-agents.py` (33 cases), `scripts/validate-skills.py` (:408 and :592,
+      the same bare `except _yaml.YAMLError` over `safe_load`),
+      `openspec/specs/agents-catalog/spec.md` (the two requirements this change modifies) and
+      `.github/workflows/ci.yml` (:136 and :142, where both gates run).
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded.
+      Each finding was reproduced first-hand in a throwaway tree holding only `scripts/` and one
+      conforming agent, `python3 scripts/validate-agents.py` after planting one defect at a time:
+      `##` alone plus the paragraph -> `agents checked: 1   findings: 0`; the heading only inside a
+      fence -> `agents checked: 1   findings: 0`; `model: [inherit]` ->
+      `TypeError: cannot use 'list' as a set element (unhashable type: 'list')`;
+      `tools: ["Read", "   "]` -> `agents checked: 1   findings: 0`;
+      `tools: ` + 500 nested flow sequences -> `RecursionError: maximum recursion depth exceeded`;
+      `model: [inherit]` plus a second broken `agents/zz-broken.md` -> `zz-broken` appears 0 times in
+      the output; `agents/rogue.MD` holding garbage -> `agents checked: 1   findings: 0`;
+      an orphan at `plugins/testing/agents/sub/ghost.md` -> `agents checked: 1   findings: 0`.
+      `NAME_RE` measured directly: a 50-character name matches, 51 does not, 2 does not, and a
+      50-character name followed by `\n` matches — a 51-character value accepted by a `$` anchor.
+- [x] E.3 Anything that could NOT be probed is written down as an open question — never stated as
+      fact, never filled with a plausible substitute. There is one, and it came back **refuted**
+      rather than unprobed. Finding 10 claimed a duplicate frontmatter key could make the gate judge
+      a value the harness does not use. Probed both directions in a scratch project with a
+      `dup-probe` agent driven by a fresh `claude -p`: with `tools: ["Read"]` then
+      `tools: ["Read", "Bash"]` the agent reported `Read, Bash`; with the order reversed it reported
+      `Read`. PyYAML reports the same value in both cases. The harness takes the last key, exactly as
+      PyYAML does, so there is no divergence to gate and no code is written for finding 10 — adding a
+      check with no defect behind it is what `skills-authoring` forbids.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed: (a) the `split_prose()` contract
+      wording in `skills/code-locale/references/check-identifier-locale.py`, where a string literal is
+      collapsed to one space while the docstring says "blanked", which reads as positional — no caller
+      depends on columns today; (b) whether mutation testing should become a CI gate of this
+      repository, which the doctrine deliberately does not decide.
+
+## 2. The two crashes
+
+- [ ] 2.1 A scalar field declared as a collection becomes a finding naming the field, checked by
+      shape before the membership test, never by wrapping the test in a handler
+- [ ] 2.2 `RecursionError` is caught beside `yaml.YAMLError` around the parse call in
+      `scripts/validate-agents.py`, and in `scripts/validate-skills.py` at `:408` and `:592`
+- [ ] 2.3 A case with two agents, the first defective, proves the run reaches the second
+
+## 3. The two false GREENs
+
+- [ ] 3.1 `WHEN_TO_INVOKE` stops matching a newline between the hashes and the text
+- [ ] 3.2 Fenced blocks are removed before the A6 search, the way the sibling validator already does
+
+## 4. Discovery and privilege
+
+- [ ] 4.1 Canonical and generated files are discovered regardless of the case of their suffix
+- [ ] 4.2 An orphan is found at any depth below `plugins/<group>/agents/`
+- [ ] 4.3 A whitespace-only entry in `tools` is reported
+- [ ] 4.4 `NAME_RE` stops accepting a trailing newline
+
+## 5. Boundary witnesses
+
+- [ ] 5.1 `DESCRIPTION_MIN`, `DESCRIPTION_MAX`, `BODY_MIN` and `BODY_MAX` each gain an accepted case
+      at the value, a rejected case one past it and an accepted case one inside it
+- [ ] 5.2 The mutation measurement is re-run under the conditions of the first one and the number is
+      recorded beside today's 54, whatever it is
+
+## 6. Simulation & Field Proof (MANDATORY)
+
+- [ ] S.1 The artifact was exercised through its real entry point; the command and a fragment of the
+      observed output are recorded (or: this change touches no runtime artifact)
+- [ ] S.2 Case matrix measured, as counts: cases that had to fire and did, cases that had to stay
+      silent and did, known escapes that stayed silent
+- [ ] S.3 What escaped or behaved differently than expected is named here — or it is stated
+      explicitly that nothing did
+
+## 7. Quality Gates (MANDATORY)
+
+- [ ] Q.1 Frontmatter uniform on every touched SKILL.md: name == directory, folded description,
+      metadata.author solvelab, semver metadata.version, category in the controlled set, license MIT,
+      compatibility present
+- [ ] Q.2 All touched skill content in English (catalog locale)
+- [ ] Q.3 Description triggers testable: phrases a user would actually say route to this skill and
+      do NOT collide with a sibling skill's triggers; "Do NOT use for" boundary present where overlap exists
+- [ ] Q.4 No duplicated doctrine: every cross-cutting rule restated inline was replaced by a link to
+      its canonical skill (see design.md Canonical Home table)
+- [ ] Q.5 Every code example in a touched skill uses English identifiers, routes, keys and event
+      names; a term kept in another language carries its reason inline (`code-locale`)
+
+## 8. Validation & Closure (MANDATORY)
+
+- [ ] V.1 `openspec validate <id> --strict` green
+- [ ] V.2 Catalog discovery intact: `npx skills add <repo> --list` finds every skill, expected count,
+      no orphan/renamed leftovers
+- [ ] V.3 README / docs updated where the change alters catalog composition or usage
+- [ ] V.4 `openspec archive <id> --yes` after all groups above are `[x]`

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -63,6 +63,21 @@ def replace(old: str, new: str) -> str:
     return GOOD.format(name="example-agent").replace(old, new, 1)
 
 
+def sized(desc_len: int, body_len: int, name: str = "example-agent") -> str:
+    """A conforming agent whose description and stripped body are EXACTLY the lengths asked for.
+
+    The limits are the point: a suite that only ever produces 62, 133 or 163 characters proves that
+    a limit fires and never where it sits, so moving the constant breaks nothing. Measured before
+    this helper existed: the 33 cases produced body lengths 17, 85 and 163 only, and `BODY_MAX` had
+    no witness at all (issue #225, findings 5 and 6).
+    """
+    body = "## When to invoke\n\n"
+    body += "x" * max(body_len - len(body), 0)
+    return (f"---\nname: {name}\n"
+            f'description: "{"d" * desc_len}"\n'
+            "model: inherit\ncolor: blue\ntools: [\"Read\"]\n---\n\n" + body + "\n")
+
+
 # (label, expected check id, how to plant it)
 CASES: list[tuple[str, str, object]] = [
     ("no frontmatter at all", "A1",
@@ -144,6 +159,44 @@ CASES: list[tuple[str, str, object]] = [
         (r / "plugins" / "testing" / "agents").mkdir(parents=True),
         (r / "plugins" / "testing" / "agents" / "example-agent.md").write_text(
             replace("color: blue", "color: red"), encoding="utf-8"))),
+    # ── issue #225: the twelve findings of the #222 field proof ──────────────────────────────
+    ("hashes alone on their line, heading text in the paragraph below", "A6",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("## When to invoke", "##\nWhen to invoke"), encoding="utf-8")),
+    ("the only invocation heading lives inside a fenced block", "A6",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("## When to invoke", "## Something else\n\n```md\n## When to invoke\n```"),
+         encoding="utf-8")),
+    ("model declared as a sequence", "A4",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("model: inherit", "model: [inherit]"), encoding="utf-8")),
+    ("color declared as a mapping", "A4",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("color: blue", "color: {a: b}"), encoding="utf-8")),
+    ("frontmatter nested deeply enough to exhaust the parser", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace('tools: ["Read", "Grep"]', "tools: " + "[" * 500 + "]" * 500), encoding="utf-8")),
+    ("a tools entry that is whitespace only", "A5",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace('tools: ["Read", "Grep"]', 'tools: ["Read", "   "]'), encoding="utf-8")),
+    ("a canonical file whose suffix differs only in case", "A1",
+     lambda r: (r / "agents" / "rogue.MD").write_text("garbage with no frontmatter\n",
+                                                      encoding="utf-8")),
+    ("an orphan nested below plugins/<group>/agents/", "A7", lambda r: (
+        (r / "plugins" / "testing" / "agents" / "sub").mkdir(parents=True),
+        (r / "plugins" / "testing" / "agents" / "sub" / "ghost.md").write_text(
+            GOOD.format(name="ghost"), encoding="utf-8"))),
+    ("a name whose value ends in a newline", "A2",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("name: example-agent", 'name: "example-agent\n"'), encoding="utf-8")),
+    ("a description one character under the minimum", "A3",
+     lambda r: (r / "agents" / "example-agent.md").write_text(sized(9, 200), encoding="utf-8")),
+    ("a description one character over the maximum", "A3",
+     lambda r: (r / "agents" / "example-agent.md").write_text(sized(5001, 200), encoding="utf-8")),
+    ("a body one character under the minimum", "A6",
+     lambda r: (r / "agents" / "example-agent.md").write_text(sized(200, 19), encoding="utf-8")),
+    ("a body one character over the maximum", "A6",
+     lambda r: (r / "agents" / "example-agent.md").write_text(sized(200, 10001), encoding="utf-8")),
 ]
 
 
@@ -221,7 +274,62 @@ def main() -> int:
         else:
             print("  OK     A7  a generated copy with a source is not an orphan")
 
-    total = len(CASES) + 4
+        # ── issue #225 ── The accepting side of every limit. A rejected case one past the limit
+        # proves the check fires; only a case AT the value proves where the limit sits. Without
+        # these, moving a constant by one breaks no test — 20 of the 54 mutants that survived the
+        # 2026-09-07 measurement sat exactly here.
+        for label, text in (
+            ("a description of exactly DESCRIPTION_MIN characters", sized(10, 200)),
+            ("a description of exactly DESCRIPTION_MAX characters", sized(5000, 200)),
+            ("a body of exactly BODY_MIN characters", sized(200, 20)),
+            ("a body of exactly BODY_MAX characters", sized(200, 10000)),
+        ):
+            shutil.rmtree(root)
+            build(root)
+            (root / "agents" / "example-agent.md").write_text(text, encoding="utf-8")
+            code, out = run(root)
+            if code != 0:
+                print(f"  FAIL   {label} was rejected\n{out}")
+                failures += 1
+            else:
+                print(f"  OK     {label} is accepted")
+
+        # A name of exactly 50 characters is legal; the file is renamed so `name != agent` cannot
+        # mask the regex. The rejecting side (51) is covered by NAME_RE itself and by the
+        # trailing-newline case in CASES.
+        shutil.rmtree(root)
+        build(root)
+        long_name = "a" + "b" * 48 + "c"
+        (root / "agents" / "example-agent.md").unlink()
+        (root / "agents" / f"{long_name}.md").write_text(sized(200, 200, name=long_name),
+                                                         encoding="utf-8")
+        code, out = run(root)
+        if code != 0:
+            print(f"  FAIL   A2  a name of exactly 50 characters was rejected\n{out}")
+            failures += 1
+        else:
+            print("  OK     A2  a name of exactly 50 characters is accepted")
+
+        # ── issue #225, finding 12 ── The property every crash guard rests on: the run REACHES the
+        # agent after the bad one. Every case above plants exactly one agent, so a gate that died on
+        # the first input looked identical to one that judged it. This is what let the A4 crash stay
+        # invisible through issue #205's hardening.
+        shutil.rmtree(root)
+        build(root)
+        (root / "agents" / "example-agent.md").write_text(
+            replace("model: inherit", "model: [inherit]"), encoding="utf-8")
+        (root / "agents" / "zz-broken.md").write_text("no frontmatter at all\n", encoding="utf-8")
+        code, out = run(root)
+        if "Traceback (most recent call last)" in out:
+            print(f"  CRASH  a defective first agent ended the run\n{out}")
+            failures += 1
+        elif "zz-broken" not in out:
+            print(f"  MISSED the agent after the defective one was never checked\n{out}")
+            failures += 1
+        else:
+            print("  OK     a defective agent does not hide the one after it")
+
+    total = len(CASES) + 4 + 5 + 1
     print(f"\n{total - failures}/{total} cases passed")
     return 1 if failures else 0
 

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -71,11 +71,23 @@ def sized(desc_len: int, body_len: int, name: str = "example-agent") -> str:
     this helper existed: the 33 cases produced body lengths 17, 85 and 163 only, and `BODY_MAX` had
     no witness at all (issue #225, findings 5 and 6).
     """
-    body = "## When to invoke\n\n"
-    body += "x" * max(body_len - len(body), 0)
+    # The gate measures `body.strip()`, so the length is built on the STRIPPED form. Measured on the
+    # first version of this helper: asking for 19 produced 17 once stripped, which is why the mutant
+    # `BODY_MIN = 20 -> 19` still survived a suite that looked like it had a witness there.
+    head = "## When to invoke"                       # 17 characters
+    if body_len >= 20:
+        stripped = head + "\n\n" + "x" * (body_len - 19)
+    elif body_len == 19:
+        stripped = head + "\nx"
+    else:
+        stripped = "x" * body_len
+    # The padding never ends in whitespace, or `.strip()` would give back a shorter body than asked.
+    assert len(stripped) == body_len and stripped == stripped.strip(), (len(stripped), body_len)
+    # No blank line between the frontmatter closer and the body: the body's first characters are the
+    # heading itself, so an off-by-one in the frontmatter split shows up as a broken heading.
     return (f"---\nname: {name}\n"
             f'description: "{"d" * desc_len}"\n'
-            "model: inherit\ncolor: blue\ntools: [\"Read\"]\n---\n\n" + body + "\n")
+            "model: inherit\ncolor: blue\ntools: [\"Read\"]\n---\n" + stripped + "\n")
 
 
 # (label, expected check id, how to plant it)

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -214,6 +214,12 @@ CASES: list[tuple[str, str, object]] = [
     # offset mutants that survive on `text.find("\n---\n", 4)` and `text[4:end]` — both the mutated
     # and the original path answer with an A1 finding here, one calling it absent and the other
     # calling it not a mapping — and that is written down rather than papered over (issue #225).
+    # A name that sorts BEFORE the file stem. Every mismatch case in this suite happened to sort
+    # after it, so `name != agent` and `name > agent` answered identically and the comparison had no
+    # witness — found by reading the survivors of the mutation run, not by reading the code.
+    ("a name that differs from the file stem and sorts before it", "A2",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         replace("name: example-agent", "name: aaa"), encoding="utf-8")),
     ("frontmatter delimiters with nothing between them", "A1",
      lambda r: (r / "agents" / "example-agent.md").write_text(
          "---\n---\n\nA body with no frontmatter fields at all, long enough to clear the minimum.\n"

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -209,6 +209,15 @@ CASES: list[tuple[str, str, object]] = [
      lambda r: (r / "agents" / "example-agent.md").write_text(sized(200, 19), encoding="utf-8")),
     ("a body one character over the maximum", "A6",
      lambda r: (r / "agents" / "example-agent.md").write_text(sized(200, 10001), encoding="utf-8")),
+    # The degenerate document the frontmatter split is least tested on: delimiters present, nothing
+    # between them. It is a legitimate malformed input the suite lacked. It does NOT kill the four
+    # offset mutants that survive on `text.find("\n---\n", 4)` and `text[4:end]` — both the mutated
+    # and the original path answer with an A1 finding here, one calling it absent and the other
+    # calling it not a mapping — and that is written down rather than papered over (issue #225).
+    ("frontmatter delimiters with nothing between them", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         "---\n---\n\nA body with no frontmatter fields at all, long enough to clear the minimum.\n"
+         "\n## When to invoke\n\n- Never. This file exists for the self-test.\n", encoding="utf-8")),
 ]
 
 

--- a/scripts/selftest-validate-skills.py
+++ b/scripts/selftest-validate-skills.py
@@ -84,6 +84,13 @@ MUTATIONS = {
  "C10 frontmatter limits": ("skills/r3f-geometry/SKILL.md",
      lambda s: s.replace("description: >-", "description: >-\n  " + "Use when the user says so. " * 44, 1),
      ("C10 frontmatter limits", "description is")),
+ # Nesting, not size: 500 nested flow sequences are about 1 KB, and PyYAML answers with a
+ # RecursionError, which is NOT a subclass of YAMLError — so the handler beside it did not catch it
+ # and the whole run ended by traceback. Same defect, same construct and same input as
+ # scripts/validate-agents.py; fixed and pinned in both in the same change (issue #225, finding 4).
+ "C10 frontmatter limits (nesting exhausts the parser)": ("skills/r3f-geometry/SKILL.md",
+     lambda s: s.replace("license: MIT", "license: MIT\nprobe: " + "[" * 500 + "]" * 500, 1),
+     ("C10 frontmatter limits", "nesting exhausts")),
  # A reference file nobody links. The path does not exist in the catalog, so the loop below starts
  # from an empty string — this is the one mutation that CREATES a file instead of editing one.
  "C11 orphan reference": ("skills/r3f-geometry/references/orphan-probe.md",

--- a/scripts/validate-agents.py
+++ b/scripts/validate-agents.py
@@ -46,11 +46,19 @@ ROOT = Path(__file__).resolve().parent.parent
 AGENTS = ROOT / "agents"
 GENERATED = ROOT / "plugins"
 
-NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]$")
-# Any whitespace after the hashes, not only an ASCII space: `##\tWhen to invoke` is a heading every
+# `\Z`, not `$`: `$` matches BEFORE a final newline, so `name: "<50 chars>\n"` — a value of 51
+# characters — used to satisfy a rule whose message promises 3-50 (measured 2026-09-07).
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,48}[a-z0-9]\Z")
+# Spaces and tabs after the hashes, not any whitespace: `##\tWhen to invoke` is a heading every
 # Markdown renderer accepts, and a gate that rejects what the tool accepts teaches the author to
-# ignore the gate (issue #205, attack 8).
-WHEN_TO_INVOKE = re.compile(r"^#{2,}\s+When to invoke\s*$", re.M | re.I)
+# ignore the gate (issue #205, attack 8). `\s` was too wide — it includes `\n`, so `##` alone on its
+# line with `When to invoke` in the paragraph below matched, and an agent with no heading at all
+# passed A6 clean (reproduced 2026-09-07, issue #225 finding 1).
+WHEN_TO_INVOKE = re.compile(r"^#{2,}[ \t]+When to invoke[ \t]*$", re.M | re.I)
+# A heading inside a fenced block is not rendered as a heading, so it does not satisfy the rule
+# either. The sibling validator already strips fences before its own citation scan; same construct,
+# same treatment (issue #225, finding 2).
+FENCE = re.compile(r"^([ \t]*)(`{3,}|~{3,}).*?^\1\2[ \t]*$", re.M | re.S)
 
 if yaml is not None:
     class _NoAliasLoader(yaml.SafeLoader):
@@ -132,6 +140,14 @@ def check_file(path: Path) -> None:
     except yaml.YAMLError as exc:                    # noqa: BLE001 - the parser's message is the finding
         add(agent, "A1 frontmatter", f"YAML does not parse: {exc}")
         return
+    except RecursionError:
+        # Raised by the parser, but NOT a subclass of YAMLError, so it used to escape the handler
+        # above and end the run by traceback — 500 nested flow sequences in ~1 KB is enough
+        # (reproduced 2026-09-07, issue #225 finding 2). Caught around the parse call only: a
+        # RecursionError in our own checks is a defect and must still surface.
+        add(agent, "A1 frontmatter",
+            "YAML nesting exhausts the parser — the payload is small and its structure is not")
+        return
     if not isinstance(meta, dict):
         add(agent, "A1 frontmatter", "frontmatter is not a mapping")
         return
@@ -164,28 +180,63 @@ def check_file(path: Path) -> None:
                 f"{len(desc)} characters — the accepted range is "
                 f"{DESCRIPTION_MIN}-{DESCRIPTION_MAX}")
 
-    model = meta.get("model")
-    if model is not None and model not in MODELS:
-        add(agent, "A4 model/color", f"`model: {model}` is not one of {sorted(MODELS)}")
-    color = meta.get("color")
-    if color is not None and color not in COLORS:
-        add(agent, "A4 model/color", f"`color: {color}` is not one of {sorted(COLORS)}")
+    # The shape is checked BEFORE the membership test, never around it: `model: [inherit]` used to
+    # raise `TypeError: cannot use 'list' as a set element` and end the run, taking every
+    # alphabetically later agent with it (reproduced 2026-09-07, issue #225 finding 3). Wrapping the
+    # test in a handler instead would turn that crash into a silent pass for the field it owns.
+    # `!!set` does not reach here: CPython converts an unhashable set key to a frozenset, so only a
+    # list or a mapping ever did.
+    for field, allowed in (("model", MODELS), ("color", COLORS)):
+        value = meta.get(field)
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            add(agent, "A4 model/color",
+                f"`{field}` is a {type(value).__name__}, not one of {sorted(allowed)}")
+        elif value not in allowed:
+            add(agent, "A4 model/color", f"`{field}: {value}` is not one of {sorted(allowed)}")
 
     tools = meta.get("tools")
     if tools is not None:
         if not isinstance(tools, list) or not tools:
             add(agent, "A5 tools", "`tools` must be a non-empty list — omitting it grants every "
                                    "tool, so the declaration is the privilege")
-        elif not all(isinstance(t, str) and t for t in tools):
-            add(agent, "A5 tools", "every entry of `tools` must be a non-empty string")
+        elif not all(isinstance(t, str) and t.strip() for t in tools):
+            # `.strip()`: `"   "` is truthy, so three spaces used to pass as a tool name — a
+            # privilege stated in form and absent in substance (issue #225, finding 11).
+            add(agent, "A5 tools", "every entry of `tools` must be a non-blank string")
 
     stripped = body.strip()
     if not BODY_MIN <= len(stripped) <= BODY_MAX:
         add(agent, "A6 body", f"{len(stripped)} characters — the accepted range is "
                               f"{BODY_MIN}-{BODY_MAX}")
-    if not WHEN_TO_INVOKE.search(body):
+    if not WHEN_TO_INVOKE.search(FENCE.sub("", body)):
         add(agent, "A6 body", "no `## When to invoke` section — a description routes to the agent, "
                               "this section tells the agent what the caller expected")
+
+
+def is_markdown(path: Path) -> bool:
+    """Suffix comparison, case-folded.
+
+    `glob("*.md")` is case-sensitive on the CI filesystem, so `agents/rogue.MD` holding anything at
+    all used to be discovered by nothing and reported by nothing — exit 0, and the summary still said
+    `agents checked: 1` (reproduced 2026-09-07, issue #225 finding 8). Discovery is the first gate:
+    what it misses is unchecked, not approved.
+    """
+    return path.suffix.lower() == ".md"
+
+
+def agent_files(directory: Path) -> list:
+    """The canonical directory is flat by rule, so this stays one level deep on purpose.
+
+    A subdirectory there is a finding of its own (A7 above), not a place to look for agents.
+
+    Deliberately NOT filtered by `is_file()`: a dangling symlink and a directory carrying the suffix
+    are exactly the malformed inputs A1 and A7 own, and `is_file()` is False for both — filtering
+    here would make the gate accept them by never looking (the shape the old `glob("*.md")` had, and
+    the one the self-test's dangling-symlink case pins).
+    """
+    return sorted(p for p in directory.iterdir() if is_markdown(p))
 
 
 def check_layout() -> None:
@@ -210,8 +261,10 @@ def check_layout() -> None:
                 f"agents/{sub.name}/ is a directory — the canonical directory is flat, because a "
                 "subdirectory changes the name the agent is invoked under")
 
-    canonical = {p.stem: p for p in AGENTS.glob("*.md") if p.is_file()} if AGENTS.is_dir() else {}
-    for generated in sorted(GENERATED.glob("*/agents/*.md")):
+    canonical = {p.stem: p for p in agent_files(AGENTS) if p.is_file()} if AGENTS.is_dir() else {}
+    for generated in sorted(GENERATED.glob("*/agents/**/*")):
+        if not is_markdown(generated) or not generated.is_file():
+            continue
         rel = generated.relative_to(ROOT)
         source = canonical.get(generated.stem)
         if source is None:
@@ -239,7 +292,7 @@ def main() -> int:
     # No early return when agents/ is missing: check_layout() owns exactly that state (issue #205,
     # attack 2). A repository that legitimately publishes no agents still reports zero findings —
     # because the check ran, not because it was skipped.
-    files = sorted(AGENTS.glob("*.md")) if AGENTS.is_dir() else []
+    files = sorted(agent_files(AGENTS)) if AGENTS.is_dir() else []
     for path in files:
         check_file(path)
     check_layout()

--- a/scripts/validate-skills.py
+++ b/scripts/validate-skills.py
@@ -409,6 +409,14 @@ def check_limits(skill: str, text: str) -> None:
     except _yaml.YAMLError as exc:
         add(skill, "C10 frontmatter limits", f"frontmatter does not parse as YAML: {str(exc)[:90]}")
         return
+    except RecursionError:
+        # Raised by the parser on deeply nested flow sequences, and NOT a subclass of YAMLError, so
+        # it escaped the handler above and ended the run by traceback. Same defect, same construct,
+        # same input as scripts/validate-agents.py — fixed in the same change on purpose, because
+        # patching only the caller a report named leaves the sibling fatal (issue #225, finding 4).
+        add(skill, "C10 frontmatter limits",
+            "frontmatter nesting exhausts the YAML parser — the payload is small, its structure is not")
+        return
     if not isinstance(data, dict):
         return                                       # the CI frontmatter loop reports the shape
     for field, limit in FRONTMATTER_LIMITS:
@@ -590,7 +598,7 @@ def check_anti_trigger(skill: str, text: str) -> None:
         return                                       # C4 already reports the missing frontmatter
     try:
         data = _yaml.safe_load(fm[1])
-    except _yaml.YAMLError:
+    except (_yaml.YAMLError, RecursionError):
         return                                       # C10 already reports the parse failure
     desc = data.get("description") if isinstance(data, dict) else None
     if not isinstance(desc, str):


### PR DESCRIPTION
Closes #225

Doze achados da prova de campo do #222, cada um reproduzido à mão antes de virar código, num tree descartável com um agente conforme e um defeito por vez. Dois deles violavam requisito já publicado: `openspec/specs/agents-catalog/spec.md` diz *"A gate that crashes on the first bad input reports nothing about the inputs after it."*

## Os doze, e o que cada um virou

| # | Achado | Antes | Depois |
|---|---|---|---|
| 1 | `model: [inherit]` / `color: {a: b}` | `TypeError`, run morto, agente posterior sem checagem | `[A4] model is a list, not one of [...]` |
| 2 | `tools:` com 500 sequências aninhadas (~1 KB) | `RecursionError`, escapava do handler | `[A1] YAML nesting exhausts the parser` |
| 3 | `##` sozinho + parágrafo `When to invoke` | 0 findings | `[A6] no ## When to invoke section` |
| 4 | heading só dentro de bloco cercado | 0 findings | `[A6]` idem |
| 5 | `BODY_MAX` sem testemunha nenhuma | mutante `>= 164` sobrevivia | casos nos dois lados e no valor |
| 6 | cadeias `<=` nunca no valor | mutantes de borda sobreviviam | idem |
| 7 | `NAME_RE` com `$` | `name` de 50 chars + `\n` (valor de 51) passava | `\Z` |
| 8 | `agents/rogue.MD` | 0 findings, e o resumo ainda dizia `agents checked: 1` | descoberto e julgado |
| 9 | órfão em `plugins/*/agents/sub/` | 0 findings | `[A7] ... has no source` |
| 10 | chave duplicada de frontmatter | 0 findings | **refutado, ver abaixo** |
| 11 | `tools: ["Read", "   "]` | 0 findings | `[A5] must be a non-blank string` |
| 12 | run não sobrevivia ao primeiro defeituoso | sem teste | caso de dois agentes |

**O achado 10 foi refutado com probe, não com palpite.** A suspeita era que o harness pudesse ler a *primeira* chave enquanto o validador julga a última, abençoando um `tools: ~`. Probado nas duas direções, com um agente `dup-probe` num projeto de rascunho dirigido por um `claude -p` novo: com `["Read"]` depois `["Read","Bash"]` o agente reportou `Read, Bash`; com a ordem invertida reportou `Read`. O harness lê a última, igual ao PyYAML. Não há divergência a fiscalizar, então **nenhum código foi escrito** — regra com defeito nenhum atrás é o que `skills-authoring` proíbe.

## Causa raiz, não o caller citado

O `RecursionError` foi corrigido também em `scripts/validate-skills.py:408` e `:592` — mesmo construto sobre a mesma entrada. A terceira chamada YAML do repositório (`:151`) já roda em subprocesso e lê o `rc`, então está isolada; isso foi conferido, não suposto. Provado que o caso novo é gate de regressão de verdade: contra o validador **pré-fix** tirado de `origin/master` ele responde `rc=1 traceback=True`; contra o corrigido, `rc=1 traceback=False finding_novo=True`.

## Medição

Mesmas condições da primeira, para os números serem comparáveis: `cosmic-ray 8.7.0`, o próprio selftest como runner, conjunto de operadores padrão.

| | Antes (#223) | Depois |
|---|---|---|
| Mutantes | 205 | 229 |
| Mortos | 151 | **184** |
| Vivos | 54 | **45** |
| Score | 73,7% | **80,3%** |
| Vivos em constante de limite e cadeia `<=` | **20** | **0** |

Suítes: `selftest-validate-agents` **33 → 54 casos**, `selftest-validate-skills` **27 → 28**.

## Known gaps

**Quatro sobreviventes continuam vivos**, todos nos offsets do split de frontmatter — `text.find("\n---\n", 4)` com 3 e com 5, e `text[4:end], text[end + 5:]` com `+4` e `+6`. Analisados um a um: mudam comportamento apenas no documento degenerado com os delimitadores e nada entre eles, e ali **o caminho mutado e o original respondem os dois com achado A1** — um chamando de ausente, o outro de não-mapeamento. O caso desse documento foi adicionado à suíte de qualquer forma, porque é entrada malformada legítima que faltava; ele não mata os quatro, e isso fica escrito em vez de maquiado. Matá-los exigiria asserção por fragmento de mensagem na suíte de agentes, que hoje só assere id de check — melhoria real, e fora dos doze achados deste item.

Dos 45 restantes: 16 são `|` em anotação de tipo, sem efeito em runtime; 25 estão em outros pontos, 8 deles em `if end == -1` e 3 em `if __name__ == "__main__"`.

## O que escapou — três, todos meus

Registrados no grupo `Simulation & Field Proof` da change, não consertados em silêncio:

1. **`agent_files()` filtrou por `is_file()`**, que é falso para symlink pendurado, então parou de julgar justamente a entrada que A1 possui. A suíte existente pegou na hora: `51/52`, `MISSED A1 a dangling symlink`.
2. **`sized()` montava o corpo antes do `.strip()`** — pedir 19 caracteres produzia 17. A suíte *parecia* ter testemunha no `BODY_MIN` e não tinha, e o mutante `20 → 19` sobreviveu à segunda medição. **A suíte não pegou; a pontuação de mutação pegou** — exatamente a afirmação que a camada de pontuação do `bug-hunter` faz, caindo na mudança escrita logo depois dela.
3. **`name != agent` sobreviveu virando `name > agent`**, porque todo caso de divergência da suíte tinha nome que ordena *depois* do stem. Caso com nome que ordena antes foi adicionado, e o mutante morreu.

## Verificações

| Verificação | Resultado |
|---|---|
| `validate-agents.py` / `validate-skills.py` (árvore real) | 3 agentes, 38 skills, 0 findings |
| `selftest-validate-agents.py` | `54/54 cases passed` |
| `selftest-validate-skills.py` | `28/28 defect classes detected` |
| `openspec validate harden-agent-validator-against-twelve --strict` | válida |
| `scripts/validate-rite.sh` | `rite gate OK` |
| `validate-skill-version.py` | `0 skill(s) changed` — nenhuma skill tocada, `generate.sh` não roda |
| `validate-spec-rite.py` | 0 findings |
| locale identifier no diff | `findings: 0` |
| selftests de hooks e scripts (9) | todos verdes |
| `smoke-install-scripts.sh` | 19/19 |
| `plugin validate . --strict` | passou |
| `npx skills add . --list` | 44 = 38 `skills/` + 6 `.claude/skills/` |

## Rito

Change `harden-agent-validator-against-twelve`, schema `skills-rite`, capability `agents-catalog` (dois requisitos MODIFIED). **Ainda ativa de propósito** — `openspec archive harden-agent-validator-against-twelve --yes` fecha o V.4 depois do merge, como em #224, #208 e #195.
