### PR TITLE
✅ test(scripts): a suíte de agentes assere qual achado disparou

### DIFF
--- a/openspec/changes/assert-agent-findings-by-fragment/.openspec.yaml
+++ b/openspec/changes/assert-agent-findings-by-fragment/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-07

--- a/openspec/changes/assert-agent-findings-by-fragment/design.md
+++ b/openspec/changes/assert-agent-findings-by-fragment/design.md
@@ -1,0 +1,65 @@
+# Design — asserting the message, not only the check
+
+## Context
+
+The agents self-test declares `(label, check, plant)` and asserts `f"[{check}" in out`. The skills
+self-test declares `(relpath, mutate, (expect, fragment))` and asserts the fragment too, reading the
+optional third element with `entry[2] if len(entry) > 2`. Two suites, one idea, one of them missing.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- A case can require the exact message, without rewriting the 54 that do not need it.
+- The two frontmatter paths become distinguishable, and the offset mutants that hide behind them die.
+- The re-measurement is published as it comes out.
+
+**Non-Goals:**
+
+- Touching `scripts/validate-agents.py`. Nothing about its behaviour is wrong here.
+- Chasing the 16 survivors that are `|` inside type annotations. They have no runtime effect, and
+  hunting equivalent mutants is the anti-pattern the `bug-hunter` skill names in the same breath as
+  the technique.
+- A second format. The skills suite's shape is adopted as-is.
+
+## Decisions
+
+**D1 — Optional fourth element, not a new tuple everywhere.** `len(entry) > 3` reads the fragment,
+absent means "assert the check id only". Rewriting 54 working cases to carry an empty string would
+be churn with no defect behind it.
+
+**D2 — The fragment is asserted in addition to the check id, never instead of it.** A defect caught
+by the right message under the wrong check is still a defect, and that is the property the suite has
+had since #205.
+
+**D3 — Two frontmatter documents, because one does not separate the offsets.** The degenerate
+`---` immediately followed by `---` distinguishes the offset `4` from the offset `3`: at 4 the closing
+delimiter is not found and the finding is "no YAML frontmatter", at 3 it is found and the frontmatter
+is empty, so the finding is "not a mapping". It does **not** separate 4 from 5, because from either
+offset the match is missed on that input. A document whose frontmatter opens with an empty line does:
+at 4 the closing delimiter is found immediately, at 5 it is missed.
+
+**D4 — What the measurement says is what gets written.** Some of these mutants may be genuinely
+equivalent — `text[3:end]` prepends a newline to a YAML document, which parses identically, and there
+is no input that separates it. Where that is the finding, it is stated as the finding, not converted
+into a contrived case whose only purpose is to move a number.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Reading survivors by class, and not chasing equivalent mutants | `bug-hunter` | already canonical — this change applies its scoring layer |
+| Reuse the shape that exists instead of inventing a second one | `lean-code` | link — D1 and the "no second format" non-goal apply it |
+| Publish the measurement as measured, including when it disagrees | `verify-before-claiming` | link — D4 applies it |
+| What the self-test that gates the agent validator must prove | `agents-catalog` (spec) | already canonical — this change modifies it |
+
+## Risks / Trade-offs
+
+- **A fragment makes a case brittle against message rewording.** Accepted, and it is the point: a
+  message a case depends on is a contract, and changing it should require looking at the case.
+- **The four mutants may not all die.** Then the ones that survive are named with the reason, which
+  is the same treatment #229 gave them.
+
+## Open questions
+
+- None. What is unknown here is a measurement, and the change runs it.

