### PR TITLE
✅ test(scripts): aceitação se prova pelo silêncio, não pelo código de saída

### DIFF
--- a/openspec/changes/assert-agent-acceptances-by-silence/.openspec.yaml
+++ b/openspec/changes/assert-agent-acceptances-by-silence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: skills-rite
+created: 2026-09-07

--- a/openspec/changes/assert-agent-acceptances-by-silence/design.md
+++ b/openspec/changes/assert-agent-acceptances-by-silence/design.md
@@ -1,0 +1,52 @@
+# Design — an acceptance is silence, not a zero
+
+## Context
+
+Two rigours in one file: the baseline block reads the output, the six accepting blocks read only the
+exit code. The fragment work of issue #232 closed the rejecting half of the same gap.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One rigour for acceptance in this suite, and it is the stricter one that already exists in it.
+- A failing acceptance names the check that fired.
+
+**Non-Goals:**
+
+- Touching `scripts/validate-agents.py`; nothing in it is wrong.
+- New cases. This is rigour on what exists, not coverage.
+- Re-running the mutation measurement: no mutant depends on this, and measuring for the sake of
+  measuring is the waste the skill names beside the technique.
+
+## Decisions
+
+**D1 — Adopt the rigour already in the file.** The baseline block's condition
+(`code != 0 or "findings: 0" not in out`) is the shape; a third form invented here would be the
+duplication `lean-code` refuses.
+
+**D2 — The helper takes the label and returns a verdict; the blocks keep their own labels.** The
+difference between the six blocks is what they plant, not how they judge, so only the judging moves.
+
+**D3 — Name the check on failure by reading it out of the output.** The findings are printed as
+`[A3 description] …`, so the first bracketed token is the check. When none is present the message
+says so — an acceptance that failed with no check id is a different defect and should not look like
+the common one.
+
+## Canonical Home & Cross-Links (MANDATORY)
+
+| Rule / doctrine touched | Canonical skill | Action (link / move / already canonical) |
+|---|---|---|
+| Reuse the shape already present instead of inventing a second | `lean-code` | link — D1 applies it |
+| What the self-test that gates the agent validator must prove | `agents-catalog` (spec) | already canonical — this change modifies it |
+| Assert what was observed, not what was expected | `verify-before-claiming` | link — the failure message reports the finding produced |
+
+## Risks / Trade-offs
+
+- **The stricter rigour could fail a block that passes today.** That is the outcome worth having: it
+  would mean a finding nobody was reading, and it goes in the pull request.
+- **A helper can hide which block failed.** Each call keeps its own label, and the label is printed.
+
+## Open questions
+
+- None.

--- a/openspec/changes/assert-agent-acceptances-by-silence/proposal.md
+++ b/openspec/changes/assert-agent-acceptances-by-silence/proposal.md
@@ -1,0 +1,39 @@
+# Change: Prove an acceptance by the absence of a finding, not by the exit code
+
+## Why
+
+`scripts/selftest-validate-agents.py` grew the fragment assertion in issue #232, and it covers only
+the cases that must be **rejected**. The six accepting blocks at the bottom of `main()` — the four
+limits at their value, the fifty-character name, and the two-agent case — still assert nothing but
+`code != 0`.
+
+The baseline block a few lines above them is stricter: it requires `"findings: 0" not in out` as well
+as the exit code. So the same file holds two rigours for the same kind of assertion, and the weaker
+one is on the blocks that exist precisely to prove the gate stays quiet.
+
+That weaker form has two costs. A validator that exited zero while reporting something would pass,
+because nothing reads the output. And when an accepting block does fail, the message is `was
+rejected` followed by the whole run — it does not name the check that fired, which is the first thing
+a reader wants and exactly what the `OTHER` line of the fragment cases now says.
+
+## What Changes
+
+- One acceptance helper, used by all six blocks, asserting the exit code **and** `findings: 0`.
+- On failure it names the check that fired, extracted from the output, before printing the rest; when
+  no check id can be found it says that rather than omitting it.
+- No case is added and no case is removed: this raises the rigour of what already exists.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `agents-catalog`: MODIFIED *A published agent declares its admission and its privilege* — the
+  self-test proves an acceptance by the absence of a finding rather than by the exit code alone, and
+  a failed acceptance names the check that fired.
+
+## Impact
+
+- `scripts/selftest-validate-agents.py` only. No skill, no agent, no generated tree, so
+  `generate.sh` does not run and the skill-version gate reports no skill changed.

