### PR TITLE
🐛 fix(scripts): tira a corrida do git do clone da fixture do smoke

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,12 @@ if [ -d "$INSTALL_DIR" ]; then
     pull_ff_only "$INSTALL_DIR" || exit 1
 else
     echo "📦 Cloning ai-skills into ~/ai-skills..."
-    git clone "$REPO_URL" "$INSTALL_DIR"
+    # --no-hardlinks is a no-op against a real remote and closes a race against a local path, which
+    # is exactly how scripts/smoke-install-scripts.sh drives this script (AI_SKILLS_REPO_URL points at
+    # a local bare repo). A local clone hardlinks the object store while git's commit-graph
+    # maintenance writes temporaries into it; the clone loses with
+    # `fatal: hardlink different from source at .../commit-graphs/tmp_graph_XXXXXX` (issue #242).
+    git clone --no-hardlinks "$REPO_URL" "$INSTALL_DIR"
 fi
 
 echo ""

--- a/scripts/smoke-install-scripts.sh
+++ b/scripts/smoke-install-scripts.sh
@@ -104,7 +104,14 @@ head_of() { git -C "$1" rev-parse HEAD; }
 git init -q --bare "$ORIGIN"
 git -C "$ORIGIN" symbolic-ref HEAD refs/heads/master
 git -C "$ROOT" push -q "$ORIGIN" HEAD:refs/heads/master
-git clone -q "$ORIGIN" "$AUTHOR"
+# --no-hardlinks: a clone from a LOCAL path hardlinks the object store, and git's own commit-graph
+# maintenance writes temporaries into that same store. The two race, and the loser is the clone:
+# `fatal: hardlink different from source at .../objects/info/commit-graphs/tmp_graph_XXXXXX`, seen in
+# CI on pull request #240 and gone on a re-run with nothing changed (issue #242). A gate that fails on
+# its own teaches people to re-run without reading, which is how a real red gets dismissed.
+# Measured cost, five clones each way on this repository's own store (git 2.47.3, 8760 packed objects,
+# 4.7 MB): 79 ms with hardlinks, 94 ms without. Fifteen milliseconds a clone. Do not remove it as free.
+git clone -q --no-hardlinks "$ORIGIN" "$AUTHOR"
 SKILL_COUNT="$(find "$AUTHOR/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d ' ')"
 echo "smoke: origin=$ORIGIN head=$(head_of "$AUTHOR" | cut -c1-7) skills=$SKILL_COUNT"
 


### PR DESCRIPTION
Closes #242

Spec-rite: none — troca de uma flag em um script de teste para fechar uma corrida do próprio git; nenhum requisito muda, nenhum comportamento publicado muda, e o que o smoke prova continua exatamente o mesmo conjunto de 19 casos.

O smoke **reprovou no CI da PR #240** e passou no re-run, sem nada mudar no meio:

```
fatal: hardlink different from source at
'/tmp/ai-skills-smoke.BrZeiD/author/.git/objects/info/commit-graphs/tmp_graph_lsUftG'
smoke aborted at line 107: git clone -q "$ORIGIN" "$AUTHOR"
```

Clone de **caminho local** faz hardlink do object store por padrão, e a manutenção de commit-graph do próprio git escreve temporário nesse mesmo store. Os dois correm; quem perde é o clone. Não era defeito da mudança em revisão.

**O custo não é o incômodo.** Um gate que reprova sozinho ensina a re-rodar sem ler, e a partir da segunda vez um vermelho de verdade corre o risco de virar "deve ser aquele flake" — que é como um defeito real atravessa o portão.

## Corrigido nos dois lugares, não só no que apareceu no log

O smoke também dirige o `install.sh` com `AI_SKILLS_REPO_URL="$ORIGIN"`, um caminho local — então **aquele** clone carrega a mesma corrida, onze vezes por execução (uma por caminho que tem de funcionar). Corrigir só a linha 107 seria o remendo de sintoma que o `lean-code` recusa.

Contra um remote de verdade o git ignora a flag, então nada muda para quem instala.

Grep de todos os `git clone` do repositório: três ocorrências, uma delas prosa num arquivo de pesquisa vendorizado. Sobrou zero clone local sem a flag.

## Custo medido, não estimado

Cinco clones de cada jeito sobre o próprio object store deste repositório — `git 2.47.3`, 8760 objetos empacotados, 4,7 MB:

| | média de 5 |
|---|---|
| hardlink | **79 ms** |
| `--no-hardlinks` | **94 ms** |

Quinze milissegundos por clone, doze clones por execução do smoke: menos de um quinto de segundo. O número está escrito no script, para ninguém remover a flag achando que é grátis.

## Verificações

| Verificação | Resultado |
|---|---|
| `bash scripts/smoke-install-scripts.sh` | `19/19 cases passed — refusals that had to fire: 8/8, paths that had to succeed: 11/11` |
| `bash -n` nos dois scripts | ok |
| grep por clone local sem a flag | nenhum |
| `validate-skills.py` / `validate-agents.py` | 38 skills, 3 agentes, 0 findings |
| `scripts/validate-rite.sh` | `rite gate OK` |
| higiene / segredos | 0 findings |

Nenhuma skill, nenhum agente e nenhuma árvore gerada foi tocada.