--- a/openspec/changes/assert-agent-findings-by-fragment/proposal.md
+++ b/openspec/changes/assert-agent-findings-by-fragment/proposal.md
@@ -1,0 +1,48 @@
+# Change: Let the agent self-test assert which finding fired, not only which check
+
+## Why
+
+`scripts/selftest-validate-agents.py` asserts the **check id** and nothing more: a case declares
+`[A1` and any A1 finding satisfies it. Its sibling `scripts/selftest-validate-skills.py` already goes
+one step further — an entry may carry `(check, fragment)` and the fragment must appear in the finding
+— which is how a case like `C12 out-of-skill path (nested reference)` proves *which* path was
+reported rather than that some path was.
+
+The measurement in PR #229 made the cost visible. After the hardening, mutation over
+`scripts/validate-agents.py` left 45 of 229 mutants alive, and four of them sit on the frontmatter
+split offsets: `text.find("\n---\n", 4)` mutated to 3 and to 5, and `text[4:end], text[end + 5:]`
+mutated to `+4` and `+6`. On the degenerate document whose delimiters are present with nothing
+between them, the mutated path and the original **both** answer with an A1 finding — one calling it
+absent, the other calling it not a mapping — so a suite that asserts `[A1` cannot tell them apart.
+That case was added in #229 anyway, because it is a legitimate malformed input, and the fact that it
+kills nothing was written into *Known gaps* rather than papered over.
+
+The gap is not those four mutants. It is that a check owning more than one message cannot be proved
+by message at all, which is exactly the reason the skills suite grew the fragment.
+
+## What Changes
+
+- `scripts/selftest-validate-agents.py`: a case may carry an optional fragment as a fourth element,
+  in the shape the skills suite already uses. A case without one behaves exactly as today, so the
+  54 existing cases are untouched.
+- Fragments added where a check owns more than one message, starting with the two frontmatter paths.
+- A case for the document whose frontmatter opens with an empty line, which is what separates the
+  offset `4` from the offset `5`.
+- The mutation measurement re-run under the conditions of #229 and reported as measured.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `agents-catalog`: MODIFIED *A published agent declares its admission and its privilege* — the
+  self-test SHALL be able to assert which message a check produced, and SHALL use that wherever a
+  check owns more than one, so two paths through the same check are distinguishable.
+
+## Impact
+
+- `scripts/selftest-validate-agents.py` only. `scripts/validate-agents.py` is not touched: its
+  behaviour is correct, and what was missing is assertion power in the suite.
+- No skill, no agent, no generated tree, so `generate.sh` does not run and the skill-version gate
+  reports no skill changed.

--- a/openspec/changes/assert-agent-findings-by-fragment/specs/agents-catalog/spec.md
+++ b/openspec/changes/assert-agent-findings-by-fragment/specs/agents-catalog/spec.md
@@ -1,0 +1,74 @@
+## MODIFIED Requirements
+
+### Requirement: A published agent declares its admission and its privilege
+
+Every `agents/<name>.md` SHALL carry the frontmatter its harness requires — an identifier equal to
+the file name, a description naming the conditions that route work to it, the model, and the colour —
+and SHALL declare `tools` explicitly. Omitting `tools` grants every tool, so the declaration is the
+difference between a stated privilege and an unstated one.
+
+A required field declared with no value SHALL be treated as absent. A key present and null satisfies
+a membership test while stating nothing, and `tools` declared null is equivalent at run time to
+omitting it — the case the privilege rule above exists to refuse. A declared tool name SHALL carry a
+non-blank value for the same reason: a name made only of spaces is a privilege stated in form and
+absent in substance.
+
+The gate SHALL NOT end by unhandled exception on malformed input. A directory carrying the file
+suffix, a file that cannot be decoded, a dangling symlink, an unencodable character in a field, an
+anchor or alias in the frontmatter, **a field whose value is a collection where a scalar is
+required, and a payload whose nesting exhausts the parser** SHALL each become a reported finding that
+names the path, and the remaining agents SHALL still be checked. A gate that crashes on the first bad
+input reports nothing about the inputs after it. Guarding a value SHALL be done by checking its shape
+before the test that cannot survive it, never by wrapping that test in a handler that would turn the
+crash into a silent pass for the field the check owns.
+
+Where a defect of this kind is fixed in one gate, every sibling gate in the repository that parses
+the same input with the same construct SHALL be fixed in the same change. A gate hardened alone
+leaves the identical input fatal one file over.
+
+The body SHALL carry a section naming the situations that invoke the agent, and SHALL state the
+output contract: the shape the caller receives and what the agent must not return. That section
+SHALL be recognised only where a Markdown renderer would render it as a heading: hashes followed on
+the same line by the heading text, outside any fenced code block. An agent whose work would produce a
+file SHALL return what to write rather than write it, unless writing inside the isolated context is
+the work being bought.
+
+Every published agent SHALL carry, in the repository, the written reason it passes the three
+admission tests of the delegation doctrine. An agent admitted by symmetry with an existing artifact,
+rather than by those tests, is a defect.
+
+The self-test that gates this validator SHALL carry, for every limit the gate enforces, a case on
+each side of the limit and one at the value itself. A suite that proves only that a limit fires
+leaves the limit's position unmeasured, so moving the constant breaks nothing and the check is
+covered on paper and untested in fact.
+
+The self-test SHALL be able to assert **which finding** a case produced, not only which check owns
+it, and SHALL do so wherever a check can produce more than one message. A check with several
+messages that is proved only by its id cannot distinguish two paths through it, and a defect that
+moves a case from one message to the other passes unnoticed.
+
+
+#### Scenario: An agent without a declared tool set fails the gate
+
+- **WHEN** an agent omits `tools`, or names a write tool while its contract says it returns what to
+  write
+- **THEN** the validator fails naming the agent and the field
+
+#### Scenario: An agent that does not say when to invoke it fails the gate
+
+- **WHEN** the body carries no section naming the situations that invoke the agent
+- **THEN** the validator fails, because a description alone routes without telling the agent what
+  the caller expected
+
+#### Scenario: The validator is itself gated
+
+- **WHEN** the agent validator ships
+- **THEN** a self-test proves each of its rules fails a violating agent and passes a conforming one,
+  so the gate is not trusted on its own word
+
+
+#### Scenario: Two paths through one check are told apart
+
+- **WHEN** a check can report more than one message and a case exists for each path
+- **THEN** the self-test asserts the message the case expects, in addition to the check id, so a
+  defect that swaps one path for the other fails a case