--- a/openspec/changes/assert-agent-acceptances-by-silence/specs/agents-catalog/spec.md
+++ b/openspec/changes/assert-agent-acceptances-by-silence/specs/agents-catalog/spec.md
@@ -1,0 +1,113 @@
+## MODIFIED Requirements
+
+### Requirement: A published agent declares its admission and its privilege
+
+Every `agents/<name>.md` SHALL carry the frontmatter its harness requires — an identifier equal to
+the file name, a description naming the conditions that route work to it, the model, and the colour —
+and SHALL declare `tools` explicitly. Omitting `tools` grants every tool, so the declaration is the
+difference between a stated privilege and an unstated one.
+
+A required field declared with no value SHALL be treated as absent. A key present and null satisfies
+a membership test while stating nothing, and `tools` declared null is equivalent at run time to
+omitting it — the case the privilege rule above exists to refuse. A declared tool name SHALL carry a
+non-blank value for the same reason: a name made only of spaces is a privilege stated in form and
+absent in substance.
+
+The gate SHALL NOT end by unhandled exception on malformed input. A directory carrying the file
+suffix, a file that cannot be decoded, a dangling symlink, an unencodable character in a field, an
+anchor or alias in the frontmatter, **a field whose value is a collection where a scalar is
+required, and a payload whose nesting exhausts the parser** SHALL each become a reported finding that
+names the path, and the remaining agents SHALL still be checked. A gate that crashes on the first bad
+input reports nothing about the inputs after it. Guarding a value SHALL be done by checking its shape
+before the test that cannot survive it, never by wrapping that test in a handler that would turn the
+crash into a silent pass for the field the check owns.
+
+Where a defect of this kind is fixed in one gate, every sibling gate in the repository that parses
+the same input with the same construct SHALL be fixed in the same change. A gate hardened alone
+leaves the identical input fatal one file over.
+
+The body SHALL carry a section naming the situations that invoke the agent, and SHALL state the
+output contract: the shape the caller receives and what the agent must not return. That section
+SHALL be recognised only where a Markdown renderer would render it as a heading: hashes followed on
+the same line by the heading text, outside any fenced code block. An agent whose work would produce a
+file SHALL return what to write rather than write it, unless writing inside the isolated context is
+the work being bought.
+
+Every published agent SHALL carry, in the repository, the written reason it passes the three
+admission tests of the delegation doctrine. An agent admitted by symmetry with an existing artifact,
+rather than by those tests, is a defect.
+
+The self-test that gates this validator SHALL carry, for every limit the gate enforces, a case on
+each side of the limit and one at the value itself. A suite that proves only that a limit fires
+leaves the limit's position unmeasured, so moving the constant breaks nothing and the check is
+covered on paper and untested in fact.
+
+The self-test SHALL be able to assert **which finding** a case produced, not only which check owns
+it, and SHALL do so wherever a check can produce more than one message. A check with several
+messages that is proved only by its id cannot distinguish two paths through it, and a defect that
+moves a case from one message to the other passes unnoticed.
+
+An acceptance in that self-test SHALL be proved by the **absence of a finding**, not by the exit code
+alone. A gate that exits successfully while reporting something is the case an exit-code assertion
+cannot see, and it is the case an accepting block exists to rule out. A failed acceptance SHALL name
+the check that fired, so the failure is readable without re-running it by hand.
+#### Scenario: An agent without a declared tool set fails the gate
+
+- **WHEN** an agent omits `tools`, or names a write tool while its contract says it returns what to
+  write
+- **THEN** the validator fails naming the agent and the field
+
+#### Scenario: An agent that does not say when to invoke it fails the gate
+
+- **WHEN** the body carries no section naming the situations that invoke the agent
+- **THEN** the validator fails, because a description alone routes without telling the agent what
+  the caller expected
+
+#### Scenario: The validator is itself gated
+
+- **WHEN** the agent validator ships
+- **THEN** a self-test proves each of its rules fails a violating agent and passes a conforming one,
+  so the gate is not trusted on its own word
+
+#### Scenario: A required field present but null fails the gate
+
+- **WHEN** an agent declares a required field with no value, or an explicit null
+- **THEN** the validator reports it as missing, and every check that field feeds still runs
+
+#### Scenario: Malformed input is reported, not fatal
+
+- **WHEN** the canonical directory contains a directory named like an agent file, a file that cannot
+  be decoded, or a dangling symlink
+- **THEN** each is reported as a finding naming the path, the remaining agents are still checked, and
+  the run still exits non-zero
+
+#### Scenario: A value of the wrong shape does not end the run
+
+- **WHEN** a scalar field is declared as a sequence or a mapping, or a value nests deeply enough to
+  exhaust the parser
+- **THEN** it is reported as a finding naming the path and the field, and an agent placed after it is
+  still checked
+
+#### Scenario: A heading that is not rendered as one does not satisfy the body rule
+
+- **WHEN** the invocation section's hashes stand alone on their line, or the only such heading lies
+  inside a fenced code block
+- **THEN** the validator reports the section as missing
+
+#### Scenario: A limit is proved at its own value
+
+- **WHEN** the gate enforces a minimum or a maximum
+- **THEN** the self-test carries an accepted case at the limit, a rejected case one past it, and an
+  accepted case one inside it, so a changed constant fails a test
+
+#### Scenario: Two paths through one check are told apart
+
+- **WHEN** a check can report more than one message and a case exists for each path
+- **THEN** the self-test asserts the message the case expects, in addition to the check id, so a
+  defect that swaps one path for the other fails a case
+
+#### Scenario: An acceptance is proved by silence
+
+- **WHEN** a self-test case exists to show that a conforming input produces no finding
+- **THEN** it asserts that the validator reported none, not merely that it exited successfully
+- **AND** when it fails, the message names the check that fired

