### PR TITLE
📝 docs(code-locale): a docstring de split_prose diz o que a função faz

### DIFF
--- a/claude/skills/code-locale/SKILL.md
+++ b/claude/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.5.0
+  version: 1.5.1
   category: process
 license: MIT
 compatibility: >-

--- a/plugins/workflow/skills/code-locale/SKILL.md
+++ b/plugins/workflow/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.5.0
+  version: 1.5.1
   category: process
 license: MIT
 compatibility: >-

--- a/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
+++ b/plugins/workflow/skills/code-locale/references/check-identifier-locale.py
@@ -311,8 +311,16 @@ def split_prose(line: str, lang: str, state: "str | None" = None) -> "tuple[str,
     """Split one line into its machine part and its prose fragments.
 
     Returns (code, new_state, fragments). `code` is exactly what `strip_prose()` has always
-    returned — comments and string literals blanked, machine-layer literals kept — and `new_state`
-    is the closing delimiter of a block still open at the end of the line, or None. `fragments` is
+    returned — comments and string literals replaced by a single space, machine-layer literals kept
+    — and `new_state` is the closing delimiter of a block still open at the end of the line, or
+    None. The replacement **collapses**; it does not blank in place, so `code` is shorter than the
+    line and column positions are NOT preserved: `a = "b"` (7 characters) comes back as `a =  `
+    (5). Every consumer today reads only the line number — `scan_text()` reports `first_line +
+    offset`, and `check-prose-locale.py` consumes the fragments — so nothing depends on the column.
+    A caller that wants one has to change this function first; it will not find the column here.
+    (The wording used to say "blanked", which reads as positional. Found by a property-based probe
+    during the field proof of issue #222, filed as issue #227: a contract gap, not a defect.)
+    `fragments` is
     what the identifier check used to throw away: a list of (kind, text) with `kind` in `comment`,
     `docstring`, `string`, in the order they appear. A triple-quoted block that opens after code on
     the same line is a `string`, not a `docstring`; the interior lines of any open block are yielded
@@ -389,6 +397,9 @@ def strip_prose(line: str, lang: str, state: "str | None" = None) -> "tuple[str,
     entry point this check and its callers have always used; the prose detector beside it
     (`check-prose-locale.py`) reads the fragments through the shared tokenizer instead of
     duplicating COMMENT_SYNTAX.
+
+    Same caveat as `split_prose()`: a literal collapses to one space, so the returned line is
+    shorter than the one given and carries no usable column.
     """
     code, new_state, _fragments = split_prose(line, lang, state)
     return code, new_state

--- a/skills/code-locale/SKILL.md
+++ b/skills/code-locale/SKILL.md
@@ -14,7 +14,7 @@ description: >-
   naming (each stack's skill), or for i18n and user-facing translation.
 metadata:
   author: solvelab
-  version: 1.5.0
+  version: 1.5.1
   category: process
 license: MIT
 compatibility: >-

--- a/skills/code-locale/references/check-identifier-locale.py
+++ b/skills/code-locale/references/check-identifier-locale.py
@@ -311,8 +311,16 @@ def split_prose(line: str, lang: str, state: "str | None" = None) -> "tuple[str,
     """Split one line into its machine part and its prose fragments.
 
     Returns (code, new_state, fragments). `code` is exactly what `strip_prose()` has always
-    returned — comments and string literals blanked, machine-layer literals kept — and `new_state`
-    is the closing delimiter of a block still open at the end of the line, or None. `fragments` is
+    returned — comments and string literals replaced by a single space, machine-layer literals kept
+    — and `new_state` is the closing delimiter of a block still open at the end of the line, or
+    None. The replacement **collapses**; it does not blank in place, so `code` is shorter than the
+    line and column positions are NOT preserved: `a = "b"` (7 characters) comes back as `a =  `
+    (5). Every consumer today reads only the line number — `scan_text()` reports `first_line +
+    offset`, and `check-prose-locale.py` consumes the fragments — so nothing depends on the column.
+    A caller that wants one has to change this function first; it will not find the column here.
+    (The wording used to say "blanked", which reads as positional. Found by a property-based probe
+    during the field proof of issue #222, filed as issue #227: a contract gap, not a defect.)
+    `fragments` is
     what the identifier check used to throw away: a list of (kind, text) with `kind` in `comment`,
     `docstring`, `string`, in the order they appear. A triple-quoted block that opens after code on
     the same line is a `string`, not a `docstring`; the interior lines of any open block are yielded
@@ -389,6 +397,9 @@ def strip_prose(line: str, lang: str, state: "str | None" = None) -> "tuple[str,
     entry point this check and its callers have always used; the prose detector beside it
     (`check-prose-locale.py`) reads the fragments through the shared tokenizer instead of
     duplicating COMMENT_SYNTAX.
+
+    Same caveat as `split_prose()`: a literal collapses to one space, so the returned line is
+    shorter than the one given and carries no usable column.
     """
     code, new_state, _fragments = split_prose(line, lang, state)
     return code, new_state


### PR DESCRIPTION
Closes #227

Spec-rite: none — correção de redação de docstring que alinha a descrição ao comportamento já existente; nenhum requisito muda, nenhum comportamento muda, e o único artefato tocado é o comentário de uma função interna.

A docstring de `split_prose()` dizia que comentários e literais de string voltam **"blanked"**, que se lê como branqueamento posicional — cada caractere trocado por espaço, comprimento e coluna preservados. A função **colapsa**:

| Entrada | `len(line)` | `code` | `len(code)` |
|---|---|---|---|
| `a = "b"` (python) | 7 | `a =  ` | 5 |
| `"'"` (bash) | 3 | ` ` | 1 |

Achado por property-based durante a prova de campo do #222: a invariante *"para todo `i`, `code[i] == line[i]` ou `code[i] == ' '"* falhou na entrada de três caracteres `"'"`. **Não é defeito** — nenhum consumidor usa coluna: `scan_text()` reporta `first_line + offset` e `check-prose-locale.py:353` consome os fragmentos. É lacuna de contrato, e a promessa antiga é o que o próximo caller acreditaria.

Agora a docstring diz o que a função faz, com o exemplo, e diz explicitamente que a posição não é preservada e que quem quiser coluna tem de mudar a função primeiro. O mesmo aviso, em uma linha, em `strip_prose()`.

## Verificações

| Verificação | Resultado |
|---|---|
| Comportamento inalterado | saída do detector sobre `skills/` e `scripts/` **byte-idêntica** antes e depois |
| `check-identifier-locale.py --selftest` | 7 content tiers, 16 clean, 6 path tiers, 10 path clean, 2 en-unknown, 5 en-unknown clean |
| `check-prose-locale.py --selftest` | `46 cases` |
| `locale-rite.py --selftest` | 13 PostToolUse, 12 PreToolUse, e o resto |
| `validate-skills.py` / `validate-agents.py` | 38 skills, 3 agentes, 0 findings |
| `validate-skill-version.py` | 1 skill mudada, `code-locale` 1.5.0 → **1.5.1** |
| `generate.sh` | rodado; árvores geradas em dia |

Sem mudança de comportamento e sem requisito novo, por isso a dispensa escrita acima em vez de uma change OpenSpec.