--- a/openspec/changes/assert-agent-findings-by-fragment/tasks.md
+++ b/openspec/changes/assert-agent-findings-by-fragment/tasks.md
@@ -1,0 +1,106 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at. Read at `4a865a2` on 2026-09-07:
+      `scripts/selftest-validate-agents.py` (the `(label, check, plant)` tuple and the loop that
+      asserts `f"[{check}" in out`), `scripts/selftest-validate-skills.py` (the shape being adopted —
+      `expect, fragment = (entry[2] if len(entry) > 2 else (check, ""))` and
+      `caught = expect.split()[0] in out and expect in out and fragment in out`),
+      `scripts/validate-agents.py` (the `split()` helper whose offsets the four survivors sit on, and
+      the two A1 messages those paths produce), and
+      `openspec/specs/agents-catalog/spec.md` (the requirement this change modifies).
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded.
+      `python3 scripts/selftest-validate-agents.py` on the base -> `54/54 cases passed`. Both A1
+      messages were read straight out of the validator, run against each document in a throwaway
+      tree with the offset patched by hand. Document `---\n---\n`: offset 4 ->
+      `[A1 frontmatter] no YAML frontmatter delimited by --- at the top of the file`, offset 3 ->
+      `[A1 frontmatter] frontmatter is not a mapping`. Document `---\n\n---\n`, whose closing
+      delimiter sits at index 4 exactly (`t.find("\n---\n", 4)` -> `4`, `... , 5)` -> `-1`):
+      offset 4 -> `frontmatter is not a mapping`, offset 5 -> `no YAML frontmatter`. The first
+      document does NOT separate 4 from 5 — from both it misses — which is why there are two.
+      `cosmic-ray 8.7.0` is the tool the re-measurement uses, the same as #229.
+- [x] E.3 Anything that could NOT be probed is written down as an open question — never stated as
+      fact, never filled with a plausible substitute. One, and it is a property rather than a gap:
+      `text[4:end]` mutated to `text[3:end]` prepends the newline at index 3 to the frontmatter, and
+      YAML parses a document with a leading blank line identically, so no input separates the two.
+      That is an equivalent mutant, stated as one rather than chased with a contrived case.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed: the same optional-fragment shape
+      would let the accepting blocks at the bottom of `main()` assert what they accept rather than
+      only that the run exited zero — a separate item, because it touches cases this change has no
+      defect against.
+
+## 2. The mechanism
+
+- [x] 2.1 A case may carry an optional fourth element, the fragment, read the way the skills suite
+      reads its optional third; a case without one behaves exactly as today
+- [x] 2.2 The fragment is asserted **in addition** to the check id, never instead of it
+- [x] 2.3 A missing fragment reports the finding that was actually produced, so the failure is
+      readable without re-running by hand
+
+## 3. The cases that need it
+
+- [x] 3.1 The degenerate document — delimiters present, nothing between them — asserts the "no YAML
+      frontmatter" message, which separates the offset `4` from the offset `3`
+- [x] 3.2 A document whose frontmatter opens with an empty line asserts its message, which separates
+      the offset `4` from the offset `5`
+- [ ] 3.3 Mutation re-run under the conditions of #229 and the number recorded beside the 45
+
+## 4. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 The artifact is a gate's self-test and its entry point is being run.
+      `python3 scripts/selftest-validate-agents.py` -> `55/55 cases passed`, and
+      `python3 scripts/validate-agents.py` on the real tree -> `agents checked: 3   findings: 0`.
+      The mechanism was then exercised against the defects it exists to catch, by patching the
+      offset by hand and re-running: offset `4 -> 3` ->
+      `OTHER  A1  frontmatter delimiters with nothing between them — expected the finding to carry
+      'no YAML frontmatter'`, `54/55 cases passed`; offset `4 -> 5` ->
+      `OTHER  A1  frontmatter that opens with an empty line — expected the finding to carry
+      'not a mapping'`, `54/55 cases passed`. Both were green before this change.
+- [x] S.2 Case matrix measured, as counts: suite 54 -> **55/55**; new cases that had to fire and
+      did, **2/2**; offset mutants the fragment had to kill and did, **2/2** (`find(..., 3)` and
+      `find(..., 5)`); existing cases that had to keep passing and did, **54/54**; mutation over
+      `scripts/validate-agents.py` under the conditions of #229 (`cosmic-ray 8.7.0`, the self-test
+      as runner, default operators): **229 mutants / 45 survivors / 80.3%** before,
+      **229 / 37 / 83.8%** after. Survivors on the frontmatter split offsets: **4 -> 2**, plus one
+      the previous run had miscounted (below).
+- [x] S.3 Two things, and the first is a correction to what #229 published. **(1) One of the four
+      offset survivors was miscounted there.** `text[end | 5:]` is a `BitOr` mutation, and the
+      classifier that grouped survivors put every `BitOr` in the "type annotation, no runtime effect"
+      bucket before looking at the line — so #229's four were `find(..., 3)`, `find(..., 5)`,
+      `text[3:end]` and `text[end + 4:]`, and `end | 5` was hidden in the wrong bucket. It is a real
+      survivor and it is named here. **(2) The two that remain are equivalent mutants, and this was
+      proved rather than assumed.** `text[3:end]` prepends the newline at index 3 to the frontmatter,
+      which YAML parses identically; `text[end + 4:]` prepends it to the body, where `.strip()`
+      removes it for the length check and `re.M` makes the heading regex indifferent. Both were run
+      against the real tree and produced output byte-identical to the original, with `55/55` on the
+      suite. Nothing can kill them, and a case that tried would be asserting an implementation detail
+      no behaviour depends on. `end | 5` is distinguishable in principle — on two of the three
+      published agents `end | 5 != end + 5` — but nothing notices, because the body it produces still
+      clears the length limits and still carries the heading; killing it needs a document whose
+      frontmatter length has a chosen bit pattern, which is a test written to the mutation operator
+      rather than to a defect. That is the anti-pattern `bug-hunter` names beside the technique, and
+      it is declined here on purpose.
+
+## 5. Quality Gates (MANDATORY)
+
+- [x] Q.1 No SKILL.md is touched — `validate-skill-version.py` -> `0 skill(s) changed`, and
+      `validate-skills.py` -> `skills checked: 38   findings: 0`
+- [x] Q.2 The one file this change edits is a Python self-test, written in English
+- [x] Q.3 No `description` and no trigger surface is touched
+- [x] Q.4 No doctrine restated; the equivalent-mutant rule stays in `bug-hunter` and is applied,
+      not copied
+- [x] Q.5 No skill example is touched; the new case labels and comments are English
+
+## 6. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate assert-agent-findings-by-fragment --strict` ->
+      `Change 'assert-agent-findings-by-fragment' is valid`; `bash scripts/validate-rite.sh` ->
+      `rite gate OK`
+- [x] V.2 `npx -y skills add . --list` -> 44 skills, the 38 under `skills/` plus the 6 under
+      `.claude/skills/`; nothing added, removed or renamed
+- [x] V.3 No composition or usage change; `README.md:592` describes the gate and names no count
+- [ ] V.4 `openspec archive assert-agent-findings-by-fragment --yes` — left for after the merge,
+      as in #233, #224 and #208; the pull request reports the change as active and names this as what
+      closes it

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -90,8 +90,15 @@ def sized(desc_len: int, body_len: int, name: str = "example-agent") -> str:
             "model: inherit\ncolor: blue\ntools: [\"Read\"]\n---\n" + stripped + "\n")
 
 