--- a/openspec/changes/assert-agent-acceptances-by-silence/tasks.md
+++ b/openspec/changes/assert-agent-acceptances-by-silence/tasks.md
@@ -1,0 +1,78 @@
+## 1. Evidence & Sources (MANDATORY)
+
+- [x] E.1 Every local path this change relies on was OPENED and read, not recalled — recorded with
+      the commit or timestamp it was read at. Read at `28d0c80` on 2026-09-07:
+      `scripts/selftest-validate-agents.py` — the baseline block
+      (`if code != 0 or "findings: 0" not in out`), the six accepting blocks that assert only
+      `if code != 0`, and the `OTHER` branch the fragment work of #232 added; and
+      `openspec/specs/agents-catalog/spec.md`, the requirement this change modifies, nine scenarios,
+      carried whole into the delta.
+- [x] E.2 Every external tool, CLI flag, config key, API name or version this change asserts was
+      probed against the installed version; the command and a fragment of its output are recorded.
+      `python3 scripts/selftest-validate-agents.py` on the base -> `55/55 cases passed`. The finding
+      format the failure message parses was read from a real run rather than assumed: planting a
+      short description gives `   [A3 description] 5 characters — the accepted range is 10-5000`, so
+      the check id is the first bracketed token of the line.
+- [x] E.3 Anything that could NOT be probed is written down as an open question — never stated as
+      fact, never filled with a plausible substitute. There is none: everything this change asserts
+      is in one file in this repository and was run.
+- [x] E.4 Scope check: this change does only what the proposal asked. Adjacent improvements noticed
+      along the way are listed here as follow-ups, not performed: `selftest-validate-skills.py`
+      compares its copy against the source after the loop, which the agents suite does not do because
+      it rebuilds the tree per case — worth a look only if that ever changes.
+
+## 2. The rigour
+
+- [x] 2.1 One acceptance helper asserting the exit code and `findings: 0`, in the shape the baseline
+      block already uses
+- [x] 2.2 All six accepting blocks go through it; none keeps the old assertion
+- [x] 2.3 A failed acceptance names the check that fired, or says explicitly that none was found
+- [x] 2.4 Demonstrated: an input that makes the validator report while exiting zero fails a block
+      under the new rigour and passed under the old
+
+## 3. Simulation & Field Proof (MANDATORY)
+
+- [x] S.1 The artifact is a self-test and its entry point is running it.
+      `python3 scripts/selftest-validate-agents.py` -> `55/55 cases passed`, with the first line now
+      `OK     a conforming agent produces zero findings is accepted`. Then, with the validator
+      patched to report a finding **and still exit zero**:
+      `FAIL   a conforming agent produces zero findings was not accepted cleanly — A9:`,
+      `FAIL   A6  a tab after the heading hashes was not accepted cleanly — A9:`,
+      `FAIL   A7  a generated copy with a source is not an orphan was not accepted cleanly — A9:`.
+      The same run judged by the OLD rule: `code=0 -> regra antiga (code != 0) julgaria: ACEITA`.
+- [x] S.2 Case matrix measured, as counts. Acceptances now judged by the helper, **8** across
+      **5 call sites**: the baseline, the four limits at their value, the fifty-character name, the
+      tab after the heading hashes, and the generated copy with a source. Acceptances that had to
+      stay silent and did, **8/8** (`55/55 cases passed`, unchanged). Acceptances the new rigour had
+      to fail under a validator that reports while exiting zero, **3/3 observed**, each naming the
+      check. Cases added, **0** — this raises rigour, not coverage.
+- [x] S.3 One thing, and it is a correction to the item that asked for this. The issue said "the
+      six accepting blocks — the four limits at their value, the fifty-character name and the
+      two-agent case". **The two-agent case is not an acceptance**: it asserts that the agent after a
+      defective one IS reported, which is a rejection-shaped check and keeps its own assertion. And
+      two acceptances the issue did not list were found while doing the work — the tab after the
+      heading hashes, and the generated copy with a canonical source — plus the baseline block, whose
+      condition is where the helper's rigour came from and which now goes through it too. The count
+      is 8 acceptances at 5 call sites, not six blocks; the item's FR3 and its criterion were
+      corrected rather than ticked as written. Nothing else behaved unexpectedly.
+
+## 4. Quality Gates (MANDATORY)
+
+- [x] Q.1 No SKILL.md is touched — `validate-skill-version.py` -> `0 skill(s) changed`, and
+      `validate-skills.py` -> `skills checked: 38   findings: 0`
+- [x] Q.2 The one file edited is a Python self-test, written in English
+- [x] Q.3 No `description` and no trigger surface is touched
+- [x] Q.4 The opposite of duplication: the file held two rigours for one assertion and now holds
+      one, taken from the stricter of the two
+- [x] Q.5 No skill example is touched; the helper and its labels are English
+
+## 5. Validation & Closure (MANDATORY)
+
+- [x] V.1 `openspec validate assert-agent-acceptances-by-silence --strict` ->
+      `Change 'assert-agent-acceptances-by-silence' is valid`; `bash scripts/validate-rite.sh` ->
+      `rite gate OK`
+- [x] V.2 `npx -y skills add . --list` -> 44 skills, the 38 under `skills/` plus the 6 under
+      `.claude/skills/`; nothing added, removed or renamed
+- [x] V.3 No composition or usage change; `README.md:592` names no counts and stays accurate
+- [ ] V.4 `openspec archive assert-agent-acceptances-by-silence --yes` — left for after the merge,
+      as in #236, #233 and #224; the pull request reports the change as active