-# (label, expected check id, how to plant it)
-CASES: list[tuple[str, str, object]] = [
+# (label, expected check id, how to plant it[, fragment the finding must carry])
+#
+# The fourth element is optional and is asserted IN ADDITION to the check id, never instead of it —
+# a defect caught by the right message under the wrong check is still a defect. Use it wherever a
+# check owns more than one message: without it, two paths through the same check are
+# indistinguishable, which is what let four offset mutants survive the measurement in issue #225.
+# Same shape as `scripts/selftest-validate-skills.py`, which reads its own optional element with
+# `entry[2] if len(entry) > 2`; one idea, one format (issue #232).
+CASES: list[tuple] = [
     ("no frontmatter at all", "A1",
      lambda r: (r / "agents" / "example-agent.md").write_text("just a body\n", encoding="utf-8")),
     ("frontmatter that does not parse", "A1",
@@ -209,21 +216,33 @@ CASES: list[tuple[str, str, object]] = [
      lambda r: (r / "agents" / "example-agent.md").write_text(sized(200, 19), encoding="utf-8")),
     ("a body one character over the maximum", "A6",
      lambda r: (r / "agents" / "example-agent.md").write_text(sized(200, 10001), encoding="utf-8")),
-    # The degenerate document the frontmatter split is least tested on: delimiters present, nothing
-    # between them. It is a legitimate malformed input the suite lacked. It does NOT kill the four
-    # offset mutants that survive on `text.find("\n---\n", 4)` and `text[4:end]` — both the mutated
-    # and the original path answer with an A1 finding here, one calling it absent and the other
-    # calling it not a mapping — and that is written down rather than papered over (issue #225).
     # A name that sorts BEFORE the file stem. Every mismatch case in this suite happened to sort
     # after it, so `name != agent` and `name > agent` answered identically and the comparison had no
     # witness — found by reading the survivors of the mutation run, not by reading the code.
     ("a name that differs from the file stem and sorts before it", "A2",
      lambda r: (r / "agents" / "example-agent.md").write_text(
          replace("name: example-agent", "name: aaa"), encoding="utf-8")),
+    # ── The two documents that separate the frontmatter split offsets (issue #232) ───────────
+    # Both are legitimate malformed inputs, and both are asserted BY MESSAGE. Asserting `[A1` alone
+    # cannot tell these paths apart, which is exactly why four offset mutants survived the #225
+    # measurement with the suite green.
+    #
+    # Delimiters present with nothing between them: from offset 4 the closing delimiter is NOT found,
+    # so the finding is "no YAML frontmatter"; from the mutated offset 3 it IS found, the frontmatter
+    # is empty, and the finding becomes "not a mapping". Measured 2026-09-07.
     ("frontmatter delimiters with nothing between them", "A1",
      lambda r: (r / "agents" / "example-agent.md").write_text(
          "---\n---\n\nA body with no frontmatter fields at all, long enough to clear the minimum.\n"
-         "\n## When to invoke\n\n- Never. This file exists for the self-test.\n", encoding="utf-8")),
+         "\n## When to invoke\n\n- Never. This file exists for the self-test.\n", encoding="utf-8"),
+     "no YAML frontmatter"),
+    # Frontmatter opening with an empty line puts the closing delimiter at index 4 exactly, so it is
+    # found from offset 4 ("not a mapping") and missed from the mutated offset 5 ("no YAML
+    # frontmatter"). The document above cannot stand in for this one: from both 4 and 5 it misses.
+    ("frontmatter that opens with an empty line", "A1",
+     lambda r: (r / "agents" / "example-agent.md").write_text(
+         "---\n\n---\n\n## When to invoke\n\n- Never. This file exists for the self-test, and "
+         "carries enough body to clear the minimum.\n", encoding="utf-8"),
+     "not a mapping"),
 ]
 
 
@@ -240,7 +259,9 @@ def main() -> int:
         else:
             print("  CLEAN  a conforming agent produces zero findings")
 
-        for label, check, plant in CASES:
+        for case in CASES:
+            label, check, plant = case[0], case[1], case[2]
+            fragment = case[3] if len(case) > 3 else ""
             shutil.rmtree(root)
             build(root)
             plant(root)
@@ -255,6 +276,12 @@ def main() -> int:
                 failures += 1
             elif f"[{check}" not in out:
                 print(f"  WRONG  {check}  {label}  — detected, but by another check:\n{out}")
+                failures += 1
+            elif fragment and fragment not in out:
+                # The check fired, but by the other path through it. Print what WAS produced, so the
+                # failure is readable without re-running the case by hand.
+                print(f"  OTHER  {check}  {label}  — expected the finding to carry "
+                      f"{fragment!r}, got:\n{out}")
                 failures += 1
             else:
                 print(f"  OK     {check}  {label}")


### PR DESCRIPTION
Closes #232

A suíte de agentes asseria só o **id do check**: um caso declarava `[A1` e qualquer achado A1 satisfazia. A irmã `scripts/selftest-validate-skills.py` já vai um passo além, com `(check, fragment)`. Uma ideia, dois lugares, um deles faltando — e a conta apareceu na medição do #229, onde quatro mutantes de offset sobreviveram porque os dois caminhos do split de frontmatter respondem **ambos** com achado A1.