--- a/scripts/selftest-validate-agents.py
+++ b/scripts/selftest-validate-agents.py
@@ -12,6 +12,7 @@ Needs only python3 and PyYAML (which validate-agents.py itself needs). Run from 
 """
 from __future__ import annotations
 
+import re
 import shutil
 import subprocess
 import sys
@@ -51,6 +52,27 @@ def run(root: Path) -> tuple[int, str]:
     p = subprocess.run([sys.executable, str(root / "scripts" / "validate-agents.py")],
                        capture_output=True, text=True)
     return p.returncode, p.stdout + p.stderr
+
+
+def accepts(root: Path, label: str) -> bool:
+    """An acceptance is proved by SILENCE, not by a zero exit.
+
+    The baseline check at the top of main() has always read the output as well as the code; the
+    accepting blocks below read only the code, so a validator that exited zero while reporting
+    something would satisfy them — the one case an accepting block exists to rule out (issue #239).
+    Same rigour as the baseline, in one place, so the file no longer holds two.
+
+    Prints the check that fired, read as the first bracketed token of a finding line, because
+    "was rejected" plus the whole run makes the reader go find it by hand.
+    """
+    code, out = run(root)
+    if code == 0 and "findings: 0" in out:
+        print(f"  OK     {label} is accepted")
+        return True
+    hit = re.search(r"\[([A-Z]\d+)", out)
+    which = hit.group(1) if hit else "no check id in the output"
+    print(f"  FAIL   {label} was not accepted cleanly — {which}:\n{out}")
+    return False
 
 
 def drop(field: str) -> str:
@@ -252,12 +274,9 @@ def main() -> int:
         root = Path(tmp) / "repo"
 
         build(root)
-        code, out = run(root)
-        if code != 0 or "findings: 0" not in out:
-            print(f"  FAIL   a conforming agent was rejected\n{out}")
-            failures += 1
-        else:
-            print("  CLEAN  a conforming agent produces zero findings")
+        # The baseline is an acceptance like the others, and now judged by the same helper — its
+        # condition is where that helper's rigour came from (issue #239).
+        failures += not accepts(root, "a conforming agent produces zero findings")
 
         for case in CASES:
             label, check, plant = case[0], case[1], case[2]
@@ -293,12 +312,7 @@ def main() -> int:
         build(root)
         (root / "agents" / "example-agent.md").write_text(
             replace("## When to invoke", "##\tWhen to invoke"), encoding="utf-8")
-        code, out = run(root)
-        if code != 0:
-            print(f"  FAIL   A6  a tab after the heading hashes was rejected\n{out}")
-            failures += 1
-        else:
-            print("  OK     A6  a tab after the heading hashes is accepted")
+        failures += not accepts(root, "A6  a tab after the heading hashes")
 
         # The canonical directory is gone and a generated copy is still published: the state A7 owns,
         # and the one the early return used to hide by never running the check (issue #205, attack 2).
@@ -321,12 +335,7 @@ def main() -> int:
         (root / "plugins" / "testing" / "agents").mkdir(parents=True)
         shutil.copy2(root / "agents" / "example-agent.md",
                      root / "plugins" / "testing" / "agents" / "example-agent.md")
-        code, out = run(root)
-        if code != 0:
-            print(f"  FAIL   a generated copy WITH a canonical source was called an orphan\n{out}")
-            failures += 1
-        else:
-            print("  OK     A7  a generated copy with a source is not an orphan")
+        failures += not accepts(root, "A7  a generated copy with a source is not an orphan")
 
         # ── issue #225 ── The accepting side of every limit. A rejected case one past the limit
         # proves the check fires; only a case AT the value proves where the limit sits. Without
@@ -341,12 +350,7 @@ def main() -> int:
             shutil.rmtree(root)
             build(root)
             (root / "agents" / "example-agent.md").write_text(text, encoding="utf-8")
-            code, out = run(root)
-            if code != 0:
-                print(f"  FAIL   {label} was rejected\n{out}")
-                failures += 1
-            else:
-                print(f"  OK     {label} is accepted")
+            failures += not accepts(root, label)
 
         # A name of exactly 50 characters is legal; the file is renamed so `name != agent` cannot
         # mask the regex. The rejecting side (51) is covered by NAME_RE itself and by the
@@ -357,12 +361,7 @@ def main() -> int:
         (root / "agents" / "example-agent.md").unlink()
         (root / "agents" / f"{long_name}.md").write_text(sized(200, 200, name=long_name),
                                                          encoding="utf-8")
-        code, out = run(root)
-        if code != 0:
-            print(f"  FAIL   A2  a name of exactly 50 characters was rejected\n{out}")
-            failures += 1
-        else:
-            print("  OK     A2  a name of exactly 50 characters is accepted")
+        failures += not accepts(root, "A2  a name of exactly 50 characters")
 
         # ── issue #225, finding 12 ── The property every crash guard rests on: the run REACHES the
         # agent after the bad one. Every case above plants exactly one agent, so a gate that died on


### PR DESCRIPTION
Closes #239

O #232 deu à suíte a asserção por fragmento, e ela cobre só os casos que **reprovam**. Os blocos de aceitação asseriam `code != 0` e nada mais — enquanto a linha de base, poucas linhas acima, já exigia `"findings: 0" not in out` além do código. **Dois rigores para a mesma asserção, no mesmo arquivo**, e o mais fraco justamente nos blocos que existem para provar que o gate fica quieto.

## O que o rigor novo compra, medido

Com o validador patchado para achar algo **e ainda sair zero**:

| Regra | Veredito |
|---|---|
| Antiga (`code != 0`) | **ACEITA** — `code=0` |
| Nova (código **e** `findings: 0`) | **REPROVA** — `'findings: 0' na saída? NAO` |

E a mensagem passou a nomear o check:

```
FAIL   a conforming agent produces zero findings was not accepted cleanly — A9:
FAIL   A6  a tab after the heading hashes was not accepted cleanly — A9:
FAIL   A7  a generated copy with a source is not an orphan was not accepted cleanly — A9:
```

Antes era `was rejected` seguido do run inteiro — o leitor indo procurar à mão qual check disparou.

## Correção ao próprio item

O #239 dizia "os seis blocos de aceitação — os quatro limites no valor, o nome de 50 caracteres e o caso de dois agentes". **Contei errado, de dois jeitos:**

- **O caso de dois agentes não é aceitação.** Ele assere que o agente depois do defeituoso **É** reportado — asserção de reprovação, e mantém a sua.
- **Duas aceitações não estavam na lista**, achadas fazendo o trabalho: a tabulação depois das cerquilhas e a cópia gerada com fonte canônica. Mais o bloco da linha de base, cuja condição é de onde o rigor do helper veio, e que agora passa por ele também.

São **8 aceitações em 5 pontos de chamada**, não seis blocos. O `FR3` e o critério foram corrigidos na issue com a contagem medida, em vez de tiquetados como escritos.

## Verificações

| Verificação | Resultado |
|---|---|
| `selftest-validate-agents.py` | `55/55 cases passed` — a mesma contagem, porque isto não acrescenta caso |
| `selftest-validate-skills.py` | `28/28 defect classes detected` |
| `validate-agents.py` / `validate-skills.py` | 3 agentes, 38 skills, 0 findings |
| `openspec validate assert-agent-acceptances-by-silence --strict` | válida |
| `scripts/validate-rite.sh` | `rite gate OK` |
| `validate-skill-version.py` | `0 skill(s) changed` |
| higiene / segredos | 0 findings |
| `npx skills add . --list` | 44 = 38 + 6 |

## Rito

Change `assert-agent-acceptances-by-silence`, capability `agents-catalog` (um requisito MODIFIED, carregando os nove cenários publicados mais um: uma aceitação se prova pela ausência de achado, e uma aceitação que falha nomeia o check). **Ainda ativa** — archive depois do merge.