## O mecanismo

Quarto elemento opcional na tupla, asserido **além** do id, nunca no lugar dele — defeito pego pela mensagem certa sob o check errado continua sendo defeito. Caso sem fragmento se comporta como antes, então os 54 existentes não foram tocados (`lean-code`: um formato, não dois).

Falha legível sem re-rodar à mão:

```
OTHER  A1  frontmatter delimiters with nothing between them
       — expected the finding to carry 'no YAML frontmatter', got: ...
```

## Dois documentos, porque um não separa os dois offsets

| Documento | offset 4 (original) | mutante |
|---|---|---|
| `---\n---\n` | `no YAML frontmatter` | offset **3** → `frontmatter is not a mapping` |
| `---\n\n---\n` | `frontmatter is not a mapping` | offset **5** → `no YAML frontmatter` |

O segundo existe porque no primeiro o delimitador é perdido tanto de 4 quanto de 5. No segundo ele cai no índice 4 exato — `t.find("\n---\n", 4)` → `4`, `..., 5)` → `-1`.

Provado que pega, patchando o offset à mão e re-rodando: `54/55` nos dois casos, ambos verdes antes desta mudança.

## Medição

Mesmas condições do #229 — `cosmic-ray 8.7.0`, o selftest como runner, operadores padrão.

| | #229 | agora |
|---|---|---|
| Mutantes | 229 | 229 |
| Vivos | 45 | **37** |
| Score | 80,3% | **83,8%** |
| Suíte | 54 casos | **55/55** |

## O que sobra, e por quê

Os dois mutantes de `text.find` morreram. Sobram três em `text[4:end], text[end + 5:]`:

- **`text[3:end]`** e **`text[end + 4:]`** — **equivalentes, e isso foi provado, não suposto**: saída **byte-idêntica** na árvore real e `55/55` na suíte. O newline a mais entra no frontmatter (que o YAML parseia igual) ou no corpo (onde o `.strip()` o come para a contagem e o `re.M` o ignora para o heading). Nada pode matá-los, e um caso que tentasse estaria asserindo detalhe de implementação do qual nenhum comportamento depende.
- **`text[end | 5:]`** — **correção ao que o #229 publicou**: ele não estava entre os quatro de lá porque o classificador jogava todo `BitOr` no balde de "anotação de tipo, sem efeito em runtime" **antes de olhar a linha**. É sobrevivente real e fica nomeado. É distinguível em princípio — em dois dos três agentes publicados `end | 5 != end + 5` — mas nada percebe: o corpo que ele produz continua dentro dos limites e continua com o heading. Matá-lo exigiria um documento cujo comprimento de frontmatter tem um padrão de bits escolhido, que é teste escrito para o operador de mutação e não para um defeito — o anti-padrão que o `bug-hunter` nomeia ao lado da técnica, recusado aqui de propósito.

O critério de aceitação do item foi **corrigido** com essa contagem e essa razão, em vez de tiquetado mudo.

## Verificações

| Verificação | Resultado |
|---|---|
| `selftest-validate-agents.py` | `55/55 cases passed` |
| `selftest-validate-skills.py` | `28/28 defect classes detected` |
| `validate-agents.py` / `validate-skills.py` | 3 agentes, 38 skills, 0 findings |
| `openspec validate assert-agent-findings-by-fragment --strict` | válida |
| `scripts/validate-rite.sh` | `rite gate OK` |
| `validate-skill-version.py` | `0 skill(s) changed` — nenhuma skill tocada |
| higiene / segredos | 0 findings, nenhuma credencial |
| `npx skills add . --list` | 44 = 38 `skills/` + 6 `.claude/skills/` |

## Rito

Change `assert-agent-findings-by-fragment`, schema `skills-rite`, capability `agents-catalog` (um requisito MODIFIED: o self-test consegue asserir qual mensagem disparou, e o faz onde um check tem mais de uma). **Ainda ativa** — `openspec archive` fecha o V.4 depois do merge.
